### PR TITLE
PP-9676 implement submit evidence for test payment disputes

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeCreated.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.dispute;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeCreatedEventDetails;
 import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
-import uk.gov.pay.connector.queue.tasks.dispute.StripeDisputeData;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
 import java.time.ZonedDateTime;
 

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeLost.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeLost.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.dispute;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeLostEventDetails;
 import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
-import uk.gov.pay.connector.queue.tasks.dispute.StripeDisputeData;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
 import java.time.ZonedDateTime;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
@@ -12,7 +12,8 @@ public enum OrderRequestType {
     STRIPE_TOKEN("authorise.create_token"), 
     STRIPE_CREATE_SOURCE("authorise.create_source"), 
     STRIPE_CREATE_CHARGE("authorise.create_charge"), 
-    STRIPE_CREATE_3DS_SOURCE("authorise.create_3ds_source");
+    STRIPE_CREATE_3DS_SOURCE("authorise.create_3ds_source"),
+    STRIPE_UPDATE_DISPUTE("dispute.update");
 
     private final String name;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeFullTestCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeFullTestCardNumbers.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Optional;
+
+public class StripeFullTestCardNumbers {
+
+    private static final String STRIPE_LOSING_EVIDENCE_CARD_NUMBER = "4000000000000259";
+    private static final String STRIPE_WINNING_EVIDENCE_CARD_NUMBER = "4000000000002685";
+
+    public static Optional<String> getSubmitTestDisputeEvidenceText(String firstSixDigits, String lastFourDigits) {
+        if (StringUtils.left(STRIPE_LOSING_EVIDENCE_CARD_NUMBER, 6).equals(firstSixDigits)) {
+            if (StringUtils.right(STRIPE_LOSING_EVIDENCE_CARD_NUMBER, 4).equals(lastFourDigits)) {
+                return Optional.of("losing_evidence");
+            } else if (StringUtils.right(STRIPE_WINNING_EVIDENCE_CARD_NUMBER, 4).equals(lastFourDigits)) {
+                return Optional.of("winning_evidence");
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -39,6 +39,8 @@ import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
+import uk.gov.pay.connector.gateway.stripe.handler.StripeDisputeHandler;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
@@ -65,6 +67,7 @@ public class StripePaymentProvider implements PaymentProvider {
     private final StripeAuthoriseHandler stripeAuthoriseHandler;
     private final StripeFailedPaymentFeeCollectionHandler stripeFailedPaymentFeeCollectionHandler;
     private final StripeQueryPaymentStatusHandler stripeQueryPaymentStatusHandler;
+    private final StripeDisputeHandler stripeDisputeHandler;
 
     @Inject
     public StripePaymentProvider(GatewayClientFactory gatewayClientFactory,
@@ -81,6 +84,7 @@ public class StripePaymentProvider implements PaymentProvider {
         stripeAuthoriseHandler = new StripeAuthoriseHandler(client, stripeGatewayConfig, configuration, jsonObjectMapper);
         stripeFailedPaymentFeeCollectionHandler = new StripeFailedPaymentFeeCollectionHandler(client, stripeGatewayConfig, jsonObjectMapper);
         stripeQueryPaymentStatusHandler = new StripeQueryPaymentStatusHandler(client, stripeGatewayConfig, jsonObjectMapper);
+        stripeDisputeHandler = new StripeDisputeHandler(client, stripeGatewayConfig, jsonObjectMapper);
     }
 
     @Override
@@ -174,4 +178,7 @@ public class StripePaymentProvider implements PaymentProvider {
         return stripeFailedPaymentFeeCollectionHandler.calculateAndTransferFees(charge);
     }
 
+    public StripeDisputeData submitTestDisputeEvidence(String disputeId, String evidenceText, String transactionId) throws GatewayException {
+        return stripeDisputeHandler.submitTestDisputeEvidence(disputeId, evidenceText, transactionId);
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeDisputeHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeDisputeHandler.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.gateway.stripe.handler;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.stripe.request.StripeSubmitTestDisputeEvidenceRequest;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+public class StripeDisputeHandler {
+    private final GatewayClient client;
+    private final StripeGatewayConfig stripeGatewayConfig;
+    private final JsonObjectMapper jsonObjectMapper;
+
+    public StripeDisputeHandler(GatewayClient client, StripeGatewayConfig stripeGatewayConfig,
+                                JsonObjectMapper jsonObjectMapper) {
+        this.client = client;
+        this.stripeGatewayConfig = stripeGatewayConfig;
+        this.jsonObjectMapper = jsonObjectMapper;
+    }
+
+    public StripeDisputeData submitTestDisputeEvidence(String disputeId, String evidenceText, String transactionId) throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        StripeSubmitTestDisputeEvidenceRequest request = StripeSubmitTestDisputeEvidenceRequest.of(stripeGatewayConfig,
+                disputeId, evidenceText, transactionId);
+        String jsonResponse = client.postRequestFor(request).getEntity();
+        return jsonObjectMapper.getObject(jsonResponse, StripeDisputeData.class);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeSubmitTestDisputeEvidenceRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeSubmitTestDisputeEvidenceRequest.java
@@ -1,0 +1,89 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import com.google.gson.GsonBuilder;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
+import uk.gov.pay.connector.gateway.util.AuthUtil;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+
+import javax.ws.rs.core.MediaType;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.gateway.model.OrderRequestType.STRIPE_UPDATE_DISPUTE;
+
+public class StripeSubmitTestDisputeEvidenceRequest implements GatewayClientPostRequest {
+    private final String disputeId;
+    private final String evidenceText;
+    private final StripeGatewayConfig stripeGatewayConfig;
+    private final String idempotencyKey;
+    private static final String URL_PATH = "/v1/disputes/%s";
+
+    private StripeSubmitTestDisputeEvidenceRequest(StripeGatewayConfig stripeGatewayConfig,
+                                                   String disputeId,
+                                                   String evidenceText,
+                                                   String transactionExternalId) {
+        this.stripeGatewayConfig = stripeGatewayConfig;
+        this.disputeId = disputeId;
+        this.evidenceText = evidenceText;
+        this.idempotencyKey = transactionExternalId;
+    }
+
+    public static StripeSubmitTestDisputeEvidenceRequest of(StripeGatewayConfig stripeGatewayConfig,
+                                                            String disputeId,
+                                                            String evidenceText,
+                                                            String transactionExternalId) {
+        return new StripeSubmitTestDisputeEvidenceRequest(stripeGatewayConfig, disputeId, evidenceText,
+                transactionExternalId);
+    }
+
+    public OrderRequestType orderRequestType() {
+        return STRIPE_UPDATE_DISPUTE;
+    }
+
+    @Override
+    public URI getUrl() {
+        return URI.create(stripeGatewayConfig.getUrl() + format(URL_PATH, disputeId));
+    }
+
+    @Override
+    public GatewayOrder getGatewayOrder() {
+        return createGatewayOrder();
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        Map<String, String> result = new HashMap<>();
+        Optional.ofNullable(idempotencyKey).ifPresent(idempotencyKey -> result.put("Idempotency-Key", orderRequestType().toString() + idempotencyKey));
+        result.putAll(AuthUtil.getStripeAuthHeader(stripeGatewayConfig, false));
+
+        return result;
+    }
+
+    @Override
+    public String getGatewayAccountType() {
+        return GatewayAccountType.TEST.toString();
+    }
+
+    @Override
+    public PaymentGatewayName getPaymentProvider() {
+        return PaymentGatewayName.STRIPE;
+    }
+
+    private GatewayOrder createGatewayOrder() {
+        String payload = new GsonBuilder()
+                .create()
+                .toJson(Map.of("evidence", Map.of("uncategorized_text", evidenceText),
+                        "submit", true));
+        Map<String, Object> result = Map.of("evidence", Map.of("uncategorized_text", evidenceText),
+                "submit", true);
+        GatewayOrder order = new GatewayOrder(orderRequestType(), payload, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        return order;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeDisputeData.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeDisputeData.java
@@ -1,7 +1,10 @@
-package uk.gov.pay.connector.queue.tasks.dispute;
+package uk.gov.pay.connector.gateway.stripe.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
+import uk.gov.pay.connector.queue.tasks.dispute.Evidence;
+import uk.gov.pay.connector.queue.tasks.dispute.EvidenceDetails;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -26,6 +29,8 @@ public class StripeDisputeData {
     private List<BalanceTransaction> balanceTransactionList;
     @JsonProperty("evidence_details")
     private EvidenceDetails evidenceDetails;
+    @JsonProperty("evidence")
+    private Evidence evidence;
 
     @JsonProperty("status")
     private String status;
@@ -37,7 +42,8 @@ public class StripeDisputeData {
     public StripeDisputeData(String id, String paymentIntentId, String status,
                              Long amount, String reason, Long created,
                              List<BalanceTransaction> balanceTransactionList,
-                             EvidenceDetails evidenceDetails
+                             EvidenceDetails evidenceDetails,
+                             Evidence evidence
     ) {
         this.id = id;
         this.status = status;
@@ -47,6 +53,7 @@ public class StripeDisputeData {
         this.created = created;
         this.balanceTransactionList = balanceTransactionList;
         this.evidenceDetails = evidenceDetails;
+        this.evidence = evidence;
     }
 
     public String getResourceType() {
@@ -83,5 +90,9 @@ public class StripeDisputeData {
 
     public String getStatus() {
         return status;
+    }
+
+    public Evidence getEvidence() {
+        return evidence;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/Evidence.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/Evidence.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.connector.queue.tasks.dispute;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Evidence {
+
+    @JsonProperty("uncategorized_text")
+    private String uncategorizedText;
+
+    public Evidence() {
+        // for jackson
+    }
+
+    public String getUncategorizedText() {
+        return uncategorizedText;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 import uk.gov.pay.connector.queue.tasks.dispute.EvidenceDetails;
-import uk.gov.pay.connector.queue.tasks.dispute.StripeDisputeData;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
 import java.util.List;
 
@@ -32,7 +32,8 @@ class DisputeCreatedTest {
         BalanceTransaction balanceTransaction = new BalanceTransaction(6500L, 1500L, -8000L);
         EvidenceDetails evidenceDetails = new EvidenceDetails(1642679160L);
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
-                "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction), evidenceDetails);
+                "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction),
+                evidenceDetails, null);
 
         DisputeCreated disputeCreated = from(stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L));
 
@@ -65,7 +66,8 @@ class DisputeCreatedTest {
         BalanceTransaction balanceTransaction2 = new BalanceTransaction(6500L, 1500L, 8000L);
         EvidenceDetails evidenceDetails = new EvidenceDetails(1642679160L);
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
-                "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction, balanceTransaction2), evidenceDetails);
+                "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction,
+                balanceTransaction2), evidenceDetails, null);
 
         var thrown = assertThrows(RuntimeException.class, () ->
                 from(stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L)));

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.dispute;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
-import uk.gov.pay.connector.queue.tasks.dispute.StripeDisputeData;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,7 +24,8 @@ public class DisputeEvidenceSubmittedTest {
                 .isLive(true)
                 .build();
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
-                "pi_123456789", "under_review", 6500L, "fradulent", 1642579160L, null, null);
+                "pi_123456789", "under_review", 6500L, "fradulent",
+                1642579160L, null, null, null);
 
         DisputeEvidenceSubmitted disputeEvidenceSubmitted = from(stripeDisputeData.getId(), toUTCZonedDateTime(1642579160L), transaction);
 

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 import uk.gov.pay.connector.queue.tasks.dispute.EvidenceDetails;
-import uk.gov.pay.connector.queue.tasks.dispute.StripeDisputeData;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
 import java.util.List;
 
@@ -31,7 +31,8 @@ class DisputeLostTest {
                 .build();
         BalanceTransaction balanceTransaction = new BalanceTransaction(6500L, 1500L, -8000L);
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
-                "pi_123456789", "lost", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction), null);
+                "pi_123456789", "lost", 6500L, "fradulent", 1642579160L,
+                List.of(balanceTransaction), null, null);
 
         DisputeLost disputeLost = from(stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction);
 
@@ -63,7 +64,8 @@ class DisputeLostTest {
         BalanceTransaction balanceTransaction2 = new BalanceTransaction(6500L, 1500L, 8000L);
         EvidenceDetails evidenceDetails = new EvidenceDetails(1642679160L);
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
-                "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction, balanceTransaction2), evidenceDetails);
+                "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction,
+                balanceTransaction2), evidenceDetails, null);
 
         var thrown = assertThrows(RuntimeException.class, () ->
                 DisputeCreated.from(stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L)));

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.dispute;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
-import uk.gov.pay.connector.queue.tasks.dispute.StripeDisputeData;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,7 +24,7 @@ public class DisputeWonTest {
                 .isLive(true)
                 .build();
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
-                "pi_123456789", "won", 6500L, "fradulent", 1642579160L, null, null);
+                "pi_123456789", "won", 6500L, "fradulent", 1642579160L, null, null, null);
 
         DisputeWon disputeWon = from(stripeDisputeData.getId(), toUTCZonedDateTime(1642579160L), transaction);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeFullTestCardNumbersTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeFullTestCardNumbersTest.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.gateway.stripe.StripeFullTestCardNumbers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class StripeFullTestCardNumbersTest {
+    private String firstSixDigits = "400000";
+
+    @Test
+    void shouldReturnLosingEvidenceText() {
+        var evidenceText = StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(firstSixDigits, "0259");
+        assertThat(evidenceText.isPresent(), is(true));
+        assertThat(evidenceText.get(), is("losing_evidence"));
+    }
+
+    @Test
+    void shouldReturnWinningEvidenceText() {
+        var evidenceText = StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(firstSixDigits, "2685");
+        assertThat(evidenceText.isPresent(), is(true));
+        assertThat(evidenceText.get(), is("winning_evidence"));
+    }
+
+    @Test
+    void shouldReturnEmpty_whenLastFourDigitsDoNotMatch() {
+        var evidenceText = StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(firstSixDigits, "1976");
+        assertThat(evidenceText.isPresent(), is(false));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeDisputeHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeDisputeHandlerTest.java
@@ -1,0 +1,73 @@
+package uk.gov.pay.connector.gateway.stripe.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.stripe.handler.StripeDisputeHandler;
+import uk.gov.pay.connector.gateway.stripe.request.StripeSubmitTestDisputeEvidenceRequest;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_SUBMIT_DISPUTE_EVIDENCE_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
+
+@ExtendWith(MockitoExtension.class)
+class StripeDisputeHandlerTest {
+    @Mock
+    private GatewayClient client;
+    @Mock
+    private StripeGatewayConfig stripeGatewayConfig;
+    @Mock
+    private GatewayClient.Response response;
+
+    private JsonObjectMapper mapper = new JsonObjectMapper(new ObjectMapper());
+
+    private StripeDisputeHandler handler;
+
+    @BeforeEach
+    public void setUp() {
+        handler = new StripeDisputeHandler(client, stripeGatewayConfig, mapper);
+    }
+
+    @Test
+    void shouldPostStripeDisputeUpdate() throws GatewayException {
+        String disputeId = "dispute-id";
+        String evidenceText = "winning_evidence";
+        String transactionId = "transaction-id";
+        when(response.getEntity()).thenReturn(load(STRIPE_SUBMIT_DISPUTE_EVIDENCE_RESPONSE));
+        when(client.postRequestFor(any())).thenReturn(response);
+        StripeDisputeData response = handler.submitTestDisputeEvidence(disputeId, evidenceText, transactionId);
+        assertThat(response.getEvidence().getUncategorizedText(), is(evidenceText));
+    }
+
+    @Test
+    void shouldCreateStripeSubmitTestDisputeEvidenceRequest() throws Exception {
+        when(response.getEntity()).thenReturn(load(STRIPE_SUBMIT_DISPUTE_EVIDENCE_RESPONSE));
+        when(client.postRequestFor(any())).thenReturn(response);
+        when(stripeGatewayConfig.getUrl()).thenReturn("https://example.org");
+
+        ArgumentCaptor<StripeSubmitTestDisputeEvidenceRequest> captor = ArgumentCaptor.forClass(StripeSubmitTestDisputeEvidenceRequest.class);
+        StripeDisputeHandler handler = new StripeDisputeHandler(client, stripeGatewayConfig, new JsonObjectMapper(new ObjectMapper()));
+
+        handler.submitTestDisputeEvidence("dispute-id", "winning_evidence", "transaction-id");
+
+        verify(client).postRequestFor(captor.capture());
+
+        assertThat(captor.getValue().getUrl().toString(), Matchers.is("https://example.org/v1/disputes/dispute-id"));
+        assertThat(captor.getValue().getGatewayOrder().getPayload(), containsString("winning_evidence"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -171,6 +171,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_NOTIFICATION_ACCOUNT_UPDATED = TEMPLATE_BASE_NAME + "/stripe/account_updated.json";
     public static final String STRIPE_NOTIFICATION_CHARGE_REFUND_UPDATED = TEMPLATE_BASE_NAME + "/stripe/charge_refund_updated.json";
     public static final String STRIPE_NOTIFICATION_CHARGE_DISPUTE = TEMPLATE_BASE_NAME + "/stripe/charge_dispute.json";
+    public static final String STRIPE_SUBMIT_DISPUTE_EVIDENCE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/dispute_submit_evidence_response.json";
 
     public static final String SQS_SEND_MESSAGE_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/send-message-response.xml";
     public static final String SQS_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/error-response.xml";

--- a/src/test/resources/templates/stripe/charge_dispute.json
+++ b/src/test/resources/templates/stripe/charge_dispute.json
@@ -73,7 +73,7 @@
         "shipping_documentation": null,
         "shipping_tracking_number": null,
         "uncategorized_file": null,
-        "uncategorized_text": null
+        "uncategorized_text": "losing_evidence"
       },
       "evidence_details": {
         "due_by": 1644883199,

--- a/src/test/resources/templates/stripe/dispute_submit_evidence_response.json
+++ b/src/test/resources/templates/stripe/dispute_submit_evidence_response.json
@@ -1,0 +1,52 @@
+{
+  "id": "dp_1LL5Er2eZvKYlo2Ciq2za9qj",
+  "object": "dispute",
+  "amount": 1000,
+  "balance_transactions": [],
+  "charge": "ch_1AZtxr2eZvKYlo2CJDX8whov",
+  "created": 1657717465,
+  "currency": "usd",
+  "evidence": {
+    "access_activity_log": null,
+    "billing_address": null,
+    "cancellation_policy": null,
+    "cancellation_policy_disclosure": null,
+    "cancellation_rebuttal": null,
+    "customer_communication": null,
+    "customer_email_address": null,
+    "customer_name": null,
+    "customer_purchase_ip": null,
+    "customer_signature": null,
+    "duplicate_charge_documentation": null,
+    "duplicate_charge_explanation": null,
+    "duplicate_charge_id": null,
+    "product_description": null,
+    "receipt": null,
+    "refund_policy": null,
+    "refund_policy_disclosure": null,
+    "refund_refusal_explanation": null,
+    "service_date": null,
+    "service_documentation": null,
+    "shipping_address": null,
+    "shipping_carrier": null,
+    "shipping_date": null,
+    "shipping_documentation": null,
+    "shipping_tracking_number": null,
+    "uncategorized_file": null,
+    "uncategorized_text": "winning_evidence"
+  },
+  "evidence_details": {
+    "due_by": 1659398399,
+    "has_evidence": false,
+    "past_due": false,
+    "submission_count": 0
+  },
+  "is_charge_refundable": true,
+  "livemode": false,
+  "metadata": {
+    "order_id": "6735"
+  },
+  "payment_intent": null,
+  "reason": "general",
+  "status": "warning_needs_response"
+}


### PR DESCRIPTION
## WHAT
PP-9676 implement submit evidence for test payment disputes

 - For the current iteration of recharging services for lost disputes, services won't have the functionality to simulate winning or losing the dispute. One way is to automatically submit evidence for test payment disputes so journeys can be tested end-to-end without having to log in to the stripe dashboard.We can use stripe test card numbers for disputes and submit losing or winning evidence based on the card numbers.

 - if first_digits_card_number is 400000 and last_digits_card_number is 0259 then submit evidence losing_evidence to Stripe.
- first_digits_card_number is 400000 and last_digits_card_number is 2685 then submit evidence winning_evidence to Stripe.

Co-authored-by: Sandor Arpa <sandor.arpa@digital.cabinet-office.gov.uk>
Co-authored-by: Alan Carter <alan.carter@digital.cabinet-office.gov.uk>
