### PR TITLE
PP-9620 update liquibase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,6 @@ updates:
   - dependencies
   - govuk-pay
   - java
-  ignore:
-  - dependency-name: org.liquibase:liquibase-core
-    versions:
-    - ">= 4.3.a"
-    - "< 4.4"
 - package-ecosystem: docker
   directory: "/"
   schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <liquibase.version>4.1.0</liquibase.version>
+        <liquibase.version>4.12.0</liquibase.version>
         <dropwizard.version>2.0.29</dropwizard.version>
         <wiremock.version>2.33.2</wiremock.version>
         <eclipselink.version>2.7.10</eclipselink.version>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1436,18 +1436,6 @@
                 constraintName="fk__refunds_charges"/>
     </changeSet>
 
-    <changeSet author="" id="drop not null constraint on charge_id on refunds table">
-        <dropNotNullConstraint columnDataType="bigserial"
-                               columnName="charge_id"
-                               tableName="refunds"/>
-    </changeSet>
-
-    <changeSet author="" id="drop not null constraint on charge_id refunds_history table">
-        <dropNotNullConstraint columnDataType="bigserial"
-                               columnName="charge_id"
-                               tableName="refunds_history"/>
-    </changeSet>
-
     <changeSet id="drop index on charge_id on refunds table" author="">
         <dropIndex tableName="refunds" indexName="idx_refunds_charge_id"/>
     </changeSet>


### PR DESCRIPTION
## WHAT YOU DID
- The Github UI is giving critical warnings for our Java apps with liquibase below v4.8.0. Patched liquibase to 4.12.0
- Thus ignoring liquibase is no longer required, remove it from dependabot yaml file.
- Since the bug that prevented previous upgrades is not yet fixed, remove offending migrations.
 