### PR TITLE
PP-9790 Make CardAuthoriseService handle auth mode agreement

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/util/PaymentInstrumentEntityToAuthCardDetailsConverter.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/PaymentInstrumentEntityToAuthCardDetailsConverter.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.connector.charge.util;
+
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+
+public class PaymentInstrumentEntityToAuthCardDetailsConverter {
+
+    public AuthCardDetails convert(PaymentInstrumentEntity paymentInstrumentEntity) {
+        var cardDetails = paymentInstrumentEntity.getCardDetails();
+        var authCardDetails = new AuthCardDetails();
+
+        authCardDetails.setCardBrand(cardDetails.getCardBrand());
+        authCardDetails.setCardHolder(cardDetails.getCardHolderName());
+        authCardDetails.setEndDate(cardDetails.getExpiryDate());
+        cardDetails.getBillingAddress()
+                .map(Address::from)
+                .ifPresent(authCardDetails::setAddress);
+        authCardDetails.setPayersCardType(PayersCardType.from(cardDetails.getCardType()));
+        return authCardDetails;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/Address.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/Address.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.common.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.connector.charge.model.AddressEntity;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Address {
@@ -30,6 +31,15 @@ public class Address {
         this.city = city;
         this.county = county;
         this.country = country;
+    }
+
+    public static Address from(AddressEntity addressEntity) {
+        return new Address(addressEntity.getLine1(),
+                addressEntity.getLine2(),
+                addressEntity.getPostcode(),
+                addressEntity.getCity(),
+                addressEntity.getCounty(),
+                addressEntity.getCountry());
     }
 
     public String getLine1() {

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway;
 
+import org.apache.commons.lang3.NotImplementedException;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
@@ -29,7 +30,11 @@ public interface PaymentProvider {
     Optional<String> generateTransactionId();
 
     GatewayResponse authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) throws GatewayException;
-    
+
+    default GatewayResponse authoriseUserNotPresent(CardAuthorisationGatewayRequest request, ChargeEntity charge) {
+        throw new NotImplementedException("User-not-present authorisation is not implemented for this payment provider");
+    }
+
     GatewayResponse authoriseMotoApi(CardAuthorisationGatewayRequest request) throws GatewayException;
 
     ChargeQueryResponse queryPaymentStatus(ChargeQueryGatewayRequest chargeQueryGatewayRequest) throws GatewayException;

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
-import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.client.cardid.model.CardInformation;
@@ -75,19 +74,10 @@ public class AuthCardDetails implements AuthorisationDetails {
         authCardDetails.setPayersCardType(CardidCardType.toPayersCardType(cardInformation.getType()));
         authCardDetails.setPayersCardPrepaidStatus(cardInformation.getPrepaidStatus());
 
-        CardDetailsEntity cardDetailsEntity = chargeEntity.getCardDetails();
-        if (cardDetailsEntity != null) {
-            Optional<Address> mayBeAddress = cardDetailsEntity.getBillingAddress()
-                    .map((AddressEntity addressEntity) -> new Address(
-                            addressEntity.getLine1(),
-                            addressEntity.getLine2(),
-                            addressEntity.getPostcode(),
-                            addressEntity.getCity(),
-                            addressEntity.getCounty(),
-                            addressEntity.getCountry()
-                    ));
-            mayBeAddress.ifPresent(authCardDetails::setAddress);
-        }
+        Optional.ofNullable(chargeEntity.getCardDetails())
+                .flatMap(CardDetailsEntity::getBillingAddress)
+                .map(Address::from)
+                .ifPresent(authCardDetails::setAddress);
 
         return authCardDetails;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/PayersCardType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/PayersCardType.java
@@ -12,7 +12,18 @@ public enum PayersCardType {
     DEBIT,
     CREDIT,
     CREDIT_OR_DEBIT;
-    
+
+    public static PayersCardType from(CardType cardType) {
+        switch (cardType) {
+            case DEBIT:
+                return PayersCardType.DEBIT;
+            case CREDIT:
+                return PayersCardType.CREDIT;
+            default:
+                return null;
+        }
+    }
+
     public static CardType toCardType(PayersCardType payersCardType) {
         switch (payersCardType) {
             case DEBIT:

--- a/src/test/java/uk/gov/pay/connector/charge/util/PaymentInstrumentEntityToAuthCardDetailsConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/util/PaymentInstrumentEntityToAuthCardDetailsConverterTest.java
@@ -1,0 +1,62 @@
+package uk.gov.pay.connector.charge.util;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.charge.model.AddressEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+
+class PaymentInstrumentEntityToAuthCardDetailsConverterTest {
+
+    private final PaymentInstrumentEntityToAuthCardDetailsConverter converter = new PaymentInstrumentEntityToAuthCardDetailsConverter();
+
+    @Test
+    void shouldReturnAuthCardDetailsWithCardAndAddressDetail() {
+        PaymentInstrumentEntity paymentInstrumentEntity = PaymentInstrumentEntity.PaymentInstrumentEntityBuilder
+                .aPaymentInstrumentEntity(Instant.parse("2022-07-11T17:45:40Z"))
+                .withCardDetails(anAuthCardDetails().getCardDetailsEntity()).build();
+
+        AuthCardDetails authCardDetails = converter.convert(paymentInstrumentEntity);
+
+        assertAuthCardDetails(authCardDetails, paymentInstrumentEntity);
+        assertThat(authCardDetails.getAddress().isPresent(), is(true));
+
+        Address address = authCardDetails.getAddress().get();
+        AddressEntity addressEntity = paymentInstrumentEntity.getCardDetails().getBillingAddress().get();
+
+        assertThat(address.getLine1(), is(addressEntity.getLine1()));
+        assertThat(address.getLine2(), is(addressEntity.getLine2()));
+        assertThat(address.getCity(), is(addressEntity.getCity()));
+        assertThat(address.getCounty(), is(addressEntity.getCounty()));
+        assertThat(address.getPostcode(), is(addressEntity.getPostcode()));
+        assertThat(address.getCountry(), is(addressEntity.getCountry()));
+    }
+
+    @Test
+    void shouldReturnAuthCardDetailsWithoutAddress() {
+        PaymentInstrumentEntity paymentInstrumentEntity = PaymentInstrumentEntity.PaymentInstrumentEntityBuilder
+                .aPaymentInstrumentEntity(Instant.parse("2022-07-11T17:45:40Z"))
+                .withCardDetails(anAuthCardDetails().withAddress(null).getCardDetailsEntity()).build();
+
+        AuthCardDetails authCardDetails = converter.convert(paymentInstrumentEntity);
+
+        assertAuthCardDetails(authCardDetails, paymentInstrumentEntity);
+        assertThat(authCardDetails.getAddress().isPresent(), is(false));
+    }
+
+    private void assertAuthCardDetails(AuthCardDetails authCardDetails, PaymentInstrumentEntity paymentInstrumentEntity) {
+        assertThat(authCardDetails.getCardHolder(), is("Mr Test"));
+        assertThat(authCardDetails.getEndDate().toString(), is("12/99"));
+
+        assertThat(authCardDetails.getCardBrand(), is(paymentInstrumentEntity.getCardDetails().getCardBrand()));
+        assertThat(authCardDetails.getPayersCardType(), is(PayersCardType.from(paymentInstrumentEntity.getCardDetails().getCardType())));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/model/AuthCardDetailsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/AuthCardDetailsTest.java
@@ -16,11 +16,11 @@ import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCar
 
 class AuthCardDetailsTest {
 
-    private final CardInformation cardInformation = CardInformationFixture.aCardInformation().build();
     private final AuthoriseRequest authoriseRequest = new AuthoriseRequest("one-time-token", "4242424242424242", "123", "11/99", "Joe");
+    private final CardInformation cardInformation = CardInformationFixture.aCardInformation().build();
 
     @Test
-    void shouldReturnAuthCardDetailsWithCardAndAddressDetail() {
+    void shouldReturnAuthCardDetailsWithCardAndAddressDetailFromAuthoriseRequest() {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withCardDetails(anAuthCardDetails().getCardDetailsEntity())
                 .build();
@@ -42,7 +42,7 @@ class AuthCardDetailsTest {
     }
 
     @Test
-    void shouldReturnAuthCardDetailsWithOutAddress() {
+    void shouldReturnAuthCardDetailsWithoutAddressFromAuthoriseRequest() {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .build();
 
@@ -54,13 +54,14 @@ class AuthCardDetailsTest {
 
     private void assertAuthCardDetails(AuthCardDetails authCardDetails, CardInformation cardInformation) {
         assertThat(authCardDetails.getCardNo(), is("4242424242424242"));
+        assertThat(authCardDetails.getCvc(), is("123"));
         assertThat(authCardDetails.getCardHolder(), is("Joe"));
         assertThat(authCardDetails.getEndDate().toString(), is("11/99"));
-        assertThat(authCardDetails.getCvc(), is("123"));
 
         assertThat(authCardDetails.getCardBrand(), is(cardInformation.getBrand()));
         assertThat(authCardDetails.isCorporateCard(), is(cardInformation.isCorporate()));
         assertThat(authCardDetails.getPayersCardType(), is(CardidCardType.toPayersCardType(cardInformation.getType())));
         assertThat(authCardDetails.getPayersCardPrepaidStatus(), is(cardInformation.getPrepaidStatus()));
     }
+
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.service.ChargeEligibleForCaptureService;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
+import uk.gov.pay.connector.charge.util.PaymentInstrumentEntityToAuthCardDetailsConverter;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.gateway.PaymentProvider;
@@ -133,7 +134,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
                 new AuthorisationService(mockExecutorService, environment, mockConfiguration),
                 chargeService,
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
-                mockChargeEligibleForCaptureService, environment);
+                mockChargeEligibleForCaptureService, mock(PaymentInstrumentEntityToAuthCardDetailsConverter.class), environment);
 
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
 


### PR DESCRIPTION
Make `CardAuthoriseService` handle authorisation mode agreement charges by extracting the necessary data from the stored payment instrument and then passing it to the payment provider class.

… which will then throw and exception because we have not implemented that bit yet.

with @sfount