### PR TITLE
PP-9503 Rename chargeExternalId in AuthorisationGatewayRequest

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -316,7 +316,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
             epdqPayloadDefinition = new EpdqPayloadDefinitionForNewOrder();
         }
 
-        epdqPayloadDefinition.setOrderId(request.getChargeExternalId());
+        epdqPayloadDefinition.setOrderId(request.getGovUkPayPaymentId());
         epdqPayloadDefinition.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
         epdqPayloadDefinition.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME));
         epdqPayloadDefinition.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -19,7 +19,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     private final String amount;
     private final String description;
     private final ServicePaymentReference reference;
-    private final String chargeExternalId;
+    private final String govUkPayPaymentId;
     private final Map<String, String> credentials;
     private final GatewayAccountEntity gatewayAccount;
 
@@ -33,7 +33,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.amount = String.valueOf(CorporateCardSurchargeCalculator.getTotalAmountFor(charge));
         this.description = charge.getDescription();
         this.reference = charge.getReference();
-        this.chargeExternalId = charge.getExternalId();
+        this.govUkPayPaymentId = charge.getExternalId();
         this.credentials = Optional.ofNullable(charge.getGatewayAccountCredentialsEntity()).map(GatewayAccountCredentialsEntity::getCredentials).orElse(null);
         this.gatewayAccount = charge.getGatewayAccount();
     }
@@ -45,7 +45,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
                                        String amount,
                                        String description,
                                        ServicePaymentReference reference,
-                                       String chargeExternalId,
+                                       String govUkPayPaymentId,
                                        Map<String, String> credentials,
                                        GatewayAccountEntity gatewayAccount) {
         this.gatewayTransactionId = gatewayTransactionId;
@@ -55,7 +55,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.amount = amount;
         this.description = description;
         this.reference = reference;
-        this.chargeExternalId = chargeExternalId;
+        this.govUkPayPaymentId = govUkPayPaymentId;
         this.credentials = credentials;
         this.gatewayAccount = gatewayAccount;
     }
@@ -88,8 +88,8 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         return reference;
     }
 
-    public String getChargeExternalId() {
-        return chargeExternalId;
+    public String getGovUkPayPaymentId() {
+        return govUkPayPaymentId;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
@@ -23,7 +23,7 @@ public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest
                 other.getAmount(),
                 other.getDescription(),
                 other.getReference(),
-                other.getChargeExternalId(),
+                other.getGovUkPayPaymentId(),
                 other.getGatewayCredentials(),
                 other.getGatewayAccount());
         this.authCardDetails = authCardDetails;

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -185,7 +185,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
 
         return smartpayOrderRequestBuilder
                 .withMerchantCode(getMerchantCode(request))
-                .withPaymentPlatformReference(request.getChargeExternalId())
+                .withPaymentPlatformReference(request.getGovUkPayPaymentId())
                 .withDescription(request.getDescription())
                 .withAmount(request.getAmount())
                 .withAuthorisationDetails(request.getAuthCardDetails())

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequest.java
@@ -39,10 +39,10 @@ public class StripeAuthoriseRequest extends StripeRequest {
                 authorisationRequest.getAmount(),
                 authorisationRequest.getDescription(),
                 sourceId,
-                authorisationRequest.getChargeExternalId(),
+                authorisationRequest.getGovUkPayPaymentId(),
                 OrderRequestType.AUTHORISE,
                 authorisationRequest.getGatewayAccount(),
-                authorisationRequest.getChargeExternalId(),
+                authorisationRequest.getGovUkPayPaymentId(),
                 stripeGatewayConfig,
                 authorisationRequest.getGatewayCredentials()
         );

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -40,13 +40,13 @@ public class StripePaymentIntentRequest extends StripeRequest {
             String frontendUrl) {
         return new StripePaymentIntentRequest(
                 request.getGatewayAccount(),
-                request.getChargeExternalId(),
+                request.getGovUkPayPaymentId(),
                 stripeGatewayConfig,
                 request.getAmount(),
                 paymentMethodId,
-                request.getChargeExternalId(),
+                request.getGovUkPayPaymentId(),
                 frontendUrl,
-                request.getChargeExternalId(),
+                request.getGovUkPayPaymentId(),
                 request.getDescription(),
                 request.isMoto(),
                 request.getGatewayCredentials()

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
@@ -30,7 +30,7 @@ public class StripePaymentMethodRequest extends StripeRequest {
     public static StripePaymentMethodRequest of(CardAuthorisationGatewayRequest request, StripeGatewayConfig config) {
         return new StripePaymentMethodRequest(
                 request.getGatewayAccount(),
-                request.getChargeExternalId(),
+                request.getGovUkPayPaymentId(),
                 config,
                 request.getAuthCardDetails(),
                 request.getGatewayCredentials()

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -63,28 +63,28 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
 
             if (response.getEntity().contains("request3DSecure")) {
-                LOGGER.info(format("Worldpay authorisation response when 3ds required for %s: %s", request.getChargeExternalId(), sanitiseMessage(response.getEntity())));
+                LOGGER.info(format("Worldpay authorisation response when 3ds required: %s", sanitiseMessage(response.getEntity())));
             }
             return getWorldpayGatewayResponse(response);
         } catch (GatewayException.GatewayErrorException e) {
             
             if (e.getStatus().isPresent() && (e.getFamily() == CLIENT_ERROR || e.getFamily() == SERVER_ERROR)) {
                 
-                LOGGER.error("Authorisation failed for charge {} due to an internal error. Reason: {}. Status code from Worldpay: {}.",
-                        request.getChargeExternalId(), e.getMessage(), e.getStatus().map(String::valueOf).orElse("no status code"));
+                LOGGER.error("Authorisation failed due to an internal error. Reason: {}. Status code from Worldpay: {}.",
+                        e.getMessage(), e.getStatus().map(String::valueOf).orElse("no status code"));
                 
                 GatewayError gatewayError = gatewayConnectionError(format("Non-success HTTP status code %s from gateway", e.getStatus().get()));
 
                 return responseBuilder().withGatewayError(gatewayError).build();
             }
             
-            LOGGER.info("Unrecognised response status when authorising. Charge_id={}, status={}, response={}",
-                    request.getChargeExternalId(), e.getStatus(), e.getResponseFromGateway());
+            LOGGER.info("Unrecognised response status when authorising - status={}, response={}",
+                    e.getStatus(), e.getResponseFromGateway());
             return responseBuilder().withGatewayError(e.toGatewayError()).build();
             
         } catch (GatewayException.GatewayConnectionTimeoutException | GatewayException.GenericGatewayException e) {
             
-            LOGGER.error("GatewayException occurred for charge external id {}, error:\n {}", request.getChargeExternalId(), e);
+            LOGGER.error("GatewayException occurred, error:\n {}", e);
 
             return responseBuilder().withGatewayError(e.toGatewayError()).build();
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -40,7 +40,7 @@ public interface WorldpayOrderBuilder {
                 request.getGatewayAccount().isRequires3ds();
 
         return (WorldpayOrderRequestBuilder) builder
-                .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getGovUkPayPaymentId()))
                 .with3dsRequired(is3dsRequired)
                 .withTransactionId(request.getTransactionId().orElse(""))
                 .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
@@ -65,7 +65,7 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
         return builder
                 .withWalletTemplateData(request.getWalletAuthorisationData())
                 .with3dsRequired(is3dsRequired)
-                .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getGovUkPayPaymentId()))
                 .withUserAgentHeader(request.getWalletAuthorisationData().getPaymentInfo().getUserAgentHeader())
                 .withUserAgentHeader(request.getWalletAuthorisationData().getPaymentInfo().getAcceptHeader())
                 .withTransactionId(request.getTransactionId().orElse(""))


### PR DESCRIPTION
Rename chargeExternalId to govUkPayPaymentId, with the intention of discouraging consumers of this class from using this id to look up the charge in the database and updating it, as code making the authorisation request to the gateway should not make database updates.

Remove usages of the chargeExternalId for logging purposes. There is no need to explicitly include the chargeExternalId in log lines, as it is already added to the structured logging by virtue of it being on the MDC.