### PR TITLE
PP-9791 Associate charge with agreement payment instrument

### DIFF
--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
@@ -231,6 +231,7 @@ class ChargeServiceCreateAgreementTest {
         assertThat(createdChargeEntity.getAgreementId().get(), is(AGREEMENT_ID));
         assertThat(createdChargeEntity.getAuthorisationMode(), is(AuthorisationMode.AGREEMENT));
         assertThat(createdChargeEntity.isSavePaymentInstrumentToAgreement(), is(false));
+        assertThat(createdChargeEntity.getPaymentInstrument(), is(Optional.of(mockPaymentInstrumentEntity)));
     }
 
     @Test
@@ -338,6 +339,8 @@ class ChargeServiceCreateAgreementTest {
 
     @Test
     void shouldThrowExceptionWhenAgreementNotPresentInDbForSavePaymentInstrumentToAgreement() {
+        when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
+
         String UNKNOWN_AGREEMENT_ID = "unknownId";
         ChargeCreateRequest request = requestBuilder.withAmount(1000).withAgreementId(UNKNOWN_AGREEMENT_ID).withSavePaymentInstrumentToAgreement(true).build();
         when(mockAgreementDao.findByExternalId(UNKNOWN_AGREEMENT_ID)).thenReturn(Optional.empty());
@@ -349,6 +352,7 @@ class ChargeServiceCreateAgreementTest {
 
     @Test
     void shouldThrowExceptionWhenAgreementNotPresentInDbForAuthorisationModeAgreement() {
+        when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
         String unknownAgreementId = "unknownId";
         final ChargeCreateRequest request = requestBuilder.withAmount(1000)
                 .withAgreementId(unknownAgreementId)
@@ -363,6 +367,7 @@ class ChargeServiceCreateAgreementTest {
 
     @Test
     void shouldThrowExceptionWhenAgreementHasNoPaymentInstrumentForAuthorisationModeAgreement() {
+        when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
         when(mockAgreementDao.findByExternalId(AGREEMENT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.empty());
 
@@ -380,6 +385,7 @@ class ChargeServiceCreateAgreementTest {
     @ParameterizedTest
     @EnumSource(mode = EXCLUDE, names = "ACTIVE")
     void shouldThrowExceptionWhenAgreementHasPaymentInstrumentInIncorrectStateForAuthorisationModeAgreement(PaymentInstrumentStatus paymentInstrumentStatus) {
+        when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
         when(mockAgreementDao.findByExternalId(AGREEMENT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
         when(mockPaymentInstrumentEntity.getPaymentInstrumentStatus()).thenReturn(paymentInstrumentStatus);


### PR DESCRIPTION
When creating a charge with `authorisation_mode` `agreement`, associate
the created charge the agreements payment instrument.

There is already validation logic in place to ensure that the
appropriate combination of parameters is used and that a valid agreement
and payment instrument are in place - we can assume these are correct by
this point in the code.

Add an assertion to make sure we are correctly setting the payment
instrument.