### PR TITLE
PP-9368 Extract code for marking charges as eligible for capture

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeEligibleForCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeEligibleForCaptureService.java
@@ -1,0 +1,78 @@
+package uk.gov.pay.connector.charge.service;
+
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
+import uk.gov.pay.connector.common.exception.InvalidStateTransitionException;
+import uk.gov.pay.connector.queue.capture.CaptureQueue;
+import uk.gov.pay.connector.usernotification.service.UserNotificationService;
+import uk.gov.service.payments.commons.queue.exception.QueueException;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
+
+public class ChargeEligibleForCaptureService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChargeEligibleForCaptureService.class);
+
+    private final ChargeService chargeService;
+    private final ChargeDao chargeDao;
+    private final CaptureQueue captureQueue;
+    private final UserNotificationService userNotificationService;
+
+    @Inject
+    public ChargeEligibleForCaptureService(ChargeService chargeService, ChargeDao chargeDao, CaptureQueue captureQueue,
+                                           UserNotificationService userNotificationService) {
+        this.chargeService = chargeService;
+        this.chargeDao = chargeDao;
+        this.captureQueue = captureQueue;
+        this.userNotificationService = userNotificationService;
+    }
+
+    public ChargeEntity markChargeAsEligibleForCapture(String externalId) {
+        ChargeEntity charge = updateToNewStatus(externalId);
+
+        if (!charge.isDelayedCapture()) {
+            addChargeToCaptureQueue(charge);
+            userNotificationService.sendPaymentConfirmedEmail(charge, charge.getGatewayAccount());
+        }
+
+        return charge;
+    }
+
+    @Transactional
+    public ChargeEntity updateToNewStatus(String externalId) {
+        return chargeDao.findByExternalId(externalId).map(charge -> {
+            ChargeStatus targetStatus = charge.isDelayedCapture() ? AWAITING_CAPTURE_REQUEST : CAPTURE_APPROVED;
+
+            try {
+                chargeService.transitionChargeState(charge, targetStatus);
+            } catch (InvalidStateTransitionException e) {
+                throw new IllegalStateRuntimeException(charge.getExternalId());
+            }
+
+            return charge;
+        }).orElseThrow(() -> new ChargeNotFoundRuntimeException(externalId));
+    }
+
+    private void addChargeToCaptureQueue(ChargeEntity charge) {
+        try {
+            captureQueue.sendForCapture(charge);
+        } catch (QueueException e) {
+            LOGGER.error("Exception sending charge [{}] to capture queue", charge.getExternalId());
+            throw new WebApplicationException(format(
+                    "Unable to schedule charge [%s] for capture - %s",
+                    charge.getExternalId(), e.getMessage()));
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/charge/service/DelayedCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/DelayedCaptureService.java
@@ -1,0 +1,84 @@
+package uk.gov.pay.connector.charge.service;
+
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
+import uk.gov.pay.connector.common.exception.InvalidStateTransitionException;
+import uk.gov.pay.connector.queue.capture.CaptureQueue;
+import uk.gov.service.payments.commons.queue.exception.QueueException;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.fromString;
+
+public class DelayedCaptureService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelayedCaptureService.class);
+
+    private final ChargeService chargeService;
+    private final ChargeDao chargeDao;
+    private final CaptureQueue captureQueue;
+
+    @Inject
+    public DelayedCaptureService(ChargeService chargeService, ChargeDao chargeDao, CaptureQueue captureQueue) {
+        this.chargeService = chargeService;
+        this.chargeDao = chargeDao;
+        this.captureQueue = captureQueue;
+    }
+
+    public ChargeEntity markDelayedCaptureChargeAsCaptureApproved(String externalId) {
+        ChargeEntity charge = updateStatusToCaptureApprovedIfCurrentStatusAwaitingCaptureRequest(externalId);
+        addChargeToCaptureQueue(charge);
+        return charge;
+    }
+
+    @Transactional
+    public ChargeEntity updateStatusToCaptureApprovedIfCurrentStatusAwaitingCaptureRequest(String externalId) {
+        return chargeDao.findByExternalId(externalId).map(charge -> {
+            switch (fromString(charge.getStatus())) {
+                case AWAITING_CAPTURE_REQUEST:
+                    try {
+                        chargeService.transitionChargeState(charge, CAPTURE_APPROVED);
+                    } catch (InvalidStateTransitionException e) {
+                        throw new ConflictRuntimeException(charge.getExternalId(),
+                                "attempt to perform delayed capture on invalid charge state " + e.getMessage());
+                    }
+
+                    return charge;
+
+                case CAPTURE_APPROVED:
+                case CAPTURE_APPROVED_RETRY:
+                case CAPTURE_READY:
+                case CAPTURE_SUBMITTED:
+                case CAPTURED:
+                    return charge;
+
+                default:
+                    throw new ConflictRuntimeException(charge.getExternalId(),
+                            format("attempt to perform delayed capture on charge not in %s state.", AWAITING_CAPTURE_REQUEST)
+                    );
+            }
+
+        }).orElseThrow(() -> new ChargeNotFoundRuntimeException(externalId));
+    }
+
+    private void addChargeToCaptureQueue(ChargeEntity charge) {
+        try {
+            captureQueue.sendForCapture(charge);
+        } catch (QueueException e) {
+            LOGGER.error("Exception sending charge [{}] to capture queue", charge.getExternalId());
+            throw new WebApplicationException(format(
+                    "Unable to schedule charge [%s] for capture - %s",
+                    charge.getExternalId(), e.getMessage()));
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeEligibleForCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeEligibleForCaptureServiceTest.java
@@ -1,0 +1,124 @@
+package uk.gov.pay.connector.charge.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
+import uk.gov.pay.connector.common.exception.InvalidStateTransitionException;
+import uk.gov.pay.connector.queue.capture.CaptureQueue;
+import uk.gov.pay.connector.usernotification.service.UserNotificationService;
+import uk.gov.service.payments.commons.queue.exception.QueueException;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
+
+@ExtendWith(MockitoExtension.class)
+class ChargeEligibleForCaptureServiceTest {
+
+    @Mock
+    private ChargeService mockChargeService;
+
+    @Mock
+    private ChargeDao mockChargeDao;
+
+    @Mock
+    private CaptureQueue mockCaptureQueue;
+
+    @Mock
+    private UserNotificationService mockUserNotificationService;
+
+    private ChargeEligibleForCaptureService chargeEligibleForCaptureService;
+
+    @BeforeEach
+    void setUp() {
+        chargeEligibleForCaptureService = new ChargeEligibleForCaptureService(mockChargeService, mockChargeDao,
+                mockCaptureQueue, mockUserNotificationService);
+    }
+
+    @Test
+    void shouldChangeStateToCaptureApprovedAddToCaptureQueueAndSendPaymentConfirmedEmail() throws QueueException {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().withStatus(AUTHORISATION_SUCCESS).build();
+        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+
+        ChargeEntity result = chargeEligibleForCaptureService.markChargeAsEligibleForCapture(chargeEntity.getExternalId());
+
+        assertThat(result, sameInstance(chargeEntity));
+
+        var inOrder = inOrder(mockChargeService, mockCaptureQueue, mockUserNotificationService);
+        inOrder.verify(mockChargeService).transitionChargeState(chargeEntity, CAPTURE_APPROVED);
+        inOrder.verify(mockCaptureQueue).sendForCapture(result);
+        inOrder.verify(mockUserNotificationService).sendPaymentConfirmedEmail(chargeEntity, chargeEntity.getGatewayAccount());
+    }
+
+    @Test
+    void shouldChangeStateToAwaitingCaptureRequestButNotAddToCaptureQueueOrSendPaymentConfirmedEmailIfDelayedCapture() {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().withStatus(AUTHORISATION_SUCCESS).withDelayedCapture(true).build();
+        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+
+        ChargeEntity result = chargeEligibleForCaptureService.markChargeAsEligibleForCapture(chargeEntity.getExternalId());
+
+        assertThat(result, sameInstance(chargeEntity));
+
+        verify(mockChargeService).transitionChargeState(chargeEntity, AWAITING_CAPTURE_REQUEST);
+        verifyNoInteractions(mockCaptureQueue);
+        verifyNoInteractions(mockUserNotificationService);
+    }
+
+    @Test
+    void shouldThrowExceptionIfChargeCannotBeTransitioned() {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().withStatus(AUTHORISATION_SUCCESS).build();
+        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+        doThrow(InvalidStateTransitionException.class).when(mockChargeService).transitionChargeState(chargeEntity, CAPTURE_APPROVED);
+
+        assertThrows(IllegalStateRuntimeException.class,
+                () -> chargeEligibleForCaptureService.markChargeAsEligibleForCapture(chargeEntity.getExternalId()));
+
+        verifyNoInteractions(mockCaptureQueue);
+        verifyNoInteractions(mockUserNotificationService);
+    }
+
+    @Test
+    void shouldThrowExceptionIfChargeCannotBeAddedToCaptureQueue() throws QueueException {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().withStatus(AUTHORISATION_SUCCESS).build();
+        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+        doThrow(QueueException.class).when(mockCaptureQueue).sendForCapture(chargeEntity);
+
+        assertThrows(WebApplicationException.class,
+                () -> chargeEligibleForCaptureService.markChargeAsEligibleForCapture(chargeEntity.getExternalId()));
+
+        verify(mockChargeService).transitionChargeState(chargeEntity, CAPTURE_APPROVED);
+        verifyNoInteractions(mockUserNotificationService);
+    }
+
+    @Test
+    void shouldThrowExceptionIfChargeNotFound() throws QueueException {
+        var externalId = "external-id";
+        when(mockChargeDao.findByExternalId(externalId)).thenReturn(Optional.empty());
+
+        assertThrows(ChargeNotFoundRuntimeException.class,
+                () -> chargeEligibleForCaptureService.markChargeAsEligibleForCapture(externalId));
+
+        verifyNoInteractions(mockChargeService);
+        verifyNoInteractions(mockCaptureQueue);
+        verifyNoInteractions(mockUserNotificationService);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -33,7 +33,6 @@ import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConver
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
-import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.InvalidForceStateTransitionException;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
@@ -462,20 +461,6 @@ public class ChargeServiceTest {
                 ENTERING_CARD_DETAILS, chargeEvent);
 
         verify(mockTaskQueueService).offerTasksOnStateTransition(chargeSpy);
-    }
-    
-    @Test
-    public void shouldNotTransitionChargeStateForNonSkippableNonConfirmedCharge() {
-        ChargeEntity createdChargeEntity = aValidChargeEntity()
-                .withStatus(AUTHORISATION_SUCCESS)
-                .build();
-
-        final String chargeEntityExternalId = createdChargeEntity.getExternalId();
-        when(mockedChargeDao.findByExternalId(chargeEntityExternalId)).thenReturn(Optional.of(createdChargeEntity));
-
-        thrown.expect(ConflictRuntimeException.class);
-        thrown.expectMessage("HTTP 409 Conflict");
-        service.markDelayedCaptureChargeAsCaptureApproved(chargeEntityExternalId);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/DelayedCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/DelayedCaptureServiceTest.java
@@ -1,0 +1,140 @@
+package uk.gov.pay.connector.charge.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
+import uk.gov.pay.connector.common.exception.InvalidStateTransitionException;
+import uk.gov.pay.connector.queue.capture.CaptureQueue;
+import uk.gov.service.payments.commons.queue.exception.QueueException;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedCaptureServiceTest {
+
+    private static final String HTTP_409_CONFLICT = "HTTP 409 Conflict";
+    
+    @Mock
+    private ChargeService mockChargeService;
+
+    @Mock
+    private ChargeDao mockChargeDao;
+
+    @Mock
+    private CaptureQueue mockCaptureQueue;
+
+    private DelayedCaptureService delayedCaptureService;
+
+    @BeforeEach
+    void setUp() {
+        delayedCaptureService = new DelayedCaptureService(mockChargeService, mockChargeDao, mockCaptureQueue);
+    }
+
+    @Test
+    void shouldChangeStateToCaptureApprovedAndAddToCaptureQueueIfChargeInAwaitingCaptureRequestState() throws QueueException {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().withStatus(AWAITING_CAPTURE_REQUEST).build();
+        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+
+        ChargeEntity result = delayedCaptureService.markDelayedCaptureChargeAsCaptureApproved(chargeEntity.getExternalId());
+
+        assertThat(result, sameInstance(chargeEntity));
+
+        var inOrder = inOrder(mockChargeService, mockCaptureQueue);
+        inOrder.verify(mockChargeService).transitionChargeState(chargeEntity, CAPTURE_APPROVED);
+        inOrder.verify(mockCaptureQueue).sendForCapture(chargeEntity);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChargeStatus.class, names = {"CAPTURE_APPROVED", "CAPTURE_APPROVED_RETRY", "CAPTURE_READY", "CAPTURE_SUBMITTED", "CAPTURED"})
+    void shouldChangeStateToCaptureApprovedAndAddToCaptureQueueIfChargeInCaptureState(ChargeStatus initialChargeStatus) throws QueueException {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().withStatus(initialChargeStatus).build();
+        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+
+        ChargeEntity result = delayedCaptureService.markDelayedCaptureChargeAsCaptureApproved(chargeEntity.getExternalId());
+
+        assertThat(result, sameInstance(chargeEntity));
+
+        verifyNoInteractions(mockChargeService);
+        verify(mockCaptureQueue).sendForCapture(chargeEntity);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfChargeIsNotHasIncorrectStatus() {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().withStatus(AUTHORISATION_SUCCESS).build();
+        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+
+        var conflictRuntimeException = assertThrows(ConflictRuntimeException.class,
+                () -> delayedCaptureService.markDelayedCaptureChargeAsCaptureApproved(chargeEntity.getExternalId()));
+
+        assertThat(conflictRuntimeException.getMessage(), containsString(HTTP_409_CONFLICT));
+
+        verifyNoInteractions(mockChargeService);
+        verifyNoInteractions(mockCaptureQueue);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfChargeCannotBeTransitioned() {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().withStatus(AWAITING_CAPTURE_REQUEST).build();
+        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+        doThrow(InvalidStateTransitionException.class).when(mockChargeService).transitionChargeState(chargeEntity, CAPTURE_APPROVED);
+
+
+        var conflictRuntimeException = assertThrows(ConflictRuntimeException.class,
+                () -> delayedCaptureService.markDelayedCaptureChargeAsCaptureApproved(chargeEntity.getExternalId()));
+
+        assertThat(conflictRuntimeException.getMessage(), containsString(HTTP_409_CONFLICT));
+
+        verifyNoInteractions(mockCaptureQueue);
+    }
+
+    @Test
+    void shouldThrowExceptionIfChargeCannotBeAddedToCaptureQueue() throws QueueException {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().withStatus(AWAITING_CAPTURE_REQUEST).build();
+        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+        doThrow(new QueueException()).when(mockCaptureQueue).sendForCapture(chargeEntity);
+
+        assertThrows(WebApplicationException.class,
+                () -> delayedCaptureService.markDelayedCaptureChargeAsCaptureApproved(chargeEntity.getExternalId()));
+
+        var inOrder = inOrder(mockChargeService, mockCaptureQueue);
+        inOrder.verify(mockChargeService).transitionChargeState(chargeEntity, CAPTURE_APPROVED);
+        inOrder.verify(mockCaptureQueue).sendForCapture(chargeEntity);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfChargeNotFound() {
+        var externalId = "external-id";
+        when(mockChargeDao.findByExternalId(externalId)).thenReturn(Optional.empty());
+
+        assertThrows(ChargeNotFoundRuntimeException.class,
+                () -> delayedCaptureService.markDelayedCaptureChargeAsCaptureApproved(externalId));
+
+        verifyNoInteractions(mockChargeService);
+        verifyNoInteractions(mockCaptureQueue);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceTest.java
@@ -14,11 +14,12 @@ import uk.gov.pay.connector.charge.exception.OneTimeTokenInvalidExceptionMapper;
 import uk.gov.pay.connector.charge.exception.OneTimeTokenUsageInvalidForMotoApiException;
 import uk.gov.pay.connector.charge.exception.OneTimeTokenUsageInvalidForMotoApiExceptionMapper;
 import uk.gov.pay.connector.charge.service.ChargeCancelService;
+import uk.gov.pay.connector.charge.service.ChargeEligibleForCaptureService;
+import uk.gov.pay.connector.charge.service.DelayedCaptureService;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.paymentprocessor.model.AuthoriseRequest;
 import uk.gov.pay.connector.paymentprocessor.service.Card3dsResponseAuthService;
 import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseService;
-import uk.gov.pay.connector.paymentprocessor.service.CardCaptureService;
 import uk.gov.pay.connector.rules.ResourceTestRuleWithCustomExceptionMappersBuilder;
 import uk.gov.pay.connector.token.TokenService;
 import uk.gov.pay.connector.wallets.applepay.ApplePayService;
@@ -48,7 +49,8 @@ class CardResourceTest {
 
     private static final CardAuthoriseService mockCardAuthoriseService = mock(CardAuthoriseService.class);
     private static final Card3dsResponseAuthService mockCard3dsResponseAuthService = mock(Card3dsResponseAuthService.class);
-    private static final CardCaptureService mockCardCaptureService = mock(CardCaptureService.class);
+    private static final ChargeEligibleForCaptureService mockChargeEligibleForCaptureService = mock(ChargeEligibleForCaptureService.class);
+    private static final DelayedCaptureService mockDelayedCaptureService = mock(DelayedCaptureService.class);
     private static final ChargeCancelService mockChargeCancelService = mock(ChargeCancelService.class);
     private static final ApplePayService mockApplePayService = mock(ApplePayService.class);
     private static final GooglePayService mockGooglePayService = mock(GooglePayService.class);
@@ -58,7 +60,8 @@ class CardResourceTest {
             .getBuilder()
             .addResource(new CardResource(mockCardAuthoriseService,
                     mockCard3dsResponseAuthService,
-                    mockCardCaptureService,
+                    mockChargeEligibleForCaptureService,
+                    mockDelayedCaptureService,
                     mockChargeCancelService,
                     mockApplePayService,
                     mockGooglePayService,


### PR DESCRIPTION
Extract the code that marks a charge as being eligible for capture into two separate classes: one that’s used for all charges and one that’s used only for capturing delayed capture charges. The code for this was previously split between `CardCaptureService` and `ChargeService`.

There are absolutely no changes to funcionality of the code.

The changes to the tests are more substantial. Previously the unit tests were ostensibly testing CardCaptureService but that `CardCaptureService` used a real `ChargeService`, so some of the code that was being exercised was actually in `ChargeService` (and some relating to state transitions was actually in `ChargeEntity`!). The new tests only exercise the specific code in the new extracted classes and stub out `ChargeService`, with the assumption that any methods being called on `ChargeService` and `ChargeEntity` are already well-tested elsewhere.

This change is being made because we’re about to make marking a charge as being eligible for capture more complicated when an initial payment is made for an agreement and we want it not to be a nightmare to implement and test.