### PR TITLE
PP-9785 Do not throw exception when stripe payment intent is not found

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeQueryResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeQueryResponse.java
@@ -2,6 +2,10 @@ package uk.gov.pay.connector.gateway.stripe.response;
 
 import uk.gov.pay.connector.gateway.model.response.BaseInquiryResponse;
 
+import java.util.StringJoiner;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 public class StripeQueryResponse implements BaseInquiryResponse {
     private String transactionId;
     private String errorCode;
@@ -30,5 +34,20 @@ public class StripeQueryResponse implements BaseInquiryResponse {
     @Override
     public String getErrorMessage() {
         return errorCode;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "Stripe query response (", ")");
+        if (isNotBlank(getTransactionId())) {
+            joiner.add("payment intent ID: " + getTransactionId());
+        }
+        if (isNotBlank(getErrorCode())) {
+            joiner.add("error code: " + getErrorCode());
+        }
+        if (isNotBlank(getErrorMessage())) {
+            joiner.add("error: " + getErrorMessage());
+        }
+        return joiner.toString();
     }
 }


### PR DESCRIPTION
## WHAT
- Stripe connection timed out payments end up in authorisation error states and the requests may never have reached Stripe. When various tasks (gateway cleanup sweep, discrepancy checker) query Stripe for the payment intent (for charge external ID), Stripe returns an empty result list.
- Currently, ChargeNotFoundException is thrown by the Stripe query payment method and is causing 500 errors for the discrepancy checker. Gateway cleanup service catches exceptions and continues onto the next payment (without updating charge status). So auth errored charges (for which there is no Stripe payment intent) are being retried continuously and new charges are not cleaned up.
- So returning `ChargeQueryResponse` with an error instead of throwing an exception.

- Fix format() in `AuthorisationErrorGatewayCleanupService` which is missing required number of args


Similar to https://github.com/alphagov/pay-connector/pull/3820