### PR TITLE
PP-8674 Update charge updated_date on state transition

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ChargeSweepConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/ChargeSweepConfig.java
@@ -9,6 +9,7 @@ public class ChargeSweepConfig extends Configuration {
     private int defaultChargeExpiryThreshold;
     private int awaitingCaptureExpiryThreshold;
     private int tokenExpiryThresholdInSeconds;
+    private int skipExpiringChargesLastUpdatedInSeconds;
 
     public Duration getDefaultChargeExpiryThreshold() {
         return Duration.ofSeconds(defaultChargeExpiryThreshold);
@@ -17,8 +18,12 @@ public class ChargeSweepConfig extends Configuration {
     public Duration getAwaitingCaptureExpiryThreshold() {
         return Duration.ofSeconds(awaitingCaptureExpiryThreshold);
     }
-    
+
     public Duration getTokenExpiryThresholdInSeconds() {
         return Duration.ofSeconds(tokenExpiryThresholdInSeconds);
+    }
+
+    public Duration getSkipExpiringChargesLastUpdatedInSeconds() {
+        return Duration.ofSeconds(skipExpiringChargesLastUpdatedInSeconds);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -212,6 +212,12 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @Enumerated(EnumType.STRING)
     private AuthorisationMode authorisationMode;
 
+    @Column(name = "updated_date")
+    @JsonIgnore
+    @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
+    @Schema(hidden = true)
+    private Instant updatedDate;
+
     public ChargeEntity() {
         //for jpa
     }
@@ -573,6 +579,14 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     public void setAuthorisationMode(AuthorisationMode authorisationMode) {
         this.authorisationMode = authorisationMode;
+    }
+
+    public void setUpdatedDate(Instant updatedDate) {
+        this.updatedDate = updatedDate;
+    }
+
+    public Instant getUpdatedDate() {
+        return updatedDate;
     }
 
     public static final class WebChargeEntityBuilder {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -254,6 +254,7 @@ chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
+  skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -70,6 +70,7 @@ public class ChargeEntityFixture {
     private boolean savePaymentInstrumentToAgreement = false;
     private PaymentInstrumentEntity paymentInstrument = null;
     private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
+    private Instant updatedDate;
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();
@@ -166,6 +167,7 @@ public class ChargeEntityFixture {
         chargeEntity.setExemption3ds(exemption3ds);
         chargeEntity.setAgreementId(agreementId);
         chargeEntity.setPaymentInstrument(paymentInstrument);
+        chargeEntity.setUpdatedDate(updatedDate);
 
         if (this.fees != null) {
             fees.stream().forEach(partialFee -> {
@@ -360,4 +362,8 @@ public class ChargeEntityFixture {
         return this;
     }
 
+    public ChargeEntityFixture withUpdatedDate(Instant updatedDate){
+        this.updatedDate = updatedDate;
+        return this;
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -368,6 +368,7 @@ class ChargeServiceTest {
         chargeService.transitionChargeState(chargeSpy, ENTERING_CARD_DETAILS);
 
         verify(chargeSpy).setStatus(ENTERING_CARD_DETAILS);
+        verify(chargeSpy).setUpdatedDate(any());
         verify(mockedChargeEventDao).persistChargeEventOf(eq(chargeSpy), isNull());
     }
 
@@ -383,6 +384,7 @@ class ChargeServiceTest {
         verify(mockStateTransitionService).offerPaymentStateTransition(chargeSpy.getExternalId(), CREATED,
                 ENTERING_CARD_DETAILS, chargeEvent);
 
+        verify(chargeSpy).setUpdatedDate(any());
         verify(mockTaskQueueService).offerTasksOnStateTransition(chargeSpy);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -499,7 +499,7 @@ public class DatabaseFixtures {
             this.allowMoto = allowMoto;
             return this;
         }
-        
+
         public TestAccount withAllowAuthApi(boolean allowAuthApi) {
             this.allowAuthApi = allowAuthApi;
             return this;
@@ -570,7 +570,7 @@ public class DatabaseFixtures {
         }
 
     }
-    
+
     public class TestAgreement {
         Long agreementId = RandomUtils.nextLong();
         Long gatewayAccountId = RandomUtils.nextLong();
@@ -581,7 +581,7 @@ public class DatabaseFixtures {
         Instant createdDate = Instant.now();
         boolean live = false;
         String serviceId = "service-id";
-        
+
         public Long getAgreementId() {
             return agreementId;
         }
@@ -618,6 +618,7 @@ public class DatabaseFixtures {
             this.agreementId = agreementId;
             return this;
         }
+
         public DatabaseFixtures.TestAgreement withExternalId(String externalId) {
             this.externalId = externalId;
             return this;
@@ -700,6 +701,7 @@ public class DatabaseFixtures {
         private ZonedDateTime parityCheckDate;
         Long gatewayCredentialId;
         private AuthorisationMode authorisationMode = WEB;
+        private Instant updatedDate;
 
         public TestCardDetails getCardDetails() {
             return cardDetails;
@@ -757,6 +759,11 @@ public class DatabaseFixtures {
 
         public TestCharge withCreatedDate(Instant createdDate) {
             this.createdDate = createdDate;
+            return this;
+        }
+
+        public TestCharge withUpdatedDate(Instant updatedDate) {
+            this.updatedDate = updatedDate;
             return this;
         }
 
@@ -820,6 +827,7 @@ public class DatabaseFixtures {
                     .withParityCheckDate(parityCheckDate)
                     .withGatewayCredentialId(gatewayCredentialId)
                     .withAuthorisationMode(authorisationMode)
+                    .withUpdatedDate(updatedDate)
                     .build());
 
             if (cardDetails != null) {

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -42,6 +42,7 @@ public class AddChargeParams {
     private final String agreementId;
     private final boolean savePaymentInstrumentToAgreement;
     private final AuthorisationMode authorisationMode;
+    private final Instant updatedDate;
 
     private AddChargeParams(AddChargeParamsBuilder builder) {
         chargeId = builder.chargeId;
@@ -71,6 +72,7 @@ public class AddChargeParams {
         agreementId = builder.agreementId;
         savePaymentInstrumentToAgreement = builder.savePaymentInstrumentToAgreement;
         authorisationMode = builder.authorisationMode;
+        this.updatedDate = builder.updatedDate;
     }
 
     public Long getChargeId() {
@@ -181,6 +183,10 @@ public class AddChargeParams {
         return authorisationMode;
     }
 
+    public Instant getUpdatedDate() {
+        return updatedDate;
+    }
+
     public static final class AddChargeParamsBuilder {
         private Long chargeId = new Random().nextLong();
         private String externalChargeId = "anExternalChargeId";
@@ -209,6 +215,7 @@ public class AddChargeParams {
         private String agreementId;
         private boolean savePaymentInstrumentToAgreement;
         private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
+        private Instant updatedDate;
 
         private AddChargeParamsBuilder() {
         }
@@ -350,6 +357,11 @@ public class AddChargeParams {
         
         public AddChargeParamsBuilder withAuthorisationMode(AuthorisationMode authorisationMode) {
             this.authorisationMode = authorisationMode;
+            return this;
+        }
+
+        public AddChargeParamsBuilder withUpdatedDate(Instant updatedDate) {
+            this.updatedDate = updatedDate;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -46,21 +46,21 @@ public class DatabaseTestHelper {
     public void addGatewayAccount(AddGatewayAccountParams params) {
         jdbi.withHandle(h ->
                 h.createUpdate("INSERT INTO gateway_accounts (id, external_id, " +
-                        "service_name, type, description, analytics_id, email_collection_mode, " +
-                        "integration_version_3ds, corporate_credit_card_surcharge_amount, " +
-                        "corporate_debit_card_surcharge_amount, " +
-                        "corporate_prepaid_debit_card_surcharge_amount, allow_moto, moto_mask_card_number_input, " +
-                        "moto_mask_card_security_code_input, allow_apple_pay, allow_google_pay, requires_3ds, " +
-                        "allow_telephone_payment_notifications, allow_authorisation_api, recurring_enabled," +
-                        "disabled, disabled_reason, provider_switch_enabled, service_id) " +
-                        "VALUES (:id, :external_id, :service_name, :type, " +
-                        ":description, :analytics_id, :email_collection_mode, :integration_version_3ds, " +
-                        ":corporate_credit_card_surcharge_amount, :corporate_debit_card_surcharge_amount, " +
-                        ":corporate_prepaid_debit_card_surcharge_amount, " +
-                        ":allow_moto, :moto_mask_card_number_input, :moto_mask_card_security_code_input, " +
-                        ":allow_apple_pay, :allow_google_pay, :requires_3ds, " +
-                        ":allow_telephone_payment_notifications, :allow_authorisation_api, :recurring_enabled," +
-                        ":disabled, :disabled_reason, :provider_switch_enabled, :service_id)")
+                                "service_name, type, description, analytics_id, email_collection_mode, " +
+                                "integration_version_3ds, corporate_credit_card_surcharge_amount, " +
+                                "corporate_debit_card_surcharge_amount, " +
+                                "corporate_prepaid_debit_card_surcharge_amount, allow_moto, moto_mask_card_number_input, " +
+                                "moto_mask_card_security_code_input, allow_apple_pay, allow_google_pay, requires_3ds, " +
+                                "allow_telephone_payment_notifications, allow_authorisation_api, recurring_enabled," +
+                                "disabled, disabled_reason, provider_switch_enabled, service_id) " +
+                                "VALUES (:id, :external_id, :service_name, :type, " +
+                                ":description, :analytics_id, :email_collection_mode, :integration_version_3ds, " +
+                                ":corporate_credit_card_surcharge_amount, :corporate_debit_card_surcharge_amount, " +
+                                ":corporate_prepaid_debit_card_surcharge_amount, " +
+                                ":allow_moto, :moto_mask_card_number_input, :moto_mask_card_security_code_input, " +
+                                ":allow_apple_pay, :allow_google_pay, :requires_3ds, " +
+                                ":allow_telephone_payment_notifications, :allow_authorisation_api, :recurring_enabled," +
+                                ":disabled, :disabled_reason, :provider_switch_enabled, :service_id)")
                         .bind("id", Long.valueOf(params.getAccountId()))
                         .bind("external_id", params.getExternalId())
                         .bind("service_name", params.getServiceName())
@@ -104,17 +104,17 @@ public class DatabaseTestHelper {
         }
         jdbi.withHandle(h ->
                 h.createUpdate("INSERT INTO charges(id, external_id, amount, " +
-                        "status, gateway_account_id, return_url, gateway_transaction_id, " +
-                        "description, created_date, reference, version, email, language, " +
-                        "delayed_capture, corporate_surcharge, parity_check_status, parity_check_date, " +
-                        "external_metadata, card_type, payment_provider, gateway_account_credential_id, service_id, " +
-                        "issuer_url_3ds, agreement_id, save_payment_instrument_to_agreement, authorisation_mode) " +
-                        "VALUES(:id, :external_id, :amount, " +
-                        ":status, :gateway_account_id, :return_url, :gateway_transaction_id, " +
-                        ":description, :created_date, :reference, :version, :email, :language, " +
-                        ":delayed_capture, :corporate_surcharge, :parity_check_status, :parity_check_date, " +
-                        ":external_metadata, :card_type, :payment_provider, :gateway_account_credential_id, :service_id, " +
-                        ":issuer_url_3ds, :agreementId, :savePaymentInstrumentToAgreement, :authorisationMode)")
+                                "status, gateway_account_id, return_url, gateway_transaction_id, " +
+                                "description, created_date, reference, version, email, language, " +
+                                "delayed_capture, corporate_surcharge, parity_check_status, parity_check_date, " +
+                                "external_metadata, card_type, payment_provider, gateway_account_credential_id, service_id, " +
+                                "issuer_url_3ds, agreement_id, save_payment_instrument_to_agreement, authorisation_mode, updated_date) " +
+                                "VALUES(:id, :external_id, :amount, " +
+                                ":status, :gateway_account_id, :return_url, :gateway_transaction_id, " +
+                                ":description, :created_date, :reference, :version, :email, :language, " +
+                                ":delayed_capture, :corporate_surcharge, :parity_check_status, :parity_check_date, " +
+                                ":external_metadata, :card_type, :payment_provider, :gateway_account_credential_id, :service_id, " +
+                                ":issuer_url_3ds, :agreementId, :savePaymentInstrumentToAgreement, :authorisationMode, :updatedDate)")
                         .bind("id", addChargeParams.getChargeId())
                         .bind("external_id", addChargeParams.getExternalChargeId())
                         .bind("amount", addChargeParams.getAmount())
@@ -141,9 +141,10 @@ public class DatabaseTestHelper {
                         .bind("agreementId", addChargeParams.getAgreementId())
                         .bind("savePaymentInstrumentToAgreement", addChargeParams.getSavePaymentInstrumentToAgreement())
                         .bind("authorisationMode", addChargeParams.getAuthorisationMode())
+                        .bind("updatedDate", addChargeParams.getUpdatedDate() != null ? LocalDateTime.ofInstant(addChargeParams.getUpdatedDate(), UTC) : null)
                         .execute());
     }
-    
+
     public void addAgreement(AddAgreementParams addAgreementParams) {
         jdbi.withHandle(h ->
                 h.createUpdate("INSERT INTO agreements(id, external_id, service_id, created_date, " +

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -193,6 +193,7 @@ chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
+  skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -193,6 +193,7 @@ chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
+  skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -183,6 +183,7 @@ chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
+  skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -191,6 +191,7 @@ chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
+  skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -191,6 +191,7 @@ chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
+  skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}


### PR DESCRIPTION
## WHAT YOU DID
- Added updated_date to ChargeEntity 
- updates charge updated_date on state transition.
- Added a new DAO method to find charges created and updated before dates and by status.
  This will be used by ChargeExpirySweeper to skip any charges updated within the last 5 minutes (as there could potentially be an authorisation in progress)

Co-authored-by: Stephen Daly <stephen.daly@digital.cabinet-office.gov.uk>
