### PR TITLE
PP-9143 Add logging fields to MDC

### DIFF
--- a/src/main/java/uk/gov/pay/connector/filters/LoggingMDCRequestFilter.java
+++ b/src/main/java/uk/gov/pay/connector/filters/LoggingMDCRequestFilter.java
@@ -6,16 +6,13 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.util.MDCUtils;
 
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import java.util.Optional;
 
-import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
-import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_TYPE;
-import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
-import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER;
 import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER_PAYMENT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.REFUND_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.SECURE_TOKEN;
@@ -34,17 +31,10 @@ public class LoggingMDCRequestFilter implements ContainerRequestFilter {
     @Override
     public void filter(ContainerRequestContext requestContext) {
         var chargeEntity = getChargeFromRequest(requestContext);
-        var gatewayAccountEntity = chargeEntity.map(ChargeEntity::getGatewayAccount)
-                .or(() -> getAccountFromRequest(requestContext));
 
-        chargeEntity.ifPresent(charge -> {
-            MDC.put(PAYMENT_EXTERNAL_ID, charge.getExternalId());
-            MDC.put(PROVIDER, charge.getPaymentProvider());
-        });
-        gatewayAccountEntity.ifPresent(gatewayAccount -> {
-            MDC.put(GATEWAY_ACCOUNT_ID, gatewayAccount.getId().toString());
-            MDC.put(GATEWAY_ACCOUNT_TYPE, gatewayAccount.getType());
-        });
+        // Fields are removed from the MDC when the API responds in LoggingMDCResponseFilter
+        chargeEntity.ifPresentOrElse(MDCUtils::addChargeAndGatewayAccountDetailsToMDC,
+                () -> getAccountFromRequest(requestContext).ifPresent(MDCUtils::addGatewayAccountDetailsToMDC));
 
         getPathParameterFromRequest("refundId", requestContext)
                 .ifPresent(refund -> MDC.put(REFUND_EXTERNAL_ID, refund));
@@ -59,7 +49,7 @@ public class LoggingMDCRequestFilter implements ContainerRequestFilter {
     private Optional<ChargeEntity> getChargeFromRequest(ContainerRequestContext requestContext) {
         try {
             return getPathParameterFromRequest("chargeId", requestContext)
-                .map(chargeService::findChargeByExternalId);
+                    .map(chargeService::findChargeByExternalId);
         } catch (ChargeNotFoundRuntimeException ex) {
             return Optional.empty();
         }

--- a/src/main/java/uk/gov/pay/connector/util/MDCUtils.java
+++ b/src/main/java/uk/gov/pay/connector/util/MDCUtils.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.connector.util;
+
+import org.slf4j.MDC;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_TYPE;
+import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER;
+
+public class MDCUtils {
+    public static void addChargeAndGatewayAccountDetailsToMDC(ChargeEntity charge) {
+        MDC.put(PAYMENT_EXTERNAL_ID, charge.getExternalId());
+        MDC.put(PROVIDER, charge.getPaymentProvider());
+        addGatewayAccountDetailsToMDC(charge.getGatewayAccount());
+    }
+    
+    public static void addGatewayAccountDetailsToMDC(GatewayAccountEntity gatewayAccount) {
+        MDC.put(GATEWAY_ACCOUNT_ID, gatewayAccount.getId().toString());
+        MDC.put(GATEWAY_ACCOUNT_TYPE, gatewayAccount.getType());
+    }
+}


### PR DESCRIPTION
Add logging field for the secure token, the charge and the gateway
account to the MDC for the authorise API.

These are added by default for other requests where the charge id or
gateway account id are included in the request, but need to be added
manually for this request.

Add MDCUtils class to ensure we are adding the same fields to the MDC
wherever they are added from.