### PR TITLE
PP-9368 On charges, payment instruments and agreements are optional

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -257,8 +257,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.id = id;
     }
 
-    public PaymentInstrumentEntity getPaymentInstrument() {
-        return paymentInstrument;
+    public Optional<PaymentInstrumentEntity> getPaymentInstrument() {
+        return Optional.ofNullable(paymentInstrument);
     }
 
     public void setPaymentInstrument(PaymentInstrumentEntity paymentInstrument) {
@@ -543,8 +543,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.serviceId = serviceId;
     }
 
-    public String getAgreementId() {
-        return agreementId;
+    public Optional<String> getAgreementId() {
+        return Optional.ofNullable(agreementId);
     }
 
     public boolean isSavePaymentInstrumentToAgreement() {

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -181,7 +181,6 @@ public class ChargesFrontendResource {
                 .withGatewayAccount(charge.getGatewayAccount())
                 .withLanguage(charge.getLanguage())
                 .withDelayedCapture(charge.isDelayedCapture())
-                .withAgreementId(charge.getAgreementId())
                 .withSavePaymentInstrumentToAgreement(charge.isSavePaymentInstrumentToAgreement())
                 .withLink("self", GET, locationUriFor("/v1/frontend/charges/{chargeId}", uriInfo, chargeId))
                 .withLink("cardAuth", POST, locationUriFor("/v1/frontend/charges/{chargeId}/cards", uriInfo, chargeId))
@@ -196,11 +195,9 @@ public class ChargesFrontendResource {
             responseBuilder.withCardDetails(persistedCard);
         }
 
-        if (charge.getAgreementId() != null) {
-            findAgreement(charge.getAgreementId())
-                    .map(responseBuilder::withAgreement);
-        }
-        
+        charge.getAgreementId().ifPresent(responseBuilder::withAgreementId);
+        charge.getAgreementId().flatMap(this::findAgreement).ifPresent(responseBuilder::withAgreement);
+
         if (charge.get3dsRequiredDetails() != null) {
             var auth3dsData = new ChargeResponse.Auth3dsData();
             auth3dsData.setPaRequest(charge.get3dsRequiredDetails().getPaRequest());

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -502,10 +502,10 @@ public class ChargeService {
                 .withLink("refunds", GET, refundsUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()))
                 .withWalletType(chargeEntity.getWalletType())
                 .withMoto(chargeEntity.isMoto())
-                .withAgreementId(chargeEntity.getAgreementId())
                 .withAuthorisationMode(chargeEntity.getAuthorisationMode());
 
         chargeEntity.getFeeAmount().ifPresent(builderOfResponse::withFee);
+        chargeEntity.getAgreementId().ifPresent(builderOfResponse::withAgreementId);
         chargeEntity.getExternalMetadata().ifPresent(builderOfResponse::withExternalMetadata);
 
         if (ChargeStatus.AWAITING_CAPTURE_REQUEST.getValue().equals(chargeEntity.getStatus())) {

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
@@ -88,9 +88,10 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 .withEmail(charge.getEmail())
                 .withSource(charge.getSource())
                 .withMoto(charge.isMoto())
-                .withAgreementId(charge.getAgreementId())
                 .withSavePaymentInstrumentToAgreement(charge.isSavePaymentInstrumentToAgreement())
                 .withAuthorisationMode(charge.getAuthorisationMode());
+
+        charge.getAgreementId().ifPresent(builder::withAgreementId);
 
         if (isInCreatedState(charge) || hasNotGoneThroughAuthorisation(charge)) {
             addCardDetailsIfExist(charge, builder);

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
@@ -142,7 +142,8 @@ class ChargeServicePostAuthorisationTest {
         chargeService.updateChargePostCardAuthorisation(EXTERNAL_ID, AUTHORISATION_SUCCESS, TRANSACTION_ID, auth3dsRequiredEntity,
                 PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN);
 
-        assertThat(chargeEntity.getPaymentInstrument(), is(mockPaymentInstrumentEntity));
+        assertThat(chargeEntity.getPaymentInstrument().isPresent(), is(true));
+        assertThat(chargeEntity.getPaymentInstrument().get(), is(mockPaymentInstrumentEntity));
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
@@ -210,7 +210,7 @@ public class PaymentCreatedTest {
 
     private void assertRecurringPaymentCreatedDetails(String actual) {
         assertBasePaymentCreatedDetails(actual);
-        assertThat(actual, hasJsonPath("$.event_details.agreement_id", equalTo(chargeEntity.getAgreementId())));
+        assertThat(actual, hasJsonPath("$.event_details.agreement_id", equalTo(chargeEntity.getAgreementId().orElseThrow(IllegalStateException::new))));
         assertThat(actual, hasJsonPath("$.event_details.save_payment_instrument_to_agreement", equalTo(chargeEntity.isSavePaymentInstrumentToAgreement())));
     }
 }


### PR DESCRIPTION
Make `Charge.getPaymentInstrument()` return `Optional<PaymentInstrument>` and `Charge.getAgreementId()` return
`Optional<String>`.

A charge may or may not have a payment instrument and agreement, so this is basically what optionals were made for.