### PR TITLE
PP-9389 validate that `return_url` is not provided for `moto_api` req…

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.exception.InvalidAttributeValueException;
 import uk.gov.pay.connector.charge.exception.MissingMandatoryAttributeException;
 import uk.gov.pay.connector.charge.exception.TelephonePaymentNotificationsNotAllowedException;
+import uk.gov.pay.connector.charge.exception.UnexpectedAttributeException;
 import uk.gov.pay.connector.charge.model.ChargeCreateRequest;
 import uk.gov.pay.connector.charge.model.telephone.TelephoneChargeCreateRequest;
 import uk.gov.pay.connector.charge.service.ChargeExpiryService;
@@ -98,6 +99,8 @@ public class ChargesApiResource {
             if (!ReturnUrlValidator.isValid(returnUrl)) {
                 throw new InvalidAttributeValueException(RETURN_URL, "Must be a valid URL format");
             }
+        } else if (authorisationMode == AuthorisationMode.MOTO_API && !isBlank(returnUrl)) {
+            throw new UnexpectedAttributeException(RETURN_URL);
         }
 
         return chargeService.create(chargeRequest, accountId, uriInfo)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -361,6 +361,27 @@ public class ChargesApiResourceCreateIT extends ChargingITestBase {
     }
 
     @Test
+    public void shouldReturn422WhenReturnUrlIsPresentAndAuthorisationModeMotoApi() {
+
+        String postBody = toJson(Map.of(
+                JSON_AMOUNT_KEY, AMOUNT,
+                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
+                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
+                JSON_EMAIL_KEY, EMAIL,
+                JSON_RETURN_URL_KEY, "https://i.should.not.be.here.co.uk",
+                JSON_AUTH_MODE_KEY, JSON_AUTH_MODE_MOTO_API
+        ));
+
+        connectorRestApiClient
+                .postCreateCharge(postBody)
+                .statusCode(422)
+                .contentType(JSON)
+                .body("message", contains("Unexpected attribute: return_url"))
+                .body("error_identifier", is(ErrorIdentifier.UNEXPECTED_ATTRIBUTE.toString()));
+
+    }
+
+    @Test
     public void shouldReturn422WhenReturnUrlIsNotValid() {
         String postBody = toJson(Map.of(
                 JSON_AMOUNT_KEY, AMOUNT,


### PR DESCRIPTION
…uests

## WHAT YOU DID
Added error handling for unexpected `return_url` keys in `moto_api` requests.