### PR TITLE
PP-9796 OpenAPI specs for card and secure token resources

### DIFF
--- a/src/main/java/uk/gov/pay/connector/cardtype/model/domain/CardBrandLabelEntity.java
+++ b/src/main/java/uk/gov/pay/connector/cardtype/model/domain/CardBrandLabelEntity.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.cardtype.model.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.common.model.domain.UuidAbstractEntity;
 
 import javax.persistence.Column;
@@ -11,9 +12,11 @@ import javax.persistence.Table;
 public class CardBrandLabelEntity extends UuidAbstractEntity {
 
     @Column
+    @Schema(example = "visa")
     private String brand;
 
     @Column
+    @Schema(example = "Visa")
     private String label;
     
     public String getBrand() {

--- a/src/main/java/uk/gov/pay/connector/charge/model/AddressEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/AddressEntity.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.charge.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.common.model.domain.Address;
 
 import javax.persistence.Column;
@@ -11,18 +12,25 @@ import static uk.gov.pay.connector.common.model.domain.NumbersInStringsSanitizer
 public class AddressEntity {
 
     @Column(name = "address_line1")
+    @Schema(example = "address line 1")
     private String line1;
     @Column(name = "address_line2")
+    @Schema(example = "address line 2")
     private String line2;
     @Column(name = "address_postcode")
+    @Schema(example = "AB1 2CD")
     private String postcode;
     @Column(name = "address_city")
+    @Schema(example = "London")
     private String city;
     @Column(name = "address_county")
+    @Schema(example = "London")
     private String county;
     @Column(name = "address_country")
+    @Schema(example = "GB")
     private String country;
     @Column(name = "address_state_province")
+    @Schema(example = "")
     private String stateOrProvince;
 
     public AddressEntity() {

--- a/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.charge.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.service.payments.commons.jpa.CardExpiryDateConverter;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
@@ -27,24 +28,28 @@ public class CardDetailsEntity {
 
     @Column(name = "first_digits_card_number")
     @JsonProperty("first_digits_card_number")
+    @Schema(example = "424242")
     @Convert(converter = FirstDigitsCardNumberConverter.class)
     @JsonSerialize(using = ToStringSerializer.class)
     private FirstDigitsCardNumber firstDigitsCardNumber;
 
     @Column(name = "last_digits_card_number")
     @JsonProperty("last_digits_card_number")
+    @Schema(example = "4242")
     @Convert(converter = LastDigitsCardNumberConverter.class)
     @JsonSerialize(using = ToStringSerializer.class)
     private LastDigitsCardNumber lastDigitsCardNumber;
 
     @Column(name = "cardholder_name")
     @JsonProperty("cardholder_name")
+    @Schema(example = "Joe B")
     private String cardHolderName;
 
     @Column(name = "expiry_date")
     @Convert(converter = CardExpiryDateConverter.class)
     @JsonProperty("expiry_date")
     @JsonSerialize(using = ToStringSerializer.class)
+    @Schema(example = "01/99")
     private CardExpiryDate expiryDate;
 
     @OneToOne(fetch = FetchType.LAZY)
@@ -52,12 +57,14 @@ public class CardDetailsEntity {
     private CardBrandLabelEntity cardTypeDetails;
 
     @Column(name = "card_brand")
+    @Schema(example = "visa")
     private String cardBrand;
 
     @Column(name = "card_type")
     @Enumerated(EnumType.STRING)
     @JsonProperty("card_type")
     @JsonSerialize(using = ToLowerCaseStringSerializer.class)
+    @Schema(example = "credit")
     private CardType cardType;
 
     @Embedded

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.charge.model.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import net.logstash.logback.argument.StructuredArgument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,21 +87,27 @@ public class ChargeEntity extends AbstractVersionedEntity {
     private Long id;
 
     @Column(name = "external_id")
+    @Schema(example = "5t2rupktnsk0a3mu800st7irts")
     private String externalId;
 
     @Column(name = "amount")
+    @Schema(example = "100")
     private Long amount;
 
     @Column(name = "status")
+    @Schema(example = "AUTHORISATION SUCCESS")
     private String status;
 
     @Column(name = "gateway_transaction_id")
+    @Schema(example = "bba59957-5155-4f59-8c69-a839f71772d3")
     private String gatewayTransactionId;
 
     @Column(name = "return_url")
+    @Schema(example = "https://service-name.gov.uk/transactions/12345")
     private String returnUrl;
 
     @Column(name = "email")
+    @Schema(example = "joe.blogs@example.org")
     private String email;
 
     @Column(name = "corporate_surcharge")
@@ -128,11 +135,13 @@ public class ChargeEntity extends AbstractVersionedEntity {
     private List<ChargeEventEntity> events = new ArrayList<>();
 
     @Column(name = "description")
+    @Schema(example = "payment description")
     private String description;
 
     @Column(name = "reference")
     @Convert(converter = ServicePaymentReferenceConverter.class)
     @JsonSerialize(using = ToStringSerializer.class)
+    @Schema(example = "payment reference")
     private ServicePaymentReference reference;
 
     @Column(name = "provider_session_id")
@@ -140,10 +149,12 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     @Column(name = "created_date")
     @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
+    @Schema(example = "1656606127.578088000")
     private Instant createdDate;
 
     @Column(name = "language", nullable = false)
     @Convert(converter = SupportedLanguageJpaConverter.class)
+    @Schema(example = "en")
     private SupportedLanguage language;
 
     @Column(name = "delayed_capture")
@@ -156,6 +167,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @Valid
     @Column(name = "external_metadata", columnDefinition = "jsonb")
     @Convert(converter = ExternalMetadataConverter.class)
+    @Schema(example = "{}")
     private ExternalMetadata externalMetadata;
 
     @Column(name = "parity_check_status")
@@ -168,6 +180,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     @Column(name = "source")
     @Enumerated(EnumType.STRING)
+    @Schema(example = "CARD_API")
     private Source source;
 
     @Column(name = "moto")
@@ -178,9 +191,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
     private Exemption3ds exemption3ds;
 
     @Column(name = "payment_provider")
+    @Schema(example = "stripe")
     private String paymentProvider;
 
     @Column(name = "service_id")
+    @Schema(example = "46eb1b601348499196c99de90482ee68")
     private String serviceId;
 
     @Column(name = "agreement_id")
@@ -384,6 +399,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.status = targetStatus.getValue();
     }
 
+    @JsonIgnore
     public Object[] getStructuredLoggingArgs() {
         return new StructuredArgument[]{
                 kv(PAYMENT_EXTERNAL_ID, externalId),

--- a/src/main/java/uk/gov/pay/connector/chargeevent/model/domain/ChargeEventEntity.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/model/domain/ChargeEventEntity.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.chargeevent.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
@@ -36,14 +37,17 @@ public class ChargeEventEntity extends AbstractVersionedEntity {
     private ChargeEntity chargeEntity;
 
     @Convert(converter = ChargeStatusConverter.class)
+    @Schema(example = "CAPTURED")
     private ChargeStatus status;
 
     @Column(name = "gateway_event_date")
     @Convert(converter = UTCDateTimeConverter.class)
+    @Schema(example = "2022-05-27T09:17:19.162Z")
     private ZonedDateTime gatewayEventDate;
 
     @Column(insertable = false, updatable = false)
     @Convert(converter = LocalDateTimeConverter.class)
+    @Schema(example = "1656606727.366582000")
     private ZonedDateTime updated;
 
     protected ChargeEventEntity() {
@@ -79,7 +83,7 @@ public class ChargeEventEntity extends AbstractVersionedEntity {
     public ChargeEntity getChargeEntity() {
         return chargeEntity;
     }
-    
+
     public static final class ChargeEventEntityBuilder {
         private ChargeEntity chargeEntity;
         private ChargeStatus status;

--- a/src/main/java/uk/gov/pay/connector/gateway/model/Auth3dsResult.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/Auth3dsResult.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Objects;
 
@@ -20,13 +21,14 @@ public class Auth3dsResult implements AuthorisationDetails {
 
     @JsonProperty("pa_response")
     public void setPaResponse(String paResponse) {
-            this.paResponse = paResponse;
-        }
+        this.paResponse = paResponse;
+    }
 
     public String getPaResponse() {
-            return paResponse;
-        }
+        return paResponse;
+    }
 
+    @Schema(hidden = true)
     public Auth3dsResultOutcome getAuth3dsResultOutcome() {
         return auth3dsResultOutcome;
     }
@@ -50,6 +52,7 @@ public class Auth3dsResult implements AuthorisationDetails {
     }
 
     @JsonProperty("three_ds_version")
+    @Schema(hidden = true)
     public void setThreeDsVersion(String threeDsVersion) {
         this.threeDsVersion = threeDsVersion;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -20,24 +21,42 @@ import static uk.gov.pay.connector.gateway.model.PayersCardType.CREDIT_OR_DEBIT;
 @ValidAuthCardDetails
 public class AuthCardDetails implements AuthorisationDetails {
 
+    @Schema(example = "4242424242424242", description = "Card number. See https://docs.payments.service.gov.uk/testing_govuk_pay/#mock-card-numbers-and-email-addresses for test card numbers")
     private String cardNo;
+    @Schema(example = "Joe B", description = "Cardholder name")
     private String cardHolder;
+    @Schema(example = "123")
     private String cvc;
+    @Schema(example = "01/99")
     private CardExpiryDate endDate;
     private Address address;
+    @Schema(example = "visa")
     private String cardBrand;
+    @Schema(example = "Mozilla/5.0")
     private String userAgentHeader;
+    @Schema(example = "text/html")
     private String acceptHeader;
+    @Schema(example = "DEBIT")
     private PayersCardType payersCardType;
+    @Schema(example = "NOT_PREPAID")
     private PayersCardPrepaidStatus payersCardPrepaidStatus;
+    @Schema(example = "false")
     private Boolean corporateCard;
+    @Schema(example = "1f1154b7-620d-4654-801b-893b5bb22db1")
     private String worldpay3dsFlexDdcResult;
+    @Schema(example = "127.0.0.1")
     private String ipAddress;
+    @Schema(example = "24")
     private String jsScreenColorDepth;
+    @Schema(example = "en-GB")
     private String jsNavigatorLanguage;
+    @Schema(example = "900")
     private String jsScreenHeight;
+    @Schema(example = "1440")
     private String jsScreenWidth;
+    @Schema(example = "-60")
     private String jsTimezoneOffsetMins;
+    @Schema(example = "fr;q=0.9, fr-CH;q=1.0, en;q=0.8, de;q=0.7, *;q=0.5")
     private String acceptLanguageHeader;
 
     public static AuthCardDetails anAuthCardDetails() {
@@ -173,8 +192,8 @@ public class AuthCardDetails implements AuthorisationDetails {
     @JsonProperty("ip_address")
     public void setIpAddress(String ipAddress) {
         this.ipAddress = ipAddress;
-    }    
-    
+    }
+
     @JsonProperty("accept_language_header")
     public void setAcceptLanguageHeader(String acceptLanguageHeader) {
         this.acceptLanguageHeader = acceptLanguageHeader;
@@ -212,10 +231,10 @@ public class AuthCardDetails implements AuthorisationDetails {
         return acceptHeader;
     }
 
-    public String getAcceptLanguageHeader () {
+    public String getAcceptLanguageHeader() {
         return acceptLanguageHeader;
     }
-    
+
     public boolean isCorporateCard() {
         return corporateCard == null ? false : corporateCard;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.eclipse.persistence.annotations.Customizer;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -41,14 +42,19 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     private Long id;
 
     @Column(name = "payment_provider")
+    @Schema(example = "stripe")
     private String paymentProvider;
 
     @Column(name = "credentials", columnDefinition = "json")
     @Convert(converter = CredentialsConverter.class)
+    @Schema(example = "{" +
+            "                \"stripe_account_id\": \"an-id\"" +
+            "            }")
     private Map<String, String> credentials;
 
     @Column(name = "state", nullable = false)
     @Enumerated(EnumType.STRING)
+    @Schema(example = "ACTIVE")
     private GatewayAccountCredentialState state;
 
     @Column(name = "last_updated_by_user_external_id")
@@ -56,10 +62,12 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
     @Column(name = "created_date")
     @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
+    @Schema(example = "2022-05-27T09:17:19.162Z")
     private Instant createdDate;
 
     @Column(name = "active_start_date")
     @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
+    @Schema(example = "2022-05-27T09:17:19.162Z")
     private Instant activeStartDate;
 
     @Column(name = "active_end_date")
@@ -72,6 +80,7 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     private GatewayAccountEntity gatewayAccountEntity;
 
     @Column(name = "external_id")
+    @Schema(example = "731193f990064e698ca1b89775b70bcc")
     private String externalId;
 
     public GatewayAccountCredentialsEntity() {
@@ -87,6 +96,7 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     }
 
     @JsonProperty("gateway_account_credential_id")
+    @Schema(example = "11")
     public Long getId() {
         return id;
     }
@@ -131,6 +141,7 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     }
 
     @JsonProperty("gateway_account_id")
+    @Schema(example = "1")
     public Long getGatewayAccountId() {
         return gatewayAccountEntity.getId();
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/model/AuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/model/AuthoriseRequest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.paymentprocessor.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.validator.constraints.Length;
 import uk.gov.pay.connector.charge.exception.InvalidAttributeValueException;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
@@ -23,21 +24,27 @@ import static uk.gov.service.payments.commons.model.CardExpiryDate.CARD_EXPIRY_D
 public class AuthoriseRequest {
 
     @NotBlank(message = "Missing mandatory attribute: one_time_token")
+    @Schema(example = "123abc123", required = true,
+            description = "the one time token provided in the `auth_url_post` link of the create payment API response")
     private String oneTimeToken;
 
     @NotBlank(message = "Missing mandatory attribute: card_number")
     @Length(min = 12, max = 19, message = "Invalid attribute value: card_number. Must be between {min} and {max} characters long")
+    @Schema(example = "4242424242424242", minLength = 12, maxLength = 19, required = true)
     private String cardNumber;
 
     @NotBlank(message = "Missing mandatory attribute: cvc")
     @Length(min = 3, max = 4, message = "Invalid attribute value: cvc. Must be between {min} and {max} characters long")
+    @Schema(example = "123", minLength = 3, maxLength = 4, required = true)
     private String cvc;
 
     @NotBlank(message = "Missing mandatory attribute: expiry_date")
+    @Schema(example = "01/99", minLength = 5, maxLength = 5, description = "5 character string in MM/YY format", required = true)
     private String expiryDate;
 
     @NotBlank(message = "Missing mandatory attribute: cardholder_name")
     @Length(min = 1, max = 255, message = "Invalid attribute value: cardholder_name. Must be less than or equal to {max} characters length")
+    @Schema(example = "Joe B", maxLength = 255, description = "Cardholder name", required = true)
     private String cardholderName;
 
     public AuthoriseRequest() {

--- a/src/main/java/uk/gov/pay/connector/token/model/domain/TokenResponse.java
+++ b/src/main/java/uk/gov/pay/connector/token/model/domain/TokenResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.token.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 
 import java.util.Objects;
@@ -8,9 +9,11 @@ import java.util.Objects;
 public class TokenResponse {
 
     @JsonProperty("used")
+    @Schema(description = "true or false depending on whether the token has been marked as used or not")
     private final boolean used;
 
     @JsonProperty("charge")
+    @Schema(description = "The charge associated with the token")
     private final ChargeEntity charge;
 
     public TokenResponse(boolean used, ChargeEntity charge) {

--- a/src/main/java/uk/gov/pay/connector/token/resource/SecurityTokensResource.java
+++ b/src/main/java/uk/gov/pay/connector/token/resource/SecurityTokensResource.java
@@ -2,6 +2,12 @@ package uk.gov.pay.connector.token.resource;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.google.inject.persist.Transactional;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
@@ -26,6 +32,7 @@ import static uk.gov.pay.connector.util.ResponseUtil.noContentResponse;
 import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
 
 @Path("/")
+@Tag(name = "Secure token")
 public class SecurityTokensResource {
 
     private final Logger logger = LoggerFactory.getLogger(SecurityTokensResource.class);
@@ -42,7 +49,15 @@ public class SecurityTokensResource {
     @Path("/v1/frontend/tokens/{chargeTokenId}")
     @Produces(APPLICATION_JSON)
     @JsonView(GatewayAccountEntity.Views.FrontendView.class)
-    public Response getToken(@PathParam("chargeTokenId") String chargeTokenId) {
+    @Operation(
+            summary = "Retrieve secure token",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not found")
+            }
+    )
+    public Response getToken(@Parameter(example = "a69a2cf3-d5d1-408f-b196-4b716767b507")
+                             @PathParam("chargeTokenId") String chargeTokenId) {
         logger.debug("get token {}", chargeTokenId);
         return tokenDao.findByTokenId(chargeTokenId)
                 .map(tokenEntity -> new TokenResponse(tokenEntity.isUsed(), tokenEntity.getChargeEntity()))
@@ -54,7 +69,15 @@ public class SecurityTokensResource {
     @Path("/v1/frontend/tokens/{chargeTokenId}/charge")
     @Produces(APPLICATION_JSON)
     @JsonView(GatewayAccountEntity.Views.FrontendView.class)
-    public Response getChargeForToken(@PathParam("chargeTokenId") String chargeTokenId) {
+    @Operation(
+            summary = "Retrieve charge for secure token",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ChargeEntity.class))),
+                    @ApiResponse(responseCode = "404", description = "Not found")
+            }
+    )
+    public Response getChargeForToken(@Parameter(example = "a69a2cf3-d5d1-408f-b196-4b716767b507")
+                                      @PathParam("chargeTokenId") String chargeTokenId) {
         logger.debug("get charge for token {}", chargeTokenId);
         Optional<ChargeEntity> chargeOpt = chargeDao.findByTokenId(chargeTokenId);
         return chargeOpt
@@ -66,7 +89,15 @@ public class SecurityTokensResource {
     @Path("/v1/frontend/tokens/{chargeTokenId}/used")
     @Produces(APPLICATION_JSON)
     @Transactional
-    public Response markTokenUsed(@PathParam("chargeTokenId") String chargeTokenId) {
+    @Operation(
+            summary = "Mark secure token as used",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "No content"),
+                    @ApiResponse(responseCode = "404", description = "Not found")
+            }
+    )
+    public Response markTokenUsed(@Parameter(example = "a69a2cf3-d5d1-408f-b196-4b716767b507")
+                                  @PathParam("chargeTokenId") String chargeTokenId) {
         logger.debug("mark token used for token {}", chargeTokenId);
         return tokenDao.findByTokenId(chargeTokenId)
                 .map(tokenEntity -> {
@@ -79,7 +110,15 @@ public class SecurityTokensResource {
     @DELETE
     @Path("/v1/frontend/tokens/{chargeTokenId}")
     @Transactional
-    public Response deleteToken(@PathParam("chargeTokenId") String chargeTokenId) {
+    @Operation(
+            summary = "Delete secure token",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "No content"),
+                    @ApiResponse(responseCode = "404", description = "Not found")
+            }
+    )
+    public Response deleteToken(@Parameter(example = "a69a2cf3-d5d1-408f-b196-4b716767b507")
+                                @PathParam("chargeTokenId") String chargeTokenId) {
         logger.debug("delete({})", chargeTokenId);
         tokenDao.findByTokenId(chargeTokenId)
                 .ifPresent(tokenDao::remove);

--- a/src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.wallets.WalletAuthorisationRequest;
 import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
 
@@ -14,31 +15,35 @@ import javax.validation.constraints.NotNull;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ApplePayAuthRequest implements WalletAuthorisationRequest {
     @NotNull @Valid private WalletPaymentInfo paymentInfo;
-    private EncryptedPaymentData encryptedPaymentData;
+    @Schema(name = "encrypted_payment_data")
+    private ApplePayEncryptedPaymentData encryptedPaymentData;
 
     @JsonProperty("payment_info")
     public WalletPaymentInfo getPaymentInfo() {
         return paymentInfo;
     }
 
-    public EncryptedPaymentData getEncryptedPaymentData() {
+    public ApplePayEncryptedPaymentData getEncryptedPaymentData() {
         return encryptedPaymentData;
     }
 
     public ApplePayAuthRequest() {
     }
 
-    public ApplePayAuthRequest(WalletPaymentInfo paymentInfo, EncryptedPaymentData encryptedPaymentData) {
+    public ApplePayAuthRequest(WalletPaymentInfo paymentInfo, ApplePayEncryptedPaymentData encryptedPaymentData) {
         this.paymentInfo = paymentInfo;
         this.encryptedPaymentData = encryptedPaymentData;
     }
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class EncryptedPaymentData {
+    public static class ApplePayEncryptedPaymentData {
+        @Schema(example = "4OZho15e9Yp5K0EtKergKzeRpPAjnK...JTga8W75IWAA==")
         private String data;
+        @Schema(example = "ECv1")
         private String version;
         private Header header;
+        @Schema(example = "MIAGCSqGSIb3DQEHAqCAMIACAQE..../tJr3SbTdxO25ZdN1bPH0Jiqgw7AAAAAAAA")
         private String signature;
 
 
@@ -58,10 +63,10 @@ public class ApplePayAuthRequest implements WalletAuthorisationRequest {
             return header;
         }
 
-        public EncryptedPaymentData() {
+        public ApplePayEncryptedPaymentData() {
         }
 
-        public EncryptedPaymentData(String version, String data, Header header, String signature) {
+        public ApplePayEncryptedPaymentData(String version, String data, Header header, String signature) {
             this.data = data;
             this.version = version;
             this.header = header;
@@ -71,8 +76,11 @@ public class ApplePayAuthRequest implements WalletAuthorisationRequest {
         @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
         @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Header {
+            @Schema(example = "LbsUwAT6w1JV9tFXocU813TCHks+LSuFF0R/eBkrWnQ=")
             private String publicKeyHash;
+            @Schema(example = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMwliotf2ICjiMwREdqyHSilqZzuV2fZey86nBIDlTY8sNMJv9CPpL5/DKg4bIEMe6qaj67mz4LWdr7Er0Ld5qA==")
             private String ephemeralPublicKey;
+            @Schema(example = "2686f5297f123ec7fd9d31074d43d201953ca75f098890375f13aed2737d92f2")
             private String transactionId;
             private String applicationData;
             private String wrappedKey;

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/EncryptedPaymentData.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/EncryptedPaymentData.java
@@ -2,21 +2,28 @@ package uk.gov.pay.connector.wallets.googlepay.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.hibernate.validator.constraints.NotEmpty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.validation.constraints.NotEmpty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EncryptedPaymentData {
     @NotEmpty(message= "Field [signed_message] must not be empty")
+    @Schema(hidden = true)
     private final String signedMessage;
     
     @NotEmpty(message= "Field [protocol_version] must not be empty")
+    @Schema(hidden = true)
     private final String protocolVersion;
 
     @NotEmpty(message= "Field [signature] must not be empty")
     private final String signature;
 
-    public EncryptedPaymentData(@JsonProperty("signed_message") String signedMessage,
+    public EncryptedPaymentData(@Schema(example = "aSignedMessage") 
+                                @JsonProperty("signed_message") String signedMessage,
+                                @Schema(example = "ECv1")
                                 @JsonProperty("protocol_version") String protocolVersion,
+                                @Schema(example = "MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ=")
                                 @JsonProperty("signature") String signature) {
         this.signedMessage = signedMessage;
         this.protocolVersion = protocolVersion;

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.wallets.googlepay.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.wallets.WalletAuthorisationRequest;
 import uk.gov.pay.connector.wallets.WalletType;
 import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
@@ -15,8 +16,14 @@ import java.util.Optional;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GooglePayAuthRequest implements WalletAuthorisationRequest, WalletAuthorisationData {
 
-    @NotNull @Valid private final WalletPaymentInfo paymentInfo;
-    @NotNull @Valid private final EncryptedPaymentData encryptedPaymentData;
+    @Schema(hidden = true)
+    @NotNull
+    @Valid
+    private final WalletPaymentInfo paymentInfo;
+    @Schema(hidden = true)
+    @NotNull
+    @Valid
+    private final EncryptedPaymentData encryptedPaymentData;
 
     GooglePayAuthRequest(@JsonProperty("payment_info") WalletPaymentInfo paymentInfo,
                          @JsonProperty("encrypted_payment_data") EncryptedPaymentData encryptedPaymentData) {
@@ -29,6 +36,7 @@ public class GooglePayAuthRequest implements WalletAuthorisationRequest, WalletA
     }
 
     @Override
+    @Schema(hidden = true)
     public Optional<LocalDate> getCardExpiryDate() {
         return Optional.empty();
     }
@@ -38,11 +46,13 @@ public class GooglePayAuthRequest implements WalletAuthorisationRequest, WalletA
     }
 
     @Override
+    @Schema(hidden = true)
     public String getLastDigitsCardNumber() {
         return getPaymentInfo().getLastDigitsCardNumber();
     }
 
     @Override
+    @Schema(hidden = true)
     public WalletType getWalletType() {
         return WalletType.GOOGLE_PAY;
     }

--- a/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.wallets.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.validator.constraints.Length;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 
@@ -12,15 +13,23 @@ import java.util.Optional;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WalletPaymentInfo {
     
+    @Schema(description = "last digits card number", example = "4242")
     private String lastDigitsCardNumber;
+    @Schema(example = "visa")
     private String brand;
+    @Schema(example = "DEBIT")
     private PayersCardType cardType;
-    @Length(max = 255, message = "Card holder name must be a maximum of 255 chars") 
+    @Length(max = 255, message = "Card holder name must be a maximum of 255 chars")
+    @Schema(example = "Joe B", maxLength = 255)
     private String cardholderName;
     @Length(max = 254, message = "Email must be a maximum of 254 chars")
+    @Schema(example = "mr@payment.test", maxLength = 254)
     private String email;
+    @Schema(example = "text/html;q=1.0, */*;q=0.9")
     private String acceptHeader;
+    @Schema(example = "Mozilla/5.0")
     private String userAgentHeader;
+    @Schema(example = "203.0.113.1")
     private String ipAddress;
 
     public WalletPaymentInfo() {

--- a/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayAuthRequestBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayAuthRequestBuilder.java
@@ -11,10 +11,10 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 public class ApplePayAuthRequestBuilder {
     private String data;
     private String ephemeralPublicKey;
-    private ApplePayAuthRequest.EncryptedPaymentData validEncryptedPaymentData;
+    private ApplePayAuthRequest.ApplePayEncryptedPaymentData validEncryptedPaymentData;
     
     private ApplePayAuthRequestBuilder() throws IOException {
-        this.validEncryptedPaymentData = new ObjectMapper().readValue(fixture("applepay/token.json"), ApplePayAuthRequest.EncryptedPaymentData.class);
+        this.validEncryptedPaymentData = new ObjectMapper().readValue(fixture("applepay/token.json"), ApplePayAuthRequest.ApplePayEncryptedPaymentData.class);
         this.data = validEncryptedPaymentData.getData();
         this.ephemeralPublicKey = validEncryptedPaymentData.getHeader().getEphemeralPublicKey();
     }
@@ -35,10 +35,10 @@ public class ApplePayAuthRequestBuilder {
     public ApplePayAuthRequest build() {
         return new ApplePayAuthRequest(
                 new WalletPaymentInfo(),
-                new ApplePayAuthRequest.EncryptedPaymentData(
+                new ApplePayAuthRequest.ApplePayEncryptedPaymentData(
                         validEncryptedPaymentData.getVersion(),
                         this.data,
-                        new ApplePayAuthRequest.EncryptedPaymentData.Header(
+                        new ApplePayAuthRequest.ApplePayEncryptedPaymentData.Header(
                                 validEncryptedPaymentData.getHeader().getPublicKeyHash(),
                                 this.ephemeralPublicKey,
                                 validEncryptedPaymentData.getHeader().getTransactionId(),


### PR DESCRIPTION
## WHAT YOU DID
- Added annotations to generate OpenAPI specs for endpoints in CardResource & SecurityTokensResource which includes below.

        POST /v1/api/accounts/{accountId}/charges/{chargeId}/cancel
        POST /v1/api/accounts/{accountId}/charges/{chargeId}/capture
        POST /v1/api/charges/authorise
        POST /v1/frontend/charges/{chargeId}/3ds
        POST /v1/frontend/charges/{chargeId}/cancel
        POST /v1/frontend/charges/{chargeId}/capture
        POST /v1/frontend/charges/{chargeId}/cards
        POST /v1/frontend/charges/{chargeId}/wallets/apple
        POST /v1/frontend/charges/{chargeId}/wallets/google
        
        DELETE /v1/frontend/tokens/{chargeTokenId}
        GET /v1/frontend/tokens/{chargeTokenId}
        GET /v1/frontend/tokens/{chargeTokenId}/charge
        POST /v1/frontend/tokens/{chargeTokenId}/used

- Renamed `ApplePayAuthRequest.EncryptedPaymentData` to `ApplePayAuthRequest.ApplePayEncryptedPaymentData` to distinguish `EncryptedPaymentData` used for GooglePay in OpenAPI specs.

- Preview using editor.swagger.io

![image](https://user-images.githubusercontent.com/40598480/176786315-0d9570a0-c13e-4958-a025-781f6de984bb.png)

![image](https://user-images.githubusercontent.com/40598480/176786376-575efcf3-2c68-420e-9915-3d1f4f11b6a2.png)

## How to test

- Add below to openapi-config.yaml and run `mvn compile` to update specs
       - uk.gov.pay.connector.paymentprocessor.resource.CardResource
       - uk.gov.pay.connector.token.resource.SecurityTokensResource
