### PR TITLE
PP-9587 Log when a gateway account is disabled

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -231,6 +231,7 @@ public class GatewayAccountService {
                 if (!disable) {
                     gatewayAccountEntity.setDisabledReason(null);
                 }
+                logger.info("Gateway account {}", disable ? "disabled" : "re-enabled");
             }),
             entry(FIELD_DISABLED_REASON, (gatewayAccountRequest, gatewayAccountEntity) ->
                     gatewayAccountEntity.setDisabledReason(gatewayAccountRequest.valueAsString()))


### PR DESCRIPTION
Log when a gateway account is disabled or re-enabled so we can audit when this is done in Splunk.