### PR TITLE
PP-9503 Don't store ChargeEntity on AuthorisationGatewayRequest

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -45,6 +46,6 @@ public interface PaymentProvider {
 
     ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundEntityList);
     
-    AuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails);
+    AuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails);
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqAuthorisationRequestSummary.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.epdq;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
@@ -14,11 +15,11 @@ public class EpdqAuthorisationRequestSummary implements AuthorisationRequestSumm
     private final Presence dataFor3ds2;
     private final String ipAddress;
 
-    public EpdqAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+    public EpdqAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
-        dataFor3ds = chargeEntity.getGatewayAccount().isRequires3ds() ? PRESENT : NOT_PRESENT;
-        dataFor3ds2 = (chargeEntity.getGatewayAccount().isRequires3ds()
-                && chargeEntity.getGatewayAccount().getIntegrationVersion3ds() == 2) ? PRESENT : NOT_PRESENT;
+        dataFor3ds = gatewayAccount.isRequires3ds() ? PRESENT : NOT_PRESENT;
+        dataFor3ds2 = (gatewayAccount.isRequires3ds()
+                && gatewayAccount.getIntegrationVersion3ds() == 2) ? PRESENT : NOT_PRESENT;
         ipAddress = authCardDetails.getIpAddress().orElse(null);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -43,6 +43,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -247,8 +248,8 @@ public class EpdqPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public EpdqAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
-        return new EpdqAuthorisationRequestSummary(chargeEntity, authCardDetails);
+    public EpdqAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
+        return new EpdqAuthorisationRequestSummary(gatewayAccount, authCardDetails);
     }
 
     /**
@@ -307,7 +308,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
 
         if (request.getGatewayAccount().isRequires3ds()) {
             if (request.getGatewayAccount().getIntegrationVersion3ds() == 2) {
-                epdqPayloadDefinition = new EpdqPayloadDefinitionForNew3ds2Order(frontendUrl, request.getGatewayAccount().isSendPayerIpAddressToGateway(), request.getCharge().getLanguage(), clock);
+                epdqPayloadDefinition = new EpdqPayloadDefinitionForNew3ds2Order(frontendUrl, request.getGatewayAccount().isSendPayerIpAddressToGateway(), request.getLanguage(), clock);
             } else {
                 epdqPayloadDefinition = new EpdqPayloadDefinitionForNew3dsOrder(frontendUrl);
             }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.model.request;
 
+import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.gateway.GatewayOperation;
@@ -17,7 +18,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     private final boolean moto;
     private final String amount;
     private final String description;
-    private final String reference;
+    private final ServicePaymentReference reference;
     private final String chargeExternalId;
     private final Map<String, String> credentials;
     private final GatewayAccountEntity gatewayAccount;
@@ -31,7 +32,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.moto = charge.isMoto();
         this.amount = String.valueOf(CorporateCardSurchargeCalculator.getTotalAmountFor(charge));
         this.description = charge.getDescription();
-        this.reference = charge.getReference().toString();
+        this.reference = charge.getReference();
         this.chargeExternalId = charge.getExternalId();
         this.credentials = Optional.ofNullable(charge.getGatewayAccountCredentialsEntity()).map(GatewayAccountCredentialsEntity::getCredentials).orElse(null);
         this.gatewayAccount = charge.getGatewayAccount();
@@ -43,7 +44,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
                                        boolean moto,
                                        String amount,
                                        String description,
-                                       String reference,
+                                       ServicePaymentReference reference,
                                        String chargeExternalId,
                                        Map<String, String> credentials,
                                        GatewayAccountEntity gatewayAccount) {
@@ -83,7 +84,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         return description;
     }
 
-    public String getReference() {
+    public ServicePaymentReference getReference() {
         return reference;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -4,26 +4,71 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.Map;
 import java.util.Optional;
 
 public abstract class AuthorisationGatewayRequest implements GatewayRequest {
-    private final ChargeEntity charge;
     private final String gatewayTransactionId;
-    
+    private final String email;
+    private final SupportedLanguage language;
+    private final boolean moto;
+    private final String amount;
+    private final String description;
+    private final String reference;
+    private final String chargeExternalId;
+    private final Map<String, String> credentials;
+    private final GatewayAccountEntity gatewayAccount;
+
     protected AuthorisationGatewayRequest(ChargeEntity charge) {
-        this.charge = charge;
+        // NOTE: we don't store the ChargeEntity as we want to discourage code that deals with this request from
+        // updating the charge in the database.
         this.gatewayTransactionId = charge.getGatewayTransactionId();
-    }
-    
-    protected AuthorisationGatewayRequest(ChargeEntity charge, String gatewayTransactionId) {
-        this.charge = charge;
-        this.gatewayTransactionId = gatewayTransactionId;
+        this.email = charge.getEmail();
+        this.language = charge.getLanguage();
+        this.moto = charge.isMoto();
+        this.amount = String.valueOf(CorporateCardSurchargeCalculator.getTotalAmountFor(charge));
+        this.description = charge.getDescription();
+        this.reference = charge.getReference().toString();
+        this.chargeExternalId = charge.getExternalId();
+        this.credentials = Optional.ofNullable(charge.getGatewayAccountCredentialsEntity()).map(GatewayAccountCredentialsEntity::getCredentials).orElse(null);
+        this.gatewayAccount = charge.getGatewayAccount();
     }
 
-    public ChargeEntity getCharge() {
-        return charge;
+    public AuthorisationGatewayRequest(String gatewayTransactionId, 
+                                       String email,
+                                       SupportedLanguage language,
+                                       boolean moto,
+                                       String amount,
+                                       String description,
+                                       String reference,
+                                       String chargeExternalId,
+                                       Map<String, String> credentials,
+                                       GatewayAccountEntity gatewayAccount) {
+        this.gatewayTransactionId = gatewayTransactionId;
+        this.email = email;
+        this.language = language;
+        this.moto = moto;
+        this.amount = amount;
+        this.description = description;
+        this.reference = reference;
+        this.chargeExternalId = chargeExternalId;
+        this.credentials = credentials;
+        this.gatewayAccount = gatewayAccount;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public boolean isMoto() {
+        return moto;
+    }
+
+    public SupportedLanguage getLanguage() {
+        return language;
     }
 
     public Optional<String> getTransactionId() {
@@ -31,29 +76,29 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     }
 
     public String getAmount() {
-        return String.valueOf(CorporateCardSurchargeCalculator.getTotalAmountFor(charge));
+        return amount;
     }
 
     public String getDescription() {
-        return charge.getDescription();
+        return description;
     }
 
     public String getReference() {
-        return charge.getReference().toString();
+        return reference;
     }
 
     public String getChargeExternalId() {
-        return charge.getExternalId();
+        return chargeExternalId;
     }
 
     @Override
     public Map<String, String> getGatewayCredentials() {
-        return charge.getGatewayAccountCredentialsEntity().getCredentials();
+        return credentials;
     }
 
     @Override
     public GatewayAccountEntity getGatewayAccount() {
-        return charge.getGatewayAccount();
+        return gatewayAccount;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
@@ -11,8 +11,21 @@ public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest
         this.authCardDetails = authCardDetails;
     }
 
-    private CardAuthorisationGatewayRequest(ChargeEntity charge, AuthCardDetails authCardDetails, String gatewayTransactionId) {
-        super(charge, gatewayTransactionId);
+    public CardAuthorisationGatewayRequest withNewTransactionId(String gatewayTransactionId) {
+        return new CardAuthorisationGatewayRequest(this, this.authCardDetails, gatewayTransactionId);
+    }
+    
+    private CardAuthorisationGatewayRequest(CardAuthorisationGatewayRequest other, AuthCardDetails authCardDetails, String gatewayTransactionId) {
+        super(gatewayTransactionId,
+                other.getEmail(),
+                other.getLanguage(),
+                other.isMoto(),
+                other.getAmount(),
+                other.getDescription(),
+                other.getReference(),
+                other.getChargeExternalId(),
+                other.getGatewayCredentials(),
+                other.getGatewayAccount());
         this.authCardDetails = authCardDetails;
     }
 
@@ -22,12 +35,5 @@ public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest
 
     public static CardAuthorisationGatewayRequest valueOf(ChargeEntity charge, AuthCardDetails authCardDetails) {
         return new CardAuthorisationGatewayRequest(charge, authCardDetails);
-    }
-
-    public static CardAuthorisationGatewayRequest valueOf(CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest, String gatewayTransactionId) {
-        return new CardAuthorisationGatewayRequest(
-                cardAuthorisationGatewayRequest.getCharge(),
-                cardAuthorisationGatewayRequest.getAuthCardDetails(),
-                gatewayTransactionId);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -25,6 +25,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayRespon
 import uk.gov.pay.connector.gateway.sandbox.applepay.SandboxWalletAuthorisationHandler;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -108,7 +109,7 @@ public class SandboxPaymentProvider implements PaymentProvider, SandboxGatewayRe
     }
 
     @Override
-    public SandboxAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+    public SandboxAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
         return new SandboxAuthorisationRequestSummary();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationRequestSummary.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.smartpay;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
@@ -13,9 +14,9 @@ public class SmartpayAuthorisationRequestSummary implements AuthorisationRequest
     private final Presence dataFor3ds;
     private final String ipAddress;
 
-    public SmartpayAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+    public SmartpayAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
-        dataFor3ds = chargeEntity.getGatewayAccount().isRequires3ds() ? PRESENT : NOT_PRESENT;
+        dataFor3ds = gatewayAccount.isRequires3ds() ? PRESENT : NOT_PRESENT;
         ipAddress = authCardDetails.getIpAddress().orElse(null);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -171,8 +171,8 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public SmartpayAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
-        return new SmartpayAuthorisationRequestSummary(chargeEntity, authCardDetails);
+    public SmartpayAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
+        return new SmartpayAuthorisationRequestSummary(gatewayAccount, authCardDetails);
     }
 
     private GatewayOrder buildAuthoriseOrderFor(CardAuthorisationGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -37,6 +37,7 @@ import uk.gov.pay.connector.gateway.stripe.handler.StripeRefundHandler;
 import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
@@ -152,7 +153,7 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public StripeAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+    public StripeAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
         return new StripeAuthorisationRequestSummary(authCardDetails);
     }
     

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -48,7 +48,7 @@ public class StripePaymentIntentRequest extends StripeRequest {
                 frontendUrl,
                 request.getChargeExternalId(),
                 request.getDescription(),
-                request.getCharge().isMoto(),
+                request.isMoto(),
                 request.getGatewayCredentials()
         );
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
@@ -16,10 +16,9 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
     private String ipAddress;
     
 
-    public WorldpayAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+    public WorldpayAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
         deviceDataCollectionResult = authCardDetails.getWorldpay3dsFlexDdcResult().map(address -> PRESENT).orElse(NOT_PRESENT);
-        GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
         dataFor3ds = (deviceDataCollectionResult == PRESENT || gatewayAccount.isRequires3ds()) ? PRESENT : NOT_PRESENT;
         ipAddress = authCardDetails.getIpAddress().orElse(null);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -31,7 +31,7 @@ public interface WorldpayOrderBuilder {
         }
 
         if (request.getGatewayAccount().isSendReferenceToGateway()) {
-            builder.withDescription(request.getReference());
+            builder.withDescription(request.getReference().toString());
         } else {
             builder.withDescription(request.getDescription());
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -27,7 +27,7 @@ public interface WorldpayOrderBuilder {
         }
 
         if (request.getGatewayAccount().isSendPayerEmailToGateway()) {
-            Optional.ofNullable(request.getCharge().getEmail()).ifPresent(builder::withPayerEmail);
+            Optional.ofNullable(request.getEmail()).ifPresent(builder::withPayerEmail);
         }
 
         if (request.getGatewayAccount().isSendReferenceToGateway()) {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -184,7 +184,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
         
         if (response.getBaseResponse().map(WorldpayOrderStatusResponse::isSoftDecline).orElse(false)) {
             
-            var authorisationRequestSummary = generateAuthorisationRequestSummary(charge, request.getAuthCardDetails());
+            var authorisationRequestSummary = generateAuthorisationRequestSummary(request.getGatewayAccount(), request.getAuthCardDetails());
 
             authorisationLogger.logChargeAuthorisation(
                     LOGGER,
@@ -196,7 +196,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                     charge.getChargeStatus(),
                     charge.getChargeStatus());
 
-            CardAuthorisationGatewayRequest newRequest = CardAuthorisationGatewayRequest.valueOf(request, newTransactionId());
+            CardAuthorisationGatewayRequest newRequest = request.withNewTransactionId(newTransactionId());
             response = worldpayAuthoriseHandler.authoriseWithoutExemption(newRequest);
         } 
 
@@ -310,8 +310,8 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     }
 
     @Override
-    public WorldpayAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
-        return new WorldpayAuthorisationRequestSummary(chargeEntity, authCardDetails);
+    public WorldpayAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
+        return new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails);
     }
 
     private GatewayOrder build3dsResponseAuthOrder(Auth3dsResponseGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -180,7 +180,7 @@ public class CardAuthoriseService {
     }
 
     private AuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
-        return getPaymentProviderFor(chargeEntity).generateAuthorisationRequestSummary(chargeEntity, authCardDetails);
+        return getPaymentProviderFor(chargeEntity).generateAuthorisationRequestSummary(chargeEntity.getGatewayAccount(), authCardDetails);
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqAuthorisationRequestSummaryTest.java
@@ -1,11 +1,9 @@
 package uk.gov.pay.connector.gateway.epdq;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -22,48 +20,42 @@ import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Pre
 
 @ExtendWith(MockitoExtension.class)
 class EpdqAuthorisationRequestSummaryTest {
-
-    @Mock private ChargeEntity mockChargeEntity;
+    
     @Mock private GatewayAccountEntity mockGatewayAccountEntity;
     @Mock private AuthCardDetails mockAuthCardDetails;
-
-    @BeforeEach
-    void setUp() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
-    }
 
     @Test
     void billingAddressPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
-        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(epdqAuthorisationRequestSummary.billingAddress(), is(PRESENT));
     }
 
     @Test
     void billingAddressNotPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
-        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(epdqAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
     }
 
     @Test
     void requires3dsTrueMeansDataFor3dsPresent() {
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
-        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(epdqAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
     }
 
     @Test
     void requires3dsFalseMeansDataFor3dsNotPresent() {
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
-        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(epdqAuthorisationRequestSummary.dataFor3ds(), is(NOT_PRESENT));
     }
 
     @Test
     void requires3dsFalseMeansDataFor3ds2NotPresent() {
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
-        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(epdqAuthorisationRequestSummary.dataFor3ds2(), is(NOT_PRESENT));
     }
     
@@ -71,7 +63,7 @@ class EpdqAuthorisationRequestSummaryTest {
     void requires3dsTrueAnd3dsVersion1MeansDataFor3ds2NotPresent() {
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
         given(mockGatewayAccountEntity.getIntegrationVersion3ds()).willReturn(1);
-        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(epdqAuthorisationRequestSummary.dataFor3ds2(), is(NOT_PRESENT));
     }
 
@@ -79,13 +71,13 @@ class EpdqAuthorisationRequestSummaryTest {
     void requires3dsTrueAnd3dsVersion2MeansDataFor3ds2Present() {
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
         given(mockGatewayAccountEntity.getIntegrationVersion3ds()).willReturn(2);
-        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(epdqAuthorisationRequestSummary.dataFor3ds2(), is(PRESENT));
     }
 
     @Test
     void deviceDataCollectionResultAlwaysNotApplicable() {
-        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(epdqAuthorisationRequestSummary.deviceDataCollectionResult(), is(NOT_APPLICABLE));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationRequestSummaryTest.java
@@ -1,11 +1,9 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -22,53 +20,47 @@ import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Pre
 
 @ExtendWith(MockitoExtension.class)
 class SmartpayAuthorisationRequestSummaryTest {
-
-    @Mock private ChargeEntity mockChargeEntity;
+    
     @Mock private GatewayAccountEntity mockGatewayAccountEntity;
     @Mock private AuthCardDetails mockAuthCardDetails;
-
-    @BeforeEach
-    void setUp() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
-    }
 
     @Test
     void billingAddressPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
-        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(smartpayAuthorisationRequestSummary.billingAddress(), is(PRESENT));
     }
 
     @Test
     void billingAddressNotPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
-        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(smartpayAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
     }
 
     @Test
     void requires3dsTrueMeansDataFor3dsPresent() {
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
-        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(smartpayAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
     }
 
     @Test
     void requires3dsFalseMeansDataFor3dsNotPresent() {
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
-        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(smartpayAuthorisationRequestSummary.dataFor3ds(), is(NOT_PRESENT));
     }
 
     @Test
     void dataFor3ds2AlwaysNotApplicable() {
-        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(smartpayAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
     }
 
     @Test
     void deviceDataCollectionResultAlwaysNotApplicable() {
-        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(smartpayAuthorisationRequestSummary.deviceDataCollectionResult(), is(NOT_APPLICABLE));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequestTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -66,6 +67,7 @@ public class StripeAuthoriseRequestTest {
         when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
         when(charge.getExternalId()).thenReturn(chargeExternalId);
         when(charge.getDescription()).thenReturn(description);
+        when(charge.getReference()).thenReturn(ServicePaymentReference.of("a-reference"));
         when(charge.getAmount()).thenReturn(amount);
         when(charge.getGatewayAccountCredentialsEntity()).thenReturn(gatewayAccountCredentialsEntity);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
@@ -67,6 +68,7 @@ public class StripePaymentIntentRequestTest {
         when(charge.getExternalId()).thenReturn(chargeExternalId);
         when(charge.getAmount()).thenReturn(amount);
         when(charge.getDescription()).thenReturn(description);
+        when(charge.getReference()).thenReturn(ServicePaymentReference.of("a-reference"));
         when(charge.getGatewayAccountCredentialsEntity()).thenReturn(gatewayAccountCredentialsEntity);
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
         when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -71,6 +72,7 @@ public class StripePaymentMethodRequestTest {
         when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
         when(charge.getExternalId()).thenReturn(chargeExternalId);
         when(charge.getGatewayAccountCredentialsEntity()).thenReturn(gatewayAccountCredentialsEntity);
+        when(charge.getReference()).thenReturn(ServicePaymentReference.of("a-reference"));
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
         when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
@@ -4,11 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 
 import java.util.Optional;
 
@@ -22,57 +20,49 @@ import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Pre
 
 @ExtendWith(MockitoExtension.class)
 class WorldpayAuthorisationRequestSummaryTest {
-
-    @Mock private ChargeEntity mockChargeEntity;
+    
     @Mock private GatewayAccountEntity mockGatewayAccountEntity;
     @Mock private AuthCardDetails mockAuthCardDetails;
-    @Mock private Worldpay3dsFlexCredentials mockWorldpay3dsFlexCredentials;
     
     @Test
     void billingAddressPresent() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.billingAddress(), is(PRESENT));
     }
 
     @Test
     void billingAddressNotPresent() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
     }
 
     @Test
     void requires3dsFalseMeansDataFor3dsNotPresent() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(NOT_PRESENT));
     }
 
     @Test
     void deviceDataCollectionResultPresentMeansDataFor3dsPresent() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
     }
 
     @Test
     void deviceDataCollectionResultPresent() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.deviceDataCollectionResult(), is(PRESENT));
     }
 
     @Test
     void dataFor3ds2AlwaysNotApplicable() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -200,7 +200,7 @@ public class WorldpayPaymentProviderTest {
         worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_NOT_REQUESTED);
-        verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_NOT_REQUESTED);
+        verifyEventEmitted(chargeEntity, EXEMPTION_NOT_REQUESTED);
     }
 
     private void verifyChargeUpdatedWith(Exemption3ds exemption3ds) {
@@ -227,7 +227,7 @@ public class WorldpayPaymentProviderTest {
         worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_NOT_REQUESTED);
-        verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_NOT_REQUESTED);
+        verifyEventEmitted(chargeEntity, EXEMPTION_NOT_REQUESTED);
     }
 
     @Test
@@ -247,7 +247,7 @@ public class WorldpayPaymentProviderTest {
         worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_NOT_REQUESTED);
-        verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_NOT_REQUESTED);
+        verifyEventEmitted(chargeEntity, EXEMPTION_NOT_REQUESTED);
     }
 
     @Test
@@ -268,7 +268,7 @@ public class WorldpayPaymentProviderTest {
         worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_REJECTED);
-        verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_REJECTED);
+        verifyEventEmitted(chargeEntity, EXEMPTION_REJECTED);
     }
 
     @Test
@@ -288,7 +288,7 @@ public class WorldpayPaymentProviderTest {
         worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_OUT_OF_SCOPE);
-        verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_OUT_OF_SCOPE);
+        verifyEventEmitted(chargeEntity, EXEMPTION_OUT_OF_SCOPE);
     }
 
     @Test
@@ -345,7 +345,7 @@ public class WorldpayPaymentProviderTest {
         worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 
         verifyChargeUpdatedWith(EXEMPTION_HONOURED);
-        verifyEventEmitted(cardAuthRequest.getCharge(), EXEMPTION_HONOURED);
+        verifyEventEmitted(chargeEntity, EXEMPTION_HONOURED);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -169,7 +169,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     public void setUpCardAuthorisationService() {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
-        when(mockedPaymentProvider.generateAuthorisationRequestSummary(any(ChargeEntity.class), any(AuthCardDetails.class)))
+        when(mockedPaymentProvider.generateAuthorisationRequestSummary(any(GatewayAccountEntity.class), any(AuthCardDetails.class)))
                 .thenReturn(new SandboxAuthorisationRequestSummary());
         when(mockAuthorisationRequestSummaryStringifier.stringify(any(AuthorisationRequestSummary.class))).thenReturn("");
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthorisationRequestSummary;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -79,10 +80,6 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
     private static final ProviderSessionIdentifier SESSION_IDENTIFIER = ProviderSessionIdentifier.of("session-identifier");
     private static final String TRANSACTION_ID = "transaction-id";
 
-    private CardAuthoriseService cardAuthorisationService;
-
-    private ChargeEntity charge;
-
     @Mock
     private CardExecutorService mockExecutorService;
 
@@ -105,6 +102,9 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
     private AuthorisationConfig mockAuthorisationConfig;
 
     private AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
+    private CardAuthoriseService cardAuthorisationService;
+    private ChargeEntity charge;
+    private GatewayAccountEntity gatewayAccount;
 
     @BeforeEach
     void setup() {
@@ -115,7 +115,8 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
         charge = createNewChargeWith(1L, ENTERING_CARD_DETAILS);
         charge.setPaymentProvider("worldpay");
-        charge.getGatewayAccount().setRequires3ds(true);
+        gatewayAccount = charge.getGatewayAccount();
+        gatewayAccount.setRequires3ds(true);
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, mock(AgreementDao.class), null, mock(ConnectorConfiguration.class), null,
@@ -138,8 +139,8 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(WORLDPAY)).thenReturn(mockedWorldpayPaymentProvider);
         when(mockedWorldpayPaymentProvider.generateTransactionId()).thenReturn(Optional.of(TRANSACTION_ID));
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails));
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails));
 
         Logger root = (Logger) LoggerFactory.getLogger(CardAuthoriseService.class);
         root.setLevel(Level.INFO);
@@ -151,9 +152,9 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
         worldpayRespondsWith(null, load(WORLDPAY_EXEMPTION_REQUEST_DECLINE_RESPONSE));
 
         var worldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build();
-        charge.getGatewayAccount().setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails));
+        gatewayAccount.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails));
 
         AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
@@ -173,9 +174,9 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
         worldpayRespondsWith(null, load(WORLDPAY_EXEMPTION_REQUEST_HONOURED_RESPONSE));
 
         var worldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build();
-        charge.getGatewayAccount().setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails));
+        gatewayAccount.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails));
 
         AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
@@ -195,7 +196,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
         worldpayRespondsWith(null, load(WORLDPAY_3DS_FLEX_RESPONSE));
 
         var worldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build();
-        charge.getGatewayAccount().setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
+        gatewayAccount.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
 
         AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
@@ -209,7 +210,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
         worldpayRespondsWith(null, load(WORLDPAY_3DS_RESPONSE));
 
         var worldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build();
-        charge.getGatewayAccount().setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
+        gatewayAccount.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
 
         AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -138,8 +138,8 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(WORLDPAY)).thenReturn(mockedWorldpayPaymentProvider);
         when(mockedWorldpayPaymentProvider.generateTransactionId()).thenReturn(Optional.of(TRANSACTION_ID));
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge, authCardDetails))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(charge, authCardDetails));
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails));
 
         Logger root = (Logger) LoggerFactory.getLogger(CardAuthoriseService.class);
         root.setLevel(Level.INFO);
@@ -152,8 +152,8 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
         var worldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build();
         charge.getGatewayAccount().setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge, authCardDetails))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(charge, authCardDetails));
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails));
 
         AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
@@ -174,8 +174,8 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
         var worldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build();
         charge.getGatewayAccount().setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge, authCardDetails))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(charge, authCardDetails));
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(charge.getGatewayAccount(), authCardDetails));
 
         AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 


### PR DESCRIPTION
We want to discourage the code that deals with the AuthorisationGatewayRequest to perform the authorisation with the gateway from updating the charge in the database.

To help with this, don't store the entire ChargeEntity on the AuthorisationGatewayRequest.