### PR TITLE
PP-8694  Add BackfillerGatewayTransactionIdSet event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/BackFillerGatewayTransactionIdSetEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/BackFillerGatewayTransactionIdSetEventDetails.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.connector.events.eventdetails.charge;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+public class BackFillerGatewayTransactionIdSetEventDetails extends EventDetails {
+    private final String gatewayTransactionId;
+
+    public BackFillerGatewayTransactionIdSetEventDetails(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
+    }
+
+    public static BackFillerGatewayTransactionIdSetEventDetails from(ChargeEntity chargeEntity) {
+        return new BackFillerGatewayTransactionIdSetEventDetails(chargeEntity.getGatewayTransactionId());
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerGatewayTransactionIdSet.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerGatewayTransactionIdSet.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.charge.exception.ChargeEventNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.charge.BackFillerGatewayTransactionIdSetEventDetails;
+
+import java.time.ZonedDateTime;
+
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+
+public class BackfillerGatewayTransactionIdSet extends PaymentEvent {
+
+    public BackfillerGatewayTransactionIdSet(String serviceId,
+                                             boolean live,
+                                             String resourceExternalId,
+                                             BackFillerGatewayTransactionIdSetEventDetails eventDetails,
+                                             ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static BackfillerGatewayTransactionIdSet from(ChargeEntity charge) {
+        ZonedDateTime lastEventDate = charge.getEvents().stream()
+                .filter(e -> e.getStatus() == ENTERING_CARD_DETAILS)
+                .map(ChargeEventEntity::getUpdated)
+                .max(ZonedDateTime::compareTo)
+                .orElseThrow(() -> new ChargeEventNotFoundRuntimeException(charge.getExternalId()));
+
+        return new BackfillerGatewayTransactionIdSet(
+                charge.getServiceId(),
+                charge.getGatewayAccount().isLive(),
+                charge.getExternalId(),
+                BackFillerGatewayTransactionIdSetEventDetails.from(charge),
+                lastEventDate);
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID

- GatewayTransactionId is set before a charge is authorised (for Worldpay payments). gateway_transaction_id
  is included in the PAYMENT_ENTERED_DETAILS event. But sometimes, the thread could terminate without updating
  the charge status and the charge will eventually expire. In this case, gateway_transaction_id is not emitted to Ledger.
  Backfill gateway_trasaction_id so the charge can be expunged.

Co-authored-by: Stephen Daly <stephen.daly@digital.cabinet-office.gov.uk>
