### PR TITLE
PP-9785 Expunge telephone payments in authorisation error states

### DIFF
--- a/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.tasks.service.ParityCheckService;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import javax.inject.Inject;
 import javax.persistence.OptimisticLockException;
@@ -45,7 +46,7 @@ public class ChargeExpungeService {
             PaymentGatewayName.WORLDPAY,
             PaymentGatewayName.STRIPE);
 
-    private final List<ChargeStatus> expungeExemptChargeStatuses = List.of(
+    private final List<ChargeStatus> expungeExemptChargeAuthorisationErrorStatuses = List.of(
             AUTHORISATION_ERROR,
             AUTHORISATION_TIMEOUT,
             AUTHORISATION_UNEXPECTED_ERROR);
@@ -69,8 +70,9 @@ public class ChargeExpungeService {
             return true;
         }
         if (expungeExemptedGateways.contains(chargeEntity.getPaymentGatewayName()) &&
-                expungeExemptChargeStatuses.contains(status)) {
-            return false;
+                expungeExemptChargeAuthorisationErrorStatuses.contains(status)) {
+
+            return AuthorisationMode.EXTERNAL == chargeEntity.getAuthorisationMode();
         }
         return status.isExpungeable();
     }


### PR DESCRIPTION
## WHAT 
- Payments in authorisation error states (AUTHORISATION_ERROR, AUTHORISATION_TIMEOUT, AUTHORISATION_UNEXPECTED_ERROR) are currently **not** expunged immediately. These are processed by the gateway cleanup sweep task which queries and then tries to cancel any payments (if authorised with gateway) and moves charges to a different state.
- External payments errored and reported to us end up in the AUTHORISATION_ERROR state and so are not expunged too. We should just
  expunge these payments. The `provider_id` (gateway_transaction_id) reported for these payments is not exactly the orderCode used for Worldpay
