### PR TITLE
PP-9785 Emit FeeIncurred event only when there is a fee

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
@@ -55,9 +55,8 @@ public class StripeCaptureHandler implements CaptureHandler {
 
             capturedCharge = captureWithPaymentIntentAPI(request);
 
-            List<Fee> feeList = generateFeeList(request.getCreatedDate(), request,
-                    capturedCharge.getFee().orElse(0L));
-            
+            List<Fee> feeList = generateFeeList(request, capturedCharge.getFee().orElse(0L));
+
             Long processingFee = StripeFeeCalculator.getTotalFeeAmount(feeList);
 
             Long netTransferAmount = request.getAmount() - processingFee;
@@ -126,10 +125,10 @@ public class StripeCaptureHandler implements CaptureHandler {
         );
     }
 
-    private List<Fee> generateFeeList(Instant createdDate, CaptureGatewayRequest request, Long stripeFee) {
+    private List<Fee> generateFeeList(CaptureGatewayRequest request, Long stripeFee) {
         if (stripeGatewayConfig.isCollectFee()) {
-                return StripeFeeCalculator.getFeeList(stripeFee, request, stripeGatewayConfig.getFeePercentage(),
-                        stripeGatewayConfig.getRadarFeeInPence(), stripeGatewayConfig.getThreeDsFeeInPence());
+            return StripeFeeCalculator.getFeeList(stripeFee, request, stripeGatewayConfig.getFeePercentage(),
+                    stripeGatewayConfig.getRadarFeeInPence(), stripeGatewayConfig.getThreeDsFeeInPence());
         }
         return List.of();
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -108,9 +108,11 @@ public class CardCaptureService {
 
         List<Fee> feeList = captureResponse.getFeeList();
         feeList.stream().map(fee -> new FeeEntity(charge, clock.instant(), fee)).forEach(charge::addFee);
-        
+
         try {
-            sendToEventQueue(FeeIncurredEvent.from(charge));
+            if (!feeList.isEmpty()) {
+                sendToEventQueue(FeeIncurredEvent.from(charge));
+            }
         } catch (EventCreationException e) {
             LOG.warn(format("Failed to create fee incurred event [%s], exception: [%s]", charge.getExternalId(), e.getMessage()));
         }


### PR DESCRIPTION
## WHAT YOU DID
- FeeIncurred event is emitted all the time and causes a warning (https://github.com/alphagov/pay-connector/blob/764bcd716d29f0adf56459785df9b2448522dbd2/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java#L115) to be logged for all payments (other than stripe) as there won't be any fee available in the capture response.
- Updated to emit FeeIncurred event only when there is a fee list on capture a response.
