### PR TITLE
PP-9369 Check agreement is valid before taking payment from it

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -25,6 +25,7 @@ import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import uk.gov.pay.connector.agreement.resource.AgreementsApiResource;
 import uk.gov.pay.connector.cardtype.resource.CardTypesResource;
 import uk.gov.pay.connector.charge.exception.AgreementIdWithIncompatibleOtherOptionsExceptionMapper;
+import uk.gov.pay.connector.charge.exception.AgreementMissingPaymentInstrumentExceptionMapper;
 import uk.gov.pay.connector.charge.exception.AgreementNotFoundExceptionMapper;
 import uk.gov.pay.connector.charge.exception.AuthorisationModeAgreementRequiresAgreementIdExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapper;
@@ -32,6 +33,7 @@ import uk.gov.pay.connector.charge.exception.GatewayAccountDisabledExceptionMapp
 import uk.gov.pay.connector.charge.exception.InvalidAttributeValueExceptionMapper;
 import uk.gov.pay.connector.charge.exception.MissingMandatoryAttributeExceptionMapper;
 import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountExceptionMapper;
+import uk.gov.pay.connector.charge.exception.PaymentInstrumentNotActiveExceptionMapper;
 import uk.gov.pay.connector.charge.exception.SavePaymentInstrumentToAgreementRequiresAgreementIdExceptionMapper;
 import uk.gov.pay.connector.charge.exception.SavePaymentInstrumentToAgreementRequiresAuthorisationModeWebExceptionMapper;
 import uk.gov.pay.connector.charge.exception.TelephonePaymentNotificationsNotAllowedExceptionMapper;
@@ -150,6 +152,8 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new AuthorisationModeAgreementRequiresAgreementIdExceptionMapper());
         environment.jersey().register(new AgreementIdWithIncompatibleOtherOptionsExceptionMapper());
         environment.jersey().register(new AgreementNotFoundExceptionMapper());
+        environment.jersey().register(new AgreementMissingPaymentInstrumentExceptionMapper());
+        environment.jersey().register(new PaymentInstrumentNotActiveExceptionMapper());
         environment.jersey().register(new OneTimeTokenInvalidExceptionMapper());
         environment.jersey().register(new OneTimeTokenAlreadyUsedExceptionMapper());
         environment.jersey().register(new OneTimeTokenUsageInvalidForMotoApiExceptionMapper());

--- a/src/main/java/uk/gov/pay/connector/charge/exception/AgreementMissingPaymentInstrumentException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/AgreementMissingPaymentInstrumentException.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.charge.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+public class AgreementMissingPaymentInstrumentException extends WebApplicationException {
+
+    public AgreementMissingPaymentInstrumentException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/AgreementMissingPaymentInstrumentExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/AgreementMissingPaymentInstrumentExceptionMapper.java
@@ -10,20 +10,19 @@ import javax.ws.rs.ext.ExceptionMapper;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
-public class AgreementNotFoundExceptionMapper implements ExceptionMapper<AgreementNotFoundException> {
+public class AgreementMissingPaymentInstrumentExceptionMapper implements ExceptionMapper<AgreementMissingPaymentInstrumentException> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AgreementNotFoundExceptionMapper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AgreementMissingPaymentInstrumentExceptionMapper.class);
 
     @Override
-    public Response toResponse(AgreementNotFoundException exception) {
+    public Response toResponse(AgreementMissingPaymentInstrumentException exception) {
         LOGGER.info(exception.getMessage());
-        
-        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.AGREEMENT_NOT_FOUND, exception.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.AGREEMENT_NOT_ACTIVE, exception.getMessage());
 
         return Response.status(Response.Status.BAD_REQUEST)
                 .entity(errorResponse)
                 .type(APPLICATION_JSON)
                 .build();
     }
-}
 
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/PaymentInstrumentNotActiveException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/PaymentInstrumentNotActiveException.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.charge.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+public class PaymentInstrumentNotActiveException extends WebApplicationException {
+
+    public PaymentInstrumentNotActiveException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/PaymentInstrumentNotActiveExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/PaymentInstrumentNotActiveExceptionMapper.java
@@ -10,20 +10,19 @@ import javax.ws.rs.ext.ExceptionMapper;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
-public class AgreementNotFoundExceptionMapper implements ExceptionMapper<AgreementNotFoundException> {
+public class PaymentInstrumentNotActiveExceptionMapper implements ExceptionMapper<PaymentInstrumentNotActiveException> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AgreementNotFoundExceptionMapper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PaymentInstrumentNotActiveExceptionMapper.class);
 
     @Override
-    public Response toResponse(AgreementNotFoundException exception) {
+    public Response toResponse(PaymentInstrumentNotActiveException exception) {
         LOGGER.info(exception.getMessage());
-        
-        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.AGREEMENT_NOT_FOUND, exception.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.AGREEMENT_NOT_ACTIVE, exception.getMessage());
 
         return Response.status(Response.Status.BAD_REQUEST)
                 .entity(errorResponse)
                 .type(APPLICATION_JSON)
                 .build();
     }
-}
 
+}

--- a/src/test/java/uk/gov/pay/connector/util/AddAgreementParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddAgreementParams.java
@@ -16,6 +16,7 @@ public class AddAgreementParams {
     private final String reference;
     private final String description;
     private final String userIdentifier;
+    private final Long paymentInstrumentId;
 
     public Long getAgreementId() {
         return agreementId;
@@ -53,6 +54,10 @@ public class AddAgreementParams {
         return userIdentifier;
     }
 
+    public Long getPaymentInstrumentId() {
+        return paymentInstrumentId;
+    }
+
     private AddAgreementParams(AddAgreementParamsBuilder builder) {
         agreementId = builder.agreementId;
         externalAgreementId = builder.externalAgreementId;
@@ -63,6 +68,7 @@ public class AddAgreementParams {
         reference = builder.reference;
         description = builder.description;
         userIdentifier = builder.userIdentifier;
+        paymentInstrumentId = builder.paymentInstrumentId;
     }
 
     public static final class AddAgreementParamsBuilder {
@@ -75,6 +81,7 @@ public class AddAgreementParams {
         private String reference = "Test reference";
         private String description = "Test description";
         private String userIdentifier = "Test user identifier";
+        private Long paymentInstrumentId;
 
         private AddAgreementParamsBuilder() {
         }
@@ -125,6 +132,11 @@ public class AddAgreementParams {
 
         public AddAgreementParamsBuilder withUserIdentifier(String userIdentifier) {
             this.userIdentifier = userIdentifier;
+            return this;
+        }
+
+        public AddAgreementParamsBuilder withPaymentInstrumentId(Long paymentInstrumentId) {
+            this.paymentInstrumentId = paymentInstrumentId;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/AddPaymentInstrumentParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddPaymentInstrumentParams.java
@@ -1,0 +1,226 @@
+package uk.gov.pay.connector.util;
+
+import uk.gov.pay.connector.cardtype.model.domain.CardType;
+import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class AddPaymentInstrumentParams {
+
+    private final Long paymentInstrumentId;
+    private final String externalPaymentInstrumentId;
+    private final Instant createdDate;
+    private final Instant startDate;
+    private final PaymentInstrumentStatus paymentInstrumentStatus;
+    private final CardType cardType;
+    private final String cardBrand;
+    private final CardExpiryDate expiryDate;
+    private final LastDigitsCardNumber lastDigitsCardNumber;
+    private final String cardholderName;
+    private final String addressLine1;
+    private final String addressLine2;
+    private final String city;
+    private final String stateOrProvince;
+    private final String postcode;
+    private final String countryCode;
+
+    public Long getPaymentInstrumentId() {
+        return paymentInstrumentId;
+    }
+
+    public String getExternalPaymentInstrumentId() {
+        return externalPaymentInstrumentId;
+    }
+
+    public Instant getCreatedDate() {
+        return createdDate;
+    }
+
+    public Instant getStartDate() {
+        return startDate;
+    }
+
+    public PaymentInstrumentStatus getPaymentInstrumentStatus() {
+        return paymentInstrumentStatus;
+    }
+
+    public CardType getCardType() {
+        return cardType;
+    }
+
+    public String getCardBrand() {
+        return cardBrand;
+    }
+
+    public CardExpiryDate getExpiryDate() {
+        return expiryDate;
+    }
+
+    public LastDigitsCardNumber getLastDigitsCardNumber() {
+        return lastDigitsCardNumber;
+    }
+
+    public String getCardholderName() {
+        return cardholderName;
+    }
+
+    public String getAddressLine1() {
+        return addressLine1;
+    }
+
+    public String getAddressLine2() {
+        return addressLine2;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getStateOrProvince() {
+        return stateOrProvince;
+    }
+
+    public String getPostcode() {
+        return postcode;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    private AddPaymentInstrumentParams(AddPaymentInstrumentParamsBuilder builder) {
+        paymentInstrumentId = builder.paymentInstrumentId;
+        externalPaymentInstrumentId = builder.externalPaymentInstrumentId;
+        createdDate = builder.createdDate;
+        startDate = builder.startDate;
+        paymentInstrumentStatus = builder.paymentInstrumentStatus;
+        cardType = builder.cardType;
+        cardBrand = builder.cardBrand;
+        expiryDate = builder.expiryDate;
+        lastDigitsCardNumber = builder.lastDigitsCardNumber;
+        cardholderName = builder.cardholderName;
+        addressLine1 = builder.addressLine1;
+        addressLine2 = builder.addressLine2;
+        city = builder.city;
+        stateOrProvince = builder.stateOrProvince;
+        postcode = builder.postcode;
+        countryCode = builder.countryCode;
+    }
+
+    public static final class AddPaymentInstrumentParamsBuilder {
+        private Long paymentInstrumentId;
+        private String externalPaymentInstrumentId = "anExternalPaymentInstrumentId";
+        private Instant createdDate = Instant.now();
+        private Instant startDate = Instant.now();
+        private PaymentInstrumentStatus paymentInstrumentStatus = PaymentInstrumentStatus.ACTIVE;
+        private CardType cardType = CardType.DEBIT;
+        private String cardBrand = "visa";
+        private CardExpiryDate expiryDate = CardExpiryDate.valueOf("12/27");
+        private LastDigitsCardNumber lastDigitsCardNumber = LastDigitsCardNumber.of("1234");
+        private String cardholderName = "Dr. Payment";
+        private String addressLine1 = "1 Money Street";
+        private String addressLine2 = "Payville";
+        private String city = "Paytown";
+        private String stateOrProvince;
+        private String postcode = "PAY ME";
+        private String countryCode = "GB";
+
+        private AddPaymentInstrumentParamsBuilder() {
+        }
+
+        public static AddPaymentInstrumentParamsBuilder anAddPaymentInstrumentParams() {
+            return new AddPaymentInstrumentParamsBuilder();
+        }
+
+        public AddPaymentInstrumentParamsBuilder withPaymentInstrumentId(Long paymentInstrumentId) {
+            this.paymentInstrumentId = paymentInstrumentId;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withExternalPaymentInstrumentId(String externalPaymentInstrumentId) {
+            this.externalPaymentInstrumentId = externalPaymentInstrumentId;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withCreatedDate(Instant createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withStartDate(Instant startDate) {
+            this.startDate = startDate;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withPaymentInstrumentStatus(PaymentInstrumentStatus paymentInstrumentStatus) {
+            this.paymentInstrumentStatus = paymentInstrumentStatus;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withCardType(CardType cardType) {
+            this.cardType = cardType;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withCardBrand(String cardBrand) {
+            this.cardBrand = cardBrand;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withExpiryDate(CardExpiryDate expiryDate) {
+            this.expiryDate = expiryDate;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withLastDigitsCardNumber(LastDigitsCardNumber lastDigitsCardNumber) {
+            this.lastDigitsCardNumber = lastDigitsCardNumber;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withCardholderName(String cardholderName) {
+            this.cardholderName = cardholderName;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withAddressLine1(String addressLine1) {
+            this.addressLine1 = addressLine1;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withAddressLine2(String addressLine2) {
+            this.addressLine2 = addressLine2;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withCity(String city) {
+            this.city = city;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withStateOrProvince(String stateOrProvince) {
+            this.stateOrProvince = stateOrProvince;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withPostcode(String postcode) {
+            this.postcode = postcode;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withCountryCode(String countryCode) {
+            this.countryCode = countryCode;
+            return this;
+        }
+
+        public AddPaymentInstrumentParams build() {
+            Stream.of(paymentInstrumentId, externalPaymentInstrumentId, createdDate, paymentInstrumentStatus).forEach(Objects::requireNonNull);
+            return new AddPaymentInstrumentParams(this);
+        }
+
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -147,9 +147,11 @@ public class DatabaseTestHelper {
     public void addAgreement(AddAgreementParams addAgreementParams) {
         jdbi.withHandle(h ->
                 h.createUpdate("INSERT INTO agreements(id, external_id, service_id, created_date, " +
-                                "reference, description, user_identifier, live, gateway_account_id) " +
+                                "reference, description, user_identifier, live, gateway_account_id, " +
+                                "payment_instrument_id) " +
                                 "VALUES(:id, :external_id, :service_id, :created_date, " +
-                                ":reference, :description, :user_identifier, :live, :gateway_account_id)")
+                                ":reference, :description, :user_identifier, :live, :gateway_account_id, " +
+                                ":payment_instrument_id)")
                         .bind("id", addAgreementParams.getAgreementId())
                         .bind("external_id", addAgreementParams.getExternalAgreementId())
                         .bind("service_id", addAgreementParams.getServiceId())
@@ -159,6 +161,63 @@ public class DatabaseTestHelper {
                         .bind("user_identifier", addAgreementParams.getUserIdentifier())
                         .bind("live", addAgreementParams.isLive())
                         .bind("gateway_account_id", Long.valueOf(addAgreementParams.getGatewayAccountId()))
+                        .bind("payment_instrument_id", addAgreementParams.getPaymentInstrumentId())
+                        .execute());
+    }
+
+    public void addPaymentInstrument(AddPaymentInstrumentParams addPaymentInstrumentParams) {
+        jdbi.withHandle(h ->
+                h.createUpdate("INSERT INTO payment_instruments(" +
+                                    "id," +
+                                    "external_id, " + 
+                                    "created_date, " +
+                                    "start_date, " +
+                                    "status, " +
+                                    "card_type, " +
+                                    "card_brand, " +
+                                    "expiry_date, " +
+                                    "last_digits_card_number, " +
+                                    "cardholder_name, " +
+                                    "address_line1, " +
+                                    "address_line2, " +
+                                    "address_city, " + 
+                                    "address_state_province, " +
+                                    "address_postcode, " + 
+                                    "address_country" +
+                                ") VALUES(" +
+                                    ":id," +
+                                    ":external_id, " +
+                                    ":created_date, " +
+                                    ":start_date, " +
+                                    ":status, " +
+                                    ":card_type, " +
+                                    ":card_brand, " +
+                                    ":expiry_date, " +
+                                    ":last_digits_card_number, " +
+                                    ":cardholder_name, " +
+                                    ":address_line1, " +
+                                    ":address_line2, " +
+                                    ":address_city, " +
+                                    ":address_state_province, " +
+                                    ":address_postcode, " +
+                                    ":address_country" +
+                                ")")
+                        .bind("id", addPaymentInstrumentParams.getPaymentInstrumentId())
+                        .bind("external_id", addPaymentInstrumentParams.getExternalPaymentInstrumentId())
+                        .bind("created_date",  LocalDateTime.ofInstant(addPaymentInstrumentParams.getCreatedDate(), UTC))
+                        .bind("start_date", LocalDateTime.ofInstant(addPaymentInstrumentParams.getStartDate(), UTC))
+                        .bind("status", addPaymentInstrumentParams.getPaymentInstrumentStatus())
+                        .bind("card_type", addPaymentInstrumentParams.getCardType())
+                        .bind("card_brand", addPaymentInstrumentParams.getCardBrand())
+                        .bind("expiry_date", addPaymentInstrumentParams.getExpiryDate().toString())
+                        .bind("last_digits_card_number", addPaymentInstrumentParams.getLastDigitsCardNumber().toString())
+                        .bind("cardholder_name", addPaymentInstrumentParams.getCardholderName())
+                        .bind("address_line1", addPaymentInstrumentParams.getAddressLine1())
+                        .bind("address_line2", addPaymentInstrumentParams.getAddressLine2())
+                        .bind("address_postcode", addPaymentInstrumentParams.getPostcode())
+                        .bind("address_city", addPaymentInstrumentParams.getCity())
+                        .bind("address_state_province", addPaymentInstrumentParams.getStateOrProvince())
+                        .bind("address_country", addPaymentInstrumentParams.getCountryCode())
                         .execute());
     }
 
@@ -335,9 +394,9 @@ public class DatabaseTestHelper {
     public List<Map<String, Object>> getRefund(long refundId) {
         List<Map<String, Object>> ret = jdbi.withHandle(h ->
                 h.createQuery("SELECT external_id, gateway_transaction_id, amount, status, created_date, user_external_id, user_email, charge_external_id," +
-                        " parity_check_status, parity_check_date " +
-                        "FROM refunds " +
-                        "WHERE id = :refund_id")
+                                " parity_check_status, parity_check_date " +
+                                "FROM refunds " +
+                                "WHERE id = :refund_id")
                         .bind("refund_id", refundId)
                         .mapToMap()
                         .list());
@@ -881,6 +940,8 @@ public class DatabaseTestHelper {
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE tokens").execute());
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE refunds").execute());
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE refunds_history").execute());
+        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE agreements CASCADE").execute());
+        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE payment_instruments CASCADE").execute());
     }
 
     public Long getChargeIdByExternalId(String externalChargeId) {


### PR DESCRIPTION
Update the validation so that if a request is received with `"authorisation_mode": "AGREEMENT"` and an `"agreement_id"`, we check that the agreement exists, has a payment instrument and the payment instrument is in the correct ACTIVE state.

None of the logic after this validation has changed yet so if the conditions above are true, we’ll just process it as a regular user-present payment but that’s fine because public API will not be sending us anything with `"authorisation_mode": "AGREEMENT"` yet.

If the agreement or payment instrument are not found, the error returned is a 400 (bad request). While a 404 (not found) may seem logical, the problem is that the request references a non-existent resource, not that the request is for a non-existent resource. Making a request to save a payment instrument to a non-existent agreement now also returns a 400 for consistency.

Based on code started by @jbz149 and @kundanscorpio, finished by @alexbishop1