### PR TITLE
PP-9796 OpenAPI specs for Gateway account resources

### DIFF
--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -108,7 +108,7 @@ paths:
   /v1/api/accounts/{accountId}/telephone-charges:
     post:
       description: "Create a new telephone charge for gateway account. These are externally\
-        \ taken payments and the outcome is reported to this endpoint.provider_id\
+        \ taken payments and the outcome is reported to this endpoint. provider_id\
         \ is used as an idempotency key for API calls. If a payment already exists\
         \ with the provider_id provided, the API will not store a record about a new\
         \ payment, or update or change the record about a payment previously stored."
@@ -648,7 +648,7 @@ components:
           type: array
           items:
             type: string
-            example: "Field [description] cannot be null"
+            example: error message
         reason:
           type: string
           example: "Optional - ex: amount_not_available"

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -141,7 +141,7 @@ public class ChargesApiResource {
     @Produces(APPLICATION_JSON)
     @Operation(
             summary = "Create a new telephone charge for gateway account.",
-            description = "Create a new telephone charge for gateway account. These are externally taken payments and the outcome is reported to this endpoint." +
+            description = "Create a new telephone charge for gateway account. These are externally taken payments and the outcome is reported to this endpoint. " +
                     "provider_id is used as an idempotency key for API calls. If a payment already exists with the provider_id provided, the API will not store a record about a new payment, or update or change the record about a payment previously stored.",
             tags = {"Charges"},
             responses = {

--- a/src/main/java/uk/gov/pay/connector/common/model/api/ErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/ErrorResponse.java
@@ -18,7 +18,7 @@ public class ErrorResponse {
     private ErrorIdentifier identifier;
     
     @JsonProperty("message")
-    @ArraySchema(schema = @Schema(example = "Field [description] cannot be null"))
+    @ArraySchema(schema = @Schema(example = "error message"))
     private List<String> messages;
     
     @JsonProperty("reason")

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/GatewayAccountSwitchPaymentProviderRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/GatewayAccountSwitchPaymentProviderRequest.java
@@ -1,7 +1,9 @@
 package uk.gov.pay.connector.gatewayaccount;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GatewayAccountSwitchPaymentProviderRequest {
@@ -9,10 +11,14 @@ public class GatewayAccountSwitchPaymentProviderRequest {
     public static final String USER_EXTERNAL_ID_FIELD = "user_external_id";
     public static final String GATEWAY_ACCOUNT_CREDENTIAL_EXTERNAL_ID = "gateway_account_credential_external_id";
 
+    @JsonIgnore
     private String userExternalId;
+    @JsonIgnore
     private String gatewayAccountCredentialExternalId;
 
-    public GatewayAccountSwitchPaymentProviderRequest(@JsonProperty(USER_EXTERNAL_ID_FIELD) String userExternalId,
+    public GatewayAccountSwitchPaymentProviderRequest(@Schema(example = "vfrg4245bd0e7453c9b1b0d7e6999f11b", description = "User external ID switching payment service provider")
+                                                      @JsonProperty(USER_EXTERNAL_ID_FIELD) String userExternalId,
+                                                      @Schema(example = "dfokpo23ji0213ldsm0123ofsm213kdfg", description = "Gateway account credential external ID to switch to")
                                                       @JsonProperty(GATEWAY_ACCOUNT_CREDENTIAL_EXTERNAL_ID) String gatewayAccountCredentialExternalId) {
         this.userExternalId = userExternalId;
         this.gatewayAccountCredentialExternalId = gatewayAccountCredentialExternalId;
@@ -22,6 +28,7 @@ public class GatewayAccountSwitchPaymentProviderRequest {
         return userExternalId;
     }
 
+    @JsonIgnore
     public String getGACredentialExternalId() {
         return gatewayAccountCredentialExternalId;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.dropwizard.validation.ValidationMethod;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 
 import java.util.Map;
@@ -25,27 +26,36 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GatewayAccountRequest {
 
+    @JsonIgnore
     private String providerAccountType;
 
+    @JsonIgnore
     private String serviceName;
 
+    @JsonIgnore
     private final String serviceId;
 
+    @JsonIgnore
     private String description;
 
+    @JsonIgnore
     private String analyticsId;
 
+    @JsonIgnore
     private String paymentProvider;
-    
+
+    @JsonIgnore
     private boolean requires3ds;
-    
-    public GatewayAccountRequest(@JsonProperty("type") String providerAccountType,
-                                 @JsonProperty("payment_provider") String paymentProvider,
-                                 @JsonProperty("service_name") String serviceName,
-                                 @JsonProperty("service_id") String serviceId,
-                                 @JsonProperty("description") String description,
-                                 @JsonProperty("analytics_id") String analyticsId,
-                                 @JsonProperty("requires_3ds") boolean requires3ds
+
+    public GatewayAccountRequest(@JsonProperty("type") @Schema(example = "live", description = "Account type for this provider (test/live)", defaultValue = "test") String providerAccountType,
+                                 @JsonProperty("payment_provider") @Schema(example = "stripe", description = "The payment provider for which this account is created", defaultValue = "sandbox")
+                                 String paymentProvider,
+                                 @JsonProperty("service_name") @Schema(example = "service name") String serviceName,
+                                 @JsonProperty("service_id") @Schema(example = "service-external-id") String serviceId,
+                                 @JsonProperty("description") @Schema(description = "Some useful non-ambiguous description about the gateway account", example = "account for some gov org") String description,
+                                 @JsonProperty("analytics_id") @Schema(description = "Google Analytics (GA) unique ID for the GOV.UK Pay platform", example = "analytics-id")
+                                 String analyticsId,
+                                 @JsonProperty("requires_3ds") @Schema(description = "Set to 'true' to enable 3DS for this account") boolean requires3ds
     ) {
         this.serviceName = serviceName;
         this.serviceId = serviceId;
@@ -102,6 +112,7 @@ public class GatewayAccountRequest {
         return analyticsId;
     }
 
+    @JsonIgnore
     public Map<String, String> getCredentialsAsMap() {
         return newHashMap();
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gatewayaccount.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 
@@ -17,76 +18,118 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 public class GatewayAccountResourceDTO {
 
     @JsonProperty("gateway_account_id")
+    @Schema(example = "1", description = "The account ID")
     private long accountId;
 
     @JsonProperty("external_id")
+    @Schema(example = "fbf905a3f7ea416c8c252410eb45ddbd", description = "External ID for the gateway account")
     private String externalId;
 
     @JsonProperty("payment_provider")
+    @Schema(example = "sandbox", description = "The payment provider for which this account is created")
     private String paymentProvider;
 
+    @Schema(example = "test", description = "Account type for the payment provider (test/live)")
     private GatewayAccountType type;
 
+    @Schema(example = "Account for service xxx", description = "An internal description to identify the gateway account. The default value is null.", defaultValue = "null")
     private String description;
 
     @JsonProperty("service_name")
+    @Schema(example = "service name", description = "The service name for the account")
     private String serviceName;
 
     @JsonProperty("service_id")
+    @Schema(example = "cd1b871207a94a7fa157dee678146acd", description = "Service external ID")
     private String serviceId;
 
     @JsonProperty("analytics_id")
+    @Schema(description = "An identifier used to identify the service in Google Analytics. The default value is null")
     private String analyticsId;
 
     @JsonProperty("corporate_credit_card_surcharge_amount")
+    @Schema(example = "250", description = "A corporate credit card surcharge amount in pence", defaultValue = "0")
     private long corporateCreditCardSurchargeAmount;
 
     @JsonProperty("corporate_debit_card_surcharge_amount")
+    @Schema(example = "250", description = "A corporate debit card surcharge amount in pence", defaultValue = "0")
     private long corporateDebitCardSurchargeAmount;
 
     @JsonProperty("_links")
+    @Schema(example = "{" +
+            "        {" +
+            "            \"href\": \"https://connector.url/v1/api/accounts/1\"," +
+            "            \"rel\": \"self\"," +
+            "            \"method\": \"GET\"" +
+            "        }" +
+            "    }")
     private Map<String, Map<String, URI>> links = new HashMap<>();
 
     @JsonProperty("allow_apple_pay")
+    @Schema(example = "true", description = "Set to true to enable Apple Pay", defaultValue = "false")
     private boolean allowApplePay;
 
     @JsonProperty("allow_google_pay")
+    @Schema(example = "true", description = "Set to true to enable Google Pay", defaultValue = "false")
     private boolean allowGooglePay;
 
     @JsonProperty("block_prepaid_cards")
+    @Schema(example = "true", description = "Whether pre-paid cards are allowed as a payment method for this gateway account", defaultValue = "false")
     private boolean blockPrepaidCards;
 
     @JsonProperty("corporate_prepaid_debit_card_surcharge_amount")
+    @Schema(example = "0", description = "A corporate prepaid debit card surcharge amount in pence")
     private long corporatePrepaidDebitCardSurchargeAmount;
 
     @JsonProperty("email_notifications")
+    @Schema(description = "The settings for the different emails (payments/refunds) that are sent out", example = "{" +
+            "        \"REFUND_ISSUED\": {" +
+            "            \"version\": 1," +
+            "            \"enabled\": true," +
+            "            \"template_body\": null" +
+            "        }," +
+            "        \"PAYMENT_CONFIRMED\": {" +
+            "            \"version\": 1," +
+            "            \"enabled\": true," +
+            "            \"template_body\": null" +
+            "        }" +
+            "    }")
     private Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
 
     @JsonProperty("email_collection_mode")
+    @Schema(description = "Whether email address is required from paying users. Can be MANDATORY, OPTIONAL or OFF")
     private EmailCollectionMode emailCollectionMode = EmailCollectionMode.MANDATORY;
 
     @JsonProperty("requires3ds")
+    @Schema(example = "true", description = "Flag to indicate whether 3DS is enabled")
     private boolean requires3ds;
 
     @JsonProperty("allow_zero_amount")
+    @Schema(example = "true", description = "Set to true to support charges with a zero amount", defaultValue = "false")
     private boolean allowZeroAmount;
 
     @JsonProperty("integration_version_3ds")
+    @Schema(example = "2", description = "3DS version used for payments for the gateway account")
     private int integrationVersion3ds;
 
     @JsonProperty("allow_moto")
+    @Schema(description = "Indicates whether the Mail Order and Telephone Order (MOTO) payments are allowed", defaultValue = "false")
     private boolean allowMoto;
 
     @JsonProperty("allow_telephone_payment_notifications")
+    @Schema(description = "Indicates if the account is used for telephone payments reporting", defaultValue = "false")
     private boolean allowTelephonePaymentNotifications;
 
     @JsonProperty("moto_mask_card_number_input")
+    @Schema(description = "Indicates whether the card number is masked when being input for MOTO payments. The default value is false.", defaultValue = "false")
     private boolean motoMaskCardNumberInput;
 
     @JsonProperty("moto_mask_card_security_code_input")
+    @Schema(description = "Indicates whether the card security code is masked when being input for MOTO payments.", defaultValue = "false")
     private boolean motoMaskCardSecurityCodeInput;
 
     @JsonProperty("provider_switch_enabled")
+    @Schema(example = "false", description = "Flag to enable payment provider switching", defaultValue = "false")
     private boolean providerSwitchEnabled;
 
     @JsonInclude(NON_NULL)
@@ -94,27 +137,38 @@ public class GatewayAccountResourceDTO {
     private Worldpay3dsFlexCredentials worldpay3dsFlexCredentials;
 
     @JsonProperty("send_payer_ip_address_to_gateway")
+    @Schema(example = "true", description = "If enabled, user IP address is sent to to gateway", defaultValue = "false")
     private boolean sendPayerIpAddressToGateway;
 
     @JsonProperty("send_payer_email_to_gateway")
+    @Schema(example = "true", description = "If enabled, user email address is included in the authorisation request to gateway", defaultValue = "false")
     private boolean sendPayerEmailToGateway;
 
     @JsonProperty("send_reference_to_gateway")
+    @Schema(example = "true", description = "If enabled, service payment reference is sent to gateway as description. " +
+            "Otherwise payment description is sent to the gateway. Only applicable for Worldpay accounts. Default value is 'false'", defaultValue = "false")
     private boolean sendReferenceToGateway;
 
     @JsonProperty("requires_additional_kyc_data")
+    @Schema(example = "true", description = "Flag to indicate whether the account requires additional KYC data. Used to enable additional KYC data collection for stripe accounts",
+            defaultValue = "false")
     private boolean requiresAdditionalKycData;
-    
+
     @JsonProperty("allow_authorisation_api")
+    @Schema(example = "true", description = "Flag to indicate whether the account is allowed to initiate MOTO payments that are authorised via " +
+            "an API request rather than the web interface", defaultValue = "false")
     private boolean allowAuthorisationApi;
 
     @JsonProperty("recurring_enabled")
+    @Schema(example = "true", description = "Flag to indicate whether the account is allowed to take recurring card payments", defaultValue = "false")
     private boolean recurringEnabled;
-    
+
     @JsonProperty("disabled")
+    @Schema(example = "false", description = "Flag to indicate whether the account is allowed to take payments and make refunds", defaultValue = "false")
     private boolean disabled;
-    
+
     @JsonProperty("disabled_reason")
+    @Schema(example = "No longer required", description = "The reason the account is disabled, if applicable")
     private String disabledReason;
 
     public GatewayAccountResourceDTO() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.net.URI;
 import java.util.List;
@@ -12,27 +13,41 @@ import java.util.Map;
 public class GatewayAccountResponse {
 
     @JsonProperty("type")
+    @Schema(example = "live")
     private final String providerAccountType;
 
     @JsonProperty("service_name")
+    @Schema(example = "service name")
     private final String serviceName;
 
     @JsonProperty("description")
+    @Schema(example = "account for some gov org")
     private final String description;
 
     @JsonProperty("external_id")
+    @Schema(example = "ab2c296ed98647e9a25f045f5e6e87a2")
     private final String externalId;
 
     @JsonProperty("analytics_id")
+    @Schema(example = "ananytics-id")
     private final String analyticsId;
 
     @JsonProperty("gateway_account_id")
+    @Schema(example = "2")
     private final String gatewayAccountId;
 
     @JsonProperty("requires_3ds")
+    @Schema(example = "true")
     private final boolean requires3ds;
 
     @JsonProperty("links")
+    @Schema(example = "[" +
+            "        {" +
+            "            \"href\": \"https://connector.url/v1/api/accounts/2\"," +
+            "            \"rel\": \"self\"," +
+            "            \"method\": \"GET\"" +
+            "        }" +
+            "    ]")
     private final List<Map<String, Object>> links;
 
     @JsonIgnore

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountsListDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountsListDTO.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+public class GatewayAccountsListDTO {
+
+    @JsonProperty("accounts")
+    private final List<GatewayAccountResourceDTO> gatewayAccountsListDTOList;
+
+    private GatewayAccountsListDTO(List<GatewayAccountResourceDTO> gatewayAccountsListDTOList) {
+        this.gatewayAccountsListDTOList = gatewayAccountsListDTOList;
+    }
+
+
+    public static GatewayAccountsListDTO of(List<GatewayAccountResourceDTO> gatewayAccountsListDTOList) {
+        return new GatewayAccountsListDTO(gatewayAccountsListDTOList);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountResponse.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gatewayaccount.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Objects;
 
@@ -9,6 +10,7 @@ import java.util.Objects;
 public class StripeAccountResponse {
 
     @JsonProperty("stripe_account_id")
+    @Schema(required = true, example = "acct_123example123")
     private final String stripeAccountId;
 
     public StripeAccountResponse(String stripeAccountId) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
@@ -3,17 +3,21 @@ package uk.gov.pay.connector.gatewayaccount.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Objects;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Worldpay3dsFlexCredentials {
 
+    @Schema(example = "issuer")
     private String issuer;
+    @Schema(example = "org_unit_id")
     private String organisationalUnitId;
 
     @JsonIgnore
     private String jwtMacKey;
+    @Schema(example = "true")
     private boolean exemptionEngineEnabled;
 
     public Worldpay3dsFlexCredentials(String issuer, String organisationalUnitId, String jwtMacKey, boolean exemptionEngineEnabled) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
@@ -1,5 +1,11 @@
 package uk.gov.pay.connector.gatewayaccount.resource;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.resource.support.StripeAccountUtils;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
@@ -15,6 +21,7 @@ import javax.ws.rs.Produces;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/")
+@Tag(name = "Gateway accounts")
 public class StripeAccountResource {
 
     private final StripeAccountService stripeAccountService;
@@ -30,7 +37,17 @@ public class StripeAccountResource {
     @GET
     @Path("/v1/api/accounts/{accountId}/stripe-account")
     @Produces(APPLICATION_JSON)
-    public StripeAccountResponse getStripeAccount(@PathParam("accountId") Long accountId) {
+    @Operation(
+            summary = "Retrieves Stripe Connect account information for a given gateway account ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(implementation = StripeAccountResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not found - Account does not exist or not a stripe gateway account or account does not have Stripe credentials, ")
+            }
+    )
+    public StripeAccountResponse getStripeAccount(
+            @Parameter(example = "1", description = "Gateway account ID")
+            @PathParam("accountId") Long accountId) {
         return gatewayAccountService.getGatewayAccount(accountId)
                 .filter(StripeAccountUtils::isStripeGatewayAccount)
                 .flatMap(stripeAccountService::buildStripeAccountResponse)

--- a/src/main/java/uk/gov/pay/connector/usernotification/model/domain/EmailNotificationEntity.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/model/domain/EmailNotificationEntity.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.usernotification.model.domain;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
@@ -32,17 +33,21 @@ public class EmailNotificationEntity extends AbstractVersionedEntity {
 
     @Column(name = "template_body")
     @JsonProperty("template_body")
+    @Schema(example = "", description = "Custom paragraph for the email template")
     private String templateBody;
 
+    @Schema(example = "true", description = "Indicates whether emails are enabled for notifications type")
     private boolean enabled;
 
     @Column(name = "type", insertable = false, updatable = false)
     @Enumerated(EnumType.STRING)
+    @Schema(description = "Email notification type - PAYMENT_CONFIRMED or REFUND_ISSUED ")
     private EmailNotificationType type;
 
     @OneToOne
     @JoinColumn(name = "account_id", nullable = false)
     @JsonBackReference
+    @Schema(hidden = true)
     private GatewayAccountEntity accountEntity;
 
     public EmailNotificationEntity() {


### PR DESCRIPTION
- Added annotations to generate OpenAPI specs for endpoints in GatewayAccountResource which includes below.

      GET /v1/api/accounts
      POST /v1/api/accounts
      GET /v1/api/accounts/{accountId}
      PATCH /v1/api/accounts/{accountId}
      PATCH /v1/api/accounts/{accountId}/description-analytics-id
      POST /v1/api/accounts/{accountId}/notification-credentials
      POST /v1/api/accounts/{accountId}/switch-psp
      GET /v1/frontend/accounts
      GET /v1/frontend/accounts/external-id/{externalId}
      GET /v1/frontend/accounts/{accountId}
      PATCH /v1/frontend/accounts/{accountId}/3ds-toggle
      GET /v1/frontend/accounts/{accountId}/card-types
      POST /v1/frontend/accounts/{accountId}/card-types
      PATCH /v1/frontend/accounts/{accountId}/servicename

      GET /v1/api/accounts/{accountId}/stripe-account
      GET /v1/api/accounts/{accountId}/stripe-setup
      PATCH /v1/api/accounts/{accountId}/stripe-setup


- Preview using editor.swagger.io (not updated OpenAPI specs to keep the PR size limited)

![image](https://user-images.githubusercontent.com/40598480/176780137-e9757f15-841c-4b86-86b2-a91495da86e1.png)

![image](https://user-images.githubusercontent.com/40598480/176780166-01a9908f-4d9a-43a9-8b7d-b81a33785fa6.png)


## How to test

- Add below to openapi-config.yaml and run `mvn compile` to update specs
    - uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountResource
    - uk.gov.pay.connector.gatewayaccount.resource.StripeAccountSetupResource
    - uk.gov.pay.connector.gatewayaccount.resource.StripeAccountResource
 
