### PR TITLE
PP-9785 Do not throw exceptions for Worldpay order not found query response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/AuthorisationErrorGatewayCleanupService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/AuthorisationErrorGatewayCleanupService.java
@@ -105,7 +105,7 @@ public class AuthorisationErrorGatewayCleanupService {
             // The charge might not be found with the gateway when the authorisation failed due to an error with ePDQ
             // before they tried to process the payment. One example of this is when the card type is not enabled in ePDQ.
             logger.info("Charge was not found on the gateway. Gateway response was: " +
-                            chargeQueryResponse.getRawGatewayResponseString(),
+                            chargeQueryResponse.getRawGatewayResponseOrErrorMessage(),
                     chargeEntity.getStructuredLoggingArgs());
             chargeService.transitionChargeState(chargeEntity.getExternalId(), AUTHORISATION_ERROR_CHARGE_MISSING);
             return true;
@@ -142,7 +142,7 @@ public class AuthorisationErrorGatewayCleanupService {
             return false;
         }).orElseGet(() -> {
             logger.error("Charge does not map to an internal charge state. Raw query response was: " +
-                            chargeQueryResponse.getRawGatewayResponseString(),
+                            chargeQueryResponse.getRawGatewayResponseOrErrorMessage(),
                     chargeEntity.getStructuredLoggingArgs());
             return false;
         });

--- a/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryResponse.java
@@ -1,30 +1,50 @@
 package uk.gov.pay.connector.gateway;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseInquiryResponse;
 
 import java.util.Optional;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class ChargeQueryResponse {
     private ChargeStatus mappedStatus;
-    private final BaseInquiryResponse rawGatewayResponse;
+    private GatewayError gatewayError;
+    private BaseInquiryResponse rawGatewayResponse;
 
     public ChargeQueryResponse(ChargeStatus mappedStatus, BaseInquiryResponse rawGatewayResponse) {
         this.mappedStatus = mappedStatus;
         this.rawGatewayResponse = rawGatewayResponse;
     }
 
+    public ChargeQueryResponse(GatewayError gatewayError) {
+        this.gatewayError = gatewayError;
+    }
+
     public Optional<ChargeStatus> getMappedStatus() {
         return Optional.ofNullable(mappedStatus);
     }
 
-    public String getRawGatewayResponseString() {
-        return rawGatewayResponse.toString();
+    public Optional<BaseInquiryResponse> getRawGatewayResponse() {
+        return Optional.ofNullable(rawGatewayResponse);
     }
-    
+
+    public String getRawGatewayResponseOrErrorMessage() {
+        return getRawGatewayResponse()
+                .map(Object::toString)
+                .or(() -> getGatewayError().map(GatewayError::getMessage))
+                .orElse(EMPTY);
+    }
+
     public boolean foundCharge() {
-        return isNotBlank(rawGatewayResponse.getTransactionId());
+        return getRawGatewayResponse()
+                .map(response -> isNotBlank(response.getTransactionId()))
+                .orElse(false);
+    }
+
+    public Optional<GatewayError> getGatewayError() {
+        return Optional.ofNullable(gatewayError);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/report/model/GatewayStatusComparison.java
+++ b/src/main/java/uk/gov/pay/connector/report/model/GatewayStatusComparison.java
@@ -35,7 +35,7 @@ public final class GatewayStatusComparison {
     private GatewayStatusComparison(Charge charge, ChargeQueryResponse gatewayQueryResponse) {
         this(charge);
         gatewayStatus = gatewayQueryResponse.getMappedStatus().orElse(null);
-        rawGatewayResponse = gatewayQueryResponse.getRawGatewayResponseString();
+        rawGatewayResponse = gatewayQueryResponse.getRawGatewayResponseOrErrorMessage();
     }
 
     private GatewayStatusComparison(Charge charge) {

--- a/src/test/java/uk/gov/pay/connector/gateway/ChargeQueryResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/ChargeQueryResponseTest.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.gateway;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayQueryResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+
+class ChargeQueryResponseTest {
+
+    @Test
+    void getRawGatewayResponseOrErrorMessage_shouldReturnGatewayResponseIfAvailable() {
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_ERROR, new WorldpayQueryResponse());
+        assertEquals("Worldpay query response ()", chargeQueryResponse.getRawGatewayResponseOrErrorMessage());
+    }
+
+    @Test
+    void getRawGatewayResponseOrErrorMessage_shouldReturnErrorMessageWhenAvailableAndGatewayResponseIsNotAvailable() {
+        GatewayError gatewayError = GatewayError.genericGatewayError("order not found");
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(gatewayError);
+        assertEquals("order not found", chargeQueryResponse.getRawGatewayResponseOrErrorMessage());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -123,7 +123,8 @@ public class WorldpayCaptureHandlerTest {
     @Test
     public void shouldErrorIfOrderReferenceNotKnownInCapture() throws Exception {
         when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
-        when(response.readEntity(String.class)).thenReturn(load("templates/worldpay/error-response.xml"));
+        when(response.readEntity(String.class)).thenReturn(load("templates/worldpay/error-response.xml")
+                .replace("{{errorDescription}}", "Order has already been paid"));
         TestResponse testResponse = new TestResponse(this.response);
         when(client.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap())).thenReturn(testResponse);
 

--- a/src/test/resources/templates/worldpay/error-response.xml
+++ b/src/test/resources/templates/worldpay/error-response.xml
@@ -4,7 +4,7 @@
 <paymentService version="1.4" merchantCode="MERCHANTCODE">
     <reply>
         <error code="5">
-            <![CDATA[Order has already been paid]]>
+            <![CDATA[{{errorDescription}}]]>
         </error>
     </reply>
 </paymentService>


### PR DESCRIPTION
## WHAT

- Worldpay connection timed out payments end up in authorisation error states and the requests may never have reached Worldpay. When various tasks (gateway cleanup sweep, discrepancy checker) query Worldpay for the transaction, an error response is returned with code `5` and the message `Could not find payment for order`.
- Currently, WebApplicationException is thrown by the Worldpay query payment method and is causing 500 errors for the discrepancy checker. Gateway cleanup service catches exceptions and continues onto the next payment (without updating charge status). So auth errored charges (for which is there is no Worldpay order) are being retried continuously and new charges are not being cleaned up (as the gateway clean service is attempting to query the same charges for every invoke and also has a limit of 100 charges)
- So returning `ChargeQueryResponse` when Worldpay returns `Could not find payment for order` error.
    - The discrepancy checker will return the message and is displayed in Toolbox
    - Gateway cleanup service will update charge status to `AUTHORISATION_ERROR_CHARGE_MISSING` (which will be expunged by connector)
