### PR TITLE
PP-9791 Do not allow return_url for agreement auth mode

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -35,6 +35,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import java.util.EnumSet;
 import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -59,6 +60,7 @@ public class ChargesApiResource {
     );
     private static final String ACCOUNT_ID = "accountId";
     private static final String RETURN_URL = "return_url";
+    private static final EnumSet<AuthorisationMode> AUTHORISATION_MODES_INCOMPATIBLE_WITH_RETURN_URL = EnumSet.of(AuthorisationMode.MOTO_API, AuthorisationMode.AGREEMENT);
     private static final Logger logger = LoggerFactory.getLogger(ChargesApiResource.class);
     public static final int MIN_AMOUNT = 1;
     public static final int MAX_AMOUNT = 10_000_000;
@@ -127,7 +129,7 @@ public class ChargesApiResource {
                         throw new MissingMandatoryAttributeException(RETURN_URL);
                     });
 
-        } else if (authorisationMode == AuthorisationMode.MOTO_API && chargeRequest.getReturnUrl().isPresent()) {
+        } else if (AUTHORISATION_MODES_INCOMPATIBLE_WITH_RETURN_URL.contains(authorisationMode) && chargeRequest.getReturnUrl().isPresent()) {
             throw new UnexpectedAttributeException(RETURN_URL);
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
@@ -86,7 +86,6 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
                 JSON_AMOUNT_KEY, AMOUNT,
                 JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
                 JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
                 JSON_AGREEMENT_ID_KEY, JSON_VALID_AGREEMENT_ID_VALUE,
                 JSON_AUTH_MODE_KEY, JSON_AUTH_MODE_AGREEMENT
         ));
@@ -162,7 +161,6 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
                 JSON_AMOUNT_KEY, AMOUNT,
                 JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
                 JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
                 JSON_AUTH_MODE_KEY, JSON_AUTH_MODE_AGREEMENT
         ));
 
@@ -172,6 +170,31 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
                 .contentType(JSON)
                 .body("message", contains("If [authorisation_mode] is [agreement], [agreement_id] must be specified"))
                 .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+    }
+
+    @Test
+    public void shouldReturn422WhenAuthorisationModeAgreementAndReturnUrlProvided() {
+        String accountId = String.valueOf(RandomUtils.nextInt());
+        AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
+                .withPaymentGateway("sandbox")
+                .withAccountId(accountId)
+                .build();
+        databaseTestHelper.addGatewayAccount(gatewayAccountParams);
+
+        String postBody = toJson(Map.of(
+                JSON_AMOUNT_KEY, AMOUNT,
+                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
+                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
+                JSON_RETURN_URL_KEY, RETURN_URL,
+                JSON_AUTH_MODE_KEY, JSON_AUTH_MODE_AGREEMENT
+        ));
+
+        connectorRestApiClient
+                .postCreateCharge(postBody, accountId)
+                .statusCode(SC_UNPROCESSABLE_ENTITY)
+                .contentType(JSON)
+                .body("message", contains("Unexpected attribute: return_url"))
+                .body("error_identifier", is(ErrorIdentifier.UNEXPECTED_ATTRIBUTE.toString()));
     }
 
     @Test
@@ -187,7 +210,6 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
                 JSON_AMOUNT_KEY, AMOUNT,
                 JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
                 JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
                 JSON_AGREEMENT_ID_KEY, JSON_VALID_AGREEMENT_ID_VALUE,
                 "authorisation_mode", "agreement"
         ));
@@ -218,7 +240,6 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
                 JSON_AMOUNT_KEY, AMOUNT,
                 JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
                 JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
                 JSON_AGREEMENT_ID_KEY, JSON_VALID_AGREEMENT_ID_VALUE,
                 "authorisation_mode", "agreement"
         ));
@@ -257,7 +278,6 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
                 JSON_AMOUNT_KEY, AMOUNT,
                 JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
                 JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
                 JSON_AGREEMENT_ID_KEY, JSON_VALID_AGREEMENT_ID_VALUE,
                 "authorisation_mode", "agreement"
         ));
@@ -311,7 +331,6 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
                 JSON_AMOUNT_KEY, AMOUNT,
                 JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
                 JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
                 JSON_AGREEMENT_ID_KEY, JSON_VALID_AGREEMENT_ID_VALUE,
                 JSON_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT_KEY, true,
                 JSON_AUTH_MODE_KEY, JSON_AUTH_MODE_AGREEMENT


### PR DESCRIPTION
`return_url` is an unexpected attribute for agreement authorisation mode
as the user is not present to be returned to a integrating service.

Add agreement auth mode to a list of unexpected modes to reject the
return url property.