### PR TITLE
PP-9599 Use newer Stripe API version for searching payment intents

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeGetRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeGetRequest.java
@@ -11,8 +11,8 @@ import java.util.Map;
 
 public abstract class StripeGetRequest implements GatewayClientGetRequest {
     
-    private GatewayAccountEntity gatewayAccount;
-    private StripeGatewayConfig stripeGatewayConfig;
+    protected GatewayAccountEntity gatewayAccount;
+    protected StripeGatewayConfig stripeGatewayConfig;
     
     protected StripeGetRequest(GatewayAccountEntity gatewayAccount, StripeGatewayConfig stripeGatewayConfig) {
         this.gatewayAccount = gatewayAccount;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeQueryPaymentStatusRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeQueryPaymentStatusRequest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.stripe.request;
 
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.util.AuthUtil;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.util.Map;
@@ -42,6 +43,16 @@ public class StripeQueryPaymentStatusRequest extends StripeGetRequest {
     @Override
     public Map<String, String> getQueryParams() {
         return Map.of("query", String.format("metadata['%s']:'%s'", GOVUK_PAY_TRANSACTION_EXTERNAL_ID, chargeExternalId));
+    }
+
+    /**
+     * We are overriding this method as we need to use a newer Stripe API version to use the search payment intents
+     * endpoint than we are using in the rest of connector. This override can be removed once all Stripe API calls are 
+     * using the same API version.
+     */
+    @Override
+    public Map<String, String> getHeaders() {
+        return AuthUtil.getStripeAuthHeaderForPaymentIntentSearch(stripeGatewayConfig, gatewayAccount.isLive());
     }
 
     public String getChargeExternalId() {

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
@@ -16,19 +16,32 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 public class AuthUtil {
     private static final String STRIPE_VERSION_HEADER = "Stripe-Version";
     private static final String STRIPE_API_VERSION = "2019-05-16";
+    
+    // We are using a separate version as searching payment intents is only supported in newer API versions.
+    // This is intended as a temporary solution, and we intend to move all requests to use the same API version.
+    public static final String STRIPE_SEARCH_PAYMENT_INTENTS_API_VERSION = "2020-08-27";
 
     private static String encode(String username, String password) {
         return "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
     }
 
+    public static Map<String, String> getStripeAuthHeaderForPaymentIntentSearch(StripeGatewayConfig stripeGatewayConfig, boolean isLiveAccount) {
+        return getStripeAuthHeaderWithApiVersion(stripeGatewayConfig, isLiveAccount, STRIPE_SEARCH_PAYMENT_INTENTS_API_VERSION);
+    }
+    
     public static Map<String, String> getStripeAuthHeader(StripeGatewayConfig stripeGatewayConfig, boolean isLiveAccount) {
+        return getStripeAuthHeaderWithApiVersion(stripeGatewayConfig, isLiveAccount, STRIPE_API_VERSION);
+    }
+
+    private static Map<String, String> getStripeAuthHeaderWithApiVersion(StripeGatewayConfig stripeGatewayConfig, boolean isLiveAccount, String apiVersion) {
         StripeAuthTokens authTokens = stripeGatewayConfig.getAuthTokens();
         String value = format("Bearer %s", isLiveAccount ? authTokens.getLive() : authTokens.getTest());
         return ImmutableMap.of(
                 AUTHORIZATION, value,
-                STRIPE_VERSION_HEADER, STRIPE_API_VERSION
+                STRIPE_VERSION_HEADER, apiVersion
         );
     }
+
 
     public static Map<String, String> getGatewayAccountCredentialsAsAuthHeader(Map<String, String> gatewayCredentials) {
         String value = encode(gatewayCredentials.get(CREDENTIALS_USERNAME), gatewayCredentials.get(CREDENTIALS_PASSWORD));


### PR DESCRIPTION
The Stripe `/v1/payment_intents/search` is only supported in version
2020-08-27 of their API. Currently in connector we use 2019-05-16.

Specify the version 2020-08-27 in the request headers only for search
payment intent requests to get this working. Keep the version used for
all other requests the same for now and we will look into upgrading
separately.