### PR TITLE
PP-9143 Validate card number check digit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.10</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.13.2</jackson.version>
-        <pay-java-commons.version>1.0.20220420155027</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20220425091635</pay-java-commons.version>
         <surefire.version>3.0.0-M6</surefire.version>
         <jooq.version>3.16.6</jooq.version>
         <postgresql.version>42.3.4</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -28,9 +28,10 @@ import uk.gov.pay.connector.charge.exception.AgreementNotFoundExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapper;
 import uk.gov.pay.connector.charge.exception.InvalidAttributeValueExceptionMapper;
 import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountExceptionMapper;
-import uk.gov.pay.connector.charge.exception.OneTimeTokenAlreadyUsedExceptionMapper;
-import uk.gov.pay.connector.charge.exception.OneTimeTokenInvalidExceptionMapper;
-import uk.gov.pay.connector.charge.exception.OneTimeTokenUsageInvalidForMotoApiExceptionMapper;
+import uk.gov.pay.connector.charge.exception.motoapi.CardNumberRejectedExceptionMapper;
+import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenAlreadyUsedExceptionMapper;
+import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenInvalidExceptionMapper;
+import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenUsageInvalidForMotoApiExceptionMapper;
 import uk.gov.pay.connector.charge.exception.TelephonePaymentNotificationsNotAllowedExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ZeroAmountNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.resource.ChargesApiResource;
@@ -138,6 +139,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new OneTimeTokenAlreadyUsedExceptionMapper());
         environment.jersey().register(new OneTimeTokenUsageInvalidForMotoApiExceptionMapper());
         environment.jersey().register(new InvalidAttributeValueExceptionMapper());
+        environment.jersey().register(new CardNumberRejectedExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/CardNumberRejectedException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/CardNumberRejectedException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.charge.exception.motoapi;
+
+import javax.ws.rs.WebApplicationException;
+
+public class CardNumberRejectedException extends WebApplicationException {
+    public CardNumberRejectedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/CardNumberRejectedExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/CardNumberRejectedExceptionMapper.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.connector.charge.exception.motoapi;
+
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.CARD_NUMBER_REJECTED;
+
+public class CardNumberRejectedExceptionMapper implements ExceptionMapper<CardNumberRejectedException> {
+    
+    @Override
+    public Response toResponse(CardNumberRejectedException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(CARD_NUMBER_REJECTED, exception.getMessage());
+
+        return Response.status(402)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenAlreadyUsedException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenAlreadyUsedException.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.connector.charge.exception;
+package uk.gov.pay.connector.charge.exception.motoapi;
 
 import javax.ws.rs.BadRequestException;
 

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenAlreadyUsedExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenAlreadyUsedExceptionMapper.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.connector.charge.exception;
+package uk.gov.pay.connector.charge.exception.motoapi;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenInvalidException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenInvalidException.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.connector.charge.exception;
+package uk.gov.pay.connector.charge.exception.motoapi;
 
 import javax.ws.rs.BadRequestException;
 

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenInvalidExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenInvalidExceptionMapper.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.connector.charge.exception;
+package uk.gov.pay.connector.charge.exception.motoapi;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenUsageInvalidForMotoApiException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenUsageInvalidForMotoApiException.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.connector.charge.exception;
+package uk.gov.pay.connector.charge.exception.motoapi;
 
 import javax.ws.rs.BadRequestException;
 

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenUsageInvalidForMotoApiExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenUsageInvalidForMotoApiExceptionMapper.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.connector.charge.exception;
+package uk.gov.pay.connector.charge.exception.motoapi;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/uk/gov/pay/connector/charge/service/motoapi/MotoApiCardNumberValidationService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/motoapi/MotoApiCardNumberValidationService.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.charge.service.motoapi;
+
+import org.apache.commons.validator.routines.checkdigit.LuhnCheckDigit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.exception.motoapi.CardNumberRejectedException;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+public class MotoApiCardNumberValidationService {
+
+    private final Logger logger = LoggerFactory.getLogger(MotoApiCardNumberValidationService.class);
+
+    private final ChargeService chargeService;
+    private final ChargeDao chargeDao;
+
+    @Inject
+    public MotoApiCardNumberValidationService(ChargeService chargeService, ChargeDao chargeDao) {
+        this.chargeService = chargeService;
+        this.chargeDao = chargeDao;
+    }
+
+    public void validateCardNumber(ChargeEntity charge, String cardNumber) {
+        checkValidAllowedCardNumber(charge, cardNumber).ifPresent(errorMessage -> {
+            transitionChargeToRejected(charge);
+            throw new CardNumberRejectedException(errorMessage);
+        });
+    }
+
+    private Optional<String> checkValidAllowedCardNumber(ChargeEntity charge, String cardNumber) {
+        return checkHasValidLuhnCheckDigit(cardNumber);
+        // TODO other checks on card number
+    }
+
+    private Optional<String> checkHasValidLuhnCheckDigit(String cardNumber) {
+        boolean valid = new LuhnCheckDigit().isValid(cardNumber);
+        if (!valid) {
+            logger.info("Card number rejected due to invalid Luhn check digit");
+            return Optional.of("The card_number is not a valid card number");
+        }
+        return Optional.empty();
+    }
+
+    private void transitionChargeToRejected(ChargeEntity charge) {
+        chargeService.transitionChargeState(charge, ChargeStatus.AUTHORISATION_REJECTED);
+        chargeDao.merge(charge);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -124,6 +124,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(CREATED, ENTERING_CARD_DETAILS, ModelledEvent.of(PaymentStarted.class));
         graph.putEdgeValue(CREATED, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));
         graph.putEdgeValue(CREATED, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
+        graph.putEdgeValue(CREATED, AUTHORISATION_REJECTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(ENTERING_CARD_DETAILS, AUTHORISATION_READY, ModelledEvent.none());
         graph.putEdgeValue(ENTERING_CARD_DETAILS, AUTHORISATION_ABORTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(ENTERING_CARD_DETAILS, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));

--- a/src/main/java/uk/gov/pay/connector/token/TokenService.java
+++ b/src/main/java/uk/gov/pay/connector/token/TokenService.java
@@ -1,8 +1,9 @@
 package uk.gov.pay.connector.token;
 
-import uk.gov.pay.connector.charge.exception.OneTimeTokenAlreadyUsedException;
-import uk.gov.pay.connector.charge.exception.OneTimeTokenInvalidException;
-import uk.gov.pay.connector.charge.exception.OneTimeTokenUsageInvalidForMotoApiException;
+import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenAlreadyUsedException;
+import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenInvalidException;
+import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenUsageInvalidForMotoApiException;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
 
@@ -19,8 +20,8 @@ public class TokenService {
         this.tokenDao = tokenDao;
     }
 
-    public void validateTokenForMotoApi(String oneTimeToken) {
-        tokenDao.findByTokenId(oneTimeToken)
+    public ChargeEntity validateTokenAndGetChargeForMotoApi(String oneTimeToken) {
+        return tokenDao.findByTokenId(oneTimeToken)
                 .map((TokenEntity tokenEntity) -> {
                     if (tokenEntity.isUsed()) {
                         throw new OneTimeTokenAlreadyUsedException();
@@ -28,7 +29,7 @@ public class TokenService {
 
                     if (tokenEntity.getChargeEntity() != null &&
                             tokenEntity.getChargeEntity().getAuthorisationMode() == MOTO_API) {
-                        return tokenEntity;
+                        return tokenEntity.getChargeEntity();
                     }
                     throw new OneTimeTokenUsageInvalidForMotoApiException();
                 })

--- a/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
+++ b/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
@@ -92,6 +92,11 @@ public class ResponseUtil {
         return responseWithEntity(status, errorResponse);
     }
 
+    public static Response buildErrorResponse(Status status, ErrorIdentifier errorIdentifier, List<String> messages) {
+        ErrorResponse errorResponse = new ErrorResponse(errorIdentifier, messages);
+        return responseWithEntity(status, errorResponse);
+    }
+
     public static Response noContentResponse() {
         return noContent().build();
     }

--- a/src/test/java/uk/gov/pay/connector/charge/service/motoapi/MotoApiCardNumberValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/motoapi/MotoApiCardNumberValidationServiceTest.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.charge.service.motoapi;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.exception.motoapi.CardNumberRejectedException;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+
+@ExtendWith(MockitoExtension.class)
+class MotoApiCardNumberValidationServiceTest {
+    
+    @Mock
+    ChargeService mockChargeService;
+    
+    @Mock
+    ChargeDao mockChargeDao;
+    
+    @InjectMocks
+    MotoApiCardNumberValidationService motoApiCardNumberValidationService;
+    
+    ChargeEntity chargeEntity = aValidChargeEntity().withStatus(ChargeStatus.CREATED).build();
+    
+    @Test
+    void shouldFailForCardNumberWithInvalidCheckDigit() {
+        CardNumberRejectedException exception = assertThrows(CardNumberRejectedException.class, () -> motoApiCardNumberValidationService.validateCardNumber(chargeEntity, "1111111111111111"));
+        
+        assertThat(exception.getMessage(), is("The card_number is not a valid card number"));
+        verify(mockChargeService).transitionChargeState(chargeEntity, AUTHORISATION_REJECTED);
+        verify(mockChargeDao).merge(chargeEntity);
+    }
+
+    @Test
+    void shouldSucceedForValidCardNumber() {
+        assertDoesNotThrow(() -> motoApiCardNumberValidationService.validateCardNumber(chargeEntity, "4242424242424242"));
+        verify(mockChargeService, never()).transitionChargeState(eq(chargeEntity), any());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/token/TokenServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/token/TokenServiceTest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.connector.charge.exception.OneTimeTokenAlreadyUsedException;
-import uk.gov.pay.connector.charge.exception.OneTimeTokenInvalidException;
-import uk.gov.pay.connector.charge.exception.OneTimeTokenUsageInvalidForMotoApiException;
+import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenAlreadyUsedException;
+import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenInvalidException;
+import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenUsageInvalidForMotoApiException;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
@@ -32,7 +32,7 @@ class TokenServiceTest {
     void validateTokenForMotoApiShouldThrowOneTimeTokenInvalidExceptionIfTokenDoesNotExist() {
         when(tokenDao.findByTokenId(any())).thenReturn(Optional.empty());
 
-        assertThrows(OneTimeTokenInvalidException.class, () -> tokenService.validateTokenForMotoApi("one-time-token-123"),
+        assertThrows(OneTimeTokenInvalidException.class, () -> tokenService.validateTokenAndGetChargeForMotoApi("one-time-token-123"),
                 "Should throw OneTimeTokenInvalidException if token is not found");
     }
 
@@ -42,7 +42,7 @@ class TokenServiceTest {
         tokenEntity.setUsed(true);
         when(tokenDao.findByTokenId(any())).thenReturn(Optional.of(tokenEntity));
 
-        assertThrows(OneTimeTokenAlreadyUsedException.class, () -> tokenService.validateTokenForMotoApi("one-time-token-123"),
+        assertThrows(OneTimeTokenAlreadyUsedException.class, () -> tokenService.validateTokenAndGetChargeForMotoApi("one-time-token-123"),
                 "Should throw OneTimeTokenAlreadyUsedException if token is already user");
     }
 
@@ -58,7 +58,7 @@ class TokenServiceTest {
 
         when(tokenDao.findByTokenId(any())).thenReturn(Optional.of(tokenEntity));
 
-        assertThrows(OneTimeTokenUsageInvalidForMotoApiException.class, () -> tokenService.validateTokenForMotoApi("one-time-token-123"),
+        assertThrows(OneTimeTokenUsageInvalidForMotoApiException.class, () -> tokenService.validateTokenAndGetChargeForMotoApi("one-time-token-123"),
                 "Should throw exception if token is not for charge with authorisation_mode=MOTO_API");
     }
 }


### PR DESCRIPTION
Perform the Luhn check to validate the card number is a valid card number. If it is not valid, transition the charge to the AUTHORISATION_REJECTED state and return an error with code 402 and error_identifier CARD_NUMBER_REJECTED.