### PR TITLE
PP-9629: Set connTTL to 60sec for Connection Manager

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/ClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/ClientFactory.java
@@ -106,7 +106,7 @@ public class ClientFactory {
                 new ManagedHttpClientConnectionFactory(),
                 null,
                 SystemDefaultDnsResolver.INSTANCE,
-                -1,
+                60000,
                 TimeUnit.MILLISECONDS,
                 format("%s.%s", gatewayName, operation)
         );


### PR DESCRIPTION
Part of investigation into Worldpay connection resets.

This setting should discard pool connections after they have been alive for 60sec, once they are no longer in use.
The setting is currently `-1` i.e. keep alive for ever, which we suspect is not being respected by the [Worldpay test environment firewall](https://techdocs.akamai.com/property-mgr/docs/persistent-connections-client-to-edge). 

See [this article](https://danlebrero.com/2019/12/11/apache-http-client-timeouts-config-production-asynchronous-http-client-pictures/): "_But why do we need the TTL? Mostly because firewalls have this tendency on dropping long live connections (especially idle ones) without telling any of the involved parts, which causes the client to take a while to realize that the connection is no longer usable._"