### PR TITLE
PP-9406 Add pact test for card information not found

### DIFF
--- a/src/test/java/uk/gov/pay/connector/client/cardid/model/CardidServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/cardid/model/CardidServiceConsumerTest.java
@@ -56,4 +56,12 @@ public class CardidServiceConsumerTest {
         assertThat(cardInformation.getPrepaidStatus(), is(PayersCardPrepaidStatus.NOT_PREPAID));
         assertThat(cardInformation.isCorporate(), is(false));
     }
+
+    @Test
+    @PactVerification("cardid")
+    @Pacts(pacts = {"connector-cardid-get-card-information-not-found"})
+    public void getCardInformation_shouldReturnEmpryOptionalWhenCardidReturns404() {
+        String cardNumber = "1000000000000000";
+        assertThat(cardidService.getCardInformation(cardNumber), is(Optional.empty()));
+    }
 }

--- a/src/test/resources/pacts/connector-cardid-get-card-information-not-found.json
+++ b/src/test/resources/pacts/connector-cardid-get-card-information-not-found.json
@@ -1,0 +1,31 @@
+{
+  "consumer": {
+    "name": "connector"
+  },
+  "provider": {
+    "name": "cardid"
+  },
+  "interactions": [
+    {
+      "description": "a get card information request when the card number is not found in the BIN ranges",
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/card",
+        "body": {
+          "cardNumber": "1000000000000000"
+        }
+      },
+      "response": {
+        "status": 404
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
Add a pact test that expects a 404 response from cardid for a card number that is not found in the BIN ranges and test that CardidService returns an empty optional when this response is handled.