### PR TITLE
PP-9503 Add timeout for synchronous authorisation API

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.charge.exception.InvalidAttributeValueExceptionMappe
 import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.exception.motoapi.AuthorisationErrorExceptionMapper;
 import uk.gov.pay.connector.charge.exception.motoapi.AuthorisationRejectedExceptionMapper;
+import uk.gov.pay.connector.charge.exception.motoapi.AuthorisationTimedOutExceptionMapper;
 import uk.gov.pay.connector.charge.exception.motoapi.CardNumberRejectedExceptionMapper;
 import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenAlreadyUsedExceptionMapper;
 import uk.gov.pay.connector.charge.exception.motoapi.OneTimeTokenInvalidExceptionMapper;
@@ -150,6 +151,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new AuthorisationApiNotAllowedForGatewayAccountExceptionMapper());
         environment.jersey().register(new AuthorisationErrorExceptionMapper());
         environment.jersey().register(new AuthorisationRejectedExceptionMapper());
+        environment.jersey().register(new AuthorisationTimedOutExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/AuthorisationTimedOutException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/AuthorisationTimedOutException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.charge.exception.motoapi;
+
+import javax.ws.rs.WebApplicationException;
+
+public class AuthorisationTimedOutException extends WebApplicationException {
+    public AuthorisationTimedOutException() {
+        super("Authorising the payment timed out");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/AuthorisationTimedOutExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/AuthorisationTimedOutExceptionMapper.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.charge.exception.motoapi;
+
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.AUTHORISATION_TIMEOUT;
+
+public class AuthorisationTimedOutExceptionMapper implements ExceptionMapper<AuthorisationTimedOutException> {
+    @Override
+    public Response toResponse(AuthorisationTimedOutException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(AUTHORISATION_TIMEOUT, exception.getMessage());
+
+        return Response.status(500)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.paymentprocessor.model.AuthoriseRequest;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.model.PayersCardType.CREDIT_OR_DEBIT;
@@ -242,5 +243,18 @@ public class AuthCardDetails implements AuthorisationDetails {
 
     public Optional<String> getJsNavigatorLanguage() {
         return Optional.ofNullable(jsNavigatorLanguage);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthCardDetails that = (AuthCardDetails) o;
+        return Objects.equals(cardNo, that.cardNo) && Objects.equals(cardHolder, that.cardHolder) && Objects.equals(cvc, that.cvc) && Objects.equals(endDate, that.endDate) && Objects.equals(address, that.address) && Objects.equals(cardBrand, that.cardBrand) && Objects.equals(userAgentHeader, that.userAgentHeader) && Objects.equals(acceptHeader, that.acceptHeader) && payersCardType == that.payersCardType && payersCardPrepaidStatus == that.payersCardPrepaidStatus && Objects.equals(corporateCard, that.corporateCard) && Objects.equals(worldpay3dsFlexDdcResult, that.worldpay3dsFlexDdcResult) && Objects.equals(ipAddress, that.ipAddress) && Objects.equals(jsScreenColorDepth, that.jsScreenColorDepth) && Objects.equals(jsNavigatorLanguage, that.jsNavigatorLanguage) && Objects.equals(jsScreenHeight, that.jsScreenHeight) && Objects.equals(jsScreenWidth, that.jsScreenWidth) && Objects.equals(jsTimezoneOffsetMins, that.jsTimezoneOffsetMins) && Objects.equals(acceptLanguageHeader, that.acceptLanguageHeader);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cardNo, cardHolder, cvc, endDate, address, cardBrand, userAgentHeader, acceptHeader, payersCardType, payersCardPrepaidStatus, corporateCard, worldpay3dsFlexDdcResult, ipAddress, jsScreenColorDepth, jsNavigatorLanguage, jsScreenHeight, jsScreenWidth, jsTimezoneOffsetMins, acceptLanguageHeader);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -188,7 +188,7 @@ public class CardResource {
         MDCUtils.addChargeAndGatewayAccountDetailsToMDC(tokenEntity.getChargeEntity());
         CardInformation cardInformation = motoApiCardNumberValidationService.validateCardNumber(tokenEntity.getChargeEntity(), authoriseRequest.getCardNumber());
 
-        AuthorisationResponse response = cardAuthoriseService.doAuthoriseSync(tokenEntity.getChargeEntity(), cardInformation, authoriseRequest);
+        AuthorisationResponse response = cardAuthoriseService.doAuthoriseMotoApi(tokenEntity.getChargeEntity(), cardInformation, authoriseRequest);
         return handleAuthResponseForMotoApi(response);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseMotoApiPaymentTimeoutIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseMotoApiPaymentTimeoutIT.java
@@ -1,0 +1,105 @@
+package uk.gov.pay.connector.it.resources;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.app.config.AuthorisationConfig;
+import uk.gov.pay.connector.client.cardid.model.CardidCardType;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.junit.ConfigOverride;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import java.lang.reflect.Field;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.client.cardid.model.CardInformationFixture.aCardInformation;
+import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonForMotoApiPaymentAuthorisation;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml",
+        configOverrides = {@ConfigOverride(key = "captureProcessConfig.backgroundProcessingEnabled", value = "true")},
+        withDockerSQS = true
+)
+public class CardResourceAuthoriseMotoApiPaymentTimeoutIT extends ChargingITestBase {
+
+    private static final String AUTHORISE_MOTO_API_URL = "/v1/api/charges/authorise";
+    private static final String VALID_CARD_NUMBER = "4242424242424242";
+    private static final String VISA = "visa";
+
+    public CardResourceAuthoriseMotoApiPaymentTimeoutIT() {
+        super("stripe");
+    }
+    
+    private DatabaseFixtures.TestToken token;
+    private DatabaseFixtures.TestCharge charge;
+    private DatabaseTestHelper databaseTestHelper;
+
+    @Before
+    public void setup() {
+        databaseTestHelper = testContext.getDatabaseTestHelper();
+
+        charge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withChargeStatus(CREATED)
+                .withAuthorisationMode(MOTO_API)
+                .withTestAccount(getTestAccount())
+                .withGatewayCredentialId((long) gatewayAccountCredentialsId)
+                .withPaymentProvider("stripe")
+                .insert();
+
+        token = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestToken()
+                .withCharge(charge)
+                .withUsed(false)
+                .insert();
+    }
+
+    @After
+    public void tearDown() {
+        databaseTestHelper.truncateAllData();
+    }
+    
+    @Test
+    public void shouldReturn500_andUpdateCharge_forAuthorisationTimeout() throws Exception {
+        AuthorisationConfig conf = testContext.getAuthorisationConfig();
+        Field timeoutInMilliseconds = conf.getClass().getDeclaredField("synchronousAuthTimeoutInMilliseconds");
+        timeoutInMilliseconds.setAccessible(true);
+        timeoutInMilliseconds.setInt(conf, 50);
+
+        stripeMockClient.mockCreatePaymentMethod();
+        stripeMockClient.mockCreatePaymentIntentDelayedResponse();
+
+        String cardHolderName = "Joe Bogs";
+        String validPayload = buildJsonForMotoApiPaymentAuthorisation(cardHolderName, VALID_CARD_NUMBER, "11/99", "123",
+                token.getSecureRedirectToken());
+        var cardInformation = aCardInformation().withBrand(VISA).withType(CardidCardType.CREDIT).build();
+        cardidStub.returnCardInformation(VALID_CARD_NUMBER, cardInformation);
+
+        givenSetup()
+                .body(validPayload)
+                .post(AUTHORISE_MOTO_API_URL)
+                .then()
+                .statusCode(500)
+                .body("message", hasItems("Authorising the payment timed out"))
+                .body("error_identifier", is(ErrorIdentifier.AUTHORISATION_TIMEOUT.toString()));
+
+        connectorRestApiClient
+                .withChargeId(charge.getExternalChargeId())
+                .getFrontendCharge()
+                .body("status", is(AUTHORISATION_TIMEOUT.getValue()))
+                .body("card_details.cardholder_name", is(cardHolderName));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceTest.java
@@ -383,7 +383,7 @@ class CardResourceTest {
 
         AuthorisationResponse authorisationResponse = new AuthorisationResponse(operationResponse);
 
-        when(mockCardAuthoriseService.doAuthoriseSync(any(), any(), any())).thenReturn(authorisationResponse);
+        when(mockCardAuthoriseService.doAuthoriseMotoApi(any(), any(), any())).thenReturn(authorisationResponse);
 
         Response response = resources.target("/v1/api/charges/authorise")
                 .request().post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE));
@@ -400,7 +400,7 @@ class CardResourceTest {
 
         AuthorisationResponse authorisationResponse = new AuthorisationResponse(operationResponse);
 
-        when(mockCardAuthoriseService.doAuthoriseSync(any(), any(), any())).thenReturn(authorisationResponse);
+        when(mockCardAuthoriseService.doAuthoriseMotoApi(any(), any(), any())).thenReturn(authorisationResponse);
     }
 
     private static void mockAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus authoriseStatus) {
@@ -412,6 +412,6 @@ class CardResourceTest {
 
         AuthorisationResponse authorisationResponse = new AuthorisationResponse(operationResponse);
 
-        when(mockCardAuthoriseService.doAuthoriseSync(any(), any(), any())).thenReturn(authorisationResponse);
+        when(mockCardAuthoriseService.doAuthoriseMotoApi(any(), any(), any())).thenReturn(authorisationResponse);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -129,7 +129,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
-        chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
+        ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
@@ -31,7 +31,6 @@ public abstract class CardServiceTest {
     protected MetricRegistry mockMetricRegistry;
     @Mock
     protected ChargeDao mockedChargeDao;
-    protected ChargeService chargeService;
     @Mock
     protected ChargeEventDao mockedChargeEventDao;
     @Mock

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -105,4 +105,15 @@ public class StripeMockClient {
         String payload = TestTemplateResourceLoader.load(STRIPE_TRANSFER_RESPONSE);
         setupResponse(payload, "/v1/transfers/" + transferid + "/reversals", 200);
     }
+    
+    public void mockCreatePaymentIntentDelayedResponse() {
+        String responseBody = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE);
+        String path = "/v1/payment_intents";
+        wireMockServer.stubFor(post(urlPathEqualTo(path))
+                .withHeader(CONTENT_TYPE, matching(APPLICATION_FORM_URLENCODED))
+                .willReturn(aResponse().withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withStatus(200)
+                        .withFixedDelay(100)
+                        .withBody(responseBody)));
+    }
 }


### PR DESCRIPTION
Time out a request to authorise a MOTO API payment made through the `/v1/api/charges/authorise` endpoint after a defined period of time, and transition the charge into the AUTHORISATION_TIMEOUT when it is timed out. Return a 500 response to the API request with error_identifier AUTHORISATION_TIMEOUT.

This differs from authorisations made via the `/v1/frontend/charges/{chargeId}/cards`, where we will respond to the request if the authorisation hasn't finished after a defined period of time, but allow the authorisation to continue on a background thread.

Call the separate `authoriseMotoApi` method in PaymentProvider to perform the authorisation. This differs from the `authorise` method called for web payments in that it will not attempt to update the charge in the database. This means that it is safe to update the charge to AUTHORISATION_TIMEOUT if the timeout is hit and then respond to the API request while the authorisation operation is still ongoing.