### PR TITLE
PP-9369 Make AgreementEntity.getPaymentInstrument() return Optional

### DIFF
--- a/src/main/java/uk/gov/pay/connector/agreement/model/AgreementEntity.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/model/AgreementEntity.java
@@ -7,19 +7,19 @@ import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneC
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
-import javax.persistence.Entity;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.persistence.Id;
 import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.ManyToOne;
-import javax.persistence.GenerationType;
-import javax.persistence.JoinColumn;
 import javax.persistence.Convert;
-
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import java.time.Instant;
+import java.util.Optional;
 
 @Entity
 @Table(name = "agreements")
@@ -152,8 +152,8 @@ public class AgreementEntity {
         this.userIdentifier = userIdentifier;
     }
 
-    public PaymentInstrumentEntity getPaymentInstrument() {
-        return paymentInstrument;
+    public Optional<PaymentInstrumentEntity> getPaymentInstrument() {
+        return Optional.ofNullable(paymentInstrument);
     }
 
     public void setPaymentInstrument(PaymentInstrumentEntity paymentInstrumentEntity) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementSetup.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementSetup.java
@@ -20,7 +20,7 @@ public class AgreementSetup extends AgreementEvent {
                 agreement.getServiceId(),
                 agreement.getGatewayAccount().isLive(),
                 agreement.getExternalId(),
-                new AgreementSetupEventDetails(agreement.getPaymentInstrument(), PaymentInstrumentStatus.ACTIVE),
+                new AgreementSetupEventDetails(agreement.getPaymentInstrument().orElse(null), PaymentInstrumentStatus.ACTIVE),
                 timestamp
         );
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentConfirmed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentConfirmed.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.events.model.charge;
 
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -14,10 +15,14 @@ public class PaymentInstrumentConfirmed extends PaymentInstrumentEvent {
     }
 
     public static PaymentInstrumentConfirmed from(AgreementEntity agreement, ZonedDateTime timestamp) {
+        String paymentInstrumentExternalId = agreement.getPaymentInstrument()
+                .map(PaymentInstrumentEntity::getExternalId)
+                .orElseThrow(() -> new IllegalArgumentException("Agreement " + agreement.getExternalId() + " does not have a payment instrument"));
+
         return new PaymentInstrumentConfirmed(
                 agreement.getServiceId(),
                 agreement.isLive(),
-                agreement.getPaymentInstrument().getExternalId(),
+                paymentInstrumentExternalId,
                 new PaymentInstrumentConfirmedDetails(agreement),
                 timestamp
         );

--- a/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
@@ -79,7 +79,8 @@ class LinkPaymentInstrumentToAgreementServiceTest {
     void linksPaymentInstrumentFromChargeToAgreementFromChargeAndSetsPaymentInstrumentToActive() {
         given(mockAgreementDao.findByExternalId(AGREEMENT_ID)).willReturn(Optional.of(mockAgreementEntity));
         when(mockAgreementEntity.getGatewayAccount()).thenReturn(mock(GatewayAccountEntity.class));
-        when(mockAgreementEntity.getPaymentInstrument()).thenReturn(mockPaymentInstrumentEntity);
+        when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
+        when(mockPaymentInstrumentEntity.getExternalId()).thenReturn("payment instrument external ID");
         var chargeEntity = aValidChargeEntity().withPaymentInstrument(mockPaymentInstrumentEntity).withAgreementId(AGREEMENT_ID).build();
 
         linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreementFromCharge(chargeEntity);


### PR DESCRIPTION
Make `getPaymentInstrument()` return `Optional<PaymentInstrumentEntity>` rather than `PaymentInstrumentEntity` since there will not always be one.