### PR TITLE
PP-9599 enable stripe can query flag

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -85,7 +85,7 @@ public class StripePaymentProvider implements PaymentProvider {
 
     @Override
     public boolean canQueryPaymentStatus() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## WHAT YOU DID
- re-enable canQueryPaymentStatus flag for StripePaymentProvider
