### PR TITLE
PP-9624: Set validateAfterInactivityPeriod

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -185,6 +185,7 @@ jerseyClient:
   retries: 0
   userAgent: connector
   gzipEnabledForRequests: false
+  validateAfterInactivityPeriod: ${VALIDATE_AFTER_INACTIVITY_PERIOD:-0ms}
 
 customJerseyClient:
   # Sets the read timeout to a specified timeout, in


### PR DESCRIPTION
Testing to see if this property helps with the SocketExceptions we're seeing.
It may be that connections need to flushed after inactivity.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
