### PR TITLE
BAU Remove dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,6 @@ updates:
     versions:
     - ">= 4.3.a"
     - "< 4.4"
-  - dependency-name: io.dropwizard/*
-    versions:
-    - ">= 2.1.0"
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
Decided not to add an ignore to the dependabot file, as the Dropwizard update seems to work fine on the repositories where the tests are passing. Removing from here so we don't forget.