### PR TITLE
PP-9796 OpenAPI specs for credentials, notifications and performance report endpoints

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
@@ -16,27 +17,39 @@ import java.util.Map;
 public class GatewayAccountCredentials {
 
     @JsonProperty("gateway_account_credential_id")
+    @Schema(example = "1")
     private Long id;
-    
+
+    @Schema(example = "787460d16d4a4d14b4c94787b8f427db")
     private String externalId;
-    
+
+    @Schema(example = "stripe")
     private String paymentProvider;
-            
+
+    @Schema(example = "{" +
+            "  \"stripe_account_id\": \"accnt_id\"" +
+            "  }")
     private Map<String, String> credentials;
-    
+
+    @Schema(example = "ACTIVE")
     private GatewayAccountCredentialState state;
-    
+
+    @Schema(example = "vdwke0d16d4a4d14b4c94787b8f427d", description = "User external ID")
     private String lastUpdatedByUserExternalId;
 
     @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    @Schema(example = "2022-06-30T15:44:19.323Z")
     private Instant createdDate;
 
     @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    @Schema(example = "2022-06-28T16:40:56.869Z")
     private Instant activeStartDate;
 
     @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    @Schema(example = " ")
     private Instant activeEndDate;
-    
+
+    @Schema(example = "1")
     private Long gatewayAccountId;
 
     public GatewayAccountCredentials(GatewayAccountCredentialsEntity entity) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsRequest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gatewayaccount.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
 
@@ -11,7 +12,13 @@ public class GatewayAccountCredentialsRequest {
     private Map<String, String> credentials;
     public static final String PAYMENT_PROVIDER_FIELD_NAME = "payment_provider";
 
-    public GatewayAccountCredentialsRequest(@JsonProperty(PAYMENT_PROVIDER_FIELD_NAME) String paymentProvider, @JsonProperty("credentials") Map<String, String> credentials) {
+    public GatewayAccountCredentialsRequest(
+            @Schema(example = "stripe", description = "Payment provider. Accepted values - stripe, worldpay")
+            @JsonProperty(PAYMENT_PROVIDER_FIELD_NAME) String paymentProvider,
+            @Schema(example = "{" +
+                    "  \"stripe_account_id\": \"accnt_id\"" +
+                    "  }")
+            @JsonProperty("credentials") Map<String, String> credentials) {
         this.credentials = credentials;
         this.paymentProvider = paymentProvider;
     }
@@ -21,6 +28,7 @@ public class GatewayAccountCredentialsRequest {
         return paymentProvider;
     }
 
+    @Schema(hidden = true)
     public Map<String, String> getCredentialsAsMap() {
         return credentials;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsRequest.java
@@ -1,23 +1,27 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.gatewayaccount.validation.ValidWorldpay3dsFlexIssuerOrOrganisationalUnitId;
 import uk.gov.pay.connector.gatewayaccount.validation.ValidWorldpay3dsFlexJwtMacKey;
-
-import javax.validation.constraints.NotNull;
 
 public class Worldpay3dsFlexCredentialsRequest {
 
     @JsonProperty("issuer")
     @ValidWorldpay3dsFlexIssuerOrOrganisationalUnitId(message = "Field [issuer] must be 24 lower-case hexadecimal characters")
+    @Schema(description = "Lower-case hexadecimal characters. Should only contain characters [0-9a-f]", minLength = 24, maxLength = 24,
+            example = "53f0917f101a4428b69d5fb0")
     private String issuer;
 
     @JsonProperty("organisational_unit_id")
     @ValidWorldpay3dsFlexIssuerOrOrganisationalUnitId(message = "Field [organisational_unit_id] must be 24 lower-case hexadecimal characters")
+    @Schema(description = "Lower-case hexadecimal characters. Should only contain characters [0-9a-f]", minLength = 24, maxLength = 24,
+            example = "57992a087a0c4849895ab8a2")
     private String organisationalUnitId;
 
     @JsonProperty("jwt_mac_key")
     @ValidWorldpay3dsFlexJwtMacKey
+    @Schema(description = "UUID in lowercase canonical representation", example = "4cabd5d2-0133-4e82-b0e5-2024dbeddaa9")
     private String jwtMacKey;
 
     public Worldpay3dsFlexCredentialsRequest() {

--- a/src/main/java/uk/gov/pay/connector/report/resource/PerformanceReportResource.java
+++ b/src/main/java/uk/gov/pay/connector/report/resource/PerformanceReportResource.java
@@ -2,6 +2,12 @@ package uk.gov.pay.connector.report.resource;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import uk.gov.pay.connector.report.dao.PerformanceReportDao;
 import uk.gov.pay.connector.report.model.domain.PerformanceReportEntity;
 import uk.gov.pay.connector.util.ResponseUtil;
@@ -19,6 +25,7 @@ import static javax.ws.rs.core.Response.ok;
 import static uk.gov.pay.connector.common.validator.ApiValidators.parseZonedDateTime;
 
 @Path("/")
+@Tag(name = "Performance reports")
 public class PerformanceReportResource {
     private PerformanceReportDao performanceReportDao;
 
@@ -30,6 +37,18 @@ public class PerformanceReportResource {
     @GET
     @Path("/v1/api/reports/performance-report")
     @Produces(APPLICATION_JSON)
+    @Operation(
+            summary = "Retrieve performance summary",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(example = "{" +
+                                    "" +
+                                    "  \"total_volume\": 12345," +
+                                    "  \"total_amount\": 12345," +
+                                    "  \"average_amount\": 1" +
+                                    "}"))),
+            }
+    )
     public Response getPerformanceReport() {
         PerformanceReportEntity performanceReport = performanceReportDao.aggregateNumberAndValueOfPayments();
 
@@ -43,36 +62,64 @@ public class PerformanceReportResource {
     @GET
     @Path("/v1/api/reports/daily-performance-report")
     @Produces(APPLICATION_JSON)
-    public Response getDailyPerformanceReport(@QueryParam("date") String rawDate) {
+    @Operation(
+            summary = "Retrieves performance summary scoped for a day",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(example = "{" +
+                                    "" +
+                                    "  \"total_volume\": 12345," +
+                                    "  \"total_amount\": 12345," +
+                                    "  \"average_amount\": 1" +
+                                    "}"))),
+            }
+    )
+    public Response getDailyPerformanceReport(@Parameter(required = true, example = "2022-06-21T00:00:00Z")
+                                              @QueryParam("date") String rawDate) {
         return parseZonedDateTime(rawDate)
-          .map(date -> {
-            PerformanceReportEntity performanceReport = performanceReportDao.aggregateNumberAndValueOfPaymentsForAGivenDay(date);
+                .map(date -> {
+                    PerformanceReportEntity performanceReport = performanceReportDao.aggregateNumberAndValueOfPaymentsForAGivenDay(date);
 
-            ImmutableMap<String, Object> responsePayload = ImmutableMap.of(
-                    "total_volume", performanceReport.getTotalVolume(),
-                    "total_amount", performanceReport.getTotalAmount(),
-                    "average_amount", performanceReport.getAverageAmount());
+                    ImmutableMap<String, Object> responsePayload = ImmutableMap.of(
+                            "total_volume", performanceReport.getTotalVolume(),
+                            "total_amount", performanceReport.getTotalAmount(),
+                            "average_amount", performanceReport.getAverageAmount());
 
-            return ok().entity(responsePayload).build();
-          })
-          .orElseGet(() -> ResponseUtil.badRequestResponse("Could not parse date"));
+                    return ok().entity(responsePayload).build();
+                })
+                .orElseGet(() -> ResponseUtil.badRequestResponse("Could not parse date"));
     }
 
     @GET
     @Path("/v1/api/reports/gateway-account-performance-report")
     @Produces(APPLICATION_JSON)
+    @Operation(
+            summary = "Retrieves performance summary segmented by gateway account",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(example = "{" +
+                                    "  \"1\": {" +
+                                    "    \"total_volume\": 100," +
+                                    "    \"total_amount\": 1000," +
+                                    "    \"average_amount\": 10," +
+                                    "    \"min_amount\": 1," +
+                                    "    \"max_amount\": 9" +
+                                    "  }" +
+                                    "}"))),
+            }
+    )
     public Response getGatewayAccountPerformanceReport() {
-         Map<String, Map<String, Object>> response = performanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount()
-                 .collect(Collectors.toMap(
-                         performance -> performance.getGatewayAccountId().toString(),
-                         performance -> ImmutableMap.of(
-                                 "total_volume", performance.getTotalVolume(),
-                                 "total_amount", performance.getTotalAmount(),
-                                 "average_amount", performance.getAverageAmount(),
-                                 "min_amount", performance.getMinAmount(),
-                                 "max_amount", performance.getMaxAmount()
-                 )));
+        Map<String, Map<String, Object>> response = performanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount()
+                .collect(Collectors.toMap(
+                        performance -> performance.getGatewayAccountId().toString(),
+                        performance -> ImmutableMap.of(
+                                "total_volume", performance.getTotalVolume(),
+                                "total_amount", performance.getTotalAmount(),
+                                "average_amount", performance.getAverageAmount(),
+                                "min_amount", performance.getMinAmount(),
+                                "max_amount", performance.getMaxAmount()
+                        )));
 
-         return ok().entity(response).build();
+        return ok().entity(response).build();
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Updates to generate OpenAPI specs for credentials, notifications and performance report endpoints below

```
    POST /v1/api/accounts/{accountId}/3ds-flex-credentials
    POST /v1/api/accounts/{accountId}/credentials
    PATCH /v1/api/accounts/{accountId}/credentials/{credentialsId}
    POST /v1/api/accounts/{accountId}/worldpay/check-3ds-flex-config
    POST /v1/api/accounts/{accountId}/worldpay/check-credentials
    
    GET /v1/api/reports/daily-performance-report
    GET /v1/api/reports/gateway-account-performance-report
    GET /v1/api/reports/performance-report
    
    POST /v1/api/notifications/epdq
    POST /v1/api/notifications/sandbox
    POST /v1/api/notifications/stripe
    POST /v1/api/notifications/worldpay
```

- Preview using editor.swagger.io

![image](https://user-images.githubusercontent.com/40598480/176881204-8503c237-502c-41bf-819e-03d6f36b3445.png)

![image](https://user-images.githubusercontent.com/40598480/176881219-eff7e744-e986-42ee-a0ae-c04658edbef6.png)



## How to test

- Add below to openapi-config.yaml and run `mvn compile` to update specs
    - uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsResource
    - uk.gov.pay.connector.report.resource.PerformanceReportResource
    - uk.gov.pay.connector.webhook.resource.NotificationResource