### PR TITLE
PP-9796 OpenAPI specs for charge events, refunds & frontend endpoints

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/NewChargeStatusRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/NewChargeStatusRequest.java
@@ -3,14 +3,16 @@ package uk.gov.pay.connector.charge.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.validation.ValidationMethod;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.validator.constraints.NotEmpty;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 
 
 public class NewChargeStatusRequest {
     @NotEmpty
+    @Schema(example = "ENTERING CARD DETAILS", description = "Only `ENTERING CARD DETAILS` is allowed")
     private final String newStatus;
-    
+
     NewChargeStatusRequest(@JsonProperty("new_status") String newStatus) {
         this.newStatus = newStatus;
     }
@@ -20,7 +22,7 @@ public class NewChargeStatusRequest {
         return newStatus;
     }
 
-    @ValidationMethod(message="invalid new status")
+    @ValidationMethod(message = "invalid new status")
     @JsonIgnore
     public boolean isValidNewStatus() {
         return ChargeStatus.ENTERING_CARD_DETAILS.toString().equals(newStatus);

--- a/src/main/java/uk/gov/pay/connector/chargeevent/model/ChargeEventsResponse.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/model/ChargeEventsResponse.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.connector.chargeevent.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChargeEventsResponse {
+    @JsonProperty("charge_id")
+    @Schema(example = "2c6vtn9pth38ppbmnt20d57t49")
+    private String chargeExternalId;
+    private List<TransactionEvent> events;
+
+    public ChargeEventsResponse(String chargeExternalId, List<TransactionEvent> events) {
+        this.chargeExternalId = chargeExternalId;
+        this.events = events;
+    }
+
+    public static ChargeEventsResponse of(String chargeExternalId, List<TransactionEvent> events) {
+        return new ChargeEventsResponse(chargeExternalId, events);
+    }
+
+    public String getChargeExternalId() {
+        return chargeExternalId;
+    }
+
+    public List<TransactionEvent> getEvents() {
+        return events;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/chargeevent/model/TransactionEvent.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/model/TransactionEvent.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.jackson.JsonSnakeCase;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
 
@@ -17,9 +18,13 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonSnakeCase
     static public class State {
+        @Schema(example = "cancelled")
         private final String status;
+        @Schema(example = "true")
         private final boolean finished;
+        @Schema(example = "P0040")
         private final String code;
+        @Schema(example = "Payment was cancelled by service")
         private final String message;
 
         public State(String status, boolean finished, String code, String message) {
@@ -110,6 +115,7 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
     }
 
     @JsonProperty("type")
+    @Schema(example = "PAYMENT")
     public Type getType() {
         return type;
     }
@@ -139,11 +145,13 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
     }
 
     @JsonProperty("amount")
+    @Schema(example = "100")
     public Long getAmount() {
         return amount;
     }
 
     @JsonProperty("updated")
+    @Schema(example = "2022-06-28T10:41:40.460Z")
     public String getUpdated() {
         return ISO_INSTANT_MILLISECOND_PRECISION.format(updated);
     }
@@ -169,10 +177,12 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
         TransactionEvent that = (TransactionEvent) o;
 
         if (type != that.type) return false;
-        if (refundGatewayTransactionId != null ? !refundGatewayTransactionId.equals(that.refundGatewayTransactionId) : that.refundGatewayTransactionId != null) return false;
+        if (refundGatewayTransactionId != null ? !refundGatewayTransactionId.equals(that.refundGatewayTransactionId) : that.refundGatewayTransactionId != null)
+            return false;
         if (extChargeId != null ? !extChargeId.equals(that.extChargeId) : that.extChargeId != null) return false;
         if (state != null ? !state.equals(that.state) : that.state != null) return false;
-        if (userExternalId != null ? !userExternalId.equals(that.userExternalId) : that.userExternalId != null) return false;
+        if (userExternalId != null ? !userExternalId.equals(that.userExternalId) : that.userExternalId != null)
+            return false;
         return !(amount != null ? !amount.equals(that.amount) : that.amount != null);
     }
 

--- a/src/main/java/uk/gov/pay/connector/expunge/resource/ExpungeResource.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/resource/ExpungeResource.java
@@ -2,15 +2,10 @@ package uk.gov.pay.connector.expunge.resource;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.MDC;
 import uk.gov.pay.connector.expunge.service.ExpungeService;
-import uk.gov.pay.connector.report.model.GatewayStatusComparison;
 
 import javax.inject.Inject;
 import javax.ws.rs.POST;

--- a/src/main/java/uk/gov/pay/connector/refund/model/RefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/RefundRequest.java
@@ -1,22 +1,28 @@
 package uk.gov.pay.connector.refund.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public class RefundRequest {
 
     @JsonProperty("amount")
+    @Schema(example = "3444", required = true, description = "Amount to refund in pence")
     private long amount;
 
     @JsonProperty("refund_amount_available")
+    @Schema(example = "30000", required = true, description = "Total amount still available before issuing the refund")
     private long amountAvailableForRefund;
 
     @JsonProperty("user_external_id")
+    @Schema(example = "3444", description = "The ID of the user who issued the refund")
     private String userExternalId;
 
     @JsonProperty("user_email")
+    @Schema(example = "joeb@example.org", description = "Email address of the user refunding payment")
     private String userEmail;
 
-    public RefundRequest() {}
+    public RefundRequest() {
+    }
 
     public RefundRequest(long amount, long amountAvailableForRefund, String userExternalId) {
         this.amount = amount;
@@ -32,7 +38,11 @@ public class RefundRequest {
         return amountAvailableForRefund;
     }
 
-    public String getUserExternalId() { return userExternalId; }
+    public String getUserExternalId() {
+        return userExternalId;
+    }
 
-    public String getUserEmail() { return userEmail; }
+    public String getUserEmail() {
+        return userEmail;
+    }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Updates to generate OpenAPI specs for charge events, refunds & frontend endpoints

      GET /v1/api/accounts/{accountId}/charges/{chargeId}/events
      GET /v1/api/accounts/{accountId}/charges/{chargeId}/refunds
      POST /v1/api/accounts/{accountId}/charges/{chargeId}/refunds
      GET /v1/api/accounts/{accountId}/charges/{chargeId}/refunds/{refundId}
      GET /v1/frontend/charges/{chargeId}
      PATCH /v1/frontend/charges/{chargeId}
      PUT /v1/frontend/charges/{chargeId}/status
      GET /v1/frontend/charges/{chargeId}/worldpay/3ds-flex/ddc

- Preview using editor.swagger.io

![image](https://user-images.githubusercontent.com/40598480/176917207-a9591f0a-e10e-4b38-8021-7c32fc8c18f1.png)

![image](https://user-images.githubusercontent.com/40598480/176917146-e46dc829-3e06-4bfd-8eaa-4f6a21926012.png)

## How to test

- Add below to openapi-config.yaml and run mvn compile to update specs
    - uk.gov.pay.connector.charge.resource.ChargesFrontendResource
    - uk.gov.pay.connector.chargeevent.resource.ChargeEventsResource
    - uk.gov.pay.connector.refund.resource.RefundsResource