### PR TITLE
PP-9406 Add pact tests for cardid

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -54,6 +54,16 @@ jobs:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
 
+  cardid-provider-contract-tests:
+    needs: publish-connector-consumer-contract-tests
+    uses: alphagov/pay-cardid/.github/workflows/_run-pact-provider-tests.yml@master
+    with:
+      consumer: connector
+      consumer_tag: master
+    secrets:
+      pact_broker_username: ${{ secrets.pact_broker_username }}
+      pact_broker_password: ${{ secrets.pact_broker_password }}
+
   provider-contract-tests:
     needs: tests
     uses: alphagov/pay-ci/.github/workflows/_run-provider-contract-tests.yml@master
@@ -64,6 +74,7 @@ jobs:
   tag-release:
     needs:
       - ledger-provider-contract-tests
+      - cardid-provider-contract-tests
       - provider-contract-tests
     permissions:
       contents: write

--- a/src/test/resources/pacts/connector-cardid-get-card-information-found.json
+++ b/src/test/resources/pacts/connector-cardid-get-card-information-found.json
@@ -1,0 +1,41 @@
+{
+  "consumer": {
+    "name": "connector"
+  },
+  "provider": {
+    "name": "cardid"
+  },
+  "interactions": [
+    {
+      "description": "a get card information request when the card number is found in the BIN ranges",
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/card",
+        "body": {
+          "cardNumber": "2221000000000000"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "brand": "master-card",
+          "type": "C",
+          "label": "MC",
+          "corporate": false,
+          "prepaid": "NOT_PREPAID"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
Add a pact test that verifies the success response from cardid when
getting card information.

Run cardid pact provider tests as part of the post-merge github actions
pipeline.