### PR TITLE
BAU add gateway account id to failed refund notification

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER;
 import static uk.gov.service.payments.logging.LoggingKeys.REFUND_EXTERNAL_ID;
@@ -36,8 +37,10 @@ public class RefundNotificationProcessor {
     public void invoke(PaymentGatewayName gatewayName, RefundStatus newStatus, GatewayAccountEntity gatewayAccountEntity,
                        String gatewayTransactionId, String transactionId, Charge charge) {
         if (isBlank(gatewayTransactionId)) {
-            logger.warn("{} refund notification could not be used to update charge [{}] (missing reference)",
-                    gatewayName, charge.getExternalId());
+            logger.warn("Refund notification could not be used to update charge (missing reference)",
+                    kv(PAYMENT_EXTERNAL_ID, charge.getExternalId()),
+                    kv(PROVIDER, gatewayName),
+                    kv(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId()));
             return;
         }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
@@ -98,9 +98,7 @@ public class RefundNotificationProcessorTest {
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
 
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
-        String expectedLogMessage = String.format("%s refund notification could not be used to update charge [%s] (missing reference)",
-                paymentGatewayName,
-                charge.getExternalId());
+        String expectedLogMessage = "Refund notification could not be used to update charge (missing reference)";
 
         assertThat(logStatement.get(0).getFormattedMessage(), is(expectedLogMessage));
     }


### PR DESCRIPTION
## WHAT YOU DID
- by adding the gateway account id, we are able to check refund notifications that has no gateway transaction id against gateways. This helps us identify certain behaviours, eg service refunding payments through Worldpay portal.
