### PR TITLE
PP-8694 Avoid adding multiple fees for failed Stripe payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueService.java
@@ -38,13 +38,14 @@ public class TaskQueueService {
         this.stripeGatewayConfig = stripeGatewayConfig;
         this.objectMapper = objectMapper;
     }
- 
+
     public void offerTasksOnStateTransition(ChargeEntity chargeEntity) {
         boolean isTerminallyFailed = chargeEntity.getChargeStatus().isExpungeable() &&
                 chargeEntity.getChargeStatus().toExternal() != ExternalChargeState.EXTERNAL_SUCCESS;
 
         if (isTerminallyFailed && chargeEntity.getPaymentGatewayName() == PaymentGatewayName.STRIPE &&
-                !isEmpty(chargeEntity.getGatewayTransactionId())) {
+                !isEmpty(chargeEntity.getGatewayTransactionId()) &&
+                chargeEntity.getFees().isEmpty()) {
             addCollectStripeFeeForFailedPaymentTask(chargeEntity);
         }
     }


### PR DESCRIPTION
When a Stripe payment is transitioned into a terminally failed state,
we offer a task to the Task SQS queue to collect fees.

For charges that enter AUTHORISATION_ERROR,
AUTHORISATION_UNEXPECTED_ERROR or AUTHORISATION_TIMEOUT events, we now
check whether they need to be expired with the gateway before moving
them on to other terminally failed states.

For this second transition to a terminally failed state, we do not want
to try to collect fees again. Therefore, before offering the task on a
state transition, check whether fees already exist.

Co-authored-by: Krishna Bottla <krishna.bottla@digital.cabinet-office.gov.uk>