### PR TITLE
PP-9143 Get card information from Cardid

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -135,8 +135,16 @@ public class ConnectorConfiguration extends Configuration {
     @JsonProperty("ledgerBaseURL")
     private String ledgerBaseUrl;
 
+    @NotNull
+    @JsonProperty("cardidBaseURL")
+    private String cardidBaseUrl;
+
     public String getLedgerBaseUrl() {
         return ledgerBaseUrl;
+    }
+
+    public String getCardidBaseUrl() {
+        return cardidBaseUrl;
     }
 
     @JsonProperty("database")

--- a/src/main/java/uk/gov/pay/connector/client/cardid/model/CardInformation.java
+++ b/src/main/java/uk/gov/pay/connector/client/cardid/model/CardInformation.java
@@ -1,0 +1,73 @@
+package uk.gov.pay.connector.client.cardid.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
+
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CardInformation {
+    @JsonProperty("brand")
+    private String brand;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("label")
+    private String label;
+
+    @JsonProperty("corporate")
+    private boolean corporate;
+
+    @JsonProperty("prepaid")
+    private PayersCardPrepaidStatus prepaidStatus;
+    
+    public CardInformation() {
+        // for Jackson deserialisation
+    }
+
+    public CardInformation(String brand, String type, String label, boolean corporate, PayersCardPrepaidStatus prepaidStatus) {
+        this.brand = brand;
+        this.type = type;
+        this.label = label;
+        this.corporate = corporate;
+        this.prepaidStatus = prepaidStatus;
+    }
+
+    public String getBrand() {
+        return brand;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public boolean isCorporate() {
+        return corporate;
+    }
+
+    public PayersCardPrepaidStatus getPrepaidStatus() {
+        return prepaidStatus;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CardInformation that = (CardInformation) o;
+        return corporate == that.corporate && Objects.equals(brand, that.brand) && Objects.equals(type, that.type) && Objects.equals(label, that.label) && prepaidStatus == that.prepaidStatus;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(brand, type, label, corporate, prepaidStatus);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/client/cardid/model/CardInformationRequest.java
+++ b/src/main/java/uk/gov/pay/connector/client/cardid/model/CardInformationRequest.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.connector.client.cardid.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CardInformationRequest {
+    
+    @JsonProperty("cardNumber")
+    private final String cardNumber;
+    
+    public CardInformationRequest(String cardNumber) {
+        this.cardNumber = cardNumber;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/client/cardid/service/CardidService.java
+++ b/src/main/java/uk/gov/pay/connector/client/cardid/service/CardidService.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.client.cardid.service;
+
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.client.cardid.model.CardInformation;
+import uk.gov.pay.connector.client.cardid.model.CardInformationRequest;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.util.Optional;
+
+import static org.apache.http.HttpStatus.SC_OK;
+
+public class CardidService {
+    
+    private static final String CARD_INFORMATION_PATH = "/v1/api/card";
+
+    private final Client client;
+    private final String cardidUrl;
+
+    @Inject
+    public CardidService(Client client, ConnectorConfiguration configuration) {
+        this.client = client;
+        this.cardidUrl = configuration.getCardidBaseUrl();
+    }
+    
+    public Optional<CardInformation> getCardInformation(String cardNumber) {
+        UriBuilder uri = UriBuilder.fromPath(cardidUrl).path(CARD_INFORMATION_PATH);
+        var cardInformationRequest = new CardInformationRequest(cardNumber);
+        Response response = client
+                .target(uri)
+                .request()
+                .accept(MediaType.APPLICATION_JSON)
+                .post(Entity.entity(cardInformationRequest, MediaType.APPLICATION_JSON));
+        
+        if (response.getStatus() == SC_OK) {
+            return Optional.of(response.readEntity(CardInformation.class));
+        }
+        
+        return Optional.empty();
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -269,6 +269,7 @@ restClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS:-false}
 
 ledgerBaseURL: ${LEDGER_URL}
+cardidBaseURL: ${CARDID_URL}
 
 expungeConfig:
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}

--- a/src/test/java/uk/gov/pay/connector/charge/service/motoapi/MotoApiCardNumberValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/motoapi/MotoApiCardNumberValidationServiceTest.java
@@ -10,17 +10,22 @@ import uk.gov.pay.connector.charge.exception.motoapi.CardNumberRejectedException
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.client.cardid.model.CardInformation;
+import uk.gov.pay.connector.client.cardid.service.CardidService;
+
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.client.cardid.model.CardInformationFixture.aCardInformation;
 
 @ExtendWith(MockitoExtension.class)
 class MotoApiCardNumberValidationServiceTest {
@@ -31,10 +36,16 @@ class MotoApiCardNumberValidationServiceTest {
     @Mock
     ChargeDao mockChargeDao;
     
+    @Mock
+    CardidService mockCardidService;
+    
     @InjectMocks
     MotoApiCardNumberValidationService motoApiCardNumberValidationService;
+
+    public static final String VALID_CARD_NUMBER = "4242424242424242";
     
     ChargeEntity chargeEntity = aValidChargeEntity().withStatus(ChargeStatus.CREATED).build();
+    CardInformation cardInformation = aCardInformation().build();
     
     @Test
     void shouldFailForCardNumberWithInvalidCheckDigit() {
@@ -46,8 +57,21 @@ class MotoApiCardNumberValidationServiceTest {
     }
 
     @Test
+    void shouldFailForCardNumberNotFoundInCardid() {
+        when(mockCardidService.getCardInformation(any())).thenReturn(Optional.empty());
+
+        CardNumberRejectedException exception = assertThrows(CardNumberRejectedException.class, () -> motoApiCardNumberValidationService.validateCardNumber(chargeEntity, VALID_CARD_NUMBER));
+
+        assertThat(exception.getMessage(), is("The card_number is not a valid card number"));
+        verify(mockChargeService).transitionChargeState(chargeEntity, AUTHORISATION_REJECTED);
+        verify(mockChargeDao).merge(chargeEntity);
+    }
+
+    @Test
     void shouldSucceedForValidCardNumber() {
-        assertDoesNotThrow(() -> motoApiCardNumberValidationService.validateCardNumber(chargeEntity, "4242424242424242"));
+        when(mockCardidService.getCardInformation(any())).thenReturn(Optional.of(cardInformation));
+        CardInformation cardInformation = motoApiCardNumberValidationService.validateCardNumber(chargeEntity, VALID_CARD_NUMBER);
+        assertThat(cardInformation, is(cardInformation));
         verify(mockChargeService, never()).transitionChargeState(eq(chargeEntity), any());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/client/cardid/model/CardInformationFixture.java
+++ b/src/test/java/uk/gov/pay/connector/client/cardid/model/CardInformationFixture.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.connector.client.cardid.model;
+
+import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
+
+public final class CardInformationFixture {
+    private String brand = "visa";
+    private String type = "C";
+    private String label = "VISA DEBIT";
+    private boolean corporate;
+    private PayersCardPrepaidStatus prepaidStatus = PayersCardPrepaidStatus.NOT_PREPAID;
+
+    private CardInformationFixture() {
+    }
+
+    public static CardInformationFixture aCardInformation() {
+        return new CardInformationFixture();
+    }
+
+    public CardInformationFixture withBrand(String brand) {
+        this.brand = brand;
+        return this;
+    }
+
+    public CardInformationFixture withType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public CardInformationFixture withLabel(String label) {
+        this.label = label;
+        return this;
+    }
+
+    public CardInformationFixture withCorporate(boolean corporate) {
+        this.corporate = corporate;
+        return this;
+    }
+
+    public CardInformationFixture withPrepaidStatus(PayersCardPrepaidStatus prepaidStatus) {
+        this.prepaidStatus = prepaidStatus;
+        return this;
+    }
+
+    public CardInformation build() {
+        return new CardInformation(brand, type, label, corporate, prepaidStatus);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -12,7 +12,8 @@ import org.junit.After;
 import org.junit.Before;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.expunge.service.LedgerStub;
+import uk.gov.pay.connector.rules.CardidStub;
+import uk.gov.pay.connector.rules.LedgerStub;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardTestContext;
 import uk.gov.pay.connector.junit.TestContext;
@@ -78,6 +79,7 @@ public class ChargingITestBase {
     protected SmartpayMockClient smartpayMockClient;
     protected EpdqMockClient epdqMockClient;
     protected LedgerStub ledgerStub;
+    protected CardidStub cardidStub;
 
     private final String paymentProvider;
     protected RestAssuredClient connectorRestApiClient;
@@ -106,6 +108,7 @@ public class ChargingITestBase {
         smartpayMockClient = new SmartpayMockClient(wireMockServer);
         epdqMockClient = new EpdqMockClient(wireMockServer);
         ledgerStub = new LedgerStub(wireMockServer);
+        cardidStub = new CardidStub(wireMockServer);
 
         credentials = Map.of(
                 CREDENTIALS_MERCHANT_ID, "merchant-id",

--- a/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
@@ -10,7 +10,7 @@ import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
-import uk.gov.pay.connector.expunge.service.LedgerStub;
+import uk.gov.pay.connector.rules.LedgerStub;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;

--- a/src/test/java/uk/gov/pay/connector/junit/DropwizardJUnitRunner.java
+++ b/src/test/java/uk/gov/pay/connector/junit/DropwizardJUnitRunner.java
@@ -89,6 +89,7 @@ public final class DropwizardJUnitRunner extends JUnitParamsRunner {
         configOverride.add(config("smartpay.urls.test", "http://localhost:" + wireMockPort + "/pal/servlet/soap/Payment"));
         configOverride.add(config("stripe.url", "http://localhost:" + wireMockPort));
         configOverride.add(config("ledgerBaseURL", "http://localhost:" + wireMockPort));
+        configOverride.add(config("cardidBaseURL", "http://localhost:" + wireMockPort));
 
         try {
             Optional<DropwizardTestSupport> createdApp = createIfNotRunning(dropwizardConfigAnnotation.app(), dropwizardConfigAnnotation.config(), configOverride.toArray(new ConfigOverride[0]));

--- a/src/test/java/uk/gov/pay/connector/rules/CardidStub.java
+++ b/src/test/java/uk/gov/pay/connector/rules/CardidStub.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.rules;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import uk.gov.pay.connector.client.cardid.model.CardInformation;
+import uk.gov.pay.connector.client.cardid.model.CardInformationRequest;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+public class CardidStub {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    private final WireMockServer wireMockServer;
+
+    public CardidStub(WireMockServer wireMockServer) {
+        this.wireMockServer = wireMockServer;
+    }
+
+    public void returnCardInformation(String cardNumber, CardInformation cardInformation) throws JsonProcessingException {
+        ResponseDefinitionBuilder response = aResponse().withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                .withStatus(200)
+                .withBody(objectMapper.writeValueAsString(cardInformation));
+        wireMockServer.stubFor(
+                post(urlPathEqualTo("/v1/api/card"))
+                        .withRequestBody(equalTo(objectMapper.writeValueAsString(new CardInformationRequest(cardNumber))))
+                        .willReturn(response));
+    }
+    
+    public void returnNotFound(String cardNumber) throws JsonProcessingException {
+        ResponseDefinitionBuilder response = aResponse().withHeader(CONTENT_TYPE, TEXT_PLAIN)
+                .withStatus(404);
+        wireMockServer.stubFor(
+                post(urlPathEqualTo("/v1/api/card"))
+                        .withRequestBody(equalTo(objectMapper.writeValueAsString(new CardInformationRequest(cardNumber))))
+                        .willReturn(response));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/rules/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/rules/LedgerStub.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.connector.expunge.service;
+package uk.gov.pay.connector.rules;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -208,6 +208,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+cardidBaseURL: ${CARDID_URL:-http://localhost:9900}
 
 expungeConfig:
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -208,6 +208,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+cardidBaseURL: ${CARDID_URL:-http://localhost:9900}
 
 expungeConfig:
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -198,6 +198,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+cardidBaseURL: ${CARDID_URL:-http://localhost:9900}
 
 expungeConfig:
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -206,6 +206,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+cardidBaseURL: ${CARDID_URL:-http://localhost:9900}
 
 expungeConfig:
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -206,6 +206,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-http://localhost:10700}
+cardidBaseURL: ${CARDID_URL:-http://localhost:9900}
 
 expungeConfig:
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}


### PR DESCRIPTION
If a card number passes the Luhn check, attempt to look up the card
information from the BIN ranges in Cardid.

If no range containing the card number is found, return an error
response with status 402 and error_identifier CARD_NUMBER_REJECTED.