### PR TITLE
PP-9622 Create dispute objects using static methods

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeCreated.java
@@ -1,14 +1,40 @@
 package uk.gov.pay.connector.events.model.dispute;
 
-import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeCreatedEventDetails;
+import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
+import uk.gov.pay.connector.queue.tasks.dispute.StripeDisputeData;
 
 import java.time.ZonedDateTime;
 
-public class DisputeCreated extends DisputeEvent{
+import static uk.gov.pay.connector.util.RandomIdGenerator.idFromExternalId;
+
+public class DisputeCreated extends DisputeEvent {
     public DisputeCreated(String resourceExternalId, String parentResourceExternalId, String serviceId,
                           Boolean live, DisputeCreatedEventDetails eventDetails, ZonedDateTime disputeCreated) {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, disputeCreated);
+    }
+
+    public static DisputeCreated from(StripeDisputeData stripeDisputeData, LedgerTransaction transaction, ZonedDateTime disputeCreatedDate) {
+        if (stripeDisputeData.getBalanceTransactionList().size() > 1) {
+            throw new RuntimeException("Dispute data has too many balance_transactions");
+        }
+        BalanceTransaction balanceTransaction = stripeDisputeData.getBalanceTransactionList().get(0);
+        DisputeCreatedEventDetails eventDetails = new DisputeCreatedEventDetails(
+                Math.abs(balanceTransaction.getFee()),
+                stripeDisputeData.getEvidenceDetails().getDueByTimestamp(),
+                transaction.getGatewayAccountId(),
+                stripeDisputeData.getAmount(),
+                balanceTransaction.getNetAmount(),
+                stripeDisputeData.getReason());
+
+        return new DisputeCreated(
+                idFromExternalId(stripeDisputeData.getId()),
+                transaction.getTransactionId(),
+                transaction.getServiceId(),
+                transaction.getLive(),
+                eventDetails,
+                disputeCreatedDate);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmitted.java
@@ -1,14 +1,27 @@
 package uk.gov.pay.connector.events.model.dispute;
 
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeEvidenceSubmittedEventDetails;
 
 import java.time.ZonedDateTime;
+
+import static uk.gov.pay.connector.util.RandomIdGenerator.idFromExternalId;
 
 public class DisputeEvidenceSubmitted extends DisputeEvent {
     public DisputeEvidenceSubmitted(String resourceExternalId, String parentResourceExternalId, String serviceId,
                                     Boolean live, DisputeEvidenceSubmittedEventDetails eventDetails,
                                     ZonedDateTime eventDate) {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, eventDate);
+    }
+
+    public static DisputeEvidenceSubmitted from(String gatewayDisputeId, ZonedDateTime eventDate, LedgerTransaction transaction) {
+        return new DisputeEvidenceSubmitted(
+                idFromExternalId(gatewayDisputeId),
+                transaction.getTransactionId(),
+                transaction.getServiceId(),
+                transaction.getLive(),
+                new DisputeEvidenceSubmittedEventDetails(transaction.getGatewayAccountId()),
+                eventDate);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeLost.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeLost.java
@@ -1,13 +1,37 @@
 package uk.gov.pay.connector.events.model.dispute;
 
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeLostEventDetails;
+import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
+import uk.gov.pay.connector.queue.tasks.dispute.StripeDisputeData;
 
 import java.time.ZonedDateTime;
+
+import static uk.gov.pay.connector.util.RandomIdGenerator.idFromExternalId;
 
 public class DisputeLost extends DisputeEvent {
     public DisputeLost(String resourceExternalId, String parentResourceExternalId, String serviceId, Boolean live,
                        DisputeLostEventDetails eventDetails, ZonedDateTime eventDate) {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, eventDate);
+    }
+
+    public static DisputeLost from(StripeDisputeData stripeDisputeData, ZonedDateTime eventDate, LedgerTransaction transaction) {
+        if (stripeDisputeData.getBalanceTransactionList().size() > 1) {
+            throw new RuntimeException("Dispute data has too many balance_transactions");
+        }
+        BalanceTransaction balanceTransaction = stripeDisputeData.getBalanceTransactionList().get(0);
+        DisputeLostEventDetails eventDetails = new DisputeLostEventDetails(
+                transaction.getGatewayAccountId(),
+                balanceTransaction.getNetAmount(),
+                stripeDisputeData.getAmount(),
+                Math.abs(balanceTransaction.getFee()));
+
+        return new DisputeLost(idFromExternalId(stripeDisputeData.getId()),
+                transaction.getTransactionId(),
+                transaction.getServiceId(),
+                transaction.getLive(),
+                eventDetails,
+                eventDate);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeWon.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeWon.java
@@ -1,13 +1,26 @@
 package uk.gov.pay.connector.events.model.dispute;
 
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeWonEventDetails;
 
 import java.time.ZonedDateTime;
+
+import static uk.gov.pay.connector.util.RandomIdGenerator.idFromExternalId;
 
 public class DisputeWon extends DisputeEvent {
     public DisputeWon(String resourceExternalId, String parentResourceExternalId, String serviceId,
                       Boolean live, DisputeWonEventDetails eventDetails, ZonedDateTime eventDate) {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, eventDate);
+    }
+
+    public static DisputeWon from(String gatewayDisputeId, ZonedDateTime eventDate,
+                                  LedgerTransaction transaction) {
+        return new DisputeWon(idFromExternalId(gatewayDisputeId),
+                transaction.getTransactionId(),
+                transaction.getServiceId(),
+                transaction.getLive(),
+                new DisputeWonEventDetails(transaction.getGatewayAccountId()),
+                eventDate);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/BalanceTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/BalanceTransaction.java
@@ -13,6 +13,16 @@ public class BalanceTransaction {
     @JsonProperty("net")
     private Long netAmount;
 
+    public BalanceTransaction() {
+        // for jackson
+    }
+
+    public BalanceTransaction(Long amount, Long fee, Long netAmount) {
+        this.amount = amount;
+        this.fee = fee;
+        this.netAmount = netAmount;
+    }
+
     public Long getAmount() {
         return amount;
     }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/EvidenceDetails.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/EvidenceDetails.java
@@ -8,6 +8,14 @@ public class EvidenceDetails {
     @JsonProperty("due_by")
     private Long dueByTimestamp;
 
+    public EvidenceDetails() {
+        // for jackson
+    }
+
+    public EvidenceDetails(Long dueByTimestamp) {
+        this.dueByTimestamp = dueByTimestamp;
+    }
+
     public Long getDueByTimestamp() {
         return dueByTimestamp;
     }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/StripeDisputeData.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/StripeDisputeData.java
@@ -30,6 +30,25 @@ public class StripeDisputeData {
     @JsonProperty("status")
     private String status;
 
+    public StripeDisputeData() {
+        // for  jackson
+    }
+
+    public StripeDisputeData(String id, String paymentIntentId, String status,
+                             Long amount, String reason, Long created,
+                             List<BalanceTransaction> balanceTransactionList,
+                             EvidenceDetails evidenceDetails
+    ) {
+        this.id = id;
+        this.status = status;
+        this.paymentIntentId = paymentIntentId;
+        this.amount = amount;
+        this.reason = reason;
+        this.created = created;
+        this.balanceTransactionList = balanceTransactionList;
+        this.evidenceDetails = evidenceDetails;
+    }
+
     public String getResourceType() {
         return resourceType;
     }

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
@@ -14,14 +14,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.gov.pay.connector.events.model.dispute.DisputeLost.from;
+import static uk.gov.pay.connector.events.model.dispute.DisputeCreated.from;
 import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
 import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 
-class DisputeLostTest {
+class DisputeCreatedTest {
 
     @Test
-    void shouldBuildAndSerialiseEventDetailsCorrectly() throws JsonProcessingException {
+    public void shouldBuildAndSerialiseEventDetailsCorrectly() throws JsonProcessingException {
         LedgerTransaction transaction = aValidLedgerTransaction()
                 .withExternalId("payment-external-id")
                 .withGatewayAccountId(1234L)
@@ -30,24 +30,26 @@ class DisputeLostTest {
                 .isLive(true)
                 .build();
         BalanceTransaction balanceTransaction = new BalanceTransaction(6500L, 1500L, -8000L);
+        EvidenceDetails evidenceDetails = new EvidenceDetails(1642679160L);
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
-                "pi_123456789", "lost", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction), null);
+                "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction), evidenceDetails);
 
-        DisputeLost disputeLost = from(stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction);
+        DisputeCreated disputeCreated = from(stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L));
 
-        String disputeLostJson = disputeLost.toJsonString();
-        assertThat(disputeLostJson, hasJsonPath("$.event_type", equalTo("DISPUTE_LOST")));
-        assertThat(disputeLostJson, hasJsonPath("$.resource_type", equalTo("dispute")));
-        assertThat(disputeLostJson, hasJsonPath("$.service_id", equalTo("service-id")));
-        assertThat(disputeLostJson, hasJsonPath("$.resource_external_id", equalTo("fca65e80d2293ee3bf158a0d12")));
-        assertThat(disputeLostJson, hasJsonPath("$.timestamp", equalTo("2022-01-19T07:59:20.000000Z")));
-        assertThat(disputeLostJson, hasJsonPath("$.live", equalTo(true)));
-        assertThat(disputeLostJson, hasJsonPath("$.parent_resource_external_id", equalTo("payment-external-id")));
+        String disputeCreatedJson = disputeCreated.toJsonString();
+        assertThat(disputeCreatedJson, hasJsonPath("$.event_type", equalTo("DISPUTE_CREATED")));
+        assertThat(disputeCreatedJson, hasJsonPath("$.resource_type", equalTo("dispute")));
+        assertThat(disputeCreatedJson, hasJsonPath("$.service_id", equalTo("service-id")));
+        assertThat(disputeCreatedJson, hasJsonPath("$.resource_external_id", equalTo("fca65e80d2293ee3bf158a0d12")));
+        assertThat(disputeCreatedJson, hasJsonPath("$.timestamp", equalTo("2022-01-19T07:59:20.000000Z")));
+        assertThat(disputeCreatedJson, hasJsonPath("$.live", equalTo(true)));
+        assertThat(disputeCreatedJson, hasJsonPath("$.parent_resource_external_id", equalTo("payment-external-id")));
 
-        assertThat(disputeLostJson, hasJsonPath("$.event_details.gateway_account_id", equalTo("1234")));
-        assertThat(disputeLostJson, hasJsonPath("$.event_details.net_amount", equalTo(-8000)));
-        assertThat(disputeLostJson, hasJsonPath("$.event_details.amount", equalTo(6500)));
-        assertThat(disputeLostJson, hasJsonPath("$.event_details.fee", equalTo(1500)));
+        assertThat(disputeCreatedJson, hasJsonPath("$.event_details.gateway_account_id", equalTo("1234")));
+        assertThat(disputeCreatedJson, hasJsonPath("$.event_details.evidence_due_date", equalTo(1642679160)));
+        assertThat(disputeCreatedJson, hasJsonPath("$.event_details.net_amount", equalTo(-8000)));
+        assertThat(disputeCreatedJson, hasJsonPath("$.event_details.amount", equalTo(6500)));
+        assertThat(disputeCreatedJson, hasJsonPath("$.event_details.fee", equalTo(1500)));
     }
 
     @Test
@@ -66,7 +68,7 @@ class DisputeLostTest {
                 "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction, balanceTransaction2), evidenceDetails);
 
         var thrown = assertThrows(RuntimeException.class, () ->
-                DisputeCreated.from(stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L)));
+                from(stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L)));
         assertThat(thrown.getMessage(), is("Dispute data has too many balance_transactions"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java
@@ -2,30 +2,42 @@ package uk.gov.pay.connector.events.model.dispute;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
-import uk.gov.pay.connector.events.eventdetails.dispute.DisputeEvidenceSubmittedEventDetails;
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.connector.queue.tasks.dispute.StripeDisputeData;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static uk.gov.pay.connector.events.model.dispute.DisputeEvidenceSubmitted.from;
+import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
 import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 
 public class DisputeEvidenceSubmittedTest {
 
     @Test
     public void shouldSerialiseEventDetails() throws JsonProcessingException {
-        DisputeEvidenceSubmittedEventDetails eventDetails = new DisputeEvidenceSubmittedEventDetails("a-gateway-account-id");
-        DisputeEvidenceSubmitted disputeEvidenceSubmitted = new DisputeEvidenceSubmitted("resource-external-id",
-                "external-id", "service-id", true, eventDetails, toUTCZonedDateTime(1642579160L));
+        LedgerTransaction transaction = aValidLedgerTransaction()
+                .withExternalId("payment-external-id")
+                .withGatewayAccountId(1234L)
+                .withGatewayTransactionId("payment-intent-id")
+                .withServiceId("service-id")
+                .isLive(true)
+                .build();
+        StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
+                "pi_123456789", "under_review", 6500L, "fradulent", 1642579160L, null, null);
+
+        DisputeEvidenceSubmitted disputeEvidenceSubmitted = from(stripeDisputeData.getId(), toUTCZonedDateTime(1642579160L), transaction);
 
         String disputeEvidenceSubmittedJson = disputeEvidenceSubmitted.toJsonString();
         assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.event_type", equalTo("DISPUTE_EVIDENCE_SUBMITTED")));
         assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.resource_type", equalTo("dispute")));
-        assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.resource_external_id", equalTo("resource-external-id")));
+        assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.service_id", equalTo("service-id")));
+        assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.resource_external_id", equalTo("fca65e80d2293ee3bf158a0d12")));
         assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.timestamp", equalTo("2022-01-19T07:59:20.000000Z")));
         assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.live", equalTo(true)));
-        assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.parent_resource_external_id", equalTo("external-id")));
+        assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.parent_resource_external_id", equalTo("payment-external-id")));
 
-        assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.event_details.gateway_account_id", equalTo("a-gateway-account-id")));
+        assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.event_details.gateway_account_id", equalTo("1234")));
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java
@@ -2,29 +2,41 @@ package uk.gov.pay.connector.events.model.dispute;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
-import uk.gov.pay.connector.events.eventdetails.dispute.DisputeWonEventDetails;
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.connector.queue.tasks.dispute.StripeDisputeData;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static uk.gov.pay.connector.events.model.dispute.DisputeWon.from;
+import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
 import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 
 public class DisputeWonTest {
 
     @Test
     public void shouldSerialiseEventDetails() throws JsonProcessingException {
-        DisputeWonEventDetails eventDetails = new DisputeWonEventDetails("a-gateway-account-id");
-        DisputeWon disputeWon = new DisputeWon("resource-external-id", "external-id",
-                "service-id", true, eventDetails, toUTCZonedDateTime(1642579160L));
+        LedgerTransaction transaction = aValidLedgerTransaction()
+                .withExternalId("payment-external-id")
+                .withGatewayAccountId(1234L)
+                .withGatewayTransactionId("payment-intent-id")
+                .withServiceId("service-id")
+                .isLive(true)
+                .build();
+        StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
+                "pi_123456789", "won", 6500L, "fradulent", 1642579160L, null, null);
+
+        DisputeWon disputeWon = from(stripeDisputeData.getId(), toUTCZonedDateTime(1642579160L), transaction);
 
         String disputeWonJson = disputeWon.toJsonString();
         assertThat(disputeWonJson, hasJsonPath("$.event_type", equalTo("DISPUTE_WON")));
         assertThat(disputeWonJson, hasJsonPath("$.resource_type", equalTo("dispute")));
-        assertThat(disputeWonJson, hasJsonPath("$.resource_external_id", equalTo("resource-external-id")));
+        assertThat(disputeWonJson, hasJsonPath("$.service_id", equalTo("service-id")));
+        assertThat(disputeWonJson, hasJsonPath("$.resource_external_id", equalTo("fca65e80d2293ee3bf158a0d12")));
         assertThat(disputeWonJson, hasJsonPath("$.timestamp", equalTo("2022-01-19T07:59:20.000000Z")));
         assertThat(disputeWonJson, hasJsonPath("$.live", equalTo(true)));
-        assertThat(disputeWonJson, hasJsonPath("$.parent_resource_external_id", equalTo("external-id")));
+        assertThat(disputeWonJson, hasJsonPath("$.parent_resource_external_id", equalTo("payment-external-id")));
 
-        assertThat(disputeWonJson, hasJsonPath("$.event_details.gateway_account_id", equalTo("a-gateway-account-id")));
+        assertThat(disputeWonJson, hasJsonPath("$.event_details.gateway_account_id", equalTo("1234")));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -72,6 +72,7 @@ public class LedgerTransactionFixture {
     private String refundedBy;
     private String refundedByUserEmail;
     private AuthorisationSummary authorisationSummary;
+    private String serviceId;
 
     public static LedgerTransactionFixture aValidLedgerTransaction() {
         return new LedgerTransactionFixture();
@@ -186,6 +187,7 @@ public class LedgerTransactionFixture {
         var ledgerTransaction = new LedgerTransaction();
         ledgerTransaction.setState(new TransactionState(status));
         ledgerTransaction.setTransactionId(externalId);
+        ledgerTransaction.setServiceId(serviceId);
         ledgerTransaction.setAmount(amount);
         ledgerTransaction.setDescription(description);
         ledgerTransaction.setReference(reference);
@@ -379,6 +381,11 @@ public class LedgerTransactionFixture {
 
     public LedgerTransactionFixture withAuthorisationSummary(AuthorisationSummary authorisationSummary) {
         this.authorisationSummary = authorisationSummary;
+        return this;
+    }
+
+    public LedgerTransactionFixture withServiceId(String serviceId) {
+        this.serviceId = serviceId;
         return this;
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Create dispute event objects using static methods which can be responsible for constructing relevant event details and returning a new dispute event object.
-  StripeWebhookTaskHandler to use these static methods instead of constructing different dispute event objects on its own.
