### PR TITLE
PP-9785 Gateway cleanup sweep - process WEB or MOTO_API payments only

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.common.dao.JpaDao;
 import uk.gov.pay.connector.events.model.ResourceType;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -276,11 +277,14 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .getResultList();
     }
 
-    public List<ChargeEntity> findWithPaymentProvidersInAndStatusIn(List<String> providers, List<ChargeStatus> statuses, int limit) {
+    public List<ChargeEntity> findWithPaymentProvidersStatusesAndAuthorisationModesIn(List<String> providers, List<ChargeStatus> statuses,
+                                                                                      List<AuthorisationMode> authorisationModes, int limit) {
         return entityManager.get()
-                .createQuery("SELECT c FROM ChargeEntity c WHERE c.paymentProvider IN :providers AND c.status IN :statuses", ChargeEntity.class)
+                .createQuery("SELECT c FROM ChargeEntity c WHERE c.paymentProvider IN :providers AND c.status IN :statuses" +
+                        " AND c.authorisationMode in :authorisationModes", ChargeEntity.class)
                 .setParameter("providers", providers)
                 .setParameter("statuses", statuses)
+                .setParameter("authorisationModes", authorisationModes)
                 .setMaxResults(limit)
                 .getResultList();
     }

--- a/src/main/java/uk/gov/pay/connector/charge/resource/GatewayCleanupResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/GatewayCleanupResource.java
@@ -30,7 +30,6 @@ public class GatewayCleanupResource {
     public GatewayCleanupResource(AuthorisationErrorGatewayCleanupService cleanupService) {
         this.cleanupService = cleanupService;
     }
-
     @POST
     @Path("/v1/tasks/gateway-cleanup-sweep")
     @Operation(

--- a/src/main/java/uk/gov/pay/connector/charge/service/AuthorisationErrorGatewayCleanupService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/AuthorisationErrorGatewayCleanupService.java
@@ -32,6 +32,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCELL
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
 
 public class AuthorisationErrorGatewayCleanupService {
 
@@ -57,15 +59,13 @@ public class AuthorisationErrorGatewayCleanupService {
     }
 
     public Map<String, Integer> sweepAndCleanupAuthorisationErrors(int limit) {
-        List<ChargeEntity> chargesToCleanUp = chargeDao.findWithPaymentProvidersInAndStatusIn(
-                List.of(EPDQ.getName(),
-                        WORLDPAY.getName(),
-                        STRIPE.getName()),
-                List.of(AUTHORISATION_ERROR,
-                        AUTHORISATION_TIMEOUT,
-                        AUTHORISATION_UNEXPECTED_ERROR
-                ),
-                limit);
+        List<ChargeEntity> chargesToCleanUp = chargeDao.findWithPaymentProvidersStatusesAndAuthorisationModesIn
+                (
+                        List.of(EPDQ.getName(), WORLDPAY.getName(), STRIPE.getName()),
+                        List.of(AUTHORISATION_ERROR, AUTHORISATION_TIMEOUT, AUTHORISATION_UNEXPECTED_ERROR),
+                        List.of(WEB, MOTO_API),
+                        limit
+                );
 
         logger.info("Found {} charges to clean up.", chargesToCleanUp.size());
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/AuthorisationErrorGatewayCleanupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/AuthorisationErrorGatewayCleanupServiceTest.java
@@ -47,6 +47,8 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AuthorisationErrorGatewayCleanupServiceTest {
@@ -106,9 +108,10 @@ public class AuthorisationErrorGatewayCleanupServiceTest {
 
     @Test
     public void shouldCleanupChargeThatIsAuthorisedOnTheGateway() throws Exception {
-        when(mockChargeDao.findWithPaymentProvidersInAndStatusIn(
+        when(mockChargeDao.findWithPaymentProvidersStatusesAndAuthorisationModesIn(
                 eq(List.of(EPDQ.getName(), WORLDPAY.getName(), STRIPE.getName())),
                 eq(List.of(AUTHORISATION_ERROR, AUTHORISATION_TIMEOUT, AUTHORISATION_UNEXPECTED_ERROR)),
+                eq(List.of(WEB, MOTO_API)),
                 any(Integer.class))).thenReturn(List.of(worldpayCharge, stripeCharge));
         when(mockPaymentProviders.byName(STRIPE)).thenReturn(mockStripePaymentProvider);
         when(worldpayQueryResponse.getTransactionId()).thenReturn("worldpay-order-code");
@@ -135,9 +138,10 @@ public class AuthorisationErrorGatewayCleanupServiceTest {
 
     @Test
     public void shouldTransitionChargeStateToErrorRejectedWhenFailedOnGateway() throws Exception {
-        when(mockChargeDao.findWithPaymentProvidersInAndStatusIn(
+        when(mockChargeDao.findWithPaymentProvidersStatusesAndAuthorisationModesIn(
                 eq(List.of(EPDQ.getName(), WORLDPAY.getName(), STRIPE.getName())),
                 eq(List.of(AUTHORISATION_ERROR, AUTHORISATION_TIMEOUT, AUTHORISATION_UNEXPECTED_ERROR)),
+                eq(List.of(WEB, MOTO_API)),
                 any(Integer.class))).thenReturn(List.of(worldpayCharge));
         when(worldpayQueryResponse.getTransactionId()).thenReturn("order-code");
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_REJECTED, worldpayQueryResponse);
@@ -154,9 +158,10 @@ public class AuthorisationErrorGatewayCleanupServiceTest {
 
     @Test
     public void shouldTransitionChargeStateToErrorChargeMissingWhenNotFoundOnGateway() throws Exception {
-        when(mockChargeDao.findWithPaymentProvidersInAndStatusIn(
+        when(mockChargeDao.findWithPaymentProvidersStatusesAndAuthorisationModesIn(
                 eq(List.of(EPDQ.getName(), WORLDPAY.getName(), STRIPE.getName())),
                 eq(List.of(AUTHORISATION_ERROR, AUTHORISATION_TIMEOUT, AUTHORISATION_UNEXPECTED_ERROR)),
+                eq(List.of(WEB, MOTO_API)),
                 any(Integer.class))).thenReturn(List.of(worldpayCharge));
         when(worldpayQueryResponse.getTransactionId()).thenReturn("");
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(null, worldpayQueryResponse);
@@ -173,9 +178,10 @@ public class AuthorisationErrorGatewayCleanupServiceTest {
 
     @Test
     public void shouldTransitionChargeStateToErrorCancelledWhenAlreadyCancelledOnGateway() throws Exception {
-        when(mockChargeDao.findWithPaymentProvidersInAndStatusIn(
+        when(mockChargeDao.findWithPaymentProvidersStatusesAndAuthorisationModesIn(
                 eq(List.of(EPDQ.getName(), WORLDPAY.getName(), STRIPE.getName())),
                 eq(List.of(AUTHORISATION_ERROR, AUTHORISATION_TIMEOUT, AUTHORISATION_UNEXPECTED_ERROR)),
+                eq(List.of(WEB, MOTO_API)),
                 any(Integer.class))).thenReturn(List.of(worldpayCharge));
         when(worldpayQueryResponse.getTransactionId()).thenReturn("order-code");
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(USER_CANCELLED, worldpayQueryResponse);
@@ -192,9 +198,10 @@ public class AuthorisationErrorGatewayCleanupServiceTest {
 
     @Test
     public void shouldReportFailureWhenGatewayCancelFails() throws Exception {
-        when(mockChargeDao.findWithPaymentProvidersInAndStatusIn(
+        when(mockChargeDao.findWithPaymentProvidersStatusesAndAuthorisationModesIn(
                 eq(List.of(EPDQ.getName(), WORLDPAY.getName(), STRIPE.getName())),
                 eq(List.of(AUTHORISATION_ERROR, AUTHORISATION_TIMEOUT, AUTHORISATION_UNEXPECTED_ERROR)),
+                eq(List.of(WEB, MOTO_API)),
                 any(Integer.class))).thenReturn(List.of(worldpayCharge));
         when(worldpayQueryResponse.getTransactionId()).thenReturn("order-code");
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, worldpayQueryResponse);
@@ -214,9 +221,10 @@ public class AuthorisationErrorGatewayCleanupServiceTest {
 
     @Test
     public void shouldReportFailureWhenGatewayStatusMapsToUnhandledStatus() throws Exception {
-        when(mockChargeDao.findWithPaymentProvidersInAndStatusIn(
+        when(mockChargeDao.findWithPaymentProvidersStatusesAndAuthorisationModesIn(
                 eq(List.of(EPDQ.getName(), WORLDPAY.getName(), STRIPE.getName())),
                 eq(List.of(AUTHORISATION_ERROR, AUTHORISATION_TIMEOUT, AUTHORISATION_UNEXPECTED_ERROR)),
+                eq(List.of(WEB, MOTO_API)),
                 any(Integer.class))).thenReturn(List.of(worldpayCharge));
         when(worldpayQueryResponse.getTransactionId()).thenReturn("order-code");
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_UNEXPECTED_ERROR, worldpayQueryResponse);
@@ -233,9 +241,10 @@ public class AuthorisationErrorGatewayCleanupServiceTest {
 
     @Test
     public void shouldReportFailureWhenGatewayStatusDoesNotMapToInternalStatus() throws Exception {
-        when(mockChargeDao.findWithPaymentProvidersInAndStatusIn(
+        when(mockChargeDao.findWithPaymentProvidersStatusesAndAuthorisationModesIn(
                 eq(List.of(EPDQ.getName(), WORLDPAY.getName(), STRIPE.getName())),
                 eq(List.of(AUTHORISATION_ERROR, AUTHORISATION_TIMEOUT, AUTHORISATION_UNEXPECTED_ERROR)),
+                eq(List.of(WEB, MOTO_API)),
                 any(Integer.class))).thenReturn(List.of(worldpayCharge));
         when(worldpayQueryResponse.getTransactionId()).thenReturn("order-code");
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(null, worldpayQueryResponse);


### PR DESCRIPTION
## WHAT YOU DID
- As part of the gateway clean sweep we should only check payments with authorisation mode `WEB` and `MOTO_API` with the gateway and cancel payments if necessary.
  Currently, the task attemtps to cancel `EXTERNAL` changes (telephone payments reported) or charges in any other modes (AGREEMENT).
