### PR TITLE
PP-9790 Sandbox recurring auth support all test card numbers

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
@@ -1,6 +1,56 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
+import java.util.Map;
+import java.util.Set;
+
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+
 public interface SandboxCardNumbers {
+    String GOOD_CARD_NUMBER = "4242424242424242";
+    String GOOD_CARD_PREPAID_NON_CORPORATE = "4000160000000004";
+    String GOOD_CORPORATE_PREPAID_UNKNOWN_CREDIT_CARD = "5101180000000007";
+    String GOOD_CORPORATE_PREPAID_UNKNOWN_DEBIT_CARD = "5200828282828210";
+    String GOOD_NON_CORPORATE_NON_PREPAID = "4000020000000000";
+    String GOOD_MASTERCARD_CREDIT_CARD = "5101110000000004";
+    String GOOD_VISA_PREPAID_UNKNOWN_CREDIT_OR_DEBIT_UNKNOWN_CARD = "4000000000000010";
+    String DECLINED_CARD_NUMBER = "4000000000000002";
+    String CVC_ERROR_CARD_NUMBER = "4000000000000127";
+    String EXPIRED_CARD_NUMBER = "4000000000000069";
+    String PROCESSING_ERROR_CARD_NUMBER = "4000000000000119";
+
+    Set<String> GOOD_CARDS = Set.of(
+            "4444333322221111",
+            "4917610000000000003",
+            "4000056655665556",
+            "5105105105105100",
+            "371449635398431",
+            "3566002020360505",
+            "6011000990139424",
+            "36148900647913",
+            GOOD_CARD_NUMBER,
+            GOOD_MASTERCARD_CREDIT_CARD,
+            GOOD_VISA_PREPAID_UNKNOWN_CREDIT_OR_DEBIT_UNKNOWN_CARD,
+            GOOD_CARD_PREPAID_NON_CORPORATE,
+            GOOD_NON_CORPORATE_NON_PREPAID);
+
+    Set<String> GOOD_CORPORATE_CARDS = Set.of(
+            "4988080000000000",
+            "4000620000000007",
+            "4293189100000008",
+            GOOD_CORPORATE_PREPAID_UNKNOWN_CREDIT_CARD);
+
+    Set<String> GOOD_CORPORATE_PREPAID_DEBIT_CARD = Set.of(
+            "4131840000000003",
+            "4000180000000002",
+            GOOD_CORPORATE_PREPAID_UNKNOWN_DEBIT_CARD);
+
+    Set<String> REJECTED_CARDS = Set.of(
+            DECLINED_CARD_NUMBER,
+            EXPIRED_CARD_NUMBER,
+            CVC_ERROR_CARD_NUMBER);
+
+    Map<String, CardError> ERROR_CARDS = Map.of(
+            PROCESSING_ERROR_CARD_NUMBER, new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed."));
 
     boolean isValidCard(String cardNumber);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxFirst6AndLast4CardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxFirst6AndLast4CardNumbers.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.connector.gateway.sandbox;
+
+import java.util.Map;
+import java.util.Set;
+
+public class SandboxFirst6AndLast4CardNumbers implements SandboxCardNumbers {
+
+    @Override
+    public boolean isValidCard(String cardNumber) {
+        return setContains(cardNumber, GOOD_CARDS) || setContains(cardNumber, GOOD_CORPORATE_CARDS) || setContains(cardNumber, GOOD_CORPORATE_PREPAID_DEBIT_CARD);
+    }
+
+    @Override
+    public boolean isRejectedCard(String cardNumber) {
+        return setContains(cardNumber, REJECTED_CARDS);
+    }
+
+    @Override
+    public boolean isErrorCard(String cardNumber) {
+        return setContains(cardNumber, ERROR_CARDS.keySet());
+    }
+    
+    private boolean setContains(String first6AndLast4CardNumber, Set<String> cardNumbers) {
+        return cardNumbers.stream().anyMatch(fullCardNumber -> matchesFirst6AndLast4Digits(first6AndLast4CardNumber, fullCardNumber));
+    }
+
+    private boolean matchesFirst6AndLast4Digits(String first6AndLast4CardNumber, String fullCardNumber) {
+        if (first6AndLast4CardNumber == null || first6AndLast4CardNumber.length() < 10) {
+            return false;
+        }
+        return fullCardNumber.startsWith(first6AndLast4CardNumber.substring(0, 6)) && fullCardNumber.endsWith(first6AndLast4CardNumber.substring(first6AndLast4CardNumber.length() - 4));
+    }
+
+    @Override
+    public CardError cardErrorFor(String first6AndLast4CardNumber) {
+        return ERROR_CARDS.entrySet()
+                .stream()
+                .filter(errorCard -> matchesFirst6AndLast4Digits(first6AndLast4CardNumber, errorCard.getKey()))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxFullCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxFullCardNumbers.java
@@ -1,56 +1,6 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
-import java.util.Map;
-import java.util.Set;
-
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
-
 public class SandboxFullCardNumbers implements SandboxCardNumbers {
-    
-    private static final String GOOD_CARD_PREPAID_NON_CORPORATE = "4000160000000004";
-    private static final String GOOD_CORPORATE_PREPAID_UNKNOWN_CREDIT_CARD = "5101180000000007";
-    private static final String GOOD_CORPORATE_PREPAID_UNKNOWN_DEBIT_CARD = "5200828282828210";
-    private static final String GOOD_NON_CORPORATE_NON_PREPAID = "4000020000000000";
-    private static final String GOOD_MASTERCARD_CREDIT_CARD = "5101110000000004";
-    private static final String GOOD_VISA_PREPAID_UNKNOWN_CREDIT_OR_DEBIT_UNKNOWN_CARD = "4000000000000010";
-    private static final String DECLINED_CARD_NUMBER = "4000000000000002";
-    private static final String CVC_ERROR_CARD_NUMBER = "4000000000000127";
-    private static final String EXPIRED_CARD_NUMBER = "4000000000000069";
-    private static final String PROCESSING_ERROR_CARD_NUMBER = "4000000000000119";
-
-    private static final Set<String> GOOD_CARDS = Set.of(
-            "4444333322221111",
-            "4242424242424242",
-            "4917610000000000003",
-            "4000056655665556",
-            "5105105105105100",
-            "371449635398431",
-            "3566002020360505",
-            "6011000990139424",
-            "36148900647913",
-            GOOD_MASTERCARD_CREDIT_CARD,
-            GOOD_VISA_PREPAID_UNKNOWN_CREDIT_OR_DEBIT_UNKNOWN_CARD,
-            GOOD_CARD_PREPAID_NON_CORPORATE,
-            GOOD_NON_CORPORATE_NON_PREPAID);
-
-    private static final Set<String> GOOD_CORPORATE_CARDS = Set.of(
-            "4988080000000000",
-            "4000620000000007",
-            "4293189100000008",
-            GOOD_CORPORATE_PREPAID_UNKNOWN_CREDIT_CARD);
-
-    private static final Set<String> GOOD_CORPORATE_PREPAID_DEBIT_CARD = Set.of(
-            "4131840000000003",
-            "4000180000000002",
-            GOOD_CORPORATE_PREPAID_UNKNOWN_DEBIT_CARD);
-
-    private static final Set<String> REJECTED_CARDS = Set.of(
-            DECLINED_CARD_NUMBER,
-            EXPIRED_CARD_NUMBER,
-            CVC_ERROR_CARD_NUMBER);
-
-    private static Map<String, CardError> ERROR_CARDS = Map.of(
-            PROCESSING_ERROR_CARD_NUMBER, new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed."));
 
     @Override
     public boolean isValidCard(String cardNumber) {

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxLast4DigitsCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxLast4DigitsCardNumbers.java
@@ -6,18 +6,16 @@ import java.util.Set;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 
 public class SandboxLast4DigitsCardNumbers implements SandboxCardNumbers {
-    
     /*
     The last four digits field for Apple and Google Pay aren't used for authorisation.
     However for testing purposes Sandbox determines the authorisation status based on the last four digits field.
      */
-
-    private static final String GOOD_WALLET_LAST_DIGITS_CARD_NUMBER = "4242";
+    private static final String GOOD_WALLET_LAST_DIGITS_CARD_NUMBER = getLast4Digits(GOOD_CARD_NUMBER);
     private static final String GOOD_WALLET_EMPTY_STRING_CARD_NUMBER = "";
-    private static final String DECLINED_WALLET_LAST_DIGITS_CARD_NUMBER = "0002";
-    private static final String CVC_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER = "0127";
-    private static final String EXPIRED_WALLET_LAST_DIGITS_CARD_NUMBER = "0069";
-    private static final String PROCESSING_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER = "0119";
+    private static final String DECLINED_WALLET_LAST_DIGITS_CARD_NUMBER = getLast4Digits(DECLINED_CARD_NUMBER);
+    private static final String CVC_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER = getLast4Digits(CVC_ERROR_CARD_NUMBER);
+    private static final String EXPIRED_WALLET_LAST_DIGITS_CARD_NUMBER = getLast4Digits(EXPIRED_CARD_NUMBER);
+    private static final String PROCESSING_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER = getLast4Digits(PROCESSING_ERROR_CARD_NUMBER);
 
     private static final Set<String> GOOD_CARDS = Set.of(
             GOOD_WALLET_EMPTY_STRING_CARD_NUMBER,
@@ -30,6 +28,10 @@ public class SandboxLast4DigitsCardNumbers implements SandboxCardNumbers {
 
     private static Map<String, CardError> ERROR_CARDS = Map.of(
             PROCESSING_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER, new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed."));
+
+    private static String getLast4Digits(String fullCardNumber) {
+        return fullCardNumber.substring(fullCardNumber.length() - 4);
+    }
 
     @Override
     public boolean isValidCard(String cardNumber) {

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -43,11 +43,12 @@ public class SandboxPaymentProvider implements PaymentProvider {
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
     private final SandboxWalletAuthorisationHandler sandboxWalletAuthorisationHandler;
     private final SandboxGatewayResponseGenerator fullCardNumberSandboxResponseGenerator = new SandboxGatewayResponseGenerator(new SandboxFullCardNumbers());
-    private final SandboxGatewayResponseGenerator last4DigitsSandboxResponseGenerator = new SandboxGatewayResponseGenerator(new SandboxLast4DigitsCardNumbers());
+    private final SandboxGatewayResponseGenerator walletSandboxResponseGenerator = new SandboxGatewayResponseGenerator(new SandboxLast4DigitsCardNumbers());
+    private final SandboxGatewayResponseGenerator recurringSandboxResponseGenerator = new SandboxGatewayResponseGenerator(new SandboxFirst6AndLast4CardNumbers());
 
     public SandboxPaymentProvider() {
         this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
-        this.sandboxWalletAuthorisationHandler = new SandboxWalletAuthorisationHandler(last4DigitsSandboxResponseGenerator);
+        this.sandboxWalletAuthorisationHandler = new SandboxWalletAuthorisationHandler(walletSandboxResponseGenerator);
     }
 
     @Override
@@ -69,8 +70,9 @@ public class SandboxPaymentProvider implements PaymentProvider {
     public GatewayResponse authoriseUserNotPresent(CardAuthorisationGatewayRequest request, ChargeEntity charge) {
         var paymentInstrumentEntity = charge.getPaymentInstrument()
                 .orElseThrow(() -> new IllegalArgumentException("Expected charge to have payment instrument but it does not"));
+        var firstDigitsCardNumber = paymentInstrumentEntity.getCardDetails().getFirstDigitsCardNumber().toString();
         var lastDigitsCardNumber = paymentInstrumentEntity.getCardDetails().getLastDigitsCardNumber().toString();
-        return last4DigitsSandboxResponseGenerator.getSandboxGatewayResponse(lastDigitsCardNumber);
+        return recurringSandboxResponseGenerator.getSandboxGatewayResponse(firstDigitsCardNumber.concat(lastDigitsCardNumber));
     }
 
     /**


### PR DESCRIPTION
Recurring card authorisation on Sandbox should respect the existing card
numbers provided in the documentation.

As a payment instrument will only have the first 6 and last 4 digits,
add a split card number generator that will check partial strings
against sets.

Also use the same definitions for card numbers across all generators 
for consistency.

Tests should continue to pass.