### PR TITLE
PP-9587 Clear disabled reason when account is re-enabled

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -225,8 +225,13 @@ public class GatewayAccountService {
                     gatewayAccountEntity.setAllowAuthorisationApi(gatewayAccountRequest.valueAsBoolean())),
             entry(FIELD_RECURRING_ENABLED, (gatewayAccountRequest, gatewayAccountEntity) ->
                     gatewayAccountEntity.setRecurringEnabled(gatewayAccountRequest.valueAsBoolean())),
-            entry(FIELD_DISABLED, (gatewayAccountRequest, gatewayAccountEntity) ->
-                    gatewayAccountEntity.setDisabled(gatewayAccountRequest.valueAsBoolean())),
+            entry(FIELD_DISABLED, (gatewayAccountRequest, gatewayAccountEntity) -> {
+                boolean disable = gatewayAccountRequest.valueAsBoolean();
+                gatewayAccountEntity.setDisabled(disable);
+                if (!disable) {
+                    gatewayAccountEntity.setDisabledReason(null);
+                }
+            }),
             entry(FIELD_DISABLED_REASON, (gatewayAccountRequest, gatewayAccountEntity) ->
                     gatewayAccountEntity.setDisabledReason(gatewayAccountRequest.valueAsString()))
     );

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -32,8 +32,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
@@ -670,10 +672,11 @@ public class GatewayAccountServiceTest {
         assertThat(optionalGatewayAccount.isPresent(), is(true));
         inOrder.verify(mockGatewayAccountEntity).setDisabled(true);
         inOrder.verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+        verify(mockGatewayAccountEntity, never()).setDisabledReason(anyString());
     }
 
     @Test
-    public void shouldUpdateDisabledToFalse() {
+    public void shouldUpdateDisabledToFalseAndClearDisabledReason() {
         var request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", FIELD_DISABLED,
@@ -686,6 +689,7 @@ public class GatewayAccountServiceTest {
         var inOrder = inOrder(mockGatewayAccountEntity, mockGatewayAccountDao);
         assertThat(optionalGatewayAccount.isPresent(), is(true));
         inOrder.verify(mockGatewayAccountEntity).setDisabled(false);
+        inOrder.verify(mockGatewayAccountEntity).setDisabledReason(null);
         inOrder.verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
     }
 


### PR DESCRIPTION
When a PATCH request is made to update a gateway account to set "disabled" to false, clear the stored "disabled_reason".