### PR TITLE
PP-9143 Reject not allowed cards

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/motoapi/MotoApiCardNumberValidationService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/motoapi/MotoApiCardNumberValidationService.java
@@ -3,15 +3,19 @@ package uk.gov.pay.connector.charge.service.motoapi;
 import org.apache.commons.validator.routines.checkdigit.LuhnCheckDigit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.exception.motoapi.CardNumberRejectedException;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.client.cardid.model.CardInformation;
+import uk.gov.pay.connector.client.cardid.model.CardidCardType;
 import uk.gov.pay.connector.client.cardid.service.CardidService;
+import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 
 import javax.inject.Inject;
+import java.util.Locale;
 
 public class MotoApiCardNumberValidationService {
 
@@ -32,20 +36,53 @@ public class MotoApiCardNumberValidationService {
     }
 
     public CardInformation validateCardNumber(ChargeEntity charge, String cardNumber) {
-        if (!hasValidLuhnCheckDigit(cardNumber)) {
-            logger.info("Card number rejected: Invalid Luhn check digit");
+        try {
+            checkHasValidLuhnCheckDigit(cardNumber);
+            return cardidService.getCardInformation(cardNumber).map(cardInformation -> {
+                checkCardIsAllowedForGatewayAccount(charge, cardInformation);
+                return cardInformation;
+            }).orElseThrow(() -> {
+                logger.info("Card number rejected: BIN range for card number not found in card id");
+                throw new CardNumberRejectedException("The card_number is not a valid card number");
+            });
+        } catch (CardNumberRejectedException e) {
             transitionChargeToRejected(charge);
-            throw new CardNumberRejectedException("The card_number is not a valid card number");
+            throw e;
         }
-        return cardidService.getCardInformation(cardNumber).orElseGet(() -> {
-            logger.info("Card number rejected: BIN range for card number not found in card id");
-            transitionChargeToRejected(charge);
-            throw new CardNumberRejectedException("The card_number is not a valid card number");
-        });
     }
 
-    private boolean hasValidLuhnCheckDigit(String cardNumber) {
-        return new LuhnCheckDigit().isValid(cardNumber);
+    private void checkHasValidLuhnCheckDigit(String cardNumber) {
+        if (!(new LuhnCheckDigit().isValid(cardNumber))) {
+            logger.info("Card number rejected: Invalid Luhn check digit");
+            throw new CardNumberRejectedException("The card_number is not a valid card number");
+        }
+    }
+
+    private void checkCardIsAllowedForGatewayAccount(ChargeEntity charge, CardInformation cardInformation) {
+        if (charge.getGatewayAccount().isBlockPrepaidCards() && cardInformation.getPrepaidStatus() == PayersCardPrepaidStatus.PREPAID) {
+            logger.info("Card number rejected: Card is prepaid and the gateway account has prepaid cards blocked");
+            throw new CardNumberRejectedException("Prepaid cards are not accepted");
+        }
+
+        CardType cardType = CardidCardType.toCardType(cardInformation.getType());
+        charge.getGatewayAccount().getCardTypes()
+                .stream()
+                .filter(cardTypeEntity -> cardTypeEntity.getBrand().equals(cardInformation.getBrand())
+                        && (cardType == null || cardTypeEntity.getType() == cardType))
+                .findFirst()
+                .orElseThrow(() -> {
+                    String formattedCardType = formatCardTypeForErrorMessage(cardType, cardInformation.getBrand());
+                    logger.info("Card number rejected: The card type is not enabled: {}", formattedCardType);
+                    throw new CardNumberRejectedException("The card type is not enabled: " + formattedCardType);
+                });
+    }
+
+    private String formatCardTypeForErrorMessage(CardType cardType, String brand) {
+        String formattedCardType = brand;
+        if (cardType != null) {
+            formattedCardType = formattedCardType + " " + cardType.toString().toLowerCase(Locale.ROOT);
+        }
+        return formattedCardType;
     }
 
     private void transitionChargeToRejected(ChargeEntity charge) {

--- a/src/main/java/uk/gov/pay/connector/client/cardid/model/CardInformation.java
+++ b/src/main/java/uk/gov/pay/connector/client/cardid/model/CardInformation.java
@@ -15,7 +15,7 @@ public class CardInformation {
     private String brand;
 
     @JsonProperty("type")
-    private String type;
+    private CardidCardType type;
 
     @JsonProperty("label")
     private String label;
@@ -30,7 +30,7 @@ public class CardInformation {
         // for Jackson deserialisation
     }
 
-    public CardInformation(String brand, String type, String label, boolean corporate, PayersCardPrepaidStatus prepaidStatus) {
+    public CardInformation(String brand, CardidCardType type, String label, boolean corporate, PayersCardPrepaidStatus prepaidStatus) {
         this.brand = brand;
         this.type = type;
         this.label = label;
@@ -42,7 +42,7 @@ public class CardInformation {
         return brand;
     }
 
-    public String getType() {
+    public CardidCardType getType() {
         return type;
     }
 

--- a/src/main/java/uk/gov/pay/connector/client/cardid/model/CardidCardType.java
+++ b/src/main/java/uk/gov/pay/connector/client/cardid/model/CardidCardType.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.client.cardid.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.connector.cardtype.model.domain.CardType;
+
+public enum CardidCardType {
+    @JsonProperty("D")
+    DEBIT,
+    @JsonProperty("C")
+    CREDIT,
+    @JsonProperty("CD")
+    CREDIT_OR_DEBIT;
+    
+    public static CardType toCardType(CardidCardType cardidCardType) {
+        switch (cardidCardType) {
+            case DEBIT:
+                return CardType.DEBIT;
+            case CREDIT:
+                return CardType.CREDIT;
+            default: 
+                return null;
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/service/motoapi/MotoApiCardNumberValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/motoapi/MotoApiCardNumberValidationServiceTest.java
@@ -5,14 +5,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.cardtype.model.domain.CardType;
+import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.exception.motoapi.CardNumberRejectedException;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.client.cardid.model.CardInformation;
+import uk.gov.pay.connector.client.cardid.model.CardidCardType;
 import uk.gov.pay.connector.client.cardid.service.CardidService;
+import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -23,9 +29,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.cardtype.dao.CardTypeEntityBuilder.aCardTypeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.client.cardid.model.CardInformationFixture.aCardInformation;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @ExtendWith(MockitoExtension.class)
 class MotoApiCardNumberValidationServiceTest {
@@ -43,9 +52,27 @@ class MotoApiCardNumberValidationServiceTest {
     MotoApiCardNumberValidationService motoApiCardNumberValidationService;
 
     public static final String VALID_CARD_NUMBER = "4242424242424242";
-    
-    ChargeEntity chargeEntity = aValidChargeEntity().withStatus(ChargeStatus.CREATED).build();
-    CardInformation cardInformation = aCardInformation().build();
+    public static final String VISA = "visa";
+
+    CardTypeEntity visaCredit = aCardTypeEntity().withType(CardType.CREDIT).withBrand(VISA).build();
+    GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withCardTypes(List.of(visaCredit)).build();
+    ChargeEntity chargeEntity = aValidChargeEntity()
+            .withStatus(ChargeStatus.CREATED)
+            .withGatewayAccountEntity(gatewayAccountEntity)
+            .build();
+    CardInformation acceptedCardTypeCardInformation = aCardInformation()
+            .withType(CardidCardType.CREDIT)
+            .withBrand(VISA)
+            .build();
+
+    GatewayAccountEntity gatewayAccountWithBlockPrepaid = aGatewayAccountEntity()
+            .withBlockPrepaidCards(true)
+            .withCardTypes(List.of(visaCredit))
+            .build();
+    ChargeEntity chargeWithBlockPrepaid = aValidChargeEntity()
+            .withStatus(CREATED)
+            .withGatewayAccountEntity(gatewayAccountWithBlockPrepaid)
+            .build();
     
     @Test
     void shouldFailForCardNumberWithInvalidCheckDigit() {
@@ -58,7 +85,7 @@ class MotoApiCardNumberValidationServiceTest {
 
     @Test
     void shouldFailForCardNumberNotFoundInCardid() {
-        when(mockCardidService.getCardInformation(any())).thenReturn(Optional.empty());
+        when(mockCardidService.getCardInformation(VALID_CARD_NUMBER)).thenReturn(Optional.empty());
 
         CardNumberRejectedException exception = assertThrows(CardNumberRejectedException.class, () -> motoApiCardNumberValidationService.validateCardNumber(chargeEntity, VALID_CARD_NUMBER));
 
@@ -68,10 +95,110 @@ class MotoApiCardNumberValidationServiceTest {
     }
 
     @Test
+    void shouldFailForPrepaidCardWhenPrepaidCardsBlocked() {
+        CardInformation cardInformation = aCardInformation().withPrepaidStatus(PayersCardPrepaidStatus.PREPAID).build();
+
+        when(mockCardidService.getCardInformation(VALID_CARD_NUMBER)).thenReturn(Optional.of(cardInformation));
+        CardNumberRejectedException exception = assertThrows(CardNumberRejectedException.class, () -> 
+                motoApiCardNumberValidationService.validateCardNumber(chargeWithBlockPrepaid, VALID_CARD_NUMBER));
+
+        assertThat(exception.getMessage(), is("Prepaid cards are not accepted"));
+        verify(mockChargeService).transitionChargeState(chargeWithBlockPrepaid, AUTHORISATION_REJECTED);
+        verify(mockChargeDao).merge(chargeWithBlockPrepaid);
+    }
+
+    @Test
+    void shouldSucceedForNotPrepayWhenPrepaidCardsBlocked() {
+        CardInformation cardInformation = aCardInformation()
+                .withPrepaidStatus(PayersCardPrepaidStatus.NOT_PREPAID)
+                .withType(CardidCardType.CREDIT)
+                .withBrand(VISA)
+                .build();
+
+        when(mockCardidService.getCardInformation(VALID_CARD_NUMBER)).thenReturn(Optional.of(cardInformation));
+
+        CardInformation result = motoApiCardNumberValidationService.validateCardNumber(chargeWithBlockPrepaid, VALID_CARD_NUMBER);
+        assertThat(result, is(cardInformation));
+    }
+    
+    @Test
+    void shouldSucceedForUnknownPrepayWhenPrepaidCardsBlocked() {
+        CardInformation cardInformation = aCardInformation()
+                .withPrepaidStatus(PayersCardPrepaidStatus.UNKNOWN)
+                .withType(CardidCardType.CREDIT)
+                .withBrand(VISA)
+                .build();
+
+        when(mockCardidService.getCardInformation(VALID_CARD_NUMBER)).thenReturn(Optional.of(cardInformation));
+
+        CardInformation result = motoApiCardNumberValidationService.validateCardNumber(chargeWithBlockPrepaid, VALID_CARD_NUMBER);
+        assertThat(result, is(cardInformation));
+    }
+
+    @Test
+    void shouldSucceedForPrepaidWhenPrepaidCardsNotBlocked() {
+        CardInformation cardInformation = aCardInformation()
+                .withPrepaidStatus(PayersCardPrepaidStatus.PREPAID)
+                .withType(CardidCardType.CREDIT)
+                .withBrand(VISA)
+                .build();
+
+        when(mockCardidService.getCardInformation(VALID_CARD_NUMBER)).thenReturn(Optional.of(cardInformation));
+
+        CardInformation result = motoApiCardNumberValidationService.validateCardNumber(chargeEntity, VALID_CARD_NUMBER);
+        assertThat(result, is(cardInformation));
+    }
+
+    @Test
+    void shouldFailForCardTypeForBrandNotEnabled() {
+        CardInformation cardInformation = aCardInformation()
+                .withType(CardidCardType.DEBIT)
+                .withBrand(VISA)
+                .build();
+
+        when(mockCardidService.getCardInformation(VALID_CARD_NUMBER)).thenReturn(Optional.of(cardInformation));
+        CardNumberRejectedException exception = assertThrows(CardNumberRejectedException.class, () ->
+                motoApiCardNumberValidationService.validateCardNumber(chargeEntity, VALID_CARD_NUMBER));
+
+        assertThat(exception.getMessage(), is("The card type is not enabled: visa debit"));
+        verify(mockChargeService).transitionChargeState(chargeEntity, AUTHORISATION_REJECTED);
+        verify(mockChargeDao).merge(chargeEntity);
+    }
+
+    @Test
+    void shouldFailForCardBrandNotEnabledWhenCardTypeIsCreditOrDebit() {
+        CardInformation cardInformation = aCardInformation()
+                .withType(CardidCardType.CREDIT_OR_DEBIT)
+                .withBrand("master-card")
+                .build();
+        
+        when(mockCardidService.getCardInformation(VALID_CARD_NUMBER)).thenReturn(Optional.of(cardInformation));
+        CardNumberRejectedException exception = assertThrows(CardNumberRejectedException.class, () ->
+                motoApiCardNumberValidationService.validateCardNumber(chargeEntity, VALID_CARD_NUMBER));
+
+        assertThat(exception.getMessage(), is("The card type is not enabled: master-card"));
+        verify(mockChargeService).transitionChargeState(chargeEntity, AUTHORISATION_REJECTED);
+        verify(mockChargeDao).merge(chargeEntity);
+    }
+
+    @Test
+    void shouldSucceedForBrandEnabledWhenCardTypeIsCreditOrDebit() {
+        CardInformation cardInformation = aCardInformation()
+                .withType(CardidCardType.CREDIT_OR_DEBIT)
+                .withBrand(VISA)
+                .build();
+
+        when(mockCardidService.getCardInformation(VALID_CARD_NUMBER)).thenReturn(Optional.of(cardInformation));
+        
+        CardInformation result = motoApiCardNumberValidationService.validateCardNumber(chargeEntity, VALID_CARD_NUMBER);
+        assertThat(result, is(cardInformation));
+    }
+
+    @Test
     void shouldSucceedForValidCardNumber() {
-        when(mockCardidService.getCardInformation(any())).thenReturn(Optional.of(cardInformation));
-        CardInformation cardInformation = motoApiCardNumberValidationService.validateCardNumber(chargeEntity, VALID_CARD_NUMBER);
-        assertThat(cardInformation, is(cardInformation));
+        when(mockCardidService.getCardInformation(VALID_CARD_NUMBER)).thenReturn(Optional.of(acceptedCardTypeCardInformation));
+        CardInformation result = motoApiCardNumberValidationService.validateCardNumber(chargeEntity, VALID_CARD_NUMBER);
+        assertThat(result, is(acceptedCardTypeCardInformation));
         verify(mockChargeService, never()).transitionChargeState(eq(chargeEntity), any());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/client/cardid/model/CardInformationFixture.java
+++ b/src/test/java/uk/gov/pay/connector/client/cardid/model/CardInformationFixture.java
@@ -4,7 +4,7 @@ import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 
 public final class CardInformationFixture {
     private String brand = "visa";
-    private String type = "C";
+    private CardidCardType type = CardidCardType.CREDIT;
     private String label = "VISA DEBIT";
     private boolean corporate;
     private PayersCardPrepaidStatus prepaidStatus = PayersCardPrepaidStatus.NOT_PREPAID;
@@ -21,7 +21,7 @@ public final class CardInformationFixture {
         return this;
     }
 
-    public CardInformationFixture withType(String type) {
+    public CardInformationFixture withType(CardidCardType type) {
         this.type = type;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
@@ -42,6 +42,7 @@ public final class GatewayAccountEntityFixture {
     private List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntities = new ArrayList<>();
     private boolean providerSwitchEnabled = false;
     private boolean requiresAdditionalKycData = false;
+    private boolean blockPrepaidCards;
 
     private GatewayAccountEntityFixture() {
     }
@@ -174,6 +175,11 @@ public final class GatewayAccountEntityFixture {
         this.requiresAdditionalKycData = requiresAdditionalKycData;
         return this;
     }
+    
+    public GatewayAccountEntityFixture withBlockPrepaidCards(boolean blockPrepaidCards) {
+        this.blockPrepaidCards = blockPrepaidCards;
+        return this;
+    }
 
     public GatewayAccountEntity build() {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity();
@@ -199,6 +205,7 @@ public final class GatewayAccountEntityFixture {
         gatewayAccountEntity.setSendPayerIpAddressToGateway(sendPayerIpAddressToGateway);
         gatewayAccountEntity.setProviderSwitchEnabled(providerSwitchEnabled);
         gatewayAccountEntity.setRequiresAdditionalKycData(requiresAdditionalKycData);
+        gatewayAccountEntity.setBlockPrepaidCards(blockPrepaidCards);
 
         if (credentials != null && !credentials.isEmpty() && gatewayAccountCredentialsEntities != null
                 && gatewayAccountCredentialsEntities.isEmpty()) {


### PR DESCRIPTION
If a card is prepaid and prepaid cards are blocked for the gateway account, or if the card type and brand is not enabled for the gateway account, return an error response with status code 402 and error_identifier CARD_NUMBER_REJECTED from the authorise MOTO API payment API.