### PR TITLE
PP-9599 add error enum to worldpay mapper

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayStatus.java
@@ -12,6 +12,7 @@ public enum WorldpayStatus {
     AUTHORISED("AUTHORISED", ChargeStatus.AUTHORISATION_SUCCESS),
     CANCELLED("CANCELLED", ChargeStatus.AUTHORISATION_CANCELLED),
     CAPTURED("CAPTURED", ChargeStatus.CAPTURED),
+    ERROR("ERROR", ChargeStatus.AUTHORISATION_ERROR),
     REFUSED("REFUSED", ChargeStatus.AUTHORISATION_REJECTED);
 
     private final String worldpayStatus;

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponseTest.java
@@ -27,4 +27,13 @@ class WorldpayOrderStatusResponseTest {
 
         assertFalse(worldpayOrderStatusResponse.isSoftDecline());
     }
+
+    @Test
+    void worldpay_response_should_not_be_soft_decline_when_error() {
+        var worldpayOrderStatusResponse = new WorldpayOrderStatusResponse();
+        worldpayOrderStatusResponse.setLastEvent("ERROR");
+        worldpayOrderStatusResponse.setExemptionResponseResult("REFUSED");
+
+        assertFalse(worldpayOrderStatusResponse.isSoftDecline());
+    }
 }


### PR DESCRIPTION
## WHAT YOU DID
- add "new" status (ERROR) to worldpay status mapper
