### PR TITLE
PP-9390 handle charges created via `moto_api` auth mode

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -25,6 +25,7 @@ import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import uk.gov.pay.connector.agreement.resource.AgreementsApiResource;
 import uk.gov.pay.connector.cardtype.resource.CardTypesResource;
 import uk.gov.pay.connector.charge.exception.AgreementNotFoundExceptionMapper;
+import uk.gov.pay.connector.charge.exception.AuthorisationApiNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapper;
 import uk.gov.pay.connector.charge.exception.InvalidAttributeValueExceptionMapper;
 import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountExceptionMapper;
@@ -140,6 +141,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new OneTimeTokenUsageInvalidForMotoApiExceptionMapper());
         environment.jersey().register(new InvalidAttributeValueExceptionMapper());
         environment.jersey().register(new CardNumberRejectedExceptionMapper());
+        environment.jersey().register(new AuthorisationApiNotAllowedForGatewayAccountExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/exception/AuthorisationApiNotAllowedForGatewayAccountException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/AuthorisationApiNotAllowedForGatewayAccountException.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.charge.exception;
+
+import static java.lang.String.format;
+
+public class AuthorisationApiNotAllowedForGatewayAccountException extends RuntimeException {
+
+    public AuthorisationApiNotAllowedForGatewayAccountException(Long gatewayAccountId) {
+        super(format("Using authorisation_mode of moto_api is not allowed for this account [%d]", gatewayAccountId));
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/AuthorisationApiNotAllowedForGatewayAccountExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/AuthorisationApiNotAllowedForGatewayAccountExceptionMapper.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.charge.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class AuthorisationApiNotAllowedForGatewayAccountExceptionMapper implements ExceptionMapper<AuthorisationApiNotAllowedForGatewayAccountException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthorisationApiNotAllowedForGatewayAccountExceptionMapper.class);
+
+    @Override
+    public Response toResponse(AuthorisationApiNotAllowedForGatewayAccountException exception) {
+        LOGGER.info(exception.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.AUTHORISATION_API_NOT_ALLOWED, exception.getMessage());
+
+        return Response.status(422)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
@@ -84,6 +84,7 @@ public class ChargeCreateRequest {
     private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
 
     public ChargeCreateRequest() {
+        // empty constructor
     }
 
     ChargeCreateRequest(long amount,
@@ -99,7 +100,8 @@ public class ChargeCreateRequest {
                         boolean moto,
                         String paymentProvider,
                         String agreementId,
-                        boolean savePaymentInstrumentToAgreement) {
+                        boolean savePaymentInstrumentToAgreement,
+                        AuthorisationMode authorisationMode) {
         this.amount = amount;
         this.description = description;
         this.reference = reference;
@@ -114,6 +116,7 @@ public class ChargeCreateRequest {
         this.paymentProvider = paymentProvider;
         this.agreementId = agreementId;
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
+        this.authorisationMode = authorisationMode;
     }
 
     public long getAmount() {
@@ -186,9 +189,9 @@ public class ChargeCreateRequest {
                 ", delayed_capture=" + delayedCapture +
                 ", source=" + source +
                 ", moto=" + moto +
-                (language != null ? ", language=" + language.toString() : "") +
+                (language != null ? ", language=" + language : "") +
                 (paymentProvider != null ? ", payment_provider=" + paymentProvider : "") +
-                (agreementId != null ? ", agreementId=" + agreementId.toString() : "") +
+                (agreementId != null ? ", agreementId=" + agreementId : "") +
                 ", savePaymentInstrumentToAgreement=" + savePaymentInstrumentToAgreement +
                 ", authorisationMode=" + authorisationMode + 
                 '}';

--- a/src/test/java/uk/gov/pay/connector/charge/model/ChargeCreateRequestBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/ChargeCreateRequestBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.charge.model;
 
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
@@ -19,6 +20,7 @@ public final class ChargeCreateRequestBuilder {
     private String paymentProvider;
     private String agreementId;
     private boolean savePaymentInstrumentToAgreement;
+    private AuthorisationMode authorisationMode;
 
     private ChargeCreateRequestBuilder() {
     }
@@ -96,9 +98,14 @@ public final class ChargeCreateRequestBuilder {
         this.paymentProvider = paymentProvider;
         return this;
     }
+    
+    public ChargeCreateRequestBuilder withAuthorisationMode(AuthorisationMode authorisationMode) {
+        this.authorisationMode = authorisationMode;
+        return this;
+    }
 
     public ChargeCreateRequest build() {
         return new ChargeCreateRequest(amount, description, reference, returnUrl, email, delayedCapture, language,
-                prefilledCardHolderDetails, externalMetadata, source, moto, paymentProvider, agreementId, savePaymentInstrumentToAgreement);
+                prefilledCardHolderDetails, externalMetadata, source, moto, paymentProvider, agreementId, savePaymentInstrumentToAgreement, authorisationMode);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
@@ -77,7 +77,6 @@ class ChargeServicePostAuthorisationTest {
 
     private final Auth3dsRequiredEntity auth3dsRequiredEntity = new Auth3dsRequiredEntity();
     private final ChargeEntityFixture chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity();
-    private final AuthCardDetailsFixture authCardDetailsFixture = AuthCardDetailsFixture.anAuthCardDetails();
     private AuthCardDetails authCardDetails;
 
     private ChargeService chargeService;

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -130,6 +130,7 @@ public class ChargingITestBase {
                 .withGatewayAccountCredentials(List.of(credentialParams))
                 .withCredentials(credentials)
                 .withServiceId(SERVICE_ID)
+                .withAllowAuthApi(true)
                 .insert();
         connectorRestApiClient = new RestAssuredClient(testContext.getPort(), accountId);
     }

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -348,6 +348,7 @@ public class DatabaseFixtures {
         private long corporatePrepaidDebitCardSurchargeAmount;
         private int integrationVersion3ds = 2;
         private boolean allowMoto;
+        private boolean allowAuthApi;
         private boolean motoMaskCardNumberInput;
         private boolean motoMaskCardSecurityCodeInput;
         private boolean allowTelephonePaymentNotifications;
@@ -497,6 +498,11 @@ public class DatabaseFixtures {
             this.allowMoto = allowMoto;
             return this;
         }
+        
+        public TestAccount withAllowAuthApi(boolean allowAuthApi) {
+            this.allowAuthApi = allowAuthApi;
+            return this;
+        }
 
         public TestAccount withMotoMaskCardNumberInput(boolean motoMaskCardNumberInput) {
             this.motoMaskCardNumberInput = motoMaskCardNumberInput;
@@ -548,6 +554,7 @@ public class DatabaseFixtures {
                     .withCorporatePrepaidDebitCardSurchargeAmount(corporatePrepaidDebitCardSurchargeAmount)
                     .withIntegrationVersion3ds(integrationVersion3ds)
                     .withAllowMoto(allowMoto)
+                    .withAllowAuthApi(allowAuthApi)
                     .withMotoMaskCardNumberInput(motoMaskCardNumberInput)
                     .withMotoMaskCardSecurityCodeInput(motoMaskCardSecurityCodeInput)
                     .withAllowTelephonePaymentNotifications(allowTelephonePaymentNotifications)

--- a/src/test/java/uk/gov/pay/connector/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/PublicApiContractTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.pact;
 
+import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
 import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.loader.PactBroker;
@@ -11,5 +12,6 @@ import org.junit.runner.RunWith;
 @PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"publicapi"})
+@IgnoreNoPactsToVerify
 public class PublicApiContractTest extends ContractTest {
 }

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -48,6 +48,7 @@ public class AddGatewayAccountParams {
     private long corporatePrepaidDebitCardSurchargeAmount;
     private int integrationVersion3ds;
     private boolean allowMoto;
+    private boolean allowAuthApi;
     private boolean motoMaskCardNumberInput;
     private boolean motoMaskCardSecurityCodeInput;
     private boolean allowApplePay;
@@ -111,6 +112,10 @@ public class AddGatewayAccountParams {
     public boolean isAllowMoto() {
         return allowMoto;
     }
+    
+    public boolean isAllowAuthApi() {
+        return allowAuthApi;
+    }
 
     public boolean isMotoMaskCardNumberInput() {
         return motoMaskCardNumberInput;
@@ -156,6 +161,7 @@ public class AddGatewayAccountParams {
         private long corporatePrepaidDebitCardSurchargeAmount;
         private int integrationVersion3ds = 2;
         private boolean allowMoto;
+        private boolean allowAuthApi;
         private boolean motoMaskCardNumberInput;
         private boolean motoMaskCardSecurityCodeInput;
         private boolean allowApplePay;
@@ -262,6 +268,11 @@ public class AddGatewayAccountParams {
             return this;
         }
 
+        public AddGatewayAccountParamsBuilder withAllowAuthApi(boolean allowAuthApi) {
+            this.allowAuthApi = allowAuthApi;
+            return this;
+        }
+
         public AddGatewayAccountParamsBuilder withMotoMaskCardNumberInput(boolean motoMaskCardNumberInput) {
             this.motoMaskCardNumberInput = motoMaskCardNumberInput;
             return this;
@@ -320,6 +331,7 @@ public class AddGatewayAccountParams {
             addGatewayAccountParams.corporateDebitCardSurchargeAmount = this.corporateDebitCardSurchargeAmount;
             addGatewayAccountParams.integrationVersion3ds = this.integrationVersion3ds;
             addGatewayAccountParams.allowMoto = this.allowMoto;
+            addGatewayAccountParams.allowAuthApi = this.allowAuthApi;
             addGatewayAccountParams.motoMaskCardNumberInput = this.motoMaskCardNumberInput;
             addGatewayAccountParams.motoMaskCardSecurityCodeInput = this.motoMaskCardSecurityCodeInput;
             addGatewayAccountParams.allowApplePay = this.allowApplePay;

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -51,14 +51,14 @@ public class DatabaseTestHelper {
                         "corporate_debit_card_surcharge_amount, " +
                         "corporate_prepaid_debit_card_surcharge_amount, allow_moto, moto_mask_card_number_input, " +
                         "moto_mask_card_security_code_input, allow_apple_pay, allow_google_pay, requires_3ds, " +
-                        "allow_telephone_payment_notifications, provider_switch_enabled, service_id) " +
+                        "allow_telephone_payment_notifications, allow_authorisation_api, provider_switch_enabled, service_id) " +
                         "VALUES (:id, :external_id, :service_name, :type, " +
                         ":description, :analytics_id, :email_collection_mode, :integration_version_3ds, " +
                         ":corporate_credit_card_surcharge_amount, :corporate_debit_card_surcharge_amount, " +
                         ":corporate_prepaid_debit_card_surcharge_amount, " +
                         ":allow_moto, :moto_mask_card_number_input, :moto_mask_card_security_code_input, " +
                         ":allow_apple_pay, :allow_google_pay, :requires_3ds, " +
-                        ":allow_telephone_payment_notifications, :provider_switch_enabled, :service_id)")
+                        ":allow_telephone_payment_notifications, :allow_authorisation_api, :provider_switch_enabled, :service_id)")
                         .bind("id", Long.valueOf(params.getAccountId()))
                         .bind("external_id", params.getExternalId())
                         .bind("service_name", params.getServiceName())
@@ -71,6 +71,7 @@ public class DatabaseTestHelper {
                         .bind("corporate_debit_card_surcharge_amount", params.getCorporateDebitCardSurchargeAmount())
                         .bind("corporate_prepaid_debit_card_surcharge_amount", params.getCorporatePrepaidDebitCardSurchargeAmount())
                         .bind("allow_moto", params.isAllowMoto())
+                        .bind("allow_authorisation_api", params.isAllowAuthApi())
                         .bind("moto_mask_card_number_input", params.isMotoMaskCardNumberInput())
                         .bind("moto_mask_card_security_code_input", params.isMotoMaskCardSecurityCodeInput())
                         .bind("allow_apple_pay", params.isAllowApplePay())


### PR DESCRIPTION
## WHAT YOU DID
- Updated the charge service to handle `moto_api` auth mode charge creation requests. The service checks that `moto_api` is enabled on the account and if enabled will return a charge with an `auth_url_post` link, in this situation the service will ignore `isAllowMoto`.
- Added a new exception mapper to return a 422 error response if the gateway account has auth api diabled. 
