### PR TITLE
PP-9790 Sandbox payment provider recurring authorisation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -635,6 +635,16 @@ public class ChargeService {
             Optional.ofNullable(emailAddress).ifPresent(charge::setEmail);
 
             CardDetailsEntity detailsEntity = authCardDetailsToCardDetailsEntityConverter.convert(authCardDetails);
+
+            // propagate details that aren't mapped from payment instrument to auth card details onto the charge
+            // this logic should be removable when payment instruments are modelled and used for all authorisation types
+            charge.getPaymentInstrument()
+                    .ifPresent(paymentInstrument -> {
+                        if (charge.getAuthorisationMode() == AuthorisationMode.AGREEMENT) {
+                            detailsEntity.setFirstDigitsCardNumber(paymentInstrument.getCardDetails().getFirstDigitsCardNumber());
+                            detailsEntity.setFirstDigitsCardNumber(paymentInstrument.getCardDetails().getFirstDigitsCardNumber());
+                        }
+                    });
             charge.setCardDetails(detailsEntity);
 
             if (charge.isSavePaymentInstrumentToAgreement()) {

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -638,13 +638,13 @@ public class ChargeService {
 
             // propagate details that aren't mapped from payment instrument to auth card details onto the charge
             // this logic should be removable when payment instruments are modelled and used for all authorisation types
-            charge.getPaymentInstrument()
-                    .ifPresent(paymentInstrument -> {
-                        if (charge.getAuthorisationMode() == AuthorisationMode.AGREEMENT) {
+            if (charge.getAuthorisationMode() == AuthorisationMode.AGREEMENT) {
+                charge.getPaymentInstrument()
+                        .ifPresent(paymentInstrument -> {
                             detailsEntity.setFirstDigitsCardNumber(paymentInstrument.getCardDetails().getFirstDigitsCardNumber());
-                            detailsEntity.setFirstDigitsCardNumber(paymentInstrument.getCardDetails().getFirstDigitsCardNumber());
-                        }
-                    });
+                            detailsEntity.setLastDigitsCardNumber(paymentInstrument.getCardDetails().getLastDigitsCardNumber());
+                        });
+            }
             charge.setCardDetails(detailsEntity);
 
             if (charge.isSavePaymentInstrumentToAgreement()) {

--- a/src/main/java/uk/gov/pay/connector/charge/util/AuthCardDetailsToCardDetailsEntityConverter.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/AuthCardDetailsToCardDetailsEntityConverter.java
@@ -12,6 +12,8 @@ import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 
 import javax.inject.Inject;
 
+import java.util.Optional;
+
 import static uk.gov.pay.connector.common.model.domain.NumbersInStringsSanitizer.sanitize;
 
 public class AuthCardDetailsToCardDetailsEntityConverter {
@@ -50,11 +52,17 @@ public class AuthCardDetailsToCardDetailsEntityConverter {
     }
 
     private static boolean hasFullCardNumber(AuthCardDetails authCardDetails) {
-        return authCardDetails.getCardNo().length() > 6;
+        return Optional.ofNullable(authCardDetails)
+                .map(AuthCardDetails::getCardNo)
+                .map(cardNumber -> cardNumber.length() > 6)
+                .orElse(false);
     }
 
     private static boolean hasLastFourCharactersCardNumber(AuthCardDetails authCardDetails) {
-        return authCardDetails.getCardNo().length() >= 4;
+        return Optional.ofNullable(authCardDetails)
+                .map(AuthCardDetails::getCardNo)
+                .map(cardNumber -> cardNumber.length() >= 4)
+                .orElse(false);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/charge/util/AuthCardDetailsToCardDetailsEntityConverter.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/AuthCardDetailsToCardDetailsEntityConverter.java
@@ -52,17 +52,15 @@ public class AuthCardDetailsToCardDetailsEntityConverter {
     }
 
     private static boolean hasFullCardNumber(AuthCardDetails authCardDetails) {
-        return Optional.ofNullable(authCardDetails)
-                .map(AuthCardDetails::getCardNo)
+        return Optional.ofNullable(authCardDetails.getCardNo())
                 .map(cardNumber -> cardNumber.length() > 6)
                 .orElse(false);
     }
 
     private static boolean hasLastFourCharactersCardNumber(AuthCardDetails authCardDetails) {
-        return Optional.ofNullable(authCardDetails)
-                .map(AuthCardDetails::getCardNo)
+        return Optional.ofNullable(authCardDetails.getCardNo())
                 .map(cardNumber -> cardNumber.length() >= 4)
                 .orElse(false);
     }
 
-}
+};

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceIT.java
@@ -25,6 +25,8 @@ import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentIns
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class CardAuthoriseServiceIT extends ChargingITestBase {
+    private final String SUCCESS_LAST_FOUR_DIGITS = "4242";
+    private final String DECLINE_LAST_FOUR_DIGITS = "0002";
 
     public CardAuthoriseServiceIT() {
         super("sandbox");
@@ -38,19 +40,25 @@ public class CardAuthoriseServiceIT extends ChargingITestBase {
         assertThat(response.getGatewayError(), is(Optional.empty()));
         assertThat(response.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED)));
     }
-    
+
     @Test
-    public void shouldAuthoriseSandboxUserNotPresentPayment() {
-        addCharge("success-charge-external-id", "4242");
-        addCharge("decline-charge-external-id", "0002");
+    public void shouldSuccessfullyAuthoriseSandboxUserNotPresentPayment() {
+        addCharge("success-charge-external-id", SUCCESS_LAST_FOUR_DIGITS);
 
         var successCharge = testContext.getInstanceFromGuiceContainer(ChargeService.class).findChargeByExternalId("success-charge-external-id");
-        var declineCharge = testContext.getInstanceFromGuiceContainer(ChargeService.class).findChargeByExternalId("decline-charge-external-id");
 
         var successResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseUserNotPresent(successCharge);
-        var declineResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseUserNotPresent(declineCharge);
         assertThat(successResponse.getGatewayError(), is(Optional.empty()));
         assertThat(successResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED)));
+    }
+
+    @Test
+    public void shouldDeclineAuthoriseSandboxUserNotPresentPayment() {
+        addCharge("decline-charge-external-id", DECLINE_LAST_FOUR_DIGITS);
+
+        var declineCharge = testContext.getInstanceFromGuiceContainer(ChargeService.class).findChargeByExternalId("decline-charge-external-id");
+
+        var declineResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseUserNotPresent(declineCharge);
         assertThat(declineResponse.getGatewayError(), is(Optional.empty()));
         assertThat(declineResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED)));
     }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceIT.java
@@ -1,0 +1,82 @@
+package uk.gov.pay.connector.paymentprocessor.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+
+import java.util.Optional;
+
+import static org.apache.commons.lang.math.RandomUtils.nextInt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
+import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
+import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class CardAuthoriseServiceIT extends ChargingITestBase {
+
+    public CardAuthoriseServiceIT() {
+        super("sandbox");
+    }
+    
+    @Test
+    public void shouldAuthoriseSandboxWebPayment() {
+        addCharge("external-charge-id", null);
+        var response = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class)
+                .doAuthoriseWeb("external-charge-id", AuthCardDetailsFixture.anAuthCardDetails().build());
+        assertThat(response.getGatewayError(), is(Optional.empty()));
+        assertThat(response.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED)));
+    }
+    
+    @Test
+    public void shouldAuthoriseSandboxUserNotPresentPayment() {
+        addCharge("success-charge-external-id", "4242");
+        addCharge("decline-charge-external-id", "0002");
+
+        var successCharge = testContext.getInstanceFromGuiceContainer(ChargeService.class).findChargeByExternalId("success-charge-external-id");
+        var declineCharge = testContext.getInstanceFromGuiceContainer(ChargeService.class).findChargeByExternalId("decline-charge-external-id");
+
+        var successResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseUserNotPresent(successCharge);
+        var declineResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseUserNotPresent(declineCharge);
+        assertThat(successResponse.getGatewayError(), is(Optional.empty()));
+        assertThat(successResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED)));
+        assertThat(declineResponse.getGatewayError(), is(Optional.empty()));
+        assertThat(declineResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED)));
+    }
+
+    private void addCharge(String externalId, String last4DigitsCardNumber) {
+        var chargeParams = anAddChargeParams()
+                .withExternalChargeId(externalId)
+                .withPaymentProvider(SANDBOX.getName())
+                .withGatewayAccountId(accountId)
+                .withAmount(10000)
+                .withStatus(ChargeStatus.ENTERING_CARD_DETAILS);
+
+        if (last4DigitsCardNumber != null) {
+            long paymentInstrumentId = nextInt();
+            databaseTestHelper.addPaymentInstrument(
+                    anAddPaymentInstrumentParams()
+                            .withPaymentInstrumentId(paymentInstrumentId)
+                            .withExternalPaymentInstrumentId(String.valueOf(nextInt()))
+                            .withLastDigitsCardNumber(LastDigitsCardNumber.of(last4DigitsCardNumber))
+                            .build()
+            );
+            chargeParams
+                   .withStatus(ChargeStatus.CREATED)
+                   .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                   .withPaymentInstrumentId(paymentInstrumentId);
+        }
+        databaseTestHelper.addCharge(chargeParams.build());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -43,6 +43,7 @@ public class AddChargeParams {
     private final boolean savePaymentInstrumentToAgreement;
     private final AuthorisationMode authorisationMode;
     private final Instant updatedDate;
+    private final Long paymentInstrumentId;
 
     private AddChargeParams(AddChargeParamsBuilder builder) {
         chargeId = builder.chargeId;
@@ -73,6 +74,7 @@ public class AddChargeParams {
         savePaymentInstrumentToAgreement = builder.savePaymentInstrumentToAgreement;
         authorisationMode = builder.authorisationMode;
         this.updatedDate = builder.updatedDate;
+        paymentInstrumentId = builder.paymentInstrumentId;
     }
 
     public Long getChargeId() {
@@ -187,6 +189,10 @@ public class AddChargeParams {
         return updatedDate;
     }
 
+    public Long getPaymentInstrumentId() {
+        return paymentInstrumentId;
+    }
+
     public static final class AddChargeParamsBuilder {
         private Long chargeId = new Random().nextLong();
         private String externalChargeId = "anExternalChargeId";
@@ -216,6 +222,7 @@ public class AddChargeParams {
         private boolean savePaymentInstrumentToAgreement;
         private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
         private Instant updatedDate;
+        private Long paymentInstrumentId;
 
         private AddChargeParamsBuilder() {
         }
@@ -362,6 +369,11 @@ public class AddChargeParams {
 
         public AddChargeParamsBuilder withUpdatedDate(Instant updatedDate) {
             this.updatedDate = updatedDate;
+            return this;
+        }
+
+        public AddChargeParamsBuilder withPaymentInstrumentId(Long paymentInstrumentId) {
+            this.paymentInstrumentId = paymentInstrumentId;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/AddPaymentInstrumentParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddPaymentInstrumentParams.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.util;
 
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
+import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
@@ -20,6 +21,7 @@ public class AddPaymentInstrumentParams {
     private final String cardBrand;
     private final CardExpiryDate expiryDate;
     private final LastDigitsCardNumber lastDigitsCardNumber;
+    private final FirstDigitsCardNumber firstDigitsCardNumber;
     private final String cardholderName;
     private final String addressLine1;
     private final String addressLine2;
@@ -92,6 +94,10 @@ public class AddPaymentInstrumentParams {
         return countryCode;
     }
 
+    public FirstDigitsCardNumber getFirstDigitsCardNumber() {
+        return firstDigitsCardNumber;
+    }
+
     private AddPaymentInstrumentParams(AddPaymentInstrumentParamsBuilder builder) {
         paymentInstrumentId = builder.paymentInstrumentId;
         externalPaymentInstrumentId = builder.externalPaymentInstrumentId;
@@ -109,6 +115,7 @@ public class AddPaymentInstrumentParams {
         stateOrProvince = builder.stateOrProvince;
         postcode = builder.postcode;
         countryCode = builder.countryCode;
+        firstDigitsCardNumber = builder.firstDigitsCardNumber;
     }
 
     public static final class AddPaymentInstrumentParamsBuilder {
@@ -121,6 +128,7 @@ public class AddPaymentInstrumentParams {
         private String cardBrand = "visa";
         private CardExpiryDate expiryDate = CardExpiryDate.valueOf("12/27");
         private LastDigitsCardNumber lastDigitsCardNumber = LastDigitsCardNumber.of("1234");
+        private FirstDigitsCardNumber firstDigitsCardNumber = FirstDigitsCardNumber.of("123456");
         private String cardholderName = "Dr. Payment";
         private String addressLine1 = "1 Money Street";
         private String addressLine2 = "Payville";
@@ -178,6 +186,11 @@ public class AddPaymentInstrumentParams {
 
         public AddPaymentInstrumentParamsBuilder withLastDigitsCardNumber(LastDigitsCardNumber lastDigitsCardNumber) {
             this.lastDigitsCardNumber = lastDigitsCardNumber;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withFirstDigitsCardNumber(FirstDigitsCardNumber firstDigitsCardNumber) {
+            this.firstDigitsCardNumber = firstDigitsCardNumber;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -108,13 +108,13 @@ public class DatabaseTestHelper {
                                 "description, created_date, reference, version, email, language, " +
                                 "delayed_capture, corporate_surcharge, parity_check_status, parity_check_date, " +
                                 "external_metadata, card_type, payment_provider, gateway_account_credential_id, service_id, " +
-                                "issuer_url_3ds, agreement_id, save_payment_instrument_to_agreement, authorisation_mode, updated_date) " +
+                                "issuer_url_3ds, agreement_id, save_payment_instrument_to_agreement, authorisation_mode, updated_date, payment_instrument_id) " +
                                 "VALUES(:id, :external_id, :amount, " +
                                 ":status, :gateway_account_id, :return_url, :gateway_transaction_id, " +
                                 ":description, :created_date, :reference, :version, :email, :language, " +
                                 ":delayed_capture, :corporate_surcharge, :parity_check_status, :parity_check_date, " +
                                 ":external_metadata, :card_type, :payment_provider, :gateway_account_credential_id, :service_id, " +
-                                ":issuer_url_3ds, :agreementId, :savePaymentInstrumentToAgreement, :authorisationMode, :updatedDate)")
+                                ":issuer_url_3ds, :agreementId, :savePaymentInstrumentToAgreement, :authorisationMode, :updatedDate, :paymentInstrumentId)")
                         .bind("id", addChargeParams.getChargeId())
                         .bind("external_id", addChargeParams.getExternalChargeId())
                         .bind("amount", addChargeParams.getAmount())
@@ -142,6 +142,7 @@ public class DatabaseTestHelper {
                         .bind("savePaymentInstrumentToAgreement", addChargeParams.getSavePaymentInstrumentToAgreement())
                         .bind("authorisationMode", addChargeParams.getAuthorisationMode())
                         .bind("updatedDate", addChargeParams.getUpdatedDate() != null ? LocalDateTime.ofInstant(addChargeParams.getUpdatedDate(), UTC) : null)
+                        .bind("paymentInstrumentId", addChargeParams.getPaymentInstrumentId())
                         .execute());
     }
 
@@ -178,6 +179,7 @@ public class DatabaseTestHelper {
                                     "card_brand, " +
                                     "expiry_date, " +
                                     "last_digits_card_number, " +
+                                    "first_digits_card_number, " +
                                     "cardholder_name, " +
                                     "address_line1, " +
                                     "address_line2, " +
@@ -195,6 +197,7 @@ public class DatabaseTestHelper {
                                     ":card_brand, " +
                                     ":expiry_date, " +
                                     ":last_digits_card_number, " +
+                                    ":first_digits_card_number, " +
                                     ":cardholder_name, " +
                                     ":address_line1, " +
                                     ":address_line2, " +
@@ -212,6 +215,7 @@ public class DatabaseTestHelper {
                         .bind("card_brand", addPaymentInstrumentParams.getCardBrand())
                         .bind("expiry_date", addPaymentInstrumentParams.getExpiryDate().toString())
                         .bind("last_digits_card_number", addPaymentInstrumentParams.getLastDigitsCardNumber().toString())
+                        .bind("first_digits_card_number", addPaymentInstrumentParams.getFirstDigitsCardNumber().toString())
                         .bind("cardholder_name", addPaymentInstrumentParams.getCardholderName())
                         .bind("address_line1", addPaymentInstrumentParams.getAddressLine1())
                         .bind("address_line2", addPaymentInstrumentParams.getAddressLine2())


### PR DESCRIPTION
Implement user not present interface for the Sandbox payment provider.

Use the new `last4DigitsSandboxResponseGenerator` to return a gateway
response which is matched to information from the payment instrument
available to user not present authorisation.

For now we will use this generator but plan to add a subsequent
generator that will respect the existing test card numbers.

---

The charge operations task queue isn't configured to do recurring
authorisations yet. Add an integration to assert that charges with
agreement authorisation mode are seen through to authorised or declined
depending on sandbox card numbers.

With @alexbishop1 