### PR TITLE
PP-8694 Emit RefundAvailableUpdated event for submitted states

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -10,6 +10,9 @@ import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdated
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.events.exception.EventCreationException;
 import uk.gov.pay.connector.events.model.charge.BackfillerRecreatedUserEmailCollected;
+import uk.gov.pay.connector.events.model.charge.CancelByExpirationSubmitted;
+import uk.gov.pay.connector.events.model.charge.CancelByExternalServiceSubmitted;
+import uk.gov.pay.connector.events.model.charge.CancelByUserSubmitted;
 import uk.gov.pay.connector.events.model.charge.CancelledByUser;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
@@ -64,7 +67,10 @@ public class EventFactory {
             UnexpectedGatewayErrorDuringAuthorisation.class,
             StatusCorrectedToAuthorisationErrorToMatchGatewayStatus.class,
             StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus.class,
-            StatusCorrectedToCapturedToMatchGatewayStatus.class
+            StatusCorrectedToCapturedToMatchGatewayStatus.class,
+            CancelByExternalServiceSubmitted.class,
+            CancelByExpirationSubmitted.class,
+            CancelByUserSubmitted.class
     );
     
     private static final List<Class> EVENTS_LEADING_TO_TERMINAL_STATE = 

--- a/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
@@ -6,7 +6,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.refund.model.domain.Refund;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/util/EpdqExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/EpdqExternalRefundAvailabilityCalculator.java
@@ -2,11 +2,9 @@ package uk.gov.pay.connector.gateway.util;
 
 import com.google.common.collect.ImmutableList;
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.refund.model.domain.Refund;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/util/ExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/ExternalRefundAvailabilityCalculator.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.gateway.util;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.refund.model.domain.Refund;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
 

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -36,9 +36,11 @@ import uk.gov.pay.connector.events.model.charge.AuthorisationErrorCheckedWithGat
 import uk.gov.pay.connector.events.model.charge.AuthorisationRejected;
 import uk.gov.pay.connector.events.model.charge.BackfillerRecreatedUserEmailCollected;
 import uk.gov.pay.connector.events.model.charge.CancelByExpirationFailed;
+import uk.gov.pay.connector.events.model.charge.CancelByExpirationSubmitted;
 import uk.gov.pay.connector.events.model.charge.CancelByExternalServiceFailed;
 import uk.gov.pay.connector.events.model.charge.CancelByExternalServiceSubmitted;
 import uk.gov.pay.connector.events.model.charge.CancelByUserFailed;
+import uk.gov.pay.connector.events.model.charge.CancelByUserSubmitted;
 import uk.gov.pay.connector.events.model.charge.CancelledByExpiration;
 import uk.gov.pay.connector.events.model.charge.CancelledByExternalService;
 import uk.gov.pay.connector.events.model.charge.CancelledByUser;
@@ -298,7 +300,7 @@ public class EventFactoryTest {
 
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
 
-        assertThat(events.size(), is(1));
+        assertThat(events.size(), is(2)); // also creates RefundAvailabilityUpdated event
         CancelByExternalServiceSubmitted event = (CancelByExternalServiceSubmitted) events.get(0);
         assertThat(event, instanceOf(CancelByExternalServiceSubmitted.class));
         assertThat(event.getEventDetails(), instanceOf(EmptyEventDetails.class));
@@ -312,6 +314,9 @@ public class EventFactoryTest {
                 new Object[]{GatewayErrorDuringAuthorisation.class, EmptyEventDetails.class},
                 new Object[]{GatewayTimeoutDuringAuthorisation.class, EmptyEventDetails.class},
                 new Object[]{UnexpectedGatewayErrorDuringAuthorisation.class, EmptyEventDetails.class},
+                new Object[]{CancelByExternalServiceSubmitted.class, EmptyEventDetails.class},
+                new Object[]{CancelByExpirationSubmitted.class, EmptyEventDetails.class},
+                new Object[]{CancelByUserSubmitted.class, EmptyEventDetails.class},
                 // terminal states
                 new Object[]{AuthorisationCancelled.class, EmptyEventDetails.class},
                 new Object[]{AuthorisationErrorCheckedWithGatewayChargeWasMissing.class, EmptyEventDetails.class},


### PR DESCRIPTION
## WHAT YOU DID
- Emits RefundAvailabilityUpdated events for all submitted (EXPIRE_CANCEL_SUBMITTED, SYSTEM_CANCEL_SUBMITTED, USER_CANCEL_SUBMITTED) states as these affect refund availability status of payments.
- For payments in submitted (other than CAPTURE_SUMITTED) states, connector calculates refund availability status as `unavailable` but ledger could be returning `pending` status as RefundAvailalbilityUpdated event is not emitted for the charges (if there are no further updates to charges).
