### PR TITLE
Revert "Bump mockito.version from 4.5.1 to 4.6.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <jjwt.version>0.11.5</jjwt.version>
         <pact.version>3.6.15</pact.version>
-        <mockito.version>4.6.0</mockito.version>
+        <mockito.version>4.5.1</mockito.version>
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>


### PR DESCRIPTION
With Mockito 4.6.0, we’re suddenly getting `PotentialStubbingProblem`s in `ChargeExpiryServiceTest`. This may be https://github.com/mockito/mockito/issues/2656 or similar.

Reverts alphagov/pay-connector#3741