### PR TITLE
PP-9503 Don't store updated gateway transaction id on ChargeEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -9,10 +9,17 @@ import java.util.Map;
 import java.util.Optional;
 
 public abstract class AuthorisationGatewayRequest implements GatewayRequest {
-    protected ChargeEntity charge;
+    private final ChargeEntity charge;
+    private final String gatewayTransactionId;
     
-    public AuthorisationGatewayRequest(ChargeEntity charge) {
+    protected AuthorisationGatewayRequest(ChargeEntity charge) {
         this.charge = charge;
+        this.gatewayTransactionId = charge.getGatewayTransactionId();
+    }
+    
+    protected AuthorisationGatewayRequest(ChargeEntity charge, String gatewayTransactionId) {
+        this.charge = charge;
+        this.gatewayTransactionId = gatewayTransactionId;
     }
 
     public ChargeEntity getCharge() {
@@ -20,7 +27,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     }
 
     public Optional<String> getTransactionId() {
-        return Optional.ofNullable(charge.getGatewayTransactionId());
+        return Optional.ofNullable(gatewayTransactionId);
     }
 
     public String getAmount() {

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
@@ -3,13 +3,16 @@ package uk.gov.pay.connector.gateway.model.request;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 
-import java.util.Map;
-
 public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest {
     private AuthCardDetails authCardDetails;
-    
+
     public CardAuthorisationGatewayRequest(ChargeEntity charge, AuthCardDetails authCardDetails) {
         super(charge);
+        this.authCardDetails = authCardDetails;
+    }
+
+    private CardAuthorisationGatewayRequest(ChargeEntity charge, AuthCardDetails authCardDetails, String gatewayTransactionId) {
+        super(charge, gatewayTransactionId);
         this.authCardDetails = authCardDetails;
     }
 
@@ -21,8 +24,10 @@ public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest
         return new CardAuthorisationGatewayRequest(charge, authCardDetails);
     }
 
-    @Override
-    public Map<String, String> getGatewayCredentials() {
-        return charge.getGatewayAccountCredentialsEntity().getCredentials();
+    public static CardAuthorisationGatewayRequest valueOf(CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest, String gatewayTransactionId) {
+        return new CardAuthorisationGatewayRequest(
+                cardAuthorisationGatewayRequest.getCharge(),
+                cardAuthorisationGatewayRequest.getAuthCardDetails(),
+                gatewayTransactionId);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -195,9 +195,9 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                     response,
                     request.getCharge().getChargeStatus(),
                     request.getCharge().getChargeStatus());
-            
-            request.getCharge().setGatewayTransactionId(newTransactionId());
-            response = worldpayAuthoriseHandler.authoriseWithoutExemption(request);
+
+            CardAuthorisationGatewayRequest newRequest = CardAuthorisationGatewayRequest.valueOf(request, newTransactionId());
+            response = worldpayAuthoriseHandler.authoriseWithoutExemption(newRequest);
         } 
 
         return response;

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthorisationGatewayRequest.java
@@ -4,8 +4,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
 
-import java.util.Map;
-
 public class WalletAuthorisationGatewayRequest extends AuthorisationGatewayRequest {
     private WalletAuthorisationData walletAuthorisationData;
 
@@ -20,10 +18,5 @@ public class WalletAuthorisationGatewayRequest extends AuthorisationGatewayReque
 
     public static WalletAuthorisationGatewayRequest valueOf(ChargeEntity charge, WalletAuthorisationData applePaymentData) {
         return new WalletAuthorisationGatewayRequest(charge, applePaymentData);
-    }
-
-    @Override
-    public Map<String, String> getGatewayCredentials() {
-        return charge.getGatewayAccountCredentialsEntity().getCredentials();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -369,7 +369,8 @@ public class WorldpayPaymentProviderTest {
 
         assertTrue(response.getBaseResponse().isPresent());
         assertEquals(secondResponse.getBaseResponse().get(), response.getBaseResponse().get());
-        assertNotEquals(cardAuthRequest.getCharge().getGatewayTransactionId(), gatewayTransactionId);
+        assertThat(cardAuthRequest.getTransactionId().isPresent(), is(true));
+        assertNotEquals(cardAuthRequest.getTransactionId().get(), gatewayTransactionId);
 
         ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseMotoApiPaymentIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseMotoApiPaymentIT.java
@@ -26,6 +26,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_QUEUED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.client.cardid.model.CardInformationFixture.aCardInformation;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonForMotoApiPaymentAuthorisation;
@@ -35,7 +36,7 @@ import static uk.gov.service.payments.commons.model.ErrorIdentifier.INVALID_ATTR
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml",
-        configOverrides = {@ConfigOverride(key = "captureProcessConfig.backgroundProcessingEnabled", value = "true")},
+        configOverrides = {@ConfigOverride(key = "captureProcessConfig.backgroundProcessingEnabled", value = "false")},
         withDockerSQS = true
 )
 public class CardResourceAuthoriseMotoApiPaymentIT extends ChargingITestBase {
@@ -94,9 +95,7 @@ public class CardResourceAuthoriseMotoApiPaymentIT extends ChargingITestBase {
         shouldAuthoriseChargeFor(validPayload);
 
         assertThat(databaseTestHelper.isChargeTokenUsed(token.getSecureRedirectToken()), is(true));
-        // Charge will be captured by the capture queue, which is not immediate. Check the charge state is the expected
-        // state before or after the capture has been processed.
-        assertThat(databaseTestHelper.getChargeStatus(charge.getChargeId()), anyOf(is(CAPTURE_QUEUED.getValue()), is(CAPTURED.getValue())));
+        assertThat(databaseTestHelper.getChargeStatus(charge.getChargeId()), is(CAPTURE_QUEUED.getValue()));
     }
 
     @Test


### PR DESCRIPTION
When making an authorisation for Worldpay, if we request a 3DS exemption and it is soft declined, we need to make the second authorisation request with a new gateway transaction id (order code).

We were updating the gatewayTransactionId field on the ChargeEntity to store this new id for retrieval when building the request to send to Worldpay. This is confusing, as this updated value is never persisted until after the Authorisation is complete, when it is extracted from the BaseGatewayResponse.

Improve this by storing the gateway transaction id in a separate field on the AuthorisationGatewayRequest. When we make the second authorisation request in WorldpayPaymentProvider, construct a new CardAuthorisationGatewayRequest from the original request and a new gatewayTransactionId. This pattern will become more obvious when the AuthorisationGatewayRequest no longer allows retrieval of the ChargeEntity object.

Also remove the overridden `getGatewayCredentials` on CardAuthorisationGatewayRequest and WalletAuthorisationGatewayRequest as these just duplicated the method on the abstract class.