### PR TITLE
PP-8694 Add updated_date to charges table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1919,4 +1919,12 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add updated date to charges table" author="">
+        <addColumn tableName="charges">
+            <column name="updated_date" type="timestamp without timezone">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
- Add updated_date to charges table which is updated whenever there is an update to charge state.
  This will be used by the expiry sweeper to ignore any charges updated (potentially being authorised) within the last few minutes.

Co-authored-by: @stephencdaly 

