### PR TITLE
PP-9503 Add ChargeEntity parameter to authorise method

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -27,7 +27,7 @@ public interface PaymentProvider {
 
     Optional<String> generateTransactionId();
 
-    GatewayResponse authorise(CardAuthorisationGatewayRequest request) throws GatewayException;
+    GatewayResponse authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) throws GatewayException;
 
     ChargeQueryResponse queryPaymentStatus(ChargeQueryGatewayRequest chargeQueryGatewayRequest) throws GatewayException;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -112,7 +112,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) throws GatewayException {
+    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) throws GatewayException {
         URI url = URI.create(String.format("%s/%s", gatewayUrlMap.get(request.getGatewayAccount().getType()), ROUTE_FOR_NEW_ORDER));
         GatewayClient.Response response = authoriseClient.postRequestFor(
                 url,

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -54,7 +54,7 @@ public class SandboxPaymentProvider implements PaymentProvider, SandboxGatewayRe
     }
     
     @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) {
+    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) {
         String cardNumber = request.getAuthCardDetails().getCardNo();
         var gatewayResponse = getSandboxGatewayResponse(cardNumber);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -85,7 +85,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) throws GatewayException {
+    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) throws GatewayException {
         GatewayClient.Response response = client.postRequestFor(
                 gatewayUrlMap.get(request.getGatewayAccount().getType()),
                 SMARTPAY,

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -100,7 +100,7 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse authorise(CardAuthorisationGatewayRequest request) {
+    public GatewayResponse authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) {
         return stripeAuthoriseHandler.authorise(request);
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -172,7 +172,7 @@ public class CardAuthoriseService {
     }
 
     private GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity charge, AuthCardDetails authCardDetails) throws GatewayException {
-        return getPaymentProviderFor(charge).authorise(CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails));
+        return getPaymentProviderFor(charge).authorise(CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails), charge);
     }
 
     private PaymentProvider getPaymentProviderFor(ChargeEntity chargeEntity) {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsIT.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.epdq;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
@@ -26,7 +27,8 @@ public class EpdqPaymentProvider3dsIT extends BaseEpdqPaymentProviderIT {
     @Test
     public void shouldRequire3dsAuthoriseRequest() throws Exception {
         mockPaymentProviderResponse(200, successAuth3dResponse());
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisation3dsRequest());
+        ChargeEntity charge = buildTestChargeFor3ds1GatewayAccount();
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildCardAuthorisationGatewayRequest(charge), charge);
         verifyPaymentProviderRequest(successAuth3dsRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(REQUIRES_3DS));
@@ -35,7 +37,8 @@ public class EpdqPaymentProvider3dsIT extends BaseEpdqPaymentProviderIT {
     @Test
     public void shouldRequire3dsFor3ds2AuthoriseRequestWithDefaultParameters() throws Exception {
         mockPaymentProviderResponse(200, successAuth3dResponse());
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisation3ds2Request());
+        ChargeEntity charge = buildTestChargeFor3ds2GatewayAccount();
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildCardAuthorisationGatewayRequest(charge), charge);
         verifyPaymentProviderRequest(successAuth3ds2Request());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(REQUIRES_3DS));
@@ -44,7 +47,8 @@ public class EpdqPaymentProvider3dsIT extends BaseEpdqPaymentProviderIT {
     @Test
     public void shouldRequire3dsFor3ds2AuthoriseRequestWithProvidedParameters() throws Exception {
         mockPaymentProviderResponse(200, successAuth3dResponse());
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisation3ds2RequestWithProvidedParameters());
+        ChargeEntity charge = buildTestChargeFor3ds2GatewayAccount();
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisation3ds2RequestWithProvidedParameters(charge), charge);
         verifyPaymentProviderRequest(successAuth3ds2RequestWithProvidedParameters());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(REQUIRES_3DS));

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -77,7 +77,8 @@ public class SandboxPaymentProviderTest {
     void authorise_shouldBeAuthorisedWhenCardNumIsExpectedToSucceedForAuthorisation() {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_SUCCESS_CARD_NUMBER);
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
+        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
         assertThat(gatewayResponse.isSuccessful(), is(true));
         assertThat(gatewayResponse.isFailed(), is(false));
@@ -97,11 +98,11 @@ public class SandboxPaymentProviderTest {
     void authorise_shouldSetRecurringAuthToken() {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_SUCCESS_CARD_NUMBER);
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity()
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withPaymentProvider(SANDBOX.getName())
                 .withCardDetails(ChargeEntityFixture.defaultCardDetails())
-                .build(), 
-                authCardDetails));
+                .build();
+        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
         assertThat(gatewayResponse.isSuccessful(), is(true));
         assertThat(gatewayResponse.isFailed(), is(false));
@@ -122,7 +123,8 @@ public class SandboxPaymentProviderTest {
 
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_REJECTED_CARD_NUMBER);
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
+        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
         assertThat(gatewayResponse.isSuccessful(), is(true));
         assertThat(gatewayResponse.isFailed(), is(false));
@@ -142,7 +144,8 @@ public class SandboxPaymentProviderTest {
 
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_ERROR_CARD_NUMBER);
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
+        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
         assertThat(gatewayResponse.isSuccessful(), is(false));
         assertThat(gatewayResponse.isFailed(), is(true));
@@ -159,7 +162,8 @@ public class SandboxPaymentProviderTest {
 
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo("3456789987654567");
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
+        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
         assertThat(gatewayResponse.isSuccessful(), is(false));
         assertThat(gatewayResponse.isFailed(), is(true));

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -69,7 +69,7 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
                 .build();
 
         CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(cardAuthorisationGatewayRequest);
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(cardAuthorisationGatewayRequest, chargeEntity);
 
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().isPresent(), is(true));
@@ -102,7 +102,7 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
                 .build();
 
         CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(cardAuthorisationGatewayRequest);
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(cardAuthorisationGatewayRequest, chargeEntity);
 
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().isPresent(), is(true));
@@ -130,7 +130,7 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
                 .build();
         mockSmartpay3dsRequiredOrderSubmitResponse();
 
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails));
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails), chargeEntity);
 
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().isPresent(), is(true));

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -178,7 +178,7 @@ public class WorldpayPaymentProviderTest {
         when(worldpayAuthoriseHandler.authoriseWithExemption(cardAuthRequest))
                 .thenReturn(responseBuilder().withGatewayError(gatewayConnectionError("connetion problemo")).build());
 
-        worldpayPaymentProvider.authorise(cardAuthRequest);
+        worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verify(chargeDao, never()).merge(any(ChargeEntity.class));
     }
@@ -191,12 +191,13 @@ public class WorldpayPaymentProviderTest {
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(null);
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
 
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), anAuthCardDetails().build());
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
 
         when(worldpayAuthoriseHandler.authoriseWithoutExemption(cardAuthRequest))
                 .thenReturn(getGatewayResponse(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
 
-        worldpayPaymentProvider.authorise(cardAuthRequest);
+        worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_NOT_REQUESTED);
         verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_NOT_REQUESTED);
@@ -217,12 +218,13 @@ public class WorldpayPaymentProviderTest {
                 aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(false).build());
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
 
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), anAuthCardDetails().build());
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
 
         when(worldpayAuthoriseHandler.authoriseWithoutExemption(cardAuthRequest))
                 .thenReturn(getGatewayResponse(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
 
-        worldpayPaymentProvider.authorise(cardAuthRequest);
+        worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_NOT_REQUESTED);
         verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_NOT_REQUESTED);
@@ -236,12 +238,13 @@ public class WorldpayPaymentProviderTest {
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
 
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), anAuthCardDetails().build());
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
 
         when(worldpayAuthoriseHandler.authoriseWithoutExemption(cardAuthRequest))
                 .thenReturn(getGatewayResponse(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
 
-        worldpayPaymentProvider.authorise(cardAuthRequest);
+        worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_NOT_REQUESTED);
         verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_NOT_REQUESTED);
@@ -262,7 +265,7 @@ public class WorldpayPaymentProviderTest {
         when(worldpayAuthoriseHandler.authoriseWithoutExemption(cardAuthRequest))
                 .thenReturn(getGatewayResponse(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
 
-        worldpayPaymentProvider.authorise(cardAuthRequest);
+        worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_REJECTED);
         verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_REJECTED);
@@ -282,7 +285,7 @@ public class WorldpayPaymentProviderTest {
         when(worldpayAuthoriseHandler.authoriseWithoutExemption(cardAuthRequest))
                 .thenReturn(getGatewayResponse(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
 
-        worldpayPaymentProvider.authorise(cardAuthRequest);
+        worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_OUT_OF_SCOPE);
         verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_OUT_OF_SCOPE);
@@ -319,7 +322,7 @@ public class WorldpayPaymentProviderTest {
 
         when(worldpayAuthoriseHandler.authoriseWithExemption(cardAuthRequest)).thenReturn(getGatewayResponse(worldpayXmlResponse));
 
-        worldpayPaymentProvider.authorise(cardAuthRequest);
+        worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verify(worldpayAuthoriseHandler, never()).authoriseWithoutExemption(cardAuthRequest);
     }
@@ -339,7 +342,7 @@ public class WorldpayPaymentProviderTest {
         when(worldpayAuthoriseHandler.authoriseWithExemption(cardAuthRequest))
                 .thenReturn(getGatewayResponse(WORLDPAY_EXEMPTION_REQUEST_HONOURED_RESPONSE));
 
-        worldpayPaymentProvider.authorise(cardAuthRequest);
+        worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_HONOURED);
         verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_HONOURED);
@@ -365,7 +368,7 @@ public class WorldpayPaymentProviderTest {
         var secondResponse = getGatewayResponse(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE);
         when(worldpayAuthoriseHandler.authoriseWithoutExemption(cardAuthRequest)).thenReturn(secondResponse);
 
-        GatewayResponse<WorldpayOrderStatusResponse> response = worldpayPaymentProvider.authorise(cardAuthRequest);
+        GatewayResponse<WorldpayOrderStatusResponse> response = worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         assertTrue(response.getBaseResponse().isPresent());
         assertEquals(secondResponse.getBaseResponse().get(), response.getBaseResponse().get());

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -145,7 +145,7 @@ public class EpdqPaymentProviderTest {
     public void shouldAuthoriseSuccessfully() throws Exception {
         setUpAndCheckThatEpdqIsUp();
         var request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetailsFixture().build());
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
     }
 
@@ -158,7 +158,7 @@ public class EpdqPaymentProviderTest {
 
         var request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
 
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
     }
 
@@ -166,7 +166,7 @@ public class EpdqPaymentProviderTest {
     public void shouldAuthoriseWith3dsOnSuccessfully() throws Exception {
         setUpFor3dsAndCheckThatEpdqIsUp();
         var request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetailsFixtureThatWillRequire3ds1().build());
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(REQUIRES_3DS));
     }
@@ -181,7 +181,7 @@ public class EpdqPaymentProviderTest {
                 .build();
 
         var request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(REQUIRES_3DS));
     }
@@ -190,7 +190,7 @@ public class EpdqPaymentProviderTest {
     public void shouldAuthoriseWith3ds2OnSuccessfully() throws Exception {
         setUpFor3ds2AndCheckThatEpdqIsUp();
         var request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetailsFixtureThatWillRequire3ds2().build());
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(REQUIRES_3DS));
     }
@@ -218,7 +218,7 @@ public class EpdqPaymentProviderTest {
                 .withUserAgentHeader(userAgentHeaderLongerThanEpdq3ds2LimitOf2048Characters)
                 .withJsNavigatorLanguage(languageTagLongerThanEpdq3ds2LimitOf8Characters)
                 .build());
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(REQUIRES_3DS));
     }
@@ -227,7 +227,7 @@ public class EpdqPaymentProviderTest {
     public void shouldCheckAuthorisationStatusSuccessfully() throws Exception {
         setUpAndCheckThatEpdqIsUp();
         var request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetailsFixture().build());
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
 
@@ -246,7 +246,7 @@ public class EpdqPaymentProviderTest {
                 .build();
 
         var request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
     }
 
@@ -255,7 +255,7 @@ public class EpdqPaymentProviderTest {
         setUpAndCheckThatEpdqIsUp();
 
         var request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetailsFixture().build());
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
 
         String transactionId = response.getBaseResponse().get().getTransactionId();
@@ -270,7 +270,7 @@ public class EpdqPaymentProviderTest {
     public void shouldCancelSuccessfully() throws Exception {
         setUpAndCheckThatEpdqIsUp();
         var request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetailsFixture().build());
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
 
         String transactionId = response.getBaseResponse().get().getTransactionId();
@@ -285,7 +285,7 @@ public class EpdqPaymentProviderTest {
         setUpAndCheckThatEpdqIsUp();
 
         var request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetailsFixture().build());
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
 
         String transactionId = response.getBaseResponse().get().getTransactionId();
@@ -304,7 +304,7 @@ public class EpdqPaymentProviderTest {
         setUpAndCheckThatEpdqIsUp();
 
         var request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetailsFixture().build());
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertThat(response.isSuccessful(), is(true));
 
         ChargeQueryGatewayRequest chargeQueryGatewayRequest = ChargeQueryGatewayRequest.valueOf(Charge.from(chargeEntity), chargeEntity.getGatewayAccount(), chargeEntity.getGatewayAccountCredentialsEntity());

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -122,7 +122,7 @@ public class SmartpayPaymentProviderTest {
     public void shouldSendSuccessfullyAnOrderForMerchant() throws Exception {
         PaymentProvider paymentProvider = getSmartpayPaymentProvider();
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(chargeEntity);
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertTrue(response.isSuccessful());
     }
 
@@ -136,7 +136,7 @@ public class SmartpayPaymentProviderTest {
 
         CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
 
-        GatewayResponse response = paymentProvider.authorise(request);
+        GatewayResponse response = paymentProvider.authorise(request, chargeEntity);
         assertTrue(response.isSuccessful());
     }
 
@@ -157,7 +157,7 @@ public class SmartpayPaymentProviderTest {
 
         CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
 
-        GatewayResponse response = paymentProvider.authorise(request);
+        GatewayResponse response = paymentProvider.authorise(request, chargeEntity);
         assertTrue(response.isSuccessful());
     }
 
@@ -178,7 +178,7 @@ public class SmartpayPaymentProviderTest {
 
         CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
 
-        GatewayResponse response = paymentProvider.authorise(request);
+        GatewayResponse response = paymentProvider.authorise(request, chargeEntity);
         assertTrue(response.isSuccessful());
     }
 
@@ -187,7 +187,7 @@ public class SmartpayPaymentProviderTest {
         gatewayAccountEntity.setRequires3ds(true);
         PaymentProvider paymentProvider = getSmartpayPaymentProvider();
         CardAuthorisationGatewayRequest request = getCard3dsAuthorisationRequest(chargeEntity);
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertTrue(response.isSuccessful());
         Auth3dsRequiredEntity auth3dsRequiredEntity = response.getBaseResponse().get().getGatewayParamsFor3ds().get().toAuth3dsRequiredEntity();
         assertThat(auth3dsRequiredEntity.getIssuerUrl(), is(notNullValue()));
@@ -206,7 +206,7 @@ public class SmartpayPaymentProviderTest {
                 .build();
 
         CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertTrue(response.isSuccessful());
         Auth3dsRequiredEntity auth3dsRequiredEntity = response.getBaseResponse().get().getGatewayParamsFor3ds().get().toAuth3dsRequiredEntity();
         assertThat(auth3dsRequiredEntity.getIssuerUrl(), is(notNullValue()));
@@ -234,7 +234,7 @@ public class SmartpayPaymentProviderTest {
 
         chargeEntity.setGatewayAccount(accountWithInvalidCredentials);
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(chargeEntity);
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
 
         assertFalse(response.isSuccessful());
         assertNotNull(response.getGatewayError());
@@ -245,7 +245,7 @@ public class SmartpayPaymentProviderTest {
         PaymentProvider paymentProvider = getSmartpayPaymentProvider();
 
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(chargeEntity);
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
 
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().isPresent(), is(true));
@@ -264,7 +264,7 @@ public class SmartpayPaymentProviderTest {
     public void shouldSuccessfullySendACancelRequest() throws Exception {
         PaymentProvider paymentProvider = getSmartpayPaymentProvider();
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(chargeEntity);
-        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request, chargeEntity);
         assertTrue(response.isSuccessful());
 
         assertThat(response.getBaseResponse().isPresent(), is(true));
@@ -283,7 +283,7 @@ public class SmartpayPaymentProviderTest {
     public void shouldRefundToAnExistingPaymentSuccessfully() throws Exception {
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(chargeEntity);
         PaymentProvider smartpay = getSmartpayPaymentProvider();
-        GatewayResponse<BaseAuthoriseResponse> authoriseResponse = smartpay.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> authoriseResponse = smartpay.authorise(request, chargeEntity);
         assertTrue(authoriseResponse.isSuccessful());
 
         SmartpayAuthorisationResponse smartpayAuthorisationResponse = (SmartpayAuthorisationResponse) authoriseResponse.getBaseResponse().get();

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -80,8 +80,9 @@ public class StripePaymentProviderTest {
                 .withAddress(null)
                 .withEndDate(CardExpiryDate.valueOf("01/30"))
                 .build();
-        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(getCharge(), authCardDetails);
-        GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request);
+        ChargeEntity charge = getCharge();
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
+        GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
         assertTrue(gatewayResponse.isSuccessful());
     }
@@ -98,8 +99,9 @@ public class StripePaymentProviderTest {
                 .withAddress(usAddress)
                 .withEndDate(CardExpiryDate.valueOf("01/30"))
                 .build();
-        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(getCharge(), authCardDetails);
-        GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request);
+        ChargeEntity charge = getCharge();
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
+        GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
         assertTrue(gatewayResponse.isSuccessful());
     }
@@ -116,8 +118,9 @@ public class StripePaymentProviderTest {
                 .withAddress(canadaAddress)
                 .withEndDate(CardExpiryDate.valueOf("01/30"))
                 .build();
-        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(getCharge(), authCardDetails);
-        GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request);
+        ChargeEntity charge = getCharge();
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
+        GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
         assertTrue(gatewayResponse.isSuccessful());
     }
@@ -218,9 +221,10 @@ public class StripePaymentProviderTest {
     }
 
     private GatewayResponse<BaseAuthoriseResponse> authorise() {
-        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(getCharge(),
+        ChargeEntity charge = getCharge();
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge,
                 anAuthCardDetails().withEndDate(CardExpiryDate.valueOf("01/21")).build());
-        return stripePaymentProvider.authorise(request);
+        return stripePaymentProvider.authorise(request, charge);
     }
 
     private ChargeEntity getChargeWithTransactionId(String transactionId) {

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -168,8 +168,9 @@ public class WorldpayPaymentProviderTest {
                 .withCardHolder("EE.REJECTED_ISSUER_REJECTED.SOFT_DECLINED")
                 .withWorldpay3dsFlexDdcResult(UUID.randomUUID().toString())
                 .build();
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        ChargeEntity charge = createChargeEntity();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getBaseResponse().get().getLastEvent().isPresent());
         assertEquals(response.getBaseResponse().get().getLastEvent().get(), "AUTHORISED");
@@ -187,8 +188,9 @@ public class WorldpayPaymentProviderTest {
                 .withCardHolder("EE.HONOURED_ISSUER_HONOURED.AUTHORISED")
                 .withWorldpay3dsFlexDdcResult(UUID.randomUUID().toString())
                 .build();
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        ChargeEntity charge = createChargeEntity();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getBaseResponse().get().getLastEvent().isPresent());
         assertEquals(response.getBaseResponse().get().getLastEvent().get(), "AUTHORISED");
@@ -201,8 +203,9 @@ public class WorldpayPaymentProviderTest {
     public void submit3DS2FlexAuthRequest() {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         var authCardDetails = anAuthCardDetails().withWorldpay3dsFlexDdcResult(UUID.randomUUID().toString()).build();
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        ChargeEntity charge = createChargeEntity();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
     }
 
@@ -213,8 +216,9 @@ public class WorldpayPaymentProviderTest {
                 .withCardHolder(MAGIC_CARDHOLDER_NAME_FOR_3DS_FLEX_CHALLENGE_REQUIRED_RESPONSE)
                 .withWorldpay3dsFlexDdcResult(UUID.randomUUID().toString())
                 .build();
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        ChargeEntity charge = createChargeEntity();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
         response.getBaseResponse().ifPresent(res -> {
             assertThat(res.getGatewayParamsFor3ds().isPresent(), is(true));
@@ -229,8 +233,9 @@ public class WorldpayPaymentProviderTest {
     public void shouldBeAbleToSendAuthorisationRequestForMerchant() {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         AuthCardDetails authCardDetails = anAuthCardDetails().build();
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        ChargeEntity charge = createChargeEntity();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
     }
 
@@ -238,8 +243,9 @@ public class WorldpayPaymentProviderTest {
     public void shouldBeAbleToSendAuthorisationRequestForMerchantWithoutAddress() {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         AuthCardDetails authCardDetails = anAuthCardDetails().withAddress(null).build();
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        ChargeEntity charge = createChargeEntity();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
     }
 
@@ -253,8 +259,9 @@ public class WorldpayPaymentProviderTest {
         usAddress.setCity("Washington D.C.");
         usAddress.setCountry("US");
         AuthCardDetails authCardDetails = anAuthCardDetails().withAddress(usAddress).build();
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        ChargeEntity charge = createChargeEntity();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
     }
 
@@ -268,8 +275,9 @@ public class WorldpayPaymentProviderTest {
         canadaAddress.setCity("Arctic Bay");
         canadaAddress.setCountry("CA");
         AuthCardDetails authCardDetails = anAuthCardDetails().withAddress(canadaAddress).build();
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        ChargeEntity charge = createChargeEntity();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
     }
 
@@ -280,8 +288,9 @@ public class WorldpayPaymentProviderTest {
                 .withCardHolder(MAGIC_CARDHOLDER_NAME_THAT_MAKES_WORLDPAY_TEST_REQUIRE_3DS)
                 .build();
 
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequestWithRequired3ds(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        ChargeEntity charge = createChargeWithRequires3ds();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
 
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getSessionIdentifier().isPresent());
@@ -299,10 +308,11 @@ public class WorldpayPaymentProviderTest {
                 .withCardHolder(MAGIC_CARDHOLDER_NAME_THAT_MAKES_WORLDPAY_TEST_REQUIRE_3DS)
                 .withAddress(null)
                 .build();
+        
+        ChargeEntity charge = createChargeWithRequires3ds();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
 
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequestWithRequired3ds(authCardDetails);
-
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getSessionIdentifier().isPresent());
         response.getBaseResponse().ifPresent(res -> {
@@ -331,7 +341,7 @@ public class WorldpayPaymentProviderTest {
 
         CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
 
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
 
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getSessionIdentifier().isPresent());
@@ -364,7 +374,7 @@ public class WorldpayPaymentProviderTest {
 
         CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
 
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
 
         assertTrue(response.getSessionIdentifier().isPresent());
         response.getBaseResponse().ifPresent(res -> {
@@ -392,8 +402,10 @@ public class WorldpayPaymentProviderTest {
     public void shouldBeAbleToSubmitAPartialRefundAfterACaptureHasBeenSubmitted() {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         AuthCardDetails authCardDetails = anAuthCardDetails().build();
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+
+        ChargeEntity charge = createChargeEntity();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         String transactionId = response.getBaseResponse().get().getTransactionId();
 
         assertThat(response.getBaseResponse().isPresent(), is(true));
@@ -416,8 +428,9 @@ public class WorldpayPaymentProviderTest {
     public void shouldBeAbleToSendCancelRequestForMerchant() throws Exception {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         AuthCardDetails authCardDetails = anAuthCardDetails().build();
-        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        ChargeEntity charge = createChargeEntity();
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
 
         assertThat(response.getBaseResponse().isPresent(), is(true));
         String transactionId = response.getBaseResponse().get().getTransactionId();
@@ -460,25 +473,23 @@ public class WorldpayPaymentProviderTest {
                 .build();
         AuthCardDetails authCardDetails = anAuthCardDetails().build();
         CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
-        assertFalse(paymentProvider.authorise(request).getBaseResponse().isPresent());
+        assertFalse(paymentProvider.authorise(request, charge).getBaseResponse().isPresent());
     }
 
-    private CardAuthorisationGatewayRequest getCardAuthorisationRequest(AuthCardDetails authCardDetails) {
-        ChargeEntity charge = aValidChargeEntity()
-                .withTransactionId(randomUUID().toString())
-                .withGatewayAccountEntity(validGatewayAccount)
-                .withGatewayAccountCredentialsEntity(validGatewayAccountCredentialsEntity)
-                .build();
-        return new CardAuthorisationGatewayRequest(charge, authCardDetails);
+    private ChargeEntity createChargeEntity() {
+        return aValidChargeEntity()
+                    .withTransactionId(randomUUID().toString())
+                    .withGatewayAccountEntity(validGatewayAccount)
+                    .withGatewayAccountCredentialsEntity(validGatewayAccountCredentialsEntity)
+                    .build();
     }
 
-    private CardAuthorisationGatewayRequest getCardAuthorisationRequestWithRequired3ds(AuthCardDetails authCardDetails) {
-        ChargeEntity charge = aValidChargeEntity()
-                .withTransactionId(randomUUID().toString())
-                .withGatewayAccountEntity(validGatewayAccountFor3ds)
-                .withGatewayAccountCredentialsEntity(validGatewayAccountCredentialsEntityFor3ds)
-                .build();
-        return new CardAuthorisationGatewayRequest(charge, authCardDetails);
+    private ChargeEntity createChargeWithRequires3ds() {
+        return aValidChargeEntity()
+                    .withTransactionId(randomUUID().toString())
+                    .withGatewayAccountEntity(validGatewayAccountFor3ds)
+                    .withGatewayAccountCredentialsEntity(validGatewayAccountCredentialsEntityFor3ds)
+                    .build();
     }
 
     private WorldpayPaymentProvider getValidWorldpayPaymentProvider() {

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -223,7 +223,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     }
 
     private void setupPaymentProviderMock(Exception gatewayError) throws Exception {
-        when(mockedPaymentProvider.authorise(any())).thenThrow(gatewayError);
+        when(mockedPaymentProvider.authorise(any(), any())).thenThrow(gatewayError);
     }
 
     @Test
@@ -424,7 +424,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.generateTransactionId()).thenReturn(Optional.of(generatedTransactionId));
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
-        when(mockedPaymentProvider.authorise(any())).thenThrow(RuntimeException.class);
+        when(mockedPaymentProvider.authorise(any(), any())).thenThrow(RuntimeException.class);
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
 
@@ -727,7 +727,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.generateTransactionId()).thenReturn(Optional.of(generatedTransactionId));
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
-        when(mockedPaymentProvider.authorise(any())).thenThrow(RuntimeException.class);
+        when(mockedPaymentProvider.authorise(any(), any())).thenThrow(RuntimeException.class);
 
         try {
             AuthorisationResponse response = cardAuthorisationService.doAuthoriseSync(charge, aCardInformation().build(), authoriseRequest);
@@ -858,7 +858,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     }
 
     private void providerWillRespondToAuthoriseWith(GatewayResponse value) throws Exception {
-        when(mockedPaymentProvider.authorise(any())).thenReturn(value);
+        when(mockedPaymentProvider.authorise(any(), any())).thenReturn(value);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.generateTransactionId()).thenReturn(Optional.empty());
@@ -880,7 +880,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         GatewayResponse epdq3dsResponse = gatewayResponseBuilder
                 .withResponse(epdqResponse)
                 .build();
-        when(mockedPaymentProvider.authorise(any())).thenReturn(epdq3dsResponse);
+        when(mockedPaymentProvider.authorise(any(), any())).thenReturn(epdq3dsResponse);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.generateTransactionId()).thenReturn(Optional.of(TRANSACTION_ID));

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -272,7 +272,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
         GatewayResponse<WorldpayOrderStatusResponse> responseBuilder = responseBuilder()
                 .withResponse(worldpayOrderStatusResponse)
                 .withSessionIdentifier(sessionIdentifier).build();
-        when(mockedWorldpayPaymentProvider.authorise(any())).thenReturn(responseBuilder);
+        when(mockedWorldpayPaymentProvider.authorise(any(), any())).thenReturn(responseBuilder);
         return worldpayOrderStatusResponse;
     }
 


### PR DESCRIPTION
Add a ChargeEntity parameter to the PaymentProvider.authorise method.

Previously this was passed inside the AuthorisationGatewayRequest. However, we don't want the code that does the actual authorisation HTTP request to have access to the ChargeEntity as this code should not be able to persist any data on the charge.

The WorldpayPaymentProvider requires the ChargeEntity as it needs to do some updates to charge using the result of a 3DS exemption request.

We are doing this because want to create a separate authorisation method that doesn't need the ChargeEntity and does not attempt to persist anything for use by the MOTO authorisation API code, which will run this code in a separate thread with a timeout before attempting to update the charge itself. This code will  still need to use the AuthorisationGatewayRequest, so removing the  ChargeEntity from this will make it easier for us to discourage introducing persistence to this code path which could cause database conflicts.