### PR TITLE
PP-9622 Refactor StripeWebhookTaskHandler

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeDisputeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeDisputeStatus.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import java.util.Arrays;
+
+public enum StripeDisputeStatus {
+    NEEDS_RESPONSE,
+    WON,
+    LOST,
+    UNDER_REVIEW,
+    UNKNOWN;
+
+    public static StripeDisputeStatus byStatus(String status) {
+        return Arrays.stream(StripeDisputeStatus.values())
+                .filter(c -> c.name().equalsIgnoreCase(status))
+                .findFirst()
+                .orElse(UNKNOWN);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationStatus.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationStatus.java
@@ -1,7 +1,0 @@
-package uk.gov.pay.connector.gateway.stripe;
-
-public enum StripeNotificationStatus {
-    WON,
-    LOST,
-    UNDER_REVIEW
-}

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
@@ -251,11 +251,19 @@ public class StripeWebhookTaskHandlerTest {
                 .thenReturn(Optional.of(transaction));
         StripeNotification stripeNotification = objectMapper.readValue(finalPayload, StripeNotification.class);
         var thrown = assertThrows(RuntimeException.class, () -> stripeWebhookTaskHandler.process(stripeNotification));
-        assertThat(thrown.getMessage(), is("Unknown stripe dispute closed status: [status: charge_refunded, payment_intent: pi_1111111111]"));
+        assertThat(thrown.getMessage(), is("Unknown stripe dispute status: [status: charge_refunded, payment_intent: pi_1111111111]"));
     }
 
     @Test
     void shouldLogWhenDisputeUpdatedAndUnknownStatus() throws JsonProcessingException {
+        LedgerTransaction transaction = aValidLedgerTransaction()
+                .withExternalId("external-id")
+                .withGatewayAccountId(1000L)
+                .withGatewayTransactionId("gateway-transaction-id")
+                .isLive(true)
+                .build();
+        when(ledgerService.getTransactionForProviderAndGatewayTransactionId(any(), any()))
+                .thenReturn(Optional.of(transaction));
         String finalPayload = payload
                 .replace(PLACEHOLDER_TYPE, "charge.dispute.updated")
                 .replace(PLACEHOLDER_STATUS, "needs_response");
@@ -272,6 +280,14 @@ public class StripeWebhookTaskHandlerTest {
 
     @Test
     void shouldThrowExceptionWhenMoreThanOneBalanceTransactionPresent() throws JsonProcessingException {
+        LedgerTransaction transaction = aValidLedgerTransaction()
+                .withExternalId("external-id")
+                .withGatewayAccountId(1000L)
+                .withGatewayTransactionId("gateway-transaction-id")
+                .isLive(true)
+                .build();
+        when(ledgerService.getTransactionForProviderAndGatewayTransactionId(any(), any()))
+                .thenReturn(Optional.of(transaction));
         String finalPayload = payload
                 .replace(PLACEHOLDER_TYPE, "charge.dispute.created")
                 .replace(PLACEHOLDER_STATUS, "needs_response")


### PR DESCRIPTION
## WHAT YOU DID
- Refactored StripeWebhookTaskHandler
   - uses static methods on dispute event classes to create objects
   - extracted common code (get a transaction, deserialise) to separate methods and called once and before a `dispute` event is processed
- Stops throwing exception if there are multiple balance transactions on Stripe dispute
  - Multiple balance_transactions are possible if a dispute is won (one transaction to debit the amount and another to credit it back). One balance transaction can only be excepted for dispute_created or dispute_lost event so the exception is thrown when building related events.
