### PR TITLE
PP-9622 DISPUTE_CREATED event: generate resource_external_id

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/StripeDisputeData.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/StripeDisputeData.java
@@ -17,7 +17,7 @@ public class StripeDisputeData {
     @JsonProperty("amount")
     private Long amount;
     @JsonProperty("id")
-    private String resourceExternalId;
+    private String id;
     @JsonProperty("reason")
     private String reason;
     @JsonProperty("created")
@@ -42,8 +42,8 @@ public class StripeDisputeData {
         return amount;
     }
 
-    public String getResourceExternalId() {
-        return resourceExternalId;
+    public String getId() {
+        return id;
     }
 
     public String getReason() {

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/CollectFeesForFailedPaymentsTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/CollectFeesForFailedPaymentsTaskHandler.java
@@ -9,7 +9,6 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.exception.EventCreationException;
 import uk.gov.pay.connector.events.model.charge.FeeIncurredEvent;
-import uk.gov.pay.connector.events.model.charge.PaymentEvent;
 import uk.gov.pay.connector.fee.model.Fee;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.stripe.StripePaymentProvider;
@@ -20,10 +19,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 
-import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.service.payments.logging.LoggingKeys.LEDGER_EVENT_TYPE;
-import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 
 public class CollectFeesForFailedPaymentsTaskHandler {
 


### PR DESCRIPTION
## WHAT YOU DID
- Generate resource_external_id based on Stripe dispute ID for dispute created event.
  We do it already for other dispute events (dispute_lost, dispute_won, dispute_evidence_submitted)
