### PR TITLE
PP-9529 Recurring journey events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
@@ -1,10 +1,13 @@
 package uk.gov.pay.connector.agreement.service;
 
+import com.google.inject.persist.Transactional;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.agreement.model.AgreementCreateRequest;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.agreement.model.AgreementResponse;
 import uk.gov.pay.connector.agreement.model.builder.AgreementResponseBuilder;
+import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.events.model.charge.AgreementCreated;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 
 import javax.inject.Inject;
@@ -17,12 +20,14 @@ public class AgreementService {
 
     private final GatewayAccountDao gatewayAccountDao;
     private final AgreementDao agreementDao;
+    private final LedgerService ledgerService;
     private final Clock clock;
 
     @Inject
-    public AgreementService(AgreementDao agreementDao, GatewayAccountDao gatewayAccountDao, Clock clock) {
+    public AgreementService(AgreementDao agreementDao, GatewayAccountDao gatewayAccountDao, LedgerService ledgerService, Clock clock) {
         this.agreementDao = agreementDao;
         this.gatewayAccountDao = gatewayAccountDao;
+        this.ledgerService = ledgerService;
         this.clock = clock;
     }
 
@@ -39,6 +44,7 @@ public class AgreementService {
                         .build());
     }
 
+    @Transactional
     public Optional<AgreementResponse> create(AgreementCreateRequest agreementCreateRequest, long accountId) {
         return gatewayAccountDao.findById(accountId).map(gatewayAccountEntity -> {
             AgreementEntity agreementEntity = anAgreementEntity(clock.instant())
@@ -51,6 +57,7 @@ public class AgreementService {
             agreementEntity.setGatewayAccount(gatewayAccountEntity);
             
             agreementDao.persist(agreementEntity);
+            ledgerService.postEvent(AgreementCreated.from(agreementEntity));
             return agreementEntity;
         }).map(agreementEntity -> {
             var agreementResponseBuilder = new AgreementResponseBuilder();

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -679,7 +679,7 @@ public class ChargeService {
     }
 
     private void setPaymentInstrument(Map<String, String> recurringAuthToken, ChargeEntity charge) {
-        var paymentInstrument = paymentInstrumentService.createPaymentInstrument(charge.getCardDetails(), recurringAuthToken);
+        var paymentInstrument = paymentInstrumentService.createPaymentInstrument(charge, recurringAuthToken);
         charge.setPaymentInstrument(paymentInstrument);
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
@@ -5,19 +5,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.events.model.charge.AgreementSetup;
+import uk.gov.pay.connector.events.model.charge.PaymentInstrumentConfirmed;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 
 import javax.inject.Inject;
+import java.util.List;
 
 public class LinkPaymentInstrumentToAgreementService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LinkPaymentInstrumentToAgreementService.class);
 
     private final AgreementDao agreementDao;
+    private final LedgerService ledgerService;
 
     @Inject
-    public LinkPaymentInstrumentToAgreementService(AgreementDao agreementDao) {
+    public LinkPaymentInstrumentToAgreementService(AgreementDao agreementDao, LedgerService ledgerService) {
         this.agreementDao = agreementDao;
+        this.ledgerService = ledgerService;
     }
 
     @Transactional
@@ -27,6 +33,10 @@ public class LinkPaymentInstrumentToAgreementService {
                 agreementDao.findByExternalId(agreementId).ifPresentOrElse(agreementEntity -> {
                     agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
                     paymentInstrumentEntity.setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
+                    ledgerService.postEvent(List.of(
+                            AgreementSetup.from(agreementEntity),
+                            PaymentInstrumentConfirmed.from(agreementEntity)
+                    ));
                 }, () -> LOGGER.error("Charge {} references agreement {} but that agreement does not exist", chargeEntity.getExternalId(), agreementId));
             }, () -> LOGGER.error("Expected charge {} to have an agreement but it does not have one", chargeEntity.getExternalId()));
         }, () -> LOGGER.error("Expected charge {} to have a payment instrument but it does not have one", chargeEntity.getExternalId()));

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementSetup.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementSetup.java
@@ -5,8 +5,8 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import java.util.Optional;
 
 public class AgreementSetup extends AgreementEvent {
@@ -15,13 +15,13 @@ public class AgreementSetup extends AgreementEvent {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static AgreementSetup from(AgreementEntity agreement) {
+    public static AgreementSetup from(AgreementEntity agreement, ZonedDateTime timestamp) {
         return new AgreementSetup(
                 agreement.getServiceId(),
                 agreement.getGatewayAccount().isLive(),
                 agreement.getExternalId(),
                 new AgreementSetupEventDetails(agreement.getPaymentInstrument(), PaymentInstrumentStatus.ACTIVE),
-                ZonedDateTime.now(ZoneOffset.UTC)
+                timestamp
         );
     }
 
@@ -42,6 +42,19 @@ public class AgreementSetup extends AgreementEvent {
 
         public String getStatus() {
             return status;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            AgreementSetupEventDetails that = (AgreementSetupEventDetails) o;
+            return Objects.equals(paymentInstrumentExternalId, that.paymentInstrumentExternalId) && Objects.equals(status, that.status);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(paymentInstrumentExternalId, status);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentConfirmed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentConfirmed.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 
 public class PaymentInstrumentConfirmed extends PaymentInstrumentEvent {
 
@@ -12,13 +13,13 @@ public class PaymentInstrumentConfirmed extends PaymentInstrumentEvent {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static PaymentInstrumentConfirmed from(AgreementEntity agreement) {
+    public static PaymentInstrumentConfirmed from(AgreementEntity agreement, ZonedDateTime timestamp) {
         return new PaymentInstrumentConfirmed(
                 agreement.getServiceId(),
                 agreement.isLive(),
                 agreement.getPaymentInstrument().getExternalId(),
                 new PaymentInstrumentConfirmedDetails(agreement),
-                ZonedDateTime.now(ZoneOffset.UTC)
+                timestamp
         );
     }
 
@@ -31,6 +32,19 @@ public class PaymentInstrumentConfirmed extends PaymentInstrumentEvent {
 
         public String getAgreementExternalId() {
             return agreementExternalId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            PaymentInstrumentConfirmedDetails that = (PaymentInstrumentConfirmedDetails) o;
+            return Objects.equals(agreementExternalId, that.agreementExternalId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(agreementExternalId);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
@@ -40,8 +40,8 @@ public class PaymentInstrumentCreated extends PaymentInstrumentEvent {
             Optional.ofNullable(paymentInstrument.getCardDetails())
                     .ifPresent(cardDetails -> {
                         this.cardholderName = cardDetails.getCardHolderName();
-                        this.lastDigitsCardNumber = cardDetails.getLastDigitsCardNumber().toString();
-                        this.expiryDate = cardDetails.getExpiryDate().toString();
+                        this.lastDigitsCardNumber = Optional.ofNullable(cardDetails.getLastDigitsCardNumber()).map(String::valueOf).orElse(null);
+                        this.expiryDate = Optional.ofNullable(cardDetails.getExpiryDate()).map(String::valueOf).orElse(null);
                         this.cardBrand = cardDetails.getCardBrand();
                         
                         cardDetails.getBillingAddress().ifPresent(billingAddress -> {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
@@ -1,8 +1,10 @@
 package uk.gov.pay.connector.events.model.charge;
 
+import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -40,8 +42,8 @@ public class PaymentInstrumentCreated extends PaymentInstrumentEvent {
             Optional.ofNullable(paymentInstrument.getCardDetails())
                     .ifPresent(cardDetails -> {
                         this.cardholderName = cardDetails.getCardHolderName();
-                        this.lastDigitsCardNumber = Optional.ofNullable(cardDetails.getLastDigitsCardNumber()).map(String::valueOf).orElse(null);
-                        this.expiryDate = Optional.ofNullable(cardDetails.getExpiryDate()).map(String::valueOf).orElse(null);
+                        this.lastDigitsCardNumber = Optional.ofNullable(cardDetails.getLastDigitsCardNumber()).map(LastDigitsCardNumber::toString).orElse(null);
+                        this.expiryDate = Optional.ofNullable(cardDetails.getExpiryDate()).map(CardExpiryDate::toString).orElse(null);
                         this.cardBrand = cardDetails.getCardBrand();
                         
                         cardDetails.getBillingAddress().ifPresent(billingAddress -> {

--- a/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceIT.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.junit.DropwizardTestContext;
 import uk.gov.pay.connector.junit.TestContext;
+import uk.gov.pay.connector.rules.LedgerStub;
 import uk.gov.pay.connector.rules.WorldpayMockClient;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
@@ -54,7 +55,8 @@ public class AgreementsApiResourceIT {
     private String credentialsExternalId;
     private Long accountId;
     private ObjectMapper objectMapper = new ObjectMapper();
-    
+    private LedgerStub ledgerStub;
+
     public AgreementsApiResourceIT() {
     }
     
@@ -63,6 +65,7 @@ public class AgreementsApiResourceIT {
         databaseTestHelper = testContext.getDatabaseTestHelper();
         wireMockServer = testContext.getWireMockServer();
         worldpayMockClient = new WorldpayMockClient(wireMockServer);
+        ledgerStub = new LedgerStub(wireMockServer);
         databaseFixtures = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper);
 
         testAccount = createTestAccount("worldpay");
@@ -70,6 +73,7 @@ public class AgreementsApiResourceIT {
 
         credentialsId = testAccount.getCredentials().get(0).getId();
         credentialsExternalId = testAccount.getCredentials().get(0).getExternalId();
+        ledgerStub.acceptPostEvent();
     }
 
     protected RequestSpecification givenSetup() {

--- a/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.agreement.model.AgreementCreateRequest;
 import uk.gov.pay.connector.agreement.model.AgreementResponse;
+import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
@@ -36,13 +37,15 @@ public class AgreementServiceTest {
 
     private GatewayAccountDao mockedGatewayAccountDao = mock(GatewayAccountDao.class);
 
+    private LedgerService mockedLedgerService = mock(LedgerService.class);
+
     private AgreementService service;
 
     @Before
     public void setUp() {
         String instantExpected = "2022-03-03T10:15:30Z";
         Clock clock = Clock.fixed(Instant.parse(instantExpected), ZoneOffset.UTC);
-        service = new AgreementService(mockedAgreementDao, mockedGatewayAccountDao, clock);
+        service = new AgreementService(mockedAgreementDao, mockedGatewayAccountDao, mockedLedgerService, clock);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
@@ -136,7 +136,7 @@ class ChargeServicePostAuthorisationTest {
         var chargeEntity = chargeEntityFixture.withSavePaymentInstrumentToAgreement(true).build();
         when(mockAuthCardDetailsToCardDetailsEntityConverter.convert(authCardDetails)).thenReturn(mockCardDetailsEntity);
         when(mockChargeDao.findByExternalId(EXTERNAL_ID)).thenReturn(Optional.of(chargeEntity));
-        when(mockPaymentInstrumentService.createPaymentInstrument(mockCardDetailsEntity, TOKEN)).thenReturn(mockPaymentInstrumentEntity);
+        when(mockPaymentInstrumentService.createPaymentInstrument(chargeEntity, TOKEN)).thenReturn(mockPaymentInstrumentEntity);
 
         chargeService.updateChargePostCardAuthorisation(EXTERNAL_ID, AUTHORISATION_SUCCESS, TRANSACTION_ID, auth3dsRequiredEntity,
                 PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN);

--- a/src/test/java/uk/gov/pay/connector/rules/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/rules/LedgerStub.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.lang.String.format;
 import static java.util.Objects.nonNull;
@@ -37,6 +38,15 @@ public class LedgerStub {
         this.wireMockServer = wireMockServer;
     }
     
+    public void acceptPostEvent() {
+        wireMockServer.stubFor(
+                post(urlPathEqualTo("/v1/event"))
+                        .willReturn(aResponse()
+                                .withStatus(202)
+                        )
+        );
+    }
+
     public void returnLedgerTransaction(String externalId, DatabaseFixtures.TestCharge testCharge, DatabaseFixtures.TestFee testFee) throws JsonProcessingException {
         Map<String, Object> ledgerTransactionFields = testChargeToLedgerTransactionJson(testCharge, testFee);
         stubResponse(externalId, ledgerTransactionFields);


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-connector/pull/3689, which depends on https://github.com/alphagov/pay-connector/pull/3688

---

Write details to event store when payment instrument is created.

Transactional guarantee: the payment instrument is guaranteed to have
been written to the database, if posting the event fails, the payment
instrument will be rolled back.

Write details to the event store when an agreement is created.
Agreements can currently only be created by as the result of an API
request.

Transaction guarantee: the agreement must be written to the database, if
posting the event fails, the agreement will be rolled back.

Persist information about an agreement setup being completed with a
given payment instrument.

Ensure it's run an an appropriate transactional enclosure to ensure the
properties in the working database reflect the event audit trail.

Add stubs and coverage for new endpoint now being used.