### PR TITLE
PP-9528 Serialise agreement events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/ResourceType.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/ResourceType.java
@@ -6,7 +6,9 @@ public enum ResourceType {
     PAYMENT,
     REFUND,
     PAYOUT,
-    DISPUTE;
+    DISPUTE,
+    AGREEMENT,
+    PAYMENT_INSTRUMENT;
 
     @JsonValue
     public String getLowercase() {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCreated.java
@@ -21,6 +21,8 @@ public class AgreementCreated extends AgreementEvent {
                 new AgreementCreatedEventDetails(
                         agreement.getGatewayAccount().getId(),
                         agreement.getReference(),
+                        agreement.getDescription(),
+                        agreement.getUserIdentifier(),
                         PaymentInstrumentStatus.CREATED
                 ),
                 ZonedDateTime.ofInstant(agreement.getCreatedDate(), ZoneOffset.UTC)
@@ -30,11 +32,15 @@ public class AgreementCreated extends AgreementEvent {
     static class AgreementCreatedEventDetails extends EventDetails {
         private final String gatewayAccountId;
         private final String reference;
+        private final String description;
+        private final String userIdentifier;
         private final String status;
 
-        public AgreementCreatedEventDetails(Long gatewayAccountId, String reference, PaymentInstrumentStatus status) {
+        public AgreementCreatedEventDetails(Long gatewayAccountId, String reference, String description, String userIdentifier, PaymentInstrumentStatus status) {
             this.gatewayAccountId = String.valueOf(gatewayAccountId);
             this.reference = reference;
+            this.description = description;
+            this.userIdentifier = userIdentifier;
             this.status = String.valueOf(status);
         }
 
@@ -48,6 +54,14 @@ public class AgreementCreated extends AgreementEvent {
 
         public String getReference() {
             return reference;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public String getUserIdentifier() {
+            return userIdentifier;
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCreated.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class AgreementCreated extends AgreementEvent {
+
+    public AgreementCreated(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static AgreementCreated from(AgreementEntity agreement) {
+        return new AgreementCreated(
+                agreement.getServiceId(),
+                agreement.getGatewayAccount().isLive(),
+                agreement.getExternalId(),
+                new AgreementCreatedEventDetails(
+                        agreement.getGatewayAccount().getId(),
+                        agreement.getReference(),
+                        PaymentInstrumentStatus.CREATED
+                ),
+                ZonedDateTime.ofInstant(agreement.getCreatedDate(), ZoneOffset.UTC)
+        );
+    }
+
+    static class AgreementCreatedEventDetails extends EventDetails {
+        private final String gatewayAccountId;
+        private final String reference;
+        private final String status;
+
+        public AgreementCreatedEventDetails(Long gatewayAccountId, String reference, PaymentInstrumentStatus status) {
+            this.gatewayAccountId = String.valueOf(gatewayAccountId);
+            this.reference = reference;
+            this.status = String.valueOf(status);
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public String getGatewayAccountId() {
+            return gatewayAccountId;
+        }
+
+        public String getReference() {
+            return reference;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementEvent.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.ResourceType;
+
+import java.time.ZonedDateTime;
+
+public class AgreementEvent extends Event {
+    private String serviceId;
+    private Boolean live;
+    
+    public AgreementEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(resourceExternalId, eventDetails, timestamp);
+        this.serviceId = serviceId;
+        this.live = live;
+    }
+
+    public AgreementEvent(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+        this.serviceId = serviceId;
+        this.live = live;
+    }
+
+    @Override
+    public ResourceType getResourceType() {
+        return ResourceType.AGREEMENT;
+    }
+
+    public Boolean isLive() {
+        return live;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    @Override
+    public String toString() {
+        return "AgreementEvent{" +
+                "resourceExternalId='" + getResourceExternalId() + '\'' +
+                ", eventDetails=" + getEventDetails() +
+                ", timestamp=" + getTimestamp() +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementSetup.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementSetup.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+public class AgreementSetup extends AgreementEvent {
+
+    public AgreementSetup(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static AgreementSetup from(AgreementEntity agreement) {
+        return new AgreementSetup(
+                agreement.getServiceId(),
+                agreement.getGatewayAccount().isLive(),
+                agreement.getExternalId(),
+                new AgreementSetupEventDetails(agreement.getPaymentInstrument(), PaymentInstrumentStatus.ACTIVE),
+                ZonedDateTime.now(ZoneOffset.UTC)
+        );
+    }
+
+    static class AgreementSetupEventDetails extends EventDetails {
+        private String paymentInstrumentExternalId;
+        private String status;
+
+        public AgreementSetupEventDetails(PaymentInstrumentEntity paymentInstrumentEntity, PaymentInstrumentStatus status) {
+            this.paymentInstrumentExternalId = Optional.ofNullable(paymentInstrumentEntity)
+                    .map(PaymentInstrumentEntity::getExternalId)
+                    .orElse(null);
+            this.status = String.valueOf(status);
+        }
+
+        public String getPaymentInstrumentExternalId() {
+            return paymentInstrumentExternalId;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentConfirmed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentConfirmed.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class PaymentInstrumentConfirmed extends PaymentInstrumentEvent {
+
+    public PaymentInstrumentConfirmed(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static PaymentInstrumentConfirmed from(AgreementEntity agreement) {
+        return new PaymentInstrumentConfirmed(
+                agreement.getServiceId(),
+                agreement.isLive(),
+                agreement.getPaymentInstrument().getExternalId(),
+                new PaymentInstrumentConfirmedDetails(agreement),
+                ZonedDateTime.now(ZoneOffset.UTC)
+        );
+    }
+
+    static class PaymentInstrumentConfirmedDetails extends EventDetails {
+        private String agreementExternalId;
+
+        public PaymentInstrumentConfirmedDetails(AgreementEntity agreement) {
+            this.agreementExternalId = agreement.getExternalId();
+        }
+
+        public String getAgreementExternalId() {
+            return agreementExternalId;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
@@ -1,0 +1,98 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+public class PaymentInstrumentCreated extends PaymentInstrumentEvent {
+
+    public PaymentInstrumentCreated(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static PaymentInstrumentCreated from(PaymentInstrumentEntity paymentInstrument, GatewayAccountEntity gatewayAccount) {
+        return new PaymentInstrumentCreated(
+                gatewayAccount.getServiceId(),
+                gatewayAccount.isLive(),
+                paymentInstrument.getExternalId(),
+                new PaymentInstrumentCreatedDetails(paymentInstrument),
+                ZonedDateTime.ofInstant(paymentInstrument.getCreatedDate(), ZoneOffset.UTC)
+        );
+    }
+
+    static class PaymentInstrumentCreatedDetails extends EventDetails {
+        private String cardholderName;
+        private String addressLine1;
+        private String addressLine2;
+        private String addressPostcode;
+        private String addressCity;
+        private String addressCounty;
+        private String addressCountry;
+        private String lastDigitsCardNumber;
+        private String expiryDate;
+        private String cardBrand; 
+
+        public PaymentInstrumentCreatedDetails(PaymentInstrumentEntity paymentInstrument) {
+            Optional.ofNullable(paymentInstrument.getCardDetails())
+                    .ifPresent(cardDetails -> {
+                        this.cardholderName = cardDetails.getCardHolderName();
+                        this.lastDigitsCardNumber = cardDetails.getLastDigitsCardNumber().toString();
+                        this.expiryDate = cardDetails.getExpiryDate().toString();
+                        this.cardBrand = cardDetails.getCardBrand();
+                        
+                        cardDetails.getBillingAddress().ifPresent(billingAddress -> {
+                            this.addressLine1 = billingAddress.getLine1();
+                            this.addressLine2 = billingAddress.getLine2();
+                            this.addressPostcode = billingAddress.getPostcode();
+                            this.addressCity = billingAddress.getCity();
+                            this.addressCounty = billingAddress.getCounty();
+                            this.addressCountry = billingAddress.getCountry();        
+                        });
+                    });
+        }
+
+        public String getCardholderName() {
+            return cardholderName;
+        }
+
+        public String getAddressLine1() {
+            return addressLine1;
+        }
+
+        public String getAddressLine2() {
+            return addressLine2;
+        }
+
+        public String getAddressPostcode() {
+            return addressPostcode;
+        }
+
+        public String getAddressCity() {
+            return addressCity;
+        }
+
+        public String getAddressCounty() {
+            return addressCounty;
+        }
+
+        public String getAddressCountry() {
+            return addressCountry;
+        }
+
+        public String getLastDigitsCardNumber() {
+            return lastDigitsCardNumber;
+        }
+
+        public String getExpiryDate() {
+            return expiryDate;
+        }
+
+        public String getCardBrand() {
+            return cardBrand;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentEvent.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.ResourceType;
+
+import java.time.ZonedDateTime;
+
+public class PaymentInstrumentEvent extends Event {
+    private String serviceId;
+    private Boolean live;
+    
+    public PaymentInstrumentEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(resourceExternalId, eventDetails, timestamp);
+        this.serviceId = serviceId;
+        this.live = live;
+    }
+
+    public PaymentInstrumentEvent(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+        this.serviceId = serviceId;
+        this.live = live;
+    }
+
+    @Override
+    public ResourceType getResourceType() {
+        return ResourceType.PAYMENT_INSTRUMENT;
+    }
+
+    public Boolean isLive() {
+        return live;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    @Override
+    public String toString() {
+        return "PaymentInstrument{" +
+                "resourceExternalId='" + getResourceExternalId() + '\'' +
+                ", eventDetails=" + getEventDetails() +
+                ", timestamp=" + getTimestamp() +
+                '}';
+    }
+}


### PR DESCRIPTION
New base events implementing the `Event` interface.

`AgreementEvent` and `PaymentInstrumentEvent` implement the simplest
possible level of top fields:
* service identifier
* live

Add POJOs to serialise the data that needs to be persisted during the
agreement and payment journey lifecycle. Extend base level agreement and
payment instrument events.

--- 

This data will drive the event store projections and should therefore line up with:

* https://github.com/alphagov/pay-ledger/blob/master/src/main/java/uk/gov/pay/ledger/agreement/entity/AgreementEntity.java
* https://github.com/alphagov/pay-ledger/blob/master/src/main/java/uk/gov/pay/ledger/agreement/entity/PaymentInstrumentEntity.java

---

This pull request doesn't do anything with the events but prepares them to be used (emitted) during the agreement/ recurring payment flow.