### PR TITLE
PP-9406 Fix flaky test

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseMotoApiPaymentIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseMotoApiPaymentIT.java
@@ -19,11 +19,13 @@ import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_QUEUED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.client.cardid.model.CardInformationFixture.aCardInformation;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonForMotoApiPaymentAuthorisation;
@@ -92,9 +94,9 @@ public class CardResourceAuthoriseMotoApiPaymentIT extends ChargingITestBase {
         shouldAuthoriseChargeFor(validPayload);
 
         assertThat(databaseTestHelper.isChargeTokenUsed(token.getSecureRedirectToken()), is(true));
-
-        Thread.sleep(100L); // wait for charge to be captured
-        assertFrontendChargeStatusIs(charge.getExternalChargeId(), CAPTURED.getValue());
+        // Charge will be captured by the capture queue, which is not immediate. Check the charge state is the expected
+        // state before or after the capture has been processed.
+        assertThat(databaseTestHelper.getChargeStatus(charge.getChargeId()), anyOf(is(CAPTURE_QUEUED.getValue()), is(CAPTURED.getValue())));
     }
 
     @Test


### PR DESCRIPTION
This test was sometimes failing when run by Github actions as the capture hadn't completed during the 100ms wait time.

Instead of increasing the wait time, just check whether the charge is in either CAPTURED or CAPTURE QUEUED states, as this integration test is not intended to test the capture process.