### PR TITLE
PP-9796 OpenAPI specs for tasks and healthcheck endpoints

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/resource/GatewayCleanupResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/GatewayCleanupResource.java
@@ -1,5 +1,11 @@
 package uk.gov.pay.connector.charge.resource;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import uk.gov.pay.connector.charge.service.AuthorisationErrorGatewayCleanupService;
 
 import javax.inject.Inject;
@@ -15,19 +21,40 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.util.ResponseUtil.successResponseWithEntity;
 
 @Path("/")
+@Tag(name = "Tasks")
 public class GatewayCleanupResource {
 
     private AuthorisationErrorGatewayCleanupService cleanupService;
 
-    @Inject 
+    @Inject
     public GatewayCleanupResource(AuthorisationErrorGatewayCleanupService cleanupService) {
         this.cleanupService = cleanupService;
     }
 
     @POST
     @Path("/v1/tasks/gateway-cleanup-sweep")
+    @Operation(
+            summary = "Cleanup charges with Gateway",
+            description = "Finds all charges (ePDQ, Worldpay, Stripe) which have a status of AUTHORISATION ERROR, AUTHORISATION UNEXPECTED ERROR, AUTHORISATION TIMEOUT " +
+                    "and checks what their status is with the payment gateway. If the charges exist on the gateway and are in a non-terminal state, " +
+                    "e.g. AUTHORISATION SUCCESS, a request is sent to cancel the charge on the gateway.<br>" +
+                    "The job will move the charge into one of three statuses when it has successfully handled it:<br>" +
+                    " - AUTHORISATION ERROR CANCELLED - the charge was authorised on the gateway but has now been cancelled. <br>" +
+                    " - AUTHORISATION ERROR REJECTED - the authorisation was rejected on the gateway and no action needed to be taken to clean up.<br>" +
+                    " - AUTHORISATION ERROR CHARGE MISSING - the charge was not found on the gateway, most likely because the error was before the gateway processed the authorisation.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(example = "{" +
+                                    "\"cleanup-success\": 90," +
+                                    "\"cleanup-failed\": 10" +
+                                    "}"))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
     @Produces(APPLICATION_JSON)
-    public Response cleanupChargesInAuthErrorWithGateway(@QueryParam("limit") @NotNull(message = "Parameter [limit] is required") Integer limit) {
+    public Response cleanupChargesInAuthErrorWithGateway(
+            @Parameter(example = "100", description = "The maximum number of charges in an error state that will be processed by the task")
+            @QueryParam("limit") @NotNull(message = "Parameter [limit] is required") Integer limit) {
         Map<String, Integer> resultMap = cleanupService.sweepAndCleanupAuthorisationErrors(limit);
         return successResponseWithEntity(resultMap);
     }

--- a/src/main/java/uk/gov/pay/connector/events/resource/EmittedEventResource.java
+++ b/src/main/java/uk/gov/pay/connector/events/resource/EmittedEventResource.java
@@ -1,5 +1,9 @@
 package uk.gov.pay.connector.events.resource;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import uk.gov.pay.connector.events.EmittedEventsBackfillService;
 import uk.gov.pay.connector.events.HistoricalEventEmitterService;
 import uk.gov.pay.connector.tasks.RecordType;
@@ -10,7 +14,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
-
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -18,12 +21,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.status;
 import static uk.gov.pay.connector.tasks.RecordType.CHARGE;
 
 @Path("/")
+@Tag(name = "Tasks")
 public class EmittedEventResource {
 
     private final EmittedEventsBackfillService emittedEventsBackfillService;
@@ -38,6 +41,17 @@ public class EmittedEventResource {
 
     @POST
     @Path("/v1/tasks/emitted-events-sweep")
+    @Operation(
+            summary = "Sweep emitted events",
+            description = "During the state transition event connector puts an event in an in-memory queue (and database) " +
+                    "which is then picked up by the background process to emit the event to SQS. If the process is interrupted there" +
+                    " is a database record which indicates that the event has been put in an in-memory queue, but not yet emitted to the SQS. <br>" +
+                    "This task retrieves all the records that haven't been fully processed, for each event it invokes the backfill process and marks the event as processed.<br>" +
+                    "The default age of the non-emitted event is at least 30 minutes. This value can be controlled with NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS environment variable.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK")
+            }
+    )
     @Produces(APPLICATION_JSON)
     public Response expireCharges() {
         emittedEventsBackfillService.backfillNotEmittedEvents();
@@ -47,9 +61,23 @@ public class EmittedEventResource {
     @POST
     @Path("/v1/tasks/historical-event-emitter")
     @Produces(APPLICATION_JSON)
-    public Response emitHistoricEvents(@QueryParam("start_id") Long startId,
+    @Operation(
+            summary = "Emit events for charges or refunds",
+            description = "Task to emit payment or refunds events for a given start_id and max_id range.<br>" +
+                    "Historical event emitter task doesn't emit event, if event was emitted previously. To re-emit events, relevant emitted events records need to be cleared<br>." +
+                    "<br>" +
+                    "Note: This task runs in the background.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK")
+            }
+    )
+    public Response emitHistoricEvents(@Parameter(example = "1", description = "Charge/Refund ID (from database) to start with to emit events. Defaults to 0")
+                                       @QueryParam("start_id") Long startId,
+                                       @Parameter(example = "100", description = "Charge/Refund ID until which events to be emitted. If not provided, this is set to maximum ID available.")
                                        @QueryParam("max_id") Long maybeMaxId,
+                                       @Parameter(example = "charge", description = "Type of records (charge/refund) for which events to be emitted. Defaults to 'charge'")
                                        @QueryParam("record_type") Optional<RecordType> maybeRecordType,
+                                       @Parameter(example = "7200", description = "Duration (in seconds) until which emitted event sweeper should ignore retrying emitting events")
                                        @QueryParam("do_not_retry_emit_until_duration") Long doNotRetryEmitUntilDuration) {
         //We run this task in the background and response 200 so the request from toolbox does not time out
         ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -69,8 +97,21 @@ public class EmittedEventResource {
     @POST
     @Path("/v1/tasks/historical-event-emitter-by-date")
     @Produces(APPLICATION_JSON)
-    public Response emitHistoricEventsByDate(@QueryParam("start_date") String startDate,
+    @Operation(
+            summary = "Emit events for charges or refunds by date",
+            description = "Task to emit payment and refunds events for a given start_date and end_date range.<br>" +
+                    "Historical event emitter by date task doesn't emit event, if event was emitted previously. To re-emit events, relevant emitted events records need to be cleared<br>" +
+                    "<br>" +
+                    "Note: This task runs in the background.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK")
+            }
+    )
+    public Response emitHistoricEventsByDate(@Parameter(example = "2016-01-25T13:23:55Z", required = true, description = "Start date of charge events or refund history events for which events to be emitted")
+                                             @QueryParam("start_date") String startDate,
+                                             @Parameter(example = "2016-01-25T13:23:55Z", required = true, description = "Date until which the events to be emitted")
                                              @QueryParam("end_date") String endDate,
+                                             @Parameter(example = "1200", description = "Duration (in seconds) until which emitted event sweeper should ignore retrying emitting events")
                                              @QueryParam("do_not_retry_emit_until_duration") Long doNotRetryEmitUntilDuration) {
         //We run this task in the background and response 200 so the request from toolbox does not time out
         ExecutorService executor = Executors.newSingleThreadExecutor();

--- a/src/main/java/uk/gov/pay/connector/report/model/GatewayStatusComparison.java
+++ b/src/main/java/uk/gov/pay/connector/report/model/GatewayStatusComparison.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
@@ -15,9 +16,11 @@ import java.util.Optional;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public final class GatewayStatusComparison {
     private final ChargeStatus payStatus;
+    @Schema(example = "EXTERNAL_SUBMITTED")
     private final String payExternalStatus;
     @JsonProperty("gatewayStatus")
     @JsonSerialize(using = ToStringSerializer.class)
+    @Schema(example = "AUTHORISED")
     private ChargeStatus gatewayStatus;
     private final String chargeId;
     private String rawGatewayResponse;
@@ -51,6 +54,7 @@ public final class GatewayStatusComparison {
     }
 
     @JsonSerialize(using = ToStringSerializer.class)
+    @Schema(example = "AUTHORISATION SUCCESS")
     public ChargeStatus getPayStatus() {
         return payStatus;
     }
@@ -61,6 +65,7 @@ public final class GatewayStatusComparison {
     }
 
     @JsonSerialize(using = ToStringSerializer.class)
+    @Schema(example = "EXTERNAL_SUBMITTED")
     public ExternalChargeState getGatewayExternalStatus() {
         return gatewayStatus != null ? gatewayStatus.toExternal() : null;
     }
@@ -69,10 +74,12 @@ public final class GatewayStatusComparison {
         return payExternalStatus;
     }
 
+    @Schema(example = "2c6vtn9pth38ppbmnt20d57t49")
     public String getChargeId() {
         return chargeId;
     }
 
+    @Schema(example = "Worldpay response ()")
     public String getRawGatewayResponse() {
         return rawGatewayResponse;
     }

--- a/src/main/java/uk/gov/pay/connector/report/resource/ParityCheckerResource.java
+++ b/src/main/java/uk/gov/pay/connector/report/resource/ParityCheckerResource.java
@@ -1,5 +1,9 @@
 package uk.gov.pay.connector.report.resource;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import uk.gov.pay.connector.report.ParityCheckerService;
 import uk.gov.pay.connector.tasks.RecordType;
 
@@ -14,12 +18,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
-import static javax.ws.rs.core.Response.status;
 import static uk.gov.pay.connector.tasks.RecordType.CHARGE;
 
 @Path("/")
+@Tag(name = "Tasks")
 public class ParityCheckerResource {
 
     private final ParityCheckerService parityCheckerService;
@@ -32,11 +35,29 @@ public class ParityCheckerResource {
     @POST
     @Path("/v1/tasks/parity-checker")
     @Produces(APPLICATION_JSON)
-    public Response parityCheck(@QueryParam("start_id") Long startId,
+    @Operation(
+            summary = "Parity check charges or refunds with ledger",
+            description = "Task to parity check charges or refunds with ledger for a given start_id and max_id range or by parity_check_status." +
+                    " Parity checker compares fields of ledger transaction to charge/refund record in connector. <br>" +
+                    "When parity check fails, new events are emitted even when the events have been emitted previously. <br>" +
+                    " Note: Task is executed in the background. ",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response parityCheck(@Parameter(example = "1", description = "Charge/Refund ID (from database) to start with for parity checking. Defaults to 0")
+                                @QueryParam("start_id") Long startId,
+                                @Parameter(example = "10", description = "Charge/Refund ID until which the records to be parity checked. If not provided, this is set to maximum ID available.")
                                 @QueryParam("max_id") Long maybeMaxId,
+                                @Parameter(example = "true", description = "Set to true to skip parity checking the records which were previously parity checked and matches with ledger transaction. Defaults to false")
                                 @QueryParam("do_not_reprocess_valid_records") boolean doNotReprocessValidRecords,
+                                @Parameter(example = "DATA_MISMATCH", description = "Parity check the records, which were parity checked and marked with parity_check_status. " +
+                                        "start_id and max_id are ignored if parity checking by parity check status")
                                 @QueryParam("parity_check_status") String maybeParityCheckStatus,
+                                @Parameter(example = "7200", description = "Duration (in seconds) until which emitted event sweeper should ignore retrying emitting events")
                                 @QueryParam("do_not_retry_emit_until") Long doNotRetryEmitUntilDuration,
+                                @Parameter(example = "charge", description = "Type of records (charge/refund) to be parity checked. Defaults to 'charge'")
                                 @QueryParam("record_type") Optional<RecordType> maybeRecordType) {
         //We run this task in the background and respond 200 so the request from toolbox does not time out
         ExecutorService executor = Executors.newSingleThreadExecutor();

--- a/src/main/java/uk/gov/pay/connector/usernotification/resource/EmailNotificationResource.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/resource/EmailNotificationResource.java
@@ -3,6 +3,12 @@ package uk.gov.pay.connector.usernotification.resource;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.persist.Transactional;
 import io.dropwizard.jersey.PATCH;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
@@ -56,7 +62,25 @@ public class EmailNotificationResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Transactional
-    public Response enableEmailNotification(@PathParam("accountId") Long gatewayAccountId, Map<String, String> emailPatchMap) {
+    @Operation(
+            summary = "Enables/disables email notifications for gateway account",
+            description = "Allowed paths <br>" +
+                    " - /payment_confirmed/enabled (values true/false) <br>" +
+                    " - /refund_issued/enabled (values true/false) <br>" +
+                    " - /payment_confirmed/template_body<br>" +
+                    " - /refund_issued/template_body",
+            tags = {"Gateway accounts"},
+            requestBody = @RequestBody(content = @Content(schema = @Schema(example = "{" +
+                    "    \"op\":\"replace\", \"path\":\"/payment_confirmed/enabled\", \"value\": false" +
+                    "}"))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "400", description = "Bad request - invalid or missing mandatory fields"),
+                    @ApiResponse(responseCode = "404", description = "Not found")
+            }
+    )
+    public Response enableEmailNotification(@Parameter(example = "1", description = "Gateway account ID")
+                                            @PathParam("accountId") Long gatewayAccountId, Map<String, String> emailPatchMap) {
         PatchRequestBuilder.PatchRequest emailPatchRequest;
         try {
             emailPatchRequest = aPatchRequestBuilder(emailPatchMap)


### PR DESCRIPTION
## WHAT YOU DID

- Updates to generate OpenAPI specs for tasks and healthcheck endpoints

```
    PATCH /v1/api/accounts/{accountId}/email-notification
    POST /v1/api/discrepancies/report
    POST /v1/api/discrepancies/resolve
    POST /v1/tasks/emitted-events-sweep
    POST /v1/tasks/expunge
    POST /v1/tasks/gateway-cleanup-sweep
    POST /v1/tasks/historical-event-emitter
    POST /v1/tasks/historical-event-emitter-by-date
    POST /v1/tasks/parity-checker
    GET /healthcheck
```

- Preview using editor.swagger.io

![image](https://user-images.githubusercontent.com/40598480/176886010-5ec0e9d3-c1e8-4caf-a261-eed56bd3f1ee.png)

![image](https://user-images.githubusercontent.com/40598480/176886053-c6128b30-d06d-4b3f-ad32-d484bfe491cc.png)

![image](https://user-images.githubusercontent.com/40598480/176886108-b6dde9ea-b154-4a59-abde-b8753767b57b.png)

![image](https://user-images.githubusercontent.com/40598480/176886300-d1acb45d-2369-4d01-8533-6ba5b16175ee.png)


## How to test
- Add below to openapi-config.yaml and run mvn compile to update specs
    - uk.gov.pay.connector.healthcheck.resource.HealthCheckResource
    - uk.gov.pay.connector.usernotification.resource.EmailNotificationResource
    - uk.gov.pay.connector.paymentprocessor.resource.DiscrepancyResource
    - uk.gov.pay.connector.expunge.resource.ExpungeResource
    - uk.gov.pay.connector.report.resource.ParityCheckerResource
    - uk.gov.pay.connector.charge.resource.GatewayCleanupResource
    - uk.gov.pay.connector.events.resource.EmittedEventResource