### PR TITLE
BAU — FirstDigitsCardNumber/LastDigitsCardNumber: Arabic numerals

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/FirstDigitsCardNumber.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/FirstDigitsCardNumber.java
@@ -4,28 +4,23 @@ import org.apache.commons.lang3.StringUtils;
 import uk.gov.service.payments.commons.model.WrappedStringValue;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 public class FirstDigitsCardNumber extends WrappedStringValue {
+
+    private static final Pattern SIX_DIGITS = Pattern.compile("[0-9]{6}");
 
     private FirstDigitsCardNumber(String firstDigitsCardNumber) {
         super(firstDigitsCardNumber);
     }
 
-    private static boolean isValid(String firstDigitsCardNumber) {
-        return firstDigitsCardNumber != null && firstDigitsCardNumber.length() == 6 && StringUtils.isNumeric(firstDigitsCardNumber);
-    }
-
     public static FirstDigitsCardNumber of(String firstDigitsCardNumber) {
-        if (!(isValid(firstDigitsCardNumber))) {
-            throw new RuntimeException("Expecting 6 first digits of card number");
-        }
-        return new FirstDigitsCardNumber(firstDigitsCardNumber);
-    }
+        Objects.requireNonNull(firstDigitsCardNumber, "firstDigitsCardNumber");
 
-    public static FirstDigitsCardNumber ofNullable(String firstDigitsCardNumber) {
-        if (!(isValid(firstDigitsCardNumber))) {
-            return null;
+        if (!SIX_DIGITS.matcher(firstDigitsCardNumber).matches()) {
+            throw new IllegalArgumentException("Expecting 6 first digits of card number");
         }
+
         return new FirstDigitsCardNumber(firstDigitsCardNumber);
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/FirstDigitsCardNumberConverter.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/FirstDigitsCardNumberConverter.java
@@ -14,7 +14,11 @@ public class FirstDigitsCardNumberConverter implements AttributeConverter<FirstD
     }
 
     @Override
-    public FirstDigitsCardNumber convertToEntityAttribute(String s) {
-        return FirstDigitsCardNumber.ofNullable(s);
+    public FirstDigitsCardNumber convertToEntityAttribute(String firstDigitsCardNumber) {
+        if (firstDigitsCardNumber == null) {
+            return null;
+        }
+        return FirstDigitsCardNumber.of(firstDigitsCardNumber);
     }
+
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/LastDigitsCardNumber.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/LastDigitsCardNumber.java
@@ -1,29 +1,25 @@
 package uk.gov.pay.connector.charge.model;
 
-import org.apache.commons.lang3.StringUtils;
 import uk.gov.service.payments.commons.model.WrappedStringValue;
 
+import java.util.Objects;
+import java.util.regex.Pattern;
+
 public class LastDigitsCardNumber extends WrappedStringValue {
+
+    private static final Pattern FOUR_DIGITS = Pattern.compile("[0-9]{4}");
 
     private LastDigitsCardNumber(String lastDigitsCardNumber) {
         super(lastDigitsCardNumber);
     }
 
-    private static boolean isValid(String lastDigitsCardNumber) {
-        return lastDigitsCardNumber != null && lastDigitsCardNumber.length() == 4 && StringUtils.isNumeric(lastDigitsCardNumber);
-    }
-
     public static LastDigitsCardNumber of(String lastDigitsCardNumber) {
-        if (!(isValid(lastDigitsCardNumber))) {
-            throw new RuntimeException("Expecting 4 last digits of card number");
-        }
-        return new LastDigitsCardNumber(lastDigitsCardNumber);
-    }
+        Objects.requireNonNull(lastDigitsCardNumber, "lastDigitsCardNumber");
 
-    public static LastDigitsCardNumber ofNullable(String lastDigitsCardNumber) {
-        if (!(isValid(lastDigitsCardNumber))) {
-            return null;
+        if (!FOUR_DIGITS.matcher(lastDigitsCardNumber).matches()) {
+            throw new IllegalArgumentException("Expecting 4 last digits of card number");
         }
+
         return new LastDigitsCardNumber(lastDigitsCardNumber);
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/LastDigitsCardNumberConverter.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/LastDigitsCardNumberConverter.java
@@ -14,7 +14,10 @@ public class LastDigitsCardNumberConverter implements AttributeConverter<LastDig
     }
 
     @Override
-    public LastDigitsCardNumber convertToEntityAttribute(String s) {
-        return LastDigitsCardNumber.ofNullable(s);
+    public LastDigitsCardNumber convertToEntityAttribute(String lastDigitsCardNumber) {
+        if (lastDigitsCardNumber == null) {
+            return null;
+        }
+        return LastDigitsCardNumber.of(lastDigitsCardNumber);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -200,8 +200,8 @@ public class ChargeService {
         checkIfZeroAmountAllowed(telephoneChargeRequest.getAmount(), gatewayAccount);
 
         CardDetailsEntity cardDetails = new CardDetailsEntity(
-                LastDigitsCardNumber.ofNullable(telephoneChargeRequest.getLastFourDigits().orElse(null)),
-                FirstDigitsCardNumber.ofNullable(telephoneChargeRequest.getFirstSixDigits().orElse(null)),
+                telephoneChargeRequest.getLastFourDigits().map(LastDigitsCardNumber::of).orElse(null),
+                telephoneChargeRequest.getFirstSixDigits().map(FirstDigitsCardNumber::of).orElse(null),
                 telephoneChargeRequest.getNameOnCard().orElse(null),
                 telephoneChargeRequest.getCardExpiry().orElse(null),
                 telephoneChargeRequest.getCardType().orElse(null),

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -239,13 +239,13 @@ public class DatabaseFixtures {
         private String cardBrand = "visa";
         private CardType cardType = null;
 
-        public TestCardDetails withLastDigitsOfCardNumber(String lastDigitsCardNumber) {
-            this.lastDigitsCardNumber = LastDigitsCardNumber.ofNullable(lastDigitsCardNumber);
+        public TestCardDetails withLastDigitsOfCardNumber(LastDigitsCardNumber lastDigitsCardNumber) {
+            this.lastDigitsCardNumber = lastDigitsCardNumber;
             return this;
         }
 
-        public TestCardDetails withFirstDigitsOfCardNumber(String firstDigitsCardNumber) {
-            this.firstDigitsCardNumber = FirstDigitsCardNumber.ofNullable(firstDigitsCardNumber);
+        public TestCardDetails withFirstDigitsOfCardNumber(FirstDigitsCardNumber firstDigitsCardNumber) {
+            this.firstDigitsCardNumber = firstDigitsCardNumber;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/model/FirstDigitsCardNumberTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/FirstDigitsCardNumberTest.java
@@ -1,39 +1,57 @@
 package uk.gov.pay.connector.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class FirstDigitsCardNumberTest {
-
+class FirstDigitsCardNumberTest {
 
     @Test
-    public void shouldConvertValidFirstSixDigitsOfCard() {
+    void shouldConvertSixDigits() {
         assertThat(FirstDigitsCardNumber.of("123456").toString(), is("123456"));
-        assertThat(FirstDigitsCardNumber.ofNullable("123456").toString(), is("123456"));
     }
 
     @Test
-    public void shouldReturnNullIfStringIsNull() {
-        assertThat(FirstDigitsCardNumber.ofNullable(null), is(nullValue()));
+    void shouldThrowIfNotArabicNumerals() {
+        assertThrows(IllegalArgumentException.class, () -> FirstDigitsCardNumber.of("१२३४५६"));
     }
 
-    @Test(expected = RuntimeException.class)
-    public void shouldThrowIfNonNumericFirstSixDigitsOfCard() {
-        FirstDigitsCardNumber.of("a23442");
+    @Test
+    void shouldThrowIfNonNumeric() {
+        assertThrows(IllegalArgumentException.class, () -> FirstDigitsCardNumber.of("1a3456"));
     }
 
-    @Test(expected = RuntimeException.class)
-    public void shouldThrowIfNotSixDigitsOfCard() {
-        FirstDigitsCardNumber.of("22345");
+    @Test
+    void shouldThrowIfFewerThanSixDigits() {
+        assertThrows(IllegalArgumentException.class, () -> FirstDigitsCardNumber.of("12345"));
     }
 
-    @Test(expected = RuntimeException.class)
-    public void shouldThrowIfNullSixDigitsOfCard() {
-        FirstDigitsCardNumber.of(null);
+    @Test
+    void shouldThrowIfMoreThanSixDigits() {
+        assertThrows(IllegalArgumentException.class, () -> FirstDigitsCardNumber.of("1234567"));
+    }
+
+    @Test
+    void shouldThrowIfPrecedingCharacters() {
+        assertThrows(IllegalArgumentException.class, () -> FirstDigitsCardNumber.of(" 123456"));
+    }
+
+    @Test
+    void shouldThrowIfTrailingCharacters() {
+        assertThrows(IllegalArgumentException.class, () -> FirstDigitsCardNumber.of("123456 "));
+    }
+
+    @Test
+    void shouldThrowIfEmptyString() {
+        assertThrows(IllegalArgumentException.class, () -> FirstDigitsCardNumber.of(""));
+    }
+
+    @Test
+    void shouldThrowIfNull() {
+        assertThrows(NullPointerException.class, () -> FirstDigitsCardNumber.of(null));
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/model/LastDigitsCardNumberTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/LastDigitsCardNumberTest.java
@@ -1,39 +1,57 @@
 package uk.gov.pay.connector.model;
 
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class LastDigitsCardNumberTest {
-
+class LastDigitsCardNumberTest {
 
     @Test
-    public void shouldConvertValidLastFourDigitsOfCard() {
-        assertThat(LastDigitsCardNumber.of("1234").toString(), is("1234"));
-        assertThat(LastDigitsCardNumber.ofNullable("1234").toString(), is("1234"));
+    void shouldConvertSixDigits() {
+        MatcherAssert.assertThat(LastDigitsCardNumber.of("1234").toString(), is("1234"));
     }
 
     @Test
-    public void shouldReturnNullIfStringIsNull() {
-        assertThat(LastDigitsCardNumber.ofNullable(null), is(nullValue()));
+    void shouldThrowIfNotArabicNumerals() {
+        assertThrows(IllegalArgumentException.class, () -> LastDigitsCardNumber.of("౧౨౩౪"));
     }
 
-    @Test(expected = RuntimeException.class)
-    public void shouldThrowIfNonNumericLastFourDigitsOfCard() {
-        LastDigitsCardNumber.of("a234");
+    @Test
+    void shouldThrowIfNonNumeric() {
+        assertThrows(IllegalArgumentException.class, () -> LastDigitsCardNumber.of("1a34"));
     }
 
-    @Test(expected = RuntimeException.class)
-    public void shouldThrowIfNotFourDigitsOfCard() {
-        LastDigitsCardNumber.of("24");
+    @Test
+    void shouldThrowIfFewerThanFourDigits() {
+        assertThrows(IllegalArgumentException.class, () -> LastDigitsCardNumber.of("123"));
     }
 
-    @Test(expected = RuntimeException.class)
-    public void shouldThrowIfNullFourDigitsOfCard() {
-        LastDigitsCardNumber.of(null);
+    @Test
+    void shouldThrowIfMoreThanFourDigits() {
+        assertThrows(IllegalArgumentException.class, () -> LastDigitsCardNumber.of("12345"));
+    }
+
+    @Test
+    void shouldThrowIfPrecedingCharacters() {
+        assertThrows(IllegalArgumentException.class, () -> LastDigitsCardNumber.of(" 1234"));
+    }
+
+    @Test
+    void shouldThrowIfTrailingCharacters() {
+        assertThrows(IllegalArgumentException.class, () -> LastDigitsCardNumber.of("1234 "));
+    }
+
+    @Test
+    void shouldThrowIfEmptyString() {
+        assertThrows(IllegalArgumentException.class, () -> LastDigitsCardNumber.of(""));
+    }
+
+    @Test
+    void shouldThrowIfNull() {
+        assertThrows(NullPointerException.class, () -> LastDigitsCardNumber.of(null));
     }
 
 }


### PR DESCRIPTION
Make `FirstDigitsCardNumber` and `LastDigitsCardNumber` only accept Arabic numberals (the 0, 1, 2, 3, 4, 5, 6, 7, 8 and 9 used in Latin scripts).

Previously, these two classes used `StringUtils.isNumeric(String)` from Apache Commons, which ultimately uses `Character.isDigit(char)`, which accepts any Unicode digit, including non-Arabic ones.

The code now uses regular expressions.

Since we validate card numbers in many other places beside `FirstDigitsCardNumber` and `LastDigitsCardNumber` we can be fairly confident that no non-Arabic numerals have slipped past, so there should be no observable change to the behaviour of the platform.

But it makes `FirstDigitsCardNumber` and `LastDigitsCardNumber` better maintain their invariants, making our code easier to reason about.

In addition:

- Remove the `FirstDigitsCardNumber.ofNullable(String)` and `LastDigitsCardNumber.ofNullable(String)` methods, which returned `null` if passed `null`. They were only used in some `AttributeConverter`s (where our convention is to have an explicit null check), some code for external telephone payments (where hey were not necessary) and some tests (where small refactorings could obviate the need for them).
- Rather than throwing a `RuntimeException` for invalid input, throw an `IllegalArgumentException` or a `NullPointerException`.
- Update the tests to JUnit 5 and add tests for some more edge cases.