### PR TITLE
PP-9527 Consume ledger events endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.gateway.PaymentGatewayName;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.time.Duration;
 
 public class ConnectorConfiguration extends Configuration {
 
@@ -157,6 +158,10 @@ public class ConnectorConfiguration extends Configuration {
 
     public Long getLedgerPostEventTimeoutInMillis() {
         return ledgerPostEventTimeoutInMillis;
+    }
+
+    public Duration getLedgerPostEventTimeout() {
+        return Duration.ofMillis(ledgerPostEventTimeoutInMillis);
     }
 
     @JsonProperty("database")

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -144,12 +144,19 @@ public class ConnectorConfiguration extends Configuration {
     @JsonProperty("cardidBaseURL")
     private String cardidBaseUrl;
 
+    @NotNull
+    private Long ledgerPostEventTimeoutInMillis;
+
     public String getLedgerBaseUrl() {
         return ledgerBaseUrl;
     }
 
     public String getCardidBaseUrl() {
         return cardidBaseUrl;
+    }
+
+    public Long getLedgerPostEventTimeoutInMillis() {
+        return ledgerPostEventTimeoutInMillis;
     }
 
     @JsonProperty("database")

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -248,7 +248,7 @@ public class ConnectorModule extends AbstractModule {
     @Named("ledgerClient")
     @Singleton
     public Client provideLedgerClient() {
-        return RestClientFactory.buildClient(configuration.getRestClientConfig(), configuration.getLedgerPostEventTimeoutInMillis());
+        return RestClientFactory.buildClient(configuration.getRestClientConfig(), configuration.getLedgerPostEventTimeout());
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -241,7 +241,14 @@ public class ConnectorModule extends AbstractModule {
     @Provides
     @Singleton
     public Client provideClient() {
-        return RestClientFactory.buildClient(configuration.getRestClientConfig());
+        return RestClientFactory.buildClient(configuration.getRestClientConfig(), null);
+    }
+
+    @Provides
+    @Named("ledgerClient")
+    @Singleton
+    public Client provideLedgerClient() {
+        return RestClientFactory.buildClient(configuration.getRestClientConfig(), configuration.getLedgerPostEventTimeoutInMillis());
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/connector/app/RestClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/app/RestClientFactory.java
@@ -8,13 +8,14 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 
 public class RestClientFactory {
     private static final String TLSV1_2 = "TLSv1.2";
 
-    public static Client buildClient(RestClientConfig clientConfig) {
+    public static Client buildClient(RestClientConfig clientConfig, Long connectTimeoutInMillis) {
         ClientBuilder clientBuilder = ClientBuilder.newBuilder();
 
         if (!clientConfig.isDisabledSecureConnection()) {
@@ -27,6 +28,9 @@ public class RestClientFactory {
             }
         }
 
+        if (connectTimeoutInMillis != null) {
+            clientBuilder.connectTimeout(connectTimeoutInMillis, TimeUnit.MILLISECONDS);
+        }
         Client client = clientBuilder.build();
         client.register(RestClientLoggingFilter.class);
 

--- a/src/main/java/uk/gov/pay/connector/app/RestClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/app/RestClientFactory.java
@@ -8,6 +8,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
@@ -15,7 +16,7 @@ import static java.lang.String.format;
 public class RestClientFactory {
     private static final String TLSV1_2 = "TLSv1.2";
 
-    public static Client buildClient(RestClientConfig clientConfig, Long connectTimeoutInMillis) {
+    public static Client buildClient(RestClientConfig clientConfig, Duration connectTimeout) {
         ClientBuilder clientBuilder = ClientBuilder.newBuilder();
 
         if (!clientConfig.isDisabledSecureConnection()) {
@@ -28,8 +29,8 @@ public class RestClientFactory {
             }
         }
 
-        if (connectTimeoutInMillis != null) {
-            clientBuilder.connectTimeout(connectTimeoutInMillis, TimeUnit.MILLISECONDS);
+        if (connectTimeout != null) {
+            clientBuilder.connectTimeout(connectTimeout.toMillis(), TimeUnit.MILLISECONDS);
         }
         Client client = clientBuilder.build();
         client.register(RestClientLoggingFilter.class);

--- a/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
@@ -34,10 +34,12 @@ public class LedgerService {
     private final Client client;
     private final Client postEventClient;
     private final String ledgerUrl;
+    private final UriBuilder eventUri;
 
     @Inject
     public LedgerService(Client client, @Named("ledgerClient") Client ledgerClient, ConnectorConfiguration configuration) {
         this.ledgerUrl = configuration.getLedgerBaseUrl();
+        this.eventUri = UriBuilder.fromPath(this.ledgerUrl).path("/v1/event");
         this.client = client;
         this.postEventClient = ledgerClient;
     }
@@ -96,16 +98,15 @@ public class LedgerService {
     }
 
     public Response postEvent(Event event) {
-        return postEventList(List.of(event)); 
+        return postEvents(List.of(event));
     }
     
     public Response postEvent(List<Event> events) {
-        return postEventList(events);
+        return postEvents(events);
     }
     
-    private Response postEventList(List<Event> events) {
-        var uri = UriBuilder.fromPath(ledgerUrl).path("/v1/event");
-        var response = postEventClient.target(uri)
+    private Response postEvents(List<Event> events) {
+        var response = postEventClient.target(eventUri)
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
                 .post(Entity.json(events));

--- a/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.client.ledger.service;
 
+import com.google.inject.name.Named;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
@@ -31,12 +32,14 @@ public class LedgerService {
     private final Logger logger = LoggerFactory.getLogger(LedgerService.class);
 
     private final Client client;
+    private final Client postEventClient;
     private final String ledgerUrl;
 
     @Inject
-    public LedgerService(Client client, ConnectorConfiguration configuration) {
-        this.client = client;
+    public LedgerService(Client client, @Named("ledgerClient") Client ledgerClient, ConnectorConfiguration configuration) {
         this.ledgerUrl = configuration.getLedgerBaseUrl();
+        this.client = client;
+        this.postEventClient = ledgerClient;
     }
 
     public Optional<LedgerTransaction> getTransaction(String id) {
@@ -102,7 +105,7 @@ public class LedgerService {
     
     private Response postEventList(List<Event> events) {
         var uri = UriBuilder.fromPath(ledgerUrl).path("/v1/event");
-        var response = client.target(uri)
+        var response = postEventClient.target(uri)
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
                 .post(Entity.json(events));

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -264,6 +264,7 @@ restClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS:-false}
 
 ledgerBaseURL: ${LEDGER_URL}
+ledgerPostEventTimeoutInMillis: ${LEDGER_POST_EVENT_TIMEOUT_IN_MILLIS:-1000}
 cardidBaseURL: ${CARDID_URL}
 
 expungeConfig:

--- a/src/test/java/uk/gov/pay/connector/app/RestClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/app/RestClientFactoryTest.java
@@ -21,7 +21,7 @@ public class RestClientFactoryTest {
         when(clientConfiguration.isDisabledSecureConnection()).thenReturn(false);
 
         //when
-        Client client = RestClientFactory.buildClient(clientConfiguration);
+        Client client = RestClientFactory.buildClient(clientConfiguration, null);
 
         //then
         SSLContext sslContext = client.getSslContext();
@@ -36,7 +36,7 @@ public class RestClientFactoryTest {
         when(clientConfiguration.isDisabledSecureConnection()).thenReturn(true);
 
         //when
-        Client client = RestClientFactory.buildClient(clientConfiguration);
+        Client client = RestClientFactory.buildClient(clientConfiguration, null);
 
         //then
         assertThat(client.getSslContext().getProtocol(), is(not("TLSv1.2")));

--- a/src/test/java/uk/gov/pay/connector/client/cardid/model/CardidServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/cardid/model/CardidServiceConsumerTest.java
@@ -37,7 +37,7 @@ public class CardidServiceConsumerTest {
     @Before
     public void setUp() throws Exception {
         when(configuration.getCardidBaseUrl()).thenReturn(cardidRule.getUrl());
-        Client client = RestClientFactory.buildClient(new RestClientConfig());
+        Client client = RestClientFactory.buildClient(new RestClientConfig(), null);
         cardidService = new CardidService(client, configuration);
     }
 

--- a/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -37,8 +38,8 @@ public class LedgerServiceConsumerTest {
     @Before
     public void setUp() {
         when(configuration.getLedgerBaseUrl()).thenReturn(ledgerRule.getUrl());
-        Client client = RestClientFactory.buildClient(new RestClientConfig());
-        ledgerService = new LedgerService(client, configuration);
+        Client client = RestClientFactory.buildClient(new RestClientConfig(), null);
+        ledgerService = new LedgerService(client, client, configuration);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceTest.java
@@ -8,39 +8,52 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.client.ledger.exception.GetRefundsForPaymentException;
 import uk.gov.pay.connector.client.ledger.exception.LedgerException;
 import uk.gov.pay.connector.client.ledger.model.RefundTransactionsForPayment;
+import uk.gov.pay.connector.events.EmittedEventFixture;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.charge.AgreementCreated;
+import uk.gov.pay.connector.events.model.charge.AgreementSetup;
 
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 
+import java.time.ZonedDateTime;
+import java.util.List;
+
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.apache.http.HttpStatus.SC_ACCEPTED;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LedgerServiceTest {
-    
     private LedgerService ledgerService;
     private Response mockResponse;
+    private Invocation.Builder mockBuilder;
 
     @Before
     public void setUp() {
         Client mockClient = mock(Client.class);
         ConnectorConfiguration mockConnectorConfiguration = mock(ConnectorConfiguration.class);
         WebTarget mockWebTarget = mock(WebTarget.class);
-        Invocation.Builder mockBuilder = mock(Invocation.Builder.class);
+        mockBuilder = mock(Invocation.Builder.class);
         mockResponse = mock(Response.class);
 
         when(mockConnectorConfiguration.getLedgerBaseUrl()).thenReturn("http://ledgerUrl");
         when(mockClient.target(any(UriBuilder.class))).thenReturn(mockWebTarget);
         when(mockWebTarget.request()).thenReturn(mockBuilder);
         when(mockBuilder.accept(APPLICATION_JSON)).thenReturn(mockBuilder);
+        when(mockBuilder.post(any())).thenReturn(mockResponse);
         when(mockBuilder.get()).thenReturn(mockResponse);
 
         when(mockResponse.getStatus()).thenReturn(SC_OK);
@@ -60,5 +73,30 @@ public class LedgerServiceTest {
                 thenThrow(ProcessingException.class);
 
         ledgerService.getRefundsForPayment(152L, "external-id");
+    }
+
+    @Test
+    public void serialiseAndSendEvent() {
+        var event = new AgreementCreated("service-id", false, "resource-id", null, ZonedDateTime.now());
+        when(mockResponse.getStatus()).thenReturn(SC_ACCEPTED);
+        ledgerService.postEvent(event);
+        verify(mockBuilder).post(Entity.json(List.of(event)));
+    }
+
+    @Test(expected = LedgerException.class)
+    public void sendEventShouldThrowExceptionIfResponseIsNotAccepted() {
+        var event = new AgreementCreated("service-id", false, "resource-id", null, ZonedDateTime.now());
+        when(mockResponse.getStatus()).thenReturn(SC_BAD_REQUEST);
+        ledgerService.postEvent(event);
+    }
+    
+    @Test
+    public void serialiseAndSendMultipleEvents() {
+        var eventOne = new AgreementCreated("service-id", false, "resource-id", null, ZonedDateTime.now());
+        var eventTwo = new AgreementSetup("service-id", false, "resource-id", null, ZonedDateTime.now());
+        List<Event> list = List.of(eventOne, eventTwo);
+        when(mockResponse.getStatus()).thenReturn(SC_ACCEPTED);
+        ledgerService.postEvent(list);
+        verify(mockBuilder).post(Entity.json(list));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceTest.java
@@ -5,10 +5,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.RestClientConfig;
 import uk.gov.pay.connector.client.ledger.exception.GetRefundsForPaymentException;
 import uk.gov.pay.connector.client.ledger.exception.LedgerException;
 import uk.gov.pay.connector.client.ledger.model.RefundTransactionsForPayment;
-import uk.gov.pay.connector.events.EmittedEventFixture;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.charge.AgreementCreated;
 import uk.gov.pay.connector.events.model.charge.AgreementSetup;
@@ -27,7 +27,6 @@ import java.util.List;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_ACCEPTED;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
-import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,7 +56,7 @@ public class LedgerServiceTest {
         when(mockBuilder.get()).thenReturn(mockResponse);
 
         when(mockResponse.getStatus()).thenReturn(SC_OK);
-        ledgerService = new LedgerService(mockClient, mockConnectorConfiguration);
+        ledgerService = new LedgerService(mockClient, mockClient, mockConnectorConfiguration);
     }
 
     @Test(expected = GetRefundsForPaymentException.class)

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -203,6 +203,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+ledgerPostEventTimeoutInMillis: ${LEDGER_POST_EVENT_TIMEOUT_IN_MILLIS:-1000}
 cardidBaseURL: ${CARDID_URL:-http://localhost:9900}
 
 expungeConfig:

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -203,6 +203,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+ledgerPostEventTimeoutInMillis: ${LEDGER_POST_EVENT_TIMEOUT_IN_MILLIS:-1000}
 cardidBaseURL: ${CARDID_URL:-http://localhost:9900}
 
 expungeConfig:

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -193,6 +193,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+ledgerPostEventTimeoutInMillis: ${LEDGER_POST_EVENT_TIMEOUT_IN_MILLIS:-1000}
 cardidBaseURL: ${CARDID_URL:-http://localhost:9900}
 
 expungeConfig:

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -201,6 +201,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+ledgerPostEventTimeoutInMillis: ${LEDGER_POST_EVENT_TIMEOUT_IN_MILLIS:-1000}
 cardidBaseURL: ${CARDID_URL:-http://localhost:9900}
 
 expungeConfig:

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -201,6 +201,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-http://localhost:10700}
+ledgerPostEventTimeoutInMillis: ${LEDGER_POST_EVENT_TIMEOUT_IN_MILLIS:-1000}
 cardidBaseURL: ${CARDID_URL:-http://localhost:9900}
 
 expungeConfig:


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-connector/pull/3688

---

Adds `postEvent` utility method to parse and POST anything extending
`Event` to Ledger's event endpoint.

Expect an `202 Accepted` response or appropriately throw a Ledger
exception to be handled upstream.

The uility is not used in this change. It will be used during the
agreement and recurring payment journeys.