### PR TITLE
PP-9632 Allow specifying reply-to email per gateway account

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
@@ -96,7 +96,7 @@ public class SendRefundEmailIT {
 
         Thread.sleep(500L); // Email sent using ExecutorService task: give it some time to complete
 
-        verify(notificationClient).sendEmail(anyString(), anyString(), anyMap(), isNull());
+        verify(notificationClient).sendEmail(anyString(), anyString(), anyMap(), isNull(), isNull());
     }
 
     private void addGatewayAccount() {

--- a/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceEmailCollectionModeTest.java
+++ b/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceEmailCollectionModeTest.java
@@ -95,7 +95,7 @@ public class UserNotificationServiceEmailCollectionModeTest {
 
         if ("OPTIONAL".equals(emailCollectionMode) && "email@example.com".equals(emailAddress) && shouldEmailBeSent) {
             when(notifyClientFactory.getInstance()).thenReturn(notificationClient);
-            when(notificationClient.sendEmail(anyString(), anyString(), anyMap(), isNull())).thenReturn(mockNotificationCreatedResponse);
+            when(notificationClient.sendEmail(anyString(), anyString(), anyMap(), isNull(), isNull())).thenReturn(mockNotificationCreatedResponse);
             when(metricRegistry.histogram(anyString())).thenReturn(mock(Histogram.class));
             when(notifyClientFactory.getInstance()).thenReturn(notificationClient);
             when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(UUID.randomUUID());
@@ -107,6 +107,6 @@ public class UserNotificationServiceEmailCollectionModeTest {
         var chargeEntity = aValidChargeEntity().withEmail(emailAddress).withGatewayAccountEntity(gatewayAccount).build();
         userNotificationService.sendPaymentConfirmedEmail(chargeEntity, chargeEntity.getGatewayAccount()).get(1000, TimeUnit.SECONDS);
 
-        verify(notificationClient, times(shouldEmailBeSent? 1 : 0)).sendEmail(anyString(), anyString(), anyMap(), isNull());
+        verify(notificationClient, times(shouldEmailBeSent? 1 : 0)).sendEmail(anyString(), anyString(), anyMap(), isNull(), isNull());
     }
 }


### PR DESCRIPTION
For gateway accounts that have email custom branding enabled, allow specifying the "email_reply_to_id" that we send to Notify in the request to send an email. This will allow for multiple services for the same organisation to use the same Notify service for custom email branding, but with different reply-to email addresses.

Read the value to send to notify from a "email_reply_to_id" field in the JSON object stored in the "notify_settings" database column on the "gateway_accounts" table. If none is set, don't send a value to Notify so that the default reply-to email address for the Notify service is used.

I have tested this locally, hooking connector up to a test account on Notify and tested sending confirmation emails for a gateway account with custom branding both with and without the "email_reply_to_id" set.