### PR TITLE
PP-9503 Refactor CardExecutorService

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ The GOV.UK Pay Connector in Java (Dropwizard).
 
 | Variable | Default | Purpose |
 |---------|---------|---------|
-| `AUTH_READ_TIMEOUT_SECONDS` | `10 seconds` | the timeout before the resource responds with an awaited auth response (202), so that frontend can choose to show a spinner and poll for auth response. Supports any duration parsable by dropwizard [Duration](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java)|
+| `AUTH_READ_TIMEOUT_MILLISECONDS` | `1000` | the timeout before the resource responds with an awaited auth response (202), so that frontend can choose to show a spinner and poll for auth response. Supports any duration parsable by dropwizard [Duration](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java)|
+| `SYNCHRONOUS_AUTH_TIMEOUT_IN_MILLISECONDS` | `10000` | the timeout before requests made to the synchronous authorisation API for MOTO payments timeout and the payment is failed |
 | `SECURE_WORLDPAY_NOTIFICATION_ENABLED` | false | whether to filter incoming notifications by domain; they will be rejected with a 403 unless they match the required domain |
 | `SECURE_WORLDPAY_NOTIFICATION_DOMAIN` | `worldpay.com` | incoming requests will have a reverse DNS lookup done on their domain. They must resolve to a domain with this suffix (see `DnsUtils.ipMatchesDomain()`) |
 | `NOTIFY_EMAIL_ENABLED` | false | Whether confirmation emails will be sent using GOV.UK Notify |

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -5,6 +5,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
 import uk.gov.pay.connector.app.config.Authorisation3dsConfig;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.app.config.EmittedEventSweepConfig;
 import uk.gov.pay.connector.app.config.EventEmitterConfig;
 import uk.gov.pay.connector.app.config.ExpungeConfig;
@@ -96,6 +97,10 @@ public class ConnectorConfiguration extends Configuration {
     @NotNull
     @JsonProperty("authorisation3dsConfig")
     private Authorisation3dsConfig authorisation3dsConfig;
+
+    @NotNull
+    @JsonProperty("authorisationConfig")
+    private AuthorisationConfig authorisationConfig;
 
     @NotNull
     private String graphiteHost;
@@ -269,6 +274,10 @@ public class ConnectorConfiguration extends Configuration {
 
     public Authorisation3dsConfig getAuthorisation3dsConfig() {
         return authorisation3dsConfig;
+    }
+
+    public AuthorisationConfig getAuthorisationConfig() {
+        return authorisationConfig;
     }
 
     public PayoutReconcileProcessConfig getPayoutReconcileProcessConfig() {

--- a/src/main/java/uk/gov/pay/connector/app/ExecutorServiceConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/ExecutorServiceConfig.java
@@ -5,13 +5,8 @@ import io.dropwizard.Configuration;
 public class ExecutorServiceConfig extends Configuration {
 
     private int threadsPerCpu;
-    private int timeoutInSeconds;
 
     public int getThreadsPerCpu() {
         return threadsPerCpu;
-    }
-
-    public int getTimeoutInSeconds() {
-        return timeoutInSeconds;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/config/AuthorisationConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/AuthorisationConfig.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.connector.app.config;
+
+import io.dropwizard.Configuration;
+
+public class AuthorisationConfig extends Configuration {
+    private int asynchronousAuthTimeoutInSeconds;
+    private int synchronousAuthTimeoutInMilliseconds;
+
+    public int getAsynchronousAuthTimeoutInSeconds() {
+        return asynchronousAuthTimeoutInSeconds;
+    }
+
+    public int getSynchronousAuthTimeoutInMilliseconds() {
+        return synchronousAuthTimeoutInMilliseconds;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/app/config/AuthorisationConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/AuthorisationConfig.java
@@ -3,11 +3,11 @@ package uk.gov.pay.connector.app.config;
 import io.dropwizard.Configuration;
 
 public class AuthorisationConfig extends Configuration {
-    private int asynchronousAuthTimeoutInSeconds;
+    private int asynchronousAuthTimeoutInMilliseconds;
     private int synchronousAuthTimeoutInMilliseconds;
 
-    public int getAsynchronousAuthTimeoutInSeconds() {
-        return asynchronousAuthTimeoutInSeconds;
+    public int getAsynchronousAuthTimeoutInMilliseconds() {
+        return asynchronousAuthTimeoutInMilliseconds;
     }
 
     public int getSynchronousAuthTimeoutInMilliseconds() {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/exception/AuthorisationExecutorTimedOutException.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/exception/AuthorisationExecutorTimedOutException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.connector.paymentprocessor.exception;
+
+public class AuthorisationExecutorTimedOutException extends Exception {
+    public AuthorisationExecutorTimedOutException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
@@ -7,6 +7,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
@@ -14,6 +16,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.exception.GenericGatewayRuntimeException;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.paymentprocessor.exception.AuthorisationExecutorTimedOutException;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
 import javax.inject.Inject;
@@ -26,30 +29,48 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus;
 
 public class AuthorisationService {
-    
+
     private final CardExecutorService cardExecutorService;
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final MetricRegistry metricRegistry;
+    private final AuthorisationConfig authorisationConfig;
 
     @Inject
-    public AuthorisationService(CardExecutorService cardExecutorService, Environment environment) {
+    public AuthorisationService(CardExecutorService cardExecutorService, Environment environment, ConnectorConfiguration configuration) {
         this.cardExecutorService = cardExecutorService;
         this.metricRegistry = environment.metrics();
+        this.authorisationConfig = configuration.getAuthorisationConfig();
     }
- 
+
     public <T> T executeAuthorise(String chargeId, Supplier<T> authorisationSupplier) {
-        Pair<ExecutionStatus, T> executeResult = cardExecutorService.execute(authorisationSupplier);
+        int timeoutInMilliseconds = authorisationConfig.getAsynchronousAuthTimeoutInSeconds() * 1000;
+        try {
+            return executeAuthorise(authorisationSupplier, timeoutInMilliseconds);
+        } catch (AuthorisationExecutorTimedOutException e) {
+            // Exception is mapped to a success response and authorisation is allowed to continue in background thread.
+            throw new OperationAlreadyInProgressRuntimeException(OperationType.AUTHORISATION.getValue(), chargeId);
+        }
+    }
+
+    public <T> T executeAuthoriseSync(Supplier<T> authorisationSupplier) throws AuthorisationExecutorTimedOutException {
+        int timeoutInMilliseconds = authorisationConfig.getSynchronousAuthTimeoutInMilliseconds();
+        return executeAuthorise(authorisationSupplier, timeoutInMilliseconds);
+    } 
+
+    private <T> T executeAuthorise(Supplier<T> authorisationSupplier, int timeoutInMilliseconds)
+            throws AuthorisationExecutorTimedOutException {
+        Pair<ExecutionStatus, T> executeResult = cardExecutorService.execute(authorisationSupplier, timeoutInMilliseconds);
 
         switch (executeResult.getLeft()) {
             case COMPLETED:
                 return executeResult.getRight();
             case IN_PROGRESS:
-                throw new OperationAlreadyInProgressRuntimeException(OperationType.AUTHORISATION.getValue(), chargeId);
+                throw new AuthorisationExecutorTimedOutException("Timeout while waiting for authorisation to complete");
             default:
                 throw new GenericGatewayRuntimeException("Exception occurred while doing authorisation");
         }
     }
-    
+
     public Optional<String> extractTransactionId(String chargeExternalId, GatewayResponse<? extends BaseAuthoriseResponse> operationResponse) {
         Optional<String> transactionId = operationResponse.getBaseResponse()
                 .map(BaseAuthoriseResponse::getTransactionId);
@@ -70,7 +91,7 @@ public class AuthorisationService {
                 charge.getStatus())
         ).inc();
     }
-    
+
     public static ChargeStatus mapFromGatewayErrorException(GatewayException e) {
         if (e instanceof GatewayException.GenericGatewayException) return AUTHORISATION_ERROR;
         if (e instanceof GatewayException.GatewayConnectionTimeoutException) return AUTHORISATION_TIMEOUT;

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
@@ -43,7 +43,7 @@ public class AuthorisationService {
     }
 
     public <T> T executeAuthorise(String chargeId, Supplier<T> authorisationSupplier) {
-        int timeoutInMilliseconds = authorisationConfig.getAsynchronousAuthTimeoutInSeconds() * 1000;
+        int timeoutInMilliseconds = authorisationConfig.getAsynchronousAuthTimeoutInMilliseconds();
         try {
             return executeAuthorise(authorisationSupplier, timeoutInMilliseconds);
         } catch (AuthorisationExecutorTimedOutException e) {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardExecutorService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardExecutorService.java
@@ -39,7 +39,8 @@ import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.
 public class CardExecutorService {
 
     private static final Logger logger = LoggerFactory.getLogger(CardExecutorService.class);
-    private static final int QUEUE_WAIT_WARN_THRESHOLD_MILLIS = 10000;
+    private static final int QUEUE_WAIT_WARN_THRESHOLD_MILLIS = 1000;
+    public static final int SHUTDOWN_AWAIT_TERMINATION_TIMEOUT_SECONDS = 10;
     private final MetricRegistry metricRegistry;
 
     private ExecutorServiceConfig config;
@@ -74,7 +75,7 @@ public class CardExecutorService {
             executor.shutdown();
             logger.info("Awaiting for {} threads to terminate", className);
             try {
-                executor.awaitTermination(1, TimeUnit.SECONDS);
+                executor.awaitTermination(SHUTDOWN_AWAIT_TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 logger.error("Error while waiting for {} threads to terminate", className);
             }
@@ -88,7 +89,7 @@ public class CardExecutorService {
 
     // accepts a supplier function and executed that in a separate Thread of its own.
     // returns a Pair of the execution status and the return type
-    public <T> Pair<ExecutionStatus, T> execute(Supplier<T> callable) {
+    public <T> Pair<ExecutionStatus, T> execute(Supplier<T> callable, int timeoutInMilliseconds) {
         Callable<T> task = callable::get;
         Map<String, String> mdcContextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Map.of());
         final long startTime = System.currentTimeMillis();
@@ -109,11 +110,11 @@ public class CardExecutorService {
         });
 
         try {
-            return Pair.of(COMPLETED, futureObject.get(config.getTimeoutInSeconds(), TimeUnit.SECONDS));
+            return Pair.of(COMPLETED, futureObject.get(timeoutInMilliseconds, TimeUnit.MILLISECONDS));
         } catch (ExecutionException | InterruptedException exception) {
             if (exception.getCause() instanceof WebApplicationException) {
                 throw (WebApplicationException) exception.getCause();
-            } else if (exception.getCause() instanceof UnsupportedOperationException) { //ooof
+            } else if (exception.getCause() instanceof UnsupportedOperationException) {
                 throw (UnsupportedOperationException) exception.getCause();
             }
             return Pair.of(FAILED, null);

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -123,7 +123,6 @@ stripe:
   enableTransactionFeeV2ForTestAccounts: ${STRIPE_ENABLE_TRANSACTION_FEE_V2_FOR_TEST_ACCOUNTS:-false}
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -284,3 +283,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -285,5 +285,5 @@ authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
 
 authorisationConfig:
-  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -13,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -142,7 +143,7 @@ public class WorldpayPaymentProviderTest {
                 worldpayAuthoriseHandler,
                 worldpayCaptureHandler,
                 worldpayRefundHandler,
-                new AuthorisationService(mock(CardExecutorService.class), mock(Environment.class)),
+                new AuthorisationService(mock(CardExecutorService.class), mock(Environment.class), mock(ConnectorConfiguration.class)),
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
                 chargeDao,
                 eventService);

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -147,7 +147,7 @@ public class WorldpayPaymentProviderTest {
         mockEnvironment = mock(Environment.class);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         when(mockConnectorConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
-        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);
 
         chargeEntity = aValidChargeEntity()
                 .withTransactionId(randomUUID().toString())

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -8,6 +8,8 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -92,6 +94,8 @@ public class WorldpayPaymentProviderTest {
     private Counter mockCounter;
     private Environment mockEnvironment;
     private CardExecutorService mockCardExecutorService = mock(CardExecutorService.class);
+    private ConnectorConfiguration mockConnectorConfiguration = mock(ConnectorConfiguration.class);
+    private AuthorisationConfig mockAuthorisationConfig = mock(AuthorisationConfig.class);
 
     @Before
     public void checkThatWorldpayIsUp() throws IOException {
@@ -142,6 +146,8 @@ public class WorldpayPaymentProviderTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         mockEnvironment = mock(Environment.class);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
+        when(mockConnectorConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
 
         chargeEntity = aValidChargeEntity()
                 .withTransactionId(randomUUID().toString())
@@ -493,7 +499,7 @@ public class WorldpayPaymentProviderTest {
                 new WorldpayAuthoriseHandler(gatewayClient, gatewayUrlMap(), new AcceptLanguageHeaderParser()), 
                 new WorldpayCaptureHandler(gatewayClient, gatewayUrlMap()),
                 new WorldpayRefundHandler(gatewayClient, gatewayUrlMap()), 
-                new AuthorisationService(mockCardExecutorService, mockEnvironment), 
+                new AuthorisationService(mockCardExecutorService, mockEnvironment, mockConnectorConfiguration), 
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()), 
                 mock(ChargeDao.class),
                 mock(EventService.class));

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
@@ -2,12 +2,12 @@ package uk.gov.pay.connector.it.resources;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.app.ExecutorServiceConfig;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.lang.reflect.Field;
 
@@ -42,8 +42,8 @@ public class CardAuthorizeDelayedGatewayResponseIT extends ChargingITestBase {
     
     @Test
     public void shouldReturn202_WhenGatewayAuthorisationResponseIsDelayed() throws NoSuchFieldException, IllegalAccessException {
-        ExecutorServiceConfig conf = testContext.getExecutorServiceConfig();
-        Field timeoutInSeconds = conf.getClass().getDeclaredField("timeoutInSeconds");
+        AuthorisationConfig conf = testContext.getAuthorisationConfig();
+        Field timeoutInSeconds = conf.getClass().getDeclaredField("asynchronousAuthTimeoutInSeconds");
         timeoutInSeconds.setAccessible(true);
         timeoutInSeconds.setInt(conf, 0);
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
@@ -43,7 +43,7 @@ public class CardAuthorizeDelayedGatewayResponseIT extends ChargingITestBase {
     @Test
     public void shouldReturn202_WhenGatewayAuthorisationResponseIsDelayed() throws NoSuchFieldException, IllegalAccessException {
         AuthorisationConfig conf = testContext.getAuthorisationConfig();
-        Field timeoutInSeconds = conf.getClass().getDeclaredField("asynchronousAuthTimeoutInSeconds");
+        Field timeoutInSeconds = conf.getClass().getDeclaredField("asynchronousAuthTimeoutInMilliseconds");
         timeoutInSeconds.setAccessible(true);
         timeoutInSeconds.setInt(conf, 0);
 

--- a/src/test/java/uk/gov/pay/connector/junit/TestContext.java
+++ b/src/test/java/uk/gov/pay/connector/junit/TestContext.java
@@ -5,7 +5,7 @@ import com.google.inject.Injector;
 import io.dropwizard.db.DataSourceFactory;
 import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.app.ExecutorServiceConfig;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
 public class TestContext {
@@ -45,9 +45,9 @@ public class TestContext {
     public WireMockServer getWireMockServer() {
         return wireMockServer;
     }
-
-    public ExecutorServiceConfig getExecutorServiceConfig() {
-        return connectorConfiguration.getExecutorServiceConfig();
+    
+    public AuthorisationConfig getAuthorisationConfig() {
+        return connectorConfiguration.getAuthorisationConfig();
     }
 
     public <T> T getInstanceFromGuiceContainer(Class<T> clazz) {

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -110,7 +110,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         when(mockConfiguration.getAuthorisation3dsConfig()).thenReturn(mockAuthorisation3dsConfig);
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
-        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
                 null, null, mockConfiguration, null, mockStateTransitionService, ledgerService,

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -173,7 +173,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
                 .thenReturn(new SandboxAuthorisationRequestSummary());
         when(mockAuthorisationRequestSummaryStringifier.stringify(any(AuthorisationRequestSummary.class))).thenReturn("");
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
-        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);
         
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null,

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.cardtype.dao.CardTypeEntityBuilder;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
@@ -73,6 +74,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.anyString;
@@ -153,8 +155,14 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     private CardDetailsEntity mockCardDetailsEntity;
 
     @Mock
-    ChargeEligibleForCaptureService mockChargeEligibleForCaptureService;
-
+    private ChargeEligibleForCaptureService mockChargeEligibleForCaptureService;
+    
+    @Mock 
+    private ConnectorConfiguration mockConfiguration;
+    
+    @Mock
+    private AuthorisationConfig mockAuthorisationConfig;
+    
     private CardAuthoriseService cardAuthorisationService;
 
     @Before
@@ -164,8 +172,9 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         when(mockedPaymentProvider.generateAuthorisationRequestSummary(any(ChargeEntity.class), any(AuthCardDetails.class)))
                 .thenReturn(new SandboxAuthorisationRequestSummary());
         when(mockAuthorisationRequestSummaryStringifier.stringify(any(AuthorisationRequestSummary.class))).thenReturn("");
-
-        ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
+        when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
+        
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null,
                 stateTransitionService, ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService,
@@ -180,7 +189,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
                         userNotificationService
                 );
 
-        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
+        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment, mockConfiguration);
         cardAuthorisationService = new CardAuthoriseService(
                 mockedCardTypeDao,
                 mockedProviders,
@@ -198,7 +207,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
     public void mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue() {
         doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
-                .when(mockExecutorService).execute(any(Supplier.class));
+                .when(mockExecutorService).execute(any(Supplier.class), anyInt());
     }
 
     private GatewayResponse mockAuthResponse(String TRANSACTION_ID, AuthoriseStatus authoriseStatus, String errorCode) {
@@ -566,7 +575,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     @Test
     public void doAuthorise_shouldThrowAnOperationAlreadyInProgressRuntimeException_whenTimeout() {
 
-        when(mockExecutorService.execute(any())).thenReturn(Pair.of(IN_PROGRESS, null));
+        when(mockExecutorService.execute(any(), anyInt())).thenReturn(Pair.of(IN_PROGRESS, null));
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
 
         try {

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -124,7 +124,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
                 mock(AuthCardDetailsToCardDetailsEntityConverter.class), mockTaskQueueService);
 
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
-        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);
         
         cardAuthorisationService = new CardAuthoriseService(
                 mockedCardTypeDao,

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
@@ -12,6 +12,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
@@ -38,6 +40,7 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -80,6 +83,12 @@ public class WalletAuthoriseServiceForGooglePay3dsTest {
 
     @Mock
     private AuthCardDetails mockAuthCardDetails;
+    
+    @Mock
+    private ConnectorConfiguration mockConfiguration;
+    
+    @Mock
+    private AuthorisationConfig mockAuthorisationConfig;
 
     @Captor
     private ArgumentCaptor<Optional<Auth3dsRequiredEntity>> auth3dsRequiredEntityArgumentCaptor;
@@ -91,11 +100,13 @@ public class WalletAuthoriseServiceForGooglePay3dsTest {
         when(mockedProviders.byName(any())).thenReturn(mockedPaymentProvider);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
+        when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
 
         doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
-                .when(mockExecutorService).execute(any(Supplier.class));
+                .when(mockExecutorService).execute(any(Supplier.class), anyInt());
         
-        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
+        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment, mockConfiguration);
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
@@ -101,7 +101,7 @@ public class WalletAuthoriseServiceForGooglePay3dsTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
-        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);
 
         doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
                 .when(mockExecutorService).execute(any(Supplier.class), anyInt());

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -179,7 +179,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         when(mockConfiguration.getEmitPaymentStateTransitionEvents()).thenReturn(true);
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
-        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);
 
         ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -69,6 +70,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.anyString;
@@ -143,6 +145,9 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private CardDetailsEntity mockCardDetailsEntity;
+    
+    @Mock
+    private AuthorisationConfig mockAuthorisationConfig;
 
     private WalletAuthoriseService walletAuthoriseService;
 
@@ -173,10 +178,12 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         when(mockConfiguration.getEmitPaymentStateTransitionEvents()).thenReturn(true);
+        when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
+        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInSeconds()).thenReturn(1);
 
         ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
-        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
+        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment, mockConfiguration);
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null, mockStateTransitionService,
                 ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
@@ -386,7 +393,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldThrowAnOperationAlreadyInProgressRuntimeException_whenTimeout() {
-        when(mockExecutorService.execute(any())).thenReturn(Pair.of(IN_PROGRESS, null));
+        when(mockExecutorService.execute(any(), anyInt())).thenReturn(Pair.of(IN_PROGRESS, null));
 
         try {
             walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -461,7 +468,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     public void mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue() {
         doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
-                .when(mockExecutorService).execute(any(Supplier.class));
+                .when(mockExecutorService).execute(any(Supplier.class), anyInt());
     }
     
     private GatewayResponse providerWillAuthorise() throws Exception {

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -103,7 +103,6 @@ customJerseyClient:
   readTimeout: 50000ms
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -223,3 +222,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -224,5 +224,5 @@ authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
 
 authorisationConfig:
-  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -103,7 +103,6 @@ customJerseyClient:
   readTimeout: 50000ms
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -223,3 +222,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -224,5 +224,5 @@ authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
 
 authorisationConfig:
-  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -93,7 +93,6 @@ customJerseyClient:
   readTimeout: 500ms
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -213,3 +212,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -214,5 +214,5 @@ authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
 
 authorisationConfig:
-  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -222,5 +222,5 @@ authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
 
 authorisationConfig:
-  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -84,7 +84,6 @@ stripe:
   enableTransactionFeeV2ForTestAccounts: ${STRIPE_ENABLE_TRANSACTION_FEE_V2_FOR_TEST_ACCOUNTS:-true}
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -221,3 +220,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -222,5 +222,5 @@ authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
 
 authorisationConfig:
-  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}
+  asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -84,7 +84,6 @@ stripe:
   enableTransactionFeeV2ForTestAccounts: ${STRIPE_ENABLE_TRANSACTION_FEE_V2_FOR_TEST_ACCOUNTS:-true}
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
@@ -221,3 +220,7 @@ expungeConfig:
 
 authorisation3dsConfig:
   maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}
+
+authorisationConfig:
+  asynchronousAuthTimeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}
+  synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}


### PR DESCRIPTION
Refactor CardExecutorService so it can be use to execute synchronous authorisations with a timeout.

Currently, the CardExecutorService executes a Future and waits for a fixed timeout defined by the timeoutInSeconds configuration option in ExecutorServiceConfig and returns an ExecutionStatus of IN_PROGRESS if it has to wait for longer than this amount of time to authorise. AuthorisationService handles this service to throw an exception that maps to a success response, and allows the authorisation to continue.

Refactor CardExecutorService so we can specify a different timeout to wait on the thread that is handling the authorisation API request for the authorisation task to complete.

Move the existing timeoutInSeconds configuration option in ExecutorServiceConfig to asynchronousAuthTimeoutInMilliseconds in AuthorisationConfig to reflect CardExecutorService now having the timeout specified externally. The environment variable used has changed to AUTH_READ_TIMEOUT_MILLISECONDS to reflect the change in time unit. It is fine to change this as it is not set to anything other than the default in our infra anywhere.

Add a method to AuthorisationService that will execute a task on the CardExecutorService synchronously with a timeout specified by a new synchronousAuthTimeoutInMilliseconds configuration option which takes its value from a SYNCHRONOUS_AUTH_TIMEOUT_IN_MILLISECONDS environment variable. This method will throw an exception if the CardExecutorService returns an ExecutionStatus of IN_PROGRESS. This method is not currently used, but will be used for authorising synchronous authorisations.

Reduce the constant QUEUE_WAIT_WARN_THRESHOLD_MILLIS from 10000 to 1000, so we are able to monitor if any authorisations are waiting longer than 1s on the executor queue - which would be an issue for synchronous authorisations.

Increase the timeout for waiting for tasks to finish on the CardExecutorService to 10s so we wait for long enough for synchronous authorisation tasks to expire before shutting down.