### PR TITLE
PP-9368 Link payment instrument to agreement on user confirm

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.connector.charge.service;
+
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.agreement.dao.AgreementDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+
+import javax.inject.Inject;
+
+public class LinkPaymentInstrumentToAgreementService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LinkPaymentInstrumentToAgreementService.class);
+
+    private final AgreementDao agreementDao;
+
+    @Inject
+    public LinkPaymentInstrumentToAgreementService(AgreementDao agreementDao) {
+        this.agreementDao = agreementDao;
+    }
+
+    @Transactional
+    public void linkPaymentInstrumentFromChargeToAgreementFromCharge(ChargeEntity chargeEntity) {
+        chargeEntity.getPaymentInstrument().ifPresentOrElse(paymentInstrumentEntity -> {
+            chargeEntity.getAgreementId().ifPresentOrElse(agreementId -> {
+                agreementDao.findByExternalId(agreementId).ifPresentOrElse(agreementEntity -> {
+                    agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
+                    paymentInstrumentEntity.setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
+                }, () -> LOGGER.error("Charge {} references agreement {} but that agreement does not exist", chargeEntity.getExternalId(), agreementId));
+            }, () -> LOGGER.error("Expected charge {} to have an agreement but it does not have one", chargeEntity.getExternalId()));
+        }, () -> LOGGER.error("Expected charge {} to have a payment instrument but it does not have one", chargeEntity.getExternalId()));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -164,6 +164,8 @@ public class ChargeEntityFixture {
         chargeEntity.set3dsRequiredDetails(auth3DsRequiredEntity);
         chargeEntity.setWalletType(walletType);
         chargeEntity.setExemption3ds(exemption3ds);
+        chargeEntity.setAgreementId(agreementId);
+        chargeEntity.setPaymentInstrument(paymentInstrument);
 
         if (this.fees != null) {
             fees.stream().forEach(partialFee -> {

--- a/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
@@ -1,0 +1,123 @@
+package uk.gov.pay.connector.charge.service;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.agreement.dao.AgreementDao;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+
+@ExtendWith(MockitoExtension.class)
+class LinkPaymentInstrumentToAgreementServiceTest {
+
+    private static final String AGREEMENT_ID = "I am very agreeable";
+    
+    @Mock
+    private AgreementDao mockAgreementDao;
+
+    @Mock
+    private AgreementEntity mockAgreementEntity;
+
+    @Mock
+    private PaymentInstrumentEntity mockPaymentInstrumentEntity;
+
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    private LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
+
+    @BeforeEach
+    public void setUp() {
+        var logger = (Logger) LoggerFactory.getLogger(LinkPaymentInstrumentToAgreementService.class);
+        logger.setLevel(Level.ERROR);
+        logger.addAppender(mockAppender);
+
+        linkPaymentInstrumentToAgreementService = new LinkPaymentInstrumentToAgreementService(mockAgreementDao);
+    }
+
+    @Test
+    void linksPaymentInstrumentFromChargeToAgreementFromChargeAndSetsPaymentInstrumentToActive() {
+        given(mockAgreementDao.findByExternalId(AGREEMENT_ID)).willReturn(Optional.of(mockAgreementEntity));
+        var chargeEntity = aValidChargeEntity().withPaymentInstrument(mockPaymentInstrumentEntity).withAgreementId(AGREEMENT_ID).build();
+
+        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreementFromCharge(chargeEntity);
+
+        verify(mockAgreementEntity).setPaymentInstrument(mockPaymentInstrumentEntity);
+        verify(mockPaymentInstrumentEntity).setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
+    }
+
+    @Test
+    void logsErrorIfChargeDoesNotHavePaymentInstrument() {
+        var chargeEntity = aValidChargeEntity().withPaymentInstrument(null).withAgreementId(AGREEMENT_ID).build();
+
+        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreementFromCharge(chargeEntity);
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+        var loggingEvent = loggingEventArgumentCaptor.getValue();
+        assertThat(loggingEvent.getLevel(), is(Level.ERROR));
+        assertThat(loggingEvent.getFormattedMessage(),
+                is("Expected charge " + chargeEntity.getExternalId() + " to have a payment instrument but it does not have one"));
+
+        verifyNoInteractions(mockAgreementEntity);
+        verifyNoInteractions(mockPaymentInstrumentEntity);
+    }
+
+    @Test
+    void logsErrorIfChargeHasPaymentInstrumentButDoesNotHaveAgreementId() {
+        var chargeEntity = aValidChargeEntity().withPaymentInstrument(mockPaymentInstrumentEntity).withAgreementId(null).build();
+
+        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreementFromCharge(chargeEntity);
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+        var loggingEvent = loggingEventArgumentCaptor.getValue();
+        assertThat(loggingEvent.getLevel(), is(Level.ERROR));
+        assertThat(loggingEvent.getFormattedMessage(),
+                is("Expected charge " + chargeEntity.getExternalId() + " to have an agreement but it does not have one"));
+
+        verifyNoInteractions(mockAgreementEntity);
+        verifyNoInteractions(mockPaymentInstrumentEntity);
+    }
+
+    @Test
+    void logsErrorIfChargeHasPaymentInstrumentAndAgreementIdButAgreementNotFound() {
+        given(mockAgreementDao.findByExternalId(AGREEMENT_ID)).willReturn(Optional.empty());
+        var chargeEntity = aValidChargeEntity().withPaymentInstrument(mockPaymentInstrumentEntity).withAgreementId(AGREEMENT_ID).build();
+
+        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreementFromCharge(chargeEntity);
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+        var loggingEvent = loggingEventArgumentCaptor.getValue();
+        assertThat(loggingEvent.getLevel(), is(Level.ERROR));
+        assertThat(loggingEvent.getFormattedMessage(),
+                is("Charge " + chargeEntity.getExternalId() + " references agreement " + AGREEMENT_ID + " but that agreement does not exist"));
+
+        verifyNoInteractions(mockAgreementEntity);
+        verifyNoInteractions(mockPaymentInstrumentEntity);
+    }
+
+}


### PR DESCRIPTION
When a user confirms a payment, marking it eligible for capture (`CAPTURE APPROVED` for most payments, `AWAITING CAPTURE REQUEST` for delayed capture payments), link the payment instrument associated with the payment to the agreement associated with the payment and set the payment instrument to active if and only if the payment has the flag to save the payment instrument to the agreement enabled.

A `@Transactional` annotation makes sure that this linking and status updating happens in the same transaction as the one that updates the status of the payment itself, ensuring consistency.

The code accounts for three errors that can Never Happen™ because they would mean the world has gotten into an inconsistent state:

1. The payment has no payment instrument on it (in which case the flag should not be set)
1. The payment has no agreement ID set on it (in which case the flag should not be set)
1. The payment has an agreement ID but there is no matching agreement in the database (in which case our foreign key constraints may have failed us)

If any of these errors occur, we log an error but continue marking the payment as eligible for capture. This means that this payment will succeed but the service will not be able to take future recurring payments from the agreement.

Other errors (for example, the database connection failing), will cause the entire process of marking the payment eligible for capture to fail, which is consistent with other parts of the system.