### PR TITLE
PP-9145 Add method to authorise payment synchronously

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsSubmittedByAPIEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsSubmittedByAPIEventDetails.java
@@ -1,11 +1,8 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
 import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
-import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
-import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
-import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -36,15 +33,16 @@ public class PaymentDetailsSubmittedByAPIEventDetails extends EventDetails {
         Builder builder = new Builder()
                 .withGatewayTransactionId(charge.getGatewayTransactionId());
 
-        Optional.ofNullable(charge.getCardDetails()).ifPresent(
-                cardDetails ->
+        Optional.ofNullable(charge.getCardDetails())
+                .ifPresent(cardDetails ->
                         builder.withCardType(Optional.ofNullable(cardDetails.getCardType()).map(Enum::toString).orElse(null))
                                 .withCardBrand(cardDetails.getCardBrand())
                                 .withCardBrandLabel(cardDetails.getCardTypeDetails().map(CardBrandLabelEntity::getLabel).orElse(null))
                                 .withFirstDigitsCardNumber(cardDetails.getFirstDigitsCardNumber().toString())
                                 .withLastDigitsCardNumber(cardDetails.getLastDigitsCardNumber().toString())
                                 .withCardholderName(cardDetails.getCardHolderName())
-                                .withExpiryDate(cardDetails.getExpiryDate().toString()));
+                                .withExpiryDate(cardDetails.getExpiryDate().toString())
+                );
 
         return builder.build();
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.client.cardid.model.CardInformation;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentProvider;
@@ -23,6 +24,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
+import uk.gov.pay.connector.paymentprocessor.model.AuthoriseRequest;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
 import javax.inject.Inject;
@@ -61,6 +63,16 @@ public class CardAuthoriseService {
 
     public AuthorisationResponse doAuthorise(String chargeId, AuthCardDetails authCardDetails) {
         return authorisationService.executeAuthorise(chargeId, () -> authoriseAndUpdateCharge(chargeId, authCardDetails));
+    }
+
+    public AuthorisationResponse doAuthoriseSync(ChargeEntity chargeEntity, CardInformation cardInformation, AuthoriseRequest authoriseRequest) {
+        AuthCardDetails authCardDetails = AuthCardDetails.of(authoriseRequest, chargeEntity, cardInformation);
+
+        AuthorisationResponse authorisationResponse = authoriseAndUpdateCharge(chargeEntity.getExternalId(), authCardDetails);
+
+        //todo: pp-9145 add charge to capture queue;
+
+        return authorisationResponse;
     }
 
     private AuthorisationResponse authoriseAndUpdateCharge(String chargeId, AuthCardDetails authCardDetails) {


### PR DESCRIPTION
## WHAT YOU DID
- Added a new method to CardAuthoriseService to authorise payment synchronously with gateway. This is to be used by moto api to authorise payment and send a response in the same api call.
- Emits PAYMENT_DETAILS_SUBMITTED_BY_API event for charges create with MOTO_API authorisation mode

