### PR TITLE
PP-9503 Add separate authorisation method for MOTO api payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -29,6 +29,8 @@ public interface PaymentProvider {
     Optional<String> generateTransactionId();
 
     GatewayResponse authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) throws GatewayException;
+    
+    GatewayResponse authoriseMotoApi(CardAuthorisationGatewayRequest request) throws GatewayException;
 
     ChargeQueryResponse queryPaymentStatus(ChargeQueryGatewayRequest chargeQueryGatewayRequest) throws GatewayException;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -137,6 +137,11 @@ public class EpdqPaymentProvider implements PaymentProvider {
     }
 
     @Override
+    public GatewayResponse authoriseMotoApi(CardAuthorisationGatewayRequest request) {
+        throw new UnsupportedOperationException("MOTO API payments are not supported for ePDQ");
+    }
+
+    @Override
     public GatewayRefundResponse refund(RefundGatewayRequest request) {
         return epdqRefundHandler.refund(request);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.ChargeQueryGatewayRequest;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -56,6 +57,20 @@ public class SandboxPaymentProvider implements PaymentProvider, SandboxGatewayRe
     
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) {
+        return authorise(request);
+    }
+
+    @Override
+    public GatewayResponse authoriseMotoApi(CardAuthorisationGatewayRequest request) {
+        return authorise(request);
+    }
+
+    /**
+     * IMPORTANT: this method should not attempt to update the Charge in the database. This is because it is executed
+     * on a worker thread and the initiating thread can attempt to update the Charge status while it is still being
+     * executed.
+     */
+    private GatewayResponse authorise(CardAuthorisationGatewayRequest request) {
         String cardNumber = request.getAuthCardDetails().getCardNo();
         var gatewayResponse = getSandboxGatewayResponse(cardNumber);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -95,6 +95,11 @@ public class SmartpayPaymentProvider implements PaymentProvider {
         return getSmartpayGatewayResponse(response, SmartpayAuthorisationResponse.class);
     }
 
+    @Override
+    public GatewayResponse authoriseMotoApi(CardAuthorisationGatewayRequest request) {
+        throw new UnsupportedOperationException("MOTO API payments are not supported for Smartpay");
+    }
+
     private static GatewayResponse getSmartpayGatewayResponse(GatewayClient.Response response, Class<? extends BaseResponse> responseClass) throws GatewayErrorException {
         GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
         responseBuilder.withResponse(unmarshallResponse(response, responseClass));

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -104,6 +104,16 @@ public class StripePaymentProvider implements PaymentProvider {
     public GatewayResponse authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) {
         return stripeAuthoriseHandler.authorise(request);
     }
+    
+    /**
+     * IMPORTANT: this method should not attempt to update the Charge in the database. This is because it is executed
+     * on a worker thread and the initiating thread can attempt to update the Charge status while it is still being
+     * executed.
+     */
+    @Override
+    public GatewayResponse authoriseMotoApi(CardAuthorisationGatewayRequest request) {
+        return stripeAuthoriseHandler.authorise(request);
+    }
 
     @Override
     public Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -203,6 +203,16 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
         return response;
     }
 
+    /**
+     * IMPORTANT: this method should not attempt to update the Charge in the database. This is because it is executed
+     * on a worker thread and the initiating thread can attempt to update the Charge status while it is still being
+     * executed.
+     */
+    @Override
+    public GatewayResponse authoriseMotoApi(CardAuthorisationGatewayRequest request) {
+        return worldpayAuthoriseHandler.authoriseWithoutExemption(request);
+    }
+
     private void calculateAndStoreExemption(boolean exemptionEngineEnabled, ChargeEntity charge, GatewayResponse<WorldpayOrderStatusResponse> response) {
         if (!exemptionEngineEnabled) {
             updateChargeWithExemption3ds(EXEMPTION_NOT_REQUESTED, charge);


### PR DESCRIPTION
Add a separate method to the PaymentProvider interface, `authoriseMotoApi` which does not accept the ChargeEntity as a parameter and does not attempt to perform any database operations on the charge.

This is so that this method can be run on a worker thread with a timeout and we can safely update the charge status to AUTHORISATION_TIMEOUT when this times out.

For the WorldpayPaymentProvider, this method does not attempt to request a 3DS exemption, as 3DS is not required on MOTO payments. For Stripe and Sandbox, the authorisation is identical to authorisation for web payments. We will not support the MOTO authorisation API for Smartpay and ePDQ.

Include warnings not to update the charge from within the method.

There is not much to be unit tested here, so this will be covered by integration tests when this method is used.