### PR TITLE
PP-9795 investigate card exec service thread pool exhaustion

### DIFF
--- a/src/main/java/uk/gov/pay/connector/healthcheck/CardExecutorServiceHealthCheck.java
+++ b/src/main/java/uk/gov/pay/connector/healthcheck/CardExecutorServiceHealthCheck.java
@@ -3,14 +3,21 @@ package uk.gov.pay.connector.healthcheck;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheck;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 
 import javax.inject.Inject;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import static java.lang.String.format;
+
 public class CardExecutorServiceHealthCheck extends HealthCheck {
 
-    private ThreadPoolExecutor threadPoolExecutor;
+    private final ThreadPoolExecutor threadPoolExecutor;
+
+    private static final Logger logger = LoggerFactory.getLogger(CardExecutorServiceHealthCheck.class);
+
 
     @Inject
     public CardExecutorServiceHealthCheck(CardExecutorService cardExecutorService) {
@@ -19,9 +26,9 @@ public class CardExecutorServiceHealthCheck extends HealthCheck {
     }
 
     private void initialiseMetrics(MetricRegistry metricRegistry) {
-        metricRegistry.<Gauge<Integer>>register("card-executor.active-threads", () -> threadPoolExecutor.getActiveCount());
-        metricRegistry.<Gauge<Integer>>register("card-executor.pool-size", () -> threadPoolExecutor.getPoolSize());
-        metricRegistry.<Gauge<Integer>>register("card-executor.core-pool-size", () -> threadPoolExecutor.getCorePoolSize());
+        metricRegistry.<Gauge<Integer>>register("card-executor.active-threads", threadPoolExecutor::getActiveCount);
+        metricRegistry.<Gauge<Integer>>register("card-executor.pool-size", threadPoolExecutor::getPoolSize);
+        metricRegistry.<Gauge<Integer>>register("card-executor.core-pool-size", threadPoolExecutor::getCorePoolSize);
         metricRegistry.<Gauge<Integer>>register("card-executor.queue-size", () ->
                 threadPoolExecutor.getQueue() == null ? 0 : threadPoolExecutor.getQueue().size());
     }
@@ -31,7 +38,14 @@ public class CardExecutorServiceHealthCheck extends HealthCheck {
         if (threadPoolExecutor.getQueue().size() <= 10) {
             return Result.healthy();
         }
-
+        
+        // log some detail on the state of the threadPoolExecutor
+        var queueSize = threadPoolExecutor.getQueue().size();
+        var activelyExecutingThreads = threadPoolExecutor.getActiveCount();
+        var corePoolSize = threadPoolExecutor.getCorePoolSize();
+        
+        logger.warn("Dumping thread pool executor stats: queue size {}, active threads {}, core pool size {}", queueSize, activelyExecutingThreads, corePoolSize);
+        
         return Result.unhealthy("CardExecutorService-Unhealthy - Check metrics");
     }
 }

--- a/src/main/java/uk/gov/pay/connector/util/TimedThreadPoolExecutor.java
+++ b/src/main/java/uk/gov/pay/connector/util/TimedThreadPoolExecutor.java
@@ -1,0 +1,82 @@
+package uk.gov.pay.connector.util;
+
+import org.eclipse.jetty.util.BlockingArrayQueue;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class TimedThreadPoolExecutor extends ThreadPoolExecutor {
+    private final long timeout;
+    private final TimeUnit timeoutUnit;
+    // use a separate executor to handle the timeout tasks
+    private final ScheduledExecutorService timeoutExecutor = Executors.newSingleThreadScheduledExecutor();
+    private final ConcurrentMap<Runnable, ScheduledFuture<?>> timeoutTasks = new ConcurrentHashMap<>();
+
+    public TimedThreadPoolExecutor(int corePoolSize, ThreadFactory threadFactory, long timeout, TimeUnit timeoutUnit) {
+        super(corePoolSize, Integer.MAX_VALUE, 10L, TimeUnit.MILLISECONDS, new BlockingArrayQueue<>(), threadFactory);
+        if (timeout <= 0) throw new IllegalArgumentException("Timeout must be a positive value");
+        this.timeout = timeout;
+        this.timeoutUnit = timeoutUnit;
+    }
+
+    @Override
+    public void shutdown() {
+        timeoutExecutor.shutdown();
+        super.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        timeoutExecutor.shutdownNow();
+        return super.shutdownNow();
+    }
+
+    /***
+     * pre execution hook that schedules a timeout task at the point the task starts executing
+     * @param t the thread that will run task {@code r}
+     * @param r the task that will be executed
+     */
+    @Override
+    protected void beforeExecute(Thread t, Runnable r) {
+        final ScheduledFuture<?> scheduled = timeoutExecutor.schedule(new TimedTask(t), timeout, timeoutUnit);
+        timeoutTasks.put(r, scheduled);
+    }
+
+    /***
+     * post execution hook that removes a timeout task if the work completed within the timeout window
+     * @param r the runnable that has completed
+     * @param t the exception that caused termination, or null if
+     * execution completed normally
+     */
+    @Override
+    protected void afterExecute(Runnable r, Throwable t) {
+        ScheduledFuture<?> timeoutTask = timeoutTasks.remove(r);
+        if(timeoutTask != null) {
+            timeoutTask.cancel(false);
+        }
+    }
+    
+    protected ConcurrentMap<Runnable, ScheduledFuture<?>> getTimeoutTasks() {
+        return timeoutTasks;
+    }
+    
+    static class TimedTask implements Runnable {
+        private final Thread thread;
+        
+        public TimedTask(Thread threadToInterrupt) {
+            this.thread = threadToInterrupt;
+        }
+
+        @Override
+        public void run() {
+            thread.interrupt();
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TimedThreadPoolExecutorTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/TimedThreadPoolExecutorTest.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.connector.util;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+class TimedThreadPoolExecutorTest {
+    
+    final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+            .build();
+    TimedThreadPoolExecutor underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new TimedThreadPoolExecutor(10, threadFactory, 3, TimeUnit.SECONDS);
+    }
+    
+    @Test
+    void timedThreadPoolExecutor_shouldSubmitAndProcessTasks() throws InterruptedException, ExecutionException {
+        var future = underTest.submit(() -> "done");
+        assertThat(future.get(), is("done"));
+        assertThat(underTest.getCompletedTaskCount(), is(1L));
+    }
+    
+    @Test
+    void timedThreadPoolExecutor_shouldScheduleTimeoutTasks() {
+        for (int i = 0; i < 5; i++) {
+            underTest.submit(() -> {
+                try {
+                    Thread.sleep(20000L);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        await().untilAsserted(() -> assertThat(underTest.getTimeoutTasks().size(), is(5)));
+        assertThat(underTest.getTaskCount(), is(5L));
+    }
+    
+    @Test
+    void timedThreadPoolExecutor_shouldInterruptLongRunningTask() {
+        assertThrows(ExecutionException.class, () -> {
+            var future = underTest.submit(() -> {
+                try {
+                    Thread.sleep(100000L);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            future.get();
+        });
+    }
+
+}


### PR DESCRIPTION
## WHAT YOU DID

During a period of degraded Worldpay service we observed Connector keeping authorisation tasks active for as long as 50 minutes. This was causing some Connector instances to completely exhaust their thread pools and trigger an `unhealthy` warning on fargate, leading to the node being rebooted.

It is still not obvious why some of these tasks were so long lived as there are a number of configured timeouts for network connections to PSPs that should terminate any active sessions long before some of the observed run times we were seeing.

To prevent this from happening in the future, the `CardExecutorService` has been updated to use a timed thread pool executor. This allows us to schedule an additional task alongside any card operation task that will interrupt the thread after a specified time has elapsed. If the task has completed successfully the cancel task is removed and work continues as normal, meaning the added overhead of an additional task per execution is minimal and is handled by a separate executor.

Additionally, the healthcheck has been updated to dump some statistics on the state of the threadpool when the check returns `unhealthy`.
