### PR TITLE
PP-9503 Add timeout for synchronous authorisation API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.10</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.13.2</jackson.version>
-        <pay-java-commons.version>1.0.20220503105713</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20220510113332</pay-java-commons.version>
         <surefire.version>3.0.0-M6</surefire.version>
         <jooq.version>3.16.6</jooq.version>
         <postgresql.version>42.3.5</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.charge.exception.InvalidAttributeValueExceptionMappe
 import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.exception.motoapi.AuthorisationErrorExceptionMapper;
 import uk.gov.pay.connector.charge.exception.motoapi.AuthorisationRejectedExceptionMapper;
+import uk.gov.pay.connector.charge.exception.motoapi.AuthorisationTimedOutExceptionMapper;
 import uk.gov.pay.connector.charge.exception.motoapi.CardNumberRejectedExceptionMapper;
 import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenAlreadyUsedExceptionMapper;
 import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenInvalidExceptionMapper;
@@ -150,6 +151,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new AuthorisationApiNotAllowedForGatewayAccountExceptionMapper());
         environment.jersey().register(new AuthorisationErrorExceptionMapper());
         environment.jersey().register(new AuthorisationRejectedExceptionMapper());
+        environment.jersey().register(new AuthorisationTimedOutExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -5,6 +5,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
 import uk.gov.pay.connector.app.config.Authorisation3dsConfig;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.app.config.EmittedEventSweepConfig;
 import uk.gov.pay.connector.app.config.EventEmitterConfig;
 import uk.gov.pay.connector.app.config.ExpungeConfig;
@@ -96,6 +97,10 @@ public class ConnectorConfiguration extends Configuration {
     @NotNull
     @JsonProperty("authorisation3dsConfig")
     private Authorisation3dsConfig authorisation3dsConfig;
+
+    @NotNull
+    @JsonProperty("authorisationConfig")
+    private AuthorisationConfig authorisationConfig;
 
     @NotNull
     private String graphiteHost;
@@ -269,6 +274,10 @@ public class ConnectorConfiguration extends Configuration {
 
     public Authorisation3dsConfig getAuthorisation3dsConfig() {
         return authorisation3dsConfig;
+    }
+
+    public AuthorisationConfig getAuthorisationConfig() {
+        return authorisationConfig;
     }
 
     public PayoutReconcileProcessConfig getPayoutReconcileProcessConfig() {

--- a/src/main/java/uk/gov/pay/connector/app/ExecutorServiceConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/ExecutorServiceConfig.java
@@ -5,13 +5,8 @@ import io.dropwizard.Configuration;
 public class ExecutorServiceConfig extends Configuration {
 
     private int threadsPerCpu;
-    private int timeoutInSeconds;
 
     public int getThreadsPerCpu() {
         return threadsPerCpu;
-    }
-
-    public int getTimeoutInSeconds() {
-        return timeoutInSeconds;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/config/AuthorisationConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/AuthorisationConfig.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.connector.app.config;
+
+import io.dropwizard.Configuration;
+
+public class AuthorisationConfig extends Configuration {
+    private int asynchronousAuthTimeoutInSeconds;
+    private int synchronousAuthTimeoutInMilliseconds;
+
+    public int getAsynchronousAuthTimeoutInSeconds() {
+        return asynchronousAuthTimeoutInSeconds;
+    }
+
+    public int getSynchronousAuthTimeoutInMilliseconds() {
+        return synchronousAuthTimeoutInMilliseconds;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/AuthorisationTimedOutException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/AuthorisationTimedOutException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.charge.exception.motoapi;
+
+import javax.ws.rs.WebApplicationException;
+
+public class AuthorisationTimedOutException extends WebApplicationException {
+    public AuthorisationTimedOutException() {
+        super("Authorising the payment timed out");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/AuthorisationTimedOutExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/AuthorisationTimedOutExceptionMapper.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.charge.exception.motoapi;
+
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.AUTHORISATION_TIMEOUT;
+
+public class AuthorisationTimedOutExceptionMapper implements ExceptionMapper<AuthorisationTimedOutException> {
+    @Override
+    public Response toResponse(AuthorisationTimedOutException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(AUTHORISATION_TIMEOUT, exception.getMessage());
+
+        return Response.status(500)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/exception/AuthorisationExecutorTimedOutException.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/exception/AuthorisationExecutorTimedOutException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.connector.paymentprocessor.exception;
+
+public class AuthorisationExecutorTimedOutException extends Exception {
+    public AuthorisationExecutorTimedOutException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
@@ -7,6 +7,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
@@ -14,6 +16,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.exception.GenericGatewayRuntimeException;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.paymentprocessor.exception.AuthorisationExecutorTimedOutException;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
 import javax.inject.Inject;
@@ -26,30 +29,48 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus;
 
 public class AuthorisationService {
-    
+
     private final CardExecutorService cardExecutorService;
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final MetricRegistry metricRegistry;
+    private final AuthorisationConfig authorisationConfig;
 
     @Inject
-    public AuthorisationService(CardExecutorService cardExecutorService, Environment environment) {
+    public AuthorisationService(CardExecutorService cardExecutorService, Environment environment, ConnectorConfiguration configuration) {
         this.cardExecutorService = cardExecutorService;
         this.metricRegistry = environment.metrics();
+        this.authorisationConfig = configuration.getAuthorisationConfig();
     }
- 
+
     public <T> T executeAuthorise(String chargeId, Supplier<T> authorisationSupplier) {
-        Pair<ExecutionStatus, T> executeResult = cardExecutorService.execute(authorisationSupplier);
+        int timeoutInMilliseconds = authorisationConfig.getAsynchronousAuthTimeoutInSeconds() * 1000;
+        try {
+            return executeAuthorise(authorisationSupplier, timeoutInMilliseconds);
+        } catch (AuthorisationExecutorTimedOutException e) {
+            // Exception is mapped to a success response and authorisation is allowed to continue in background thread.
+            throw new OperationAlreadyInProgressRuntimeException(OperationType.AUTHORISATION.getValue(), chargeId);
+        }
+    }
+
+    public <T> T executeAuthoriseSync(Supplier<T> authorisationSupplier) throws AuthorisationExecutorTimedOutException {
+        int timeoutInMilliseconds = authorisationConfig.getSynchronousAuthTimeoutInMilliseconds();
+        return executeAuthorise(authorisationSupplier, timeoutInMilliseconds);
+    } 
+
+    private <T> T executeAuthorise(Supplier<T> authorisationSupplier, int timeoutInMilliseconds)
+            throws AuthorisationExecutorTimedOutException {
+        Pair<ExecutionStatus, T> executeResult = cardExecutorService.execute(authorisationSupplier, timeoutInMilliseconds);
 
         switch (executeResult.getLeft()) {
             case COMPLETED:
                 return executeResult.getRight();
             case IN_PROGRESS:
-                throw new OperationAlreadyInProgressRuntimeException(OperationType.AUTHORISATION.getValue(), chargeId);
+                throw new AuthorisationExecutorTimedOutException("Timeout while waiting for authorisation to complete");
             default:
                 throw new GenericGatewayRuntimeException("Exception occurred while doing authorisation");
         }
     }
-    
+
     public Optional<String> extractTransactionId(String chargeExternalId, GatewayResponse<? extends BaseAuthoriseResponse> operationResponse) {
         Optional<String> transactionId = operationResponse.getBaseResponse()
                 .map(BaseAuthoriseResponse::getTransactionId);
@@ -70,7 +91,7 @@ public class AuthorisationService {
                 charge.getStatus())
         ).inc();
     }
-    
+
     public static ChargeStatus mapFromGatewayErrorException(GatewayException e) {
         if (e instanceof GatewayException.GenericGatewayException) return AUTHORISATION_ERROR;
         if (e instanceof GatewayException.GatewayConnectionTimeoutException) return AUTHORISATION_TIMEOUT;

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -123,7 +123,6 @@ stripe:
   enableTransactionFeeV2ForTestAccounts: ${STRIPE_ENABLE_TRANSACTION_FEE_V2_FOR_TEST_ACCOUNTS:-false}
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -284,3 +283,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -13,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -142,7 +143,7 @@ public class WorldpayPaymentProviderTest {
                 worldpayAuthoriseHandler,
                 worldpayCaptureHandler,
                 worldpayRefundHandler,
-                new AuthorisationService(mock(CardExecutorService.class), mock(Environment.class)),
+                new AuthorisationService(mock(CardExecutorService.class), mock(Environment.class), mock(ConnectorConfiguration.class)),
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
                 chargeDao,
                 eventService);

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -20,6 +20,7 @@ import uk.gov.pay.connector.rules.CardidStub;
 import uk.gov.pay.connector.rules.EpdqMockClient;
 import uk.gov.pay.connector.rules.LedgerStub;
 import uk.gov.pay.connector.rules.SmartpayMockClient;
+import uk.gov.pay.connector.rules.StripeMockClient;
 import uk.gov.pay.connector.rules.WorldpayMockClient;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
@@ -94,6 +95,7 @@ public class ChargingITestBase {
     protected WorldpayMockClient worldpayMockClient;
     protected SmartpayMockClient smartpayMockClient;
     protected EpdqMockClient epdqMockClient;
+    protected StripeMockClient stripeMockClient;
     protected LedgerStub ledgerStub;
     protected CardidStub cardidStub;
 
@@ -123,6 +125,7 @@ public class ChargingITestBase {
         worldpayMockClient = new WorldpayMockClient(wireMockServer);
         smartpayMockClient = new SmartpayMockClient(wireMockServer);
         epdqMockClient = new EpdqMockClient(wireMockServer);
+        stripeMockClient = new StripeMockClient(wireMockServer);
         ledgerStub = new LedgerStub(wireMockServer);
         cardidStub = new CardidStub(wireMockServer);
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -8,6 +8,8 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -92,6 +94,8 @@ public class WorldpayPaymentProviderTest {
     private Counter mockCounter;
     private Environment mockEnvironment;
     private CardExecutorService mockCardExecutorService = mock(CardExecutorService.class);
+    private ConnectorConfiguration mockConnectorConfiguration = mock(ConnectorConfiguration.class);
+    private AuthorisationConfig mockAuthorisationConfig = mock(AuthorisationConfig.class);
 
     @Before
     public void checkThatWorldpayIsUp() throws IOException {
@@ -142,6 +146,8 @@ public class WorldpayPaymentProviderTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         mockEnvironment = mock(Environment.class);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
+        when(mockConnectorConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
 
         chargeEntity = aValidChargeEntity()
                 .withTransactionId(randomUUID().toString())
@@ -493,7 +499,7 @@ public class WorldpayPaymentProviderTest {
                 new WorldpayAuthoriseHandler(gatewayClient, gatewayUrlMap(), new AcceptLanguageHeaderParser()), 
                 new WorldpayCaptureHandler(gatewayClient, gatewayUrlMap()),
                 new WorldpayRefundHandler(gatewayClient, gatewayUrlMap()), 
-                new AuthorisationService(mockCardExecutorService, mockEnvironment), 
+                new AuthorisationService(mockCardExecutorService, mockEnvironment, mockConnectorConfiguration), 
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()), 
                 mock(ChargeDao.class),
                 mock(EventService.class));

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.it.resources;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.app.ExecutorServiceConfig;
@@ -42,8 +43,8 @@ public class CardAuthorizeDelayedGatewayResponseIT extends ChargingITestBase {
     
     @Test
     public void shouldReturn202_WhenGatewayAuthorisationResponseIsDelayed() throws NoSuchFieldException, IllegalAccessException {
-        ExecutorServiceConfig conf = testContext.getExecutorServiceConfig();
-        Field timeoutInSeconds = conf.getClass().getDeclaredField("timeoutInSeconds");
+        AuthorisationConfig conf = testContext.getAuthorisationConfig();
+        Field timeoutInSeconds = conf.getClass().getDeclaredField("asynchronousAuthTimeoutInSeconds");
         timeoutInSeconds.setAccessible(true);
         timeoutInSeconds.setInt(conf, 0);
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseMotoApiPaymentDelayedGatewayResponseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseMotoApiPaymentDelayedGatewayResponseIT.java
@@ -1,0 +1,115 @@
+package uk.gov.pay.connector.it.resources;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
+import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
+import uk.gov.pay.connector.client.cardid.model.CardidCardType;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.junit.ConfigOverride;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_QUEUED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.client.cardid.model.CardInformationFixture.aCardInformation;
+import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonForMotoApiPaymentAuthorisation;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.INVALID_ATTRIBUTE_VALUE;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml",
+        configOverrides = {@ConfigOverride(key = "captureProcessConfig.backgroundProcessingEnabled", value = "true")},
+        withDockerSQS = true
+)
+public class CardResourceAuthoriseMotoApiPaymentDelayedGatewayResponseIT extends ChargingITestBase {
+
+    private static final String AUTHORISE_MOTO_API_URL = "/v1/api/charges/authorise";
+    private static final String VALID_CARD_NUMBER = "4242424242424242";
+    private static final String VISA = "visa";
+
+    public CardResourceAuthoriseMotoApiPaymentDelayedGatewayResponseIT() {
+        super("stripe");
+    }
+
+    private DatabaseFixtures.TestToken token;
+    private DatabaseFixtures.TestCharge charge;
+    private DatabaseTestHelper databaseTestHelper;
+
+    @Before
+    public void setup() {
+        databaseTestHelper = testContext.getDatabaseTestHelper();
+        
+        CardTypeEntity visaCreditCard = databaseTestHelper.getVisaCreditCard();
+        DatabaseFixtures.TestAccount gatewayAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .withCardTypeEntities(List.of(visaCreditCard))
+                .insert();
+
+        charge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withChargeStatus(CREATED)
+                .withAuthorisationMode(MOTO_API)
+                .withTestAccount(gatewayAccount)
+                .insert();
+
+        token = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestToken()
+                .withCharge(charge)
+                .withUsed(false)
+                .insert();
+    }
+
+    @After
+    public void tearDown() {
+        databaseTestHelper.truncateAllData();
+    }
+    
+    @Test
+    public void shouldReturn500ForAuthorisationTimeout() throws Exception {
+        AuthorisationConfig conf = testContext.getAuthorisationConfig();
+        Field timeoutInMilliseconds = conf.getClass().getDeclaredField("synchronousAuthTimeoutInMilliseconds");
+        timeoutInMilliseconds.setAccessible(true);
+        timeoutInMilliseconds.setInt(conf, 0);
+
+        stripeMockClient.mockCreatePaymentIntentDelayedResponse();
+
+        String validPayload = buildJsonForMotoApiPaymentAuthorisation("Joe Bogs ", VALID_CARD_NUMBER, "11/99", "123",
+                token.getSecureRedirectToken());
+        var cardInformation = aCardInformation().withBrand(VISA).withType(CardidCardType.CREDIT).build();
+        cardidStub.returnCardInformation(VALID_CARD_NUMBER, cardInformation);
+
+        givenSetup()
+                .body(validPayload)
+                .post(AUTHORISE_MOTO_API_URL)
+                .then()
+                .statusCode(500)
+                .body("message", hasItems("Authorising the payment timed out"))
+                .body("error_identifier", is(ErrorIdentifier.AUTHORISATION_TIMEOUT.toString()));
+
+        assertFrontendChargeStatusIs(charge.getExternalChargeId(), AUTHORISATION_TIMEOUT.getValue());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/junit/TestContext.java
+++ b/src/test/java/uk/gov/pay/connector/junit/TestContext.java
@@ -6,6 +6,7 @@ import io.dropwizard.db.DataSourceFactory;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.ExecutorServiceConfig;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
 public class TestContext {
@@ -45,9 +46,9 @@ public class TestContext {
     public WireMockServer getWireMockServer() {
         return wireMockServer;
     }
-
-    public ExecutorServiceConfig getExecutorServiceConfig() {
-        return connectorConfiguration.getExecutorServiceConfig();
+    
+    public AuthorisationConfig getAuthorisationConfig() {
+        return connectorConfiguration.getAuthorisationConfig();
     }
 
     public <T> T getInstanceFromGuiceContainer(Class<T> clazz) {

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.service.ChargeEligibleForCaptureService;
 import uk.gov.pay.connector.charge.service.ChargeService;
@@ -48,6 +49,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -95,6 +97,12 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private Appender<ILoggingEvent> mockAppender;
+    
+    @Mock
+    private ConnectorConfiguration mockConfiguration;
+    
+    @Mock
+    private AuthorisationConfig mockAuthorisationConfig;
 
     private AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
 
@@ -115,10 +123,14 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
                 mock(EventService.class), mock(PaymentInstrumentService.class), mock(GatewayAccountCredentialsService.class),
                 mock(AuthCardDetailsToCardDetailsEntityConverter.class), mockTaskQueueService);
 
+        when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
+        
         cardAuthorisationService = new CardAuthoriseService(
                 mockedCardTypeDao,
+                mockedChargeDao,
                 mockedProviders,
-                new AuthorisationService(mockExecutorService, environment),
+                new AuthorisationService(mockExecutorService, environment, mockConfiguration),
                 chargeService,
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
                 mockChargeEligibleForCaptureService, environment);
@@ -267,6 +279,6 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
     private void mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue() {
         doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
-                .when(mockExecutorService).execute(any(Supplier.class));
+                .when(mockExecutorService).execute(any(Supplier.class), anyInt());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -105,4 +105,15 @@ public class StripeMockClient {
         String payload = TestTemplateResourceLoader.load(STRIPE_TRANSFER_RESPONSE);
         setupResponse(payload, "/v1/transfers/" + transferid + "/reversals", 200);
     }
+    
+    public void mockCreatePaymentIntentDelayedResponse() {
+        String responseBody = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE);
+        String path = "/v1/payment_intents";
+        wireMockServer.stubFor(post(urlPathEqualTo(path))
+                .withHeader(CONTENT_TYPE, matching(APPLICATION_FORM_URLENCODED))
+                .willReturn(aResponse().withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withStatus(200)
+                        .withFixedDelay(100)
+                        .withBody(responseBody)));
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
@@ -12,6 +12,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
@@ -38,6 +40,7 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -80,6 +83,12 @@ public class WalletAuthoriseServiceForGooglePay3dsTest {
 
     @Mock
     private AuthCardDetails mockAuthCardDetails;
+    
+    @Mock
+    private ConnectorConfiguration mockConfiguration;
+    
+    @Mock
+    private AuthorisationConfig mockAuthorisationConfig;
 
     @Captor
     private ArgumentCaptor<Optional<Auth3dsRequiredEntity>> auth3dsRequiredEntityArgumentCaptor;
@@ -91,11 +100,13 @@ public class WalletAuthoriseServiceForGooglePay3dsTest {
         when(mockedProviders.byName(any())).thenReturn(mockedPaymentProvider);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
+        when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
 
         doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
-                .when(mockExecutorService).execute(any(Supplier.class));
+                .when(mockExecutorService).execute(any(Supplier.class), anyInt());
         
-        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
+        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment, mockConfiguration);
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -69,6 +70,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.anyString;
@@ -143,6 +145,9 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private CardDetailsEntity mockCardDetailsEntity;
+    
+    @Mock
+    private AuthorisationConfig mockAuthorisationConfig;
 
     private WalletAuthoriseService walletAuthoriseService;
 
@@ -173,10 +178,12 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         when(mockConfiguration.getEmitPaymentStateTransitionEvents()).thenReturn(true);
+        when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
 
         ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
-        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
+        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment, mockConfiguration);
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null, mockStateTransitionService,
                 ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
@@ -386,7 +393,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldThrowAnOperationAlreadyInProgressRuntimeException_whenTimeout() {
-        when(mockExecutorService.execute(any())).thenReturn(Pair.of(IN_PROGRESS, null));
+        when(mockExecutorService.execute(any(), anyInt())).thenReturn(Pair.of(IN_PROGRESS, null));
 
         try {
             walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -461,7 +468,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     public void mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue() {
         doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
-                .when(mockExecutorService).execute(any(Supplier.class));
+                .when(mockExecutorService).execute(any(Supplier.class), anyInt());
     }
     
     private GatewayResponse providerWillAuthorise() throws Exception {

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -103,7 +103,6 @@ customJerseyClient:
   readTimeout: 50000ms
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -223,3 +222,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -103,7 +103,6 @@ customJerseyClient:
   readTimeout: 50000ms
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -223,3 +222,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -93,7 +93,6 @@ customJerseyClient:
   readTimeout: 500ms
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -213,3 +212,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -84,7 +84,6 @@ stripe:
   enableTransactionFeeV2ForTestAccounts: ${STRIPE_ENABLE_TRANSACTION_FEE_V2_FOR_TEST_ACCOUNTS:-true}
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -221,3 +220,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -84,7 +84,6 @@ stripe:
   enableTransactionFeeV2ForTestAccounts: ${STRIPE_ENABLE_TRANSACTION_FEE_V2_FOR_TEST_ACCOUNTS:-true}
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -221,3 +220,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}


### PR DESCRIPTION
Time out a request to authorise a payment made through the `/v1/api/charges/authorise` endpoint after a defined period of time, and transition the charge into the AUTHORISATION_TIMEOUT when it is timed out. This API is used for authorising MOTO payments, which needs to be done synchronously.

This differs from authorisations made via the `/v1/frontend/charges/{chargeId}/cards`, where we will respond to the request if the authorisation hasn't finished after a defined period of time, but allow the authorisation to continue on a background thread.

Re-use the CardExecutorService to execute a Future to allow for the request to be timed out after a certain period of time.

The timeout is configured using a new environment variable, SYNCHRONOUS_AUTH_TIMEOUT_IN_MILLISECONDS.

Move the existing timeoutInSeconds configuration option in ExecutorServiceConfig to asynchronousAuthTimeoutInSeconds in AuthorisationConfig to reflect CardExecutorService now having the timeout specified externally. This new configuration option uses the existing environment variable AUTH_READ_TIMEOUT_SECONDS.

Reduce the constant QUEUE_WAIT_WARN_THRESHOLD_MILLIS from 10000 to 1000, so we are able to monitor if any authorisations are waiting longer than 1s on the executor queue - which would be an issue for synchronous authorisations.