### PR TITLE
PP-9788 Update DISPUTE_CREATED event details

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/dispute/DisputeCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/dispute/DisputeCreatedEventDetails.java
@@ -1,35 +1,29 @@
 package uk.gov.pay.connector.events.eventdetails.dispute;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
+
+import java.time.ZonedDateTime;
+
 public class DisputeCreatedEventDetails extends DisputeEventDetails {
-    private final Long fee;
-    private final Long evidenceDueDate;
+    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
+    private final ZonedDateTime evidenceDueDate;
     private final Long amount;
-    private final Long netAmount;
     private final String reason;
 
-    public DisputeCreatedEventDetails(Long fee, Long evidenceDueDate, String gatewayAccountId, Long amount, Long netAmount, String reason) {
+    public DisputeCreatedEventDetails(ZonedDateTime evidenceDueDate, String gatewayAccountId, Long amount, String reason) {
         super(gatewayAccountId);
-        this.fee = fee;
         this.evidenceDueDate = evidenceDueDate;
         this.amount = amount;
-        this.netAmount = netAmount;
         this.reason = reason;
     }
 
-    public Long getFee() {
-        return fee;
-    }
-
-    public Long getEvidenceDueDate() {
+    public ZonedDateTime getEvidenceDueDate() {
         return evidenceDueDate;
     }
 
     public Long getAmount() {
         return amount;
-    }
-
-    public Long getNetAmount() {
-        return netAmount;
     }
 
     public String getReason() {

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeCreated.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.events.model.dispute;
 
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeCreatedEventDetails;
-import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
 import java.time.ZonedDateTime;
@@ -16,16 +15,10 @@ public class DisputeCreated extends DisputeEvent {
     }
 
     public static DisputeCreated from(StripeDisputeData stripeDisputeData, LedgerTransaction transaction, ZonedDateTime disputeCreatedDate) {
-        if (stripeDisputeData.getBalanceTransactionList().size() > 1) {
-            throw new RuntimeException("Dispute data has too many balance_transactions");
-        }
-        BalanceTransaction balanceTransaction = stripeDisputeData.getBalanceTransactionList().get(0);
         DisputeCreatedEventDetails eventDetails = new DisputeCreatedEventDetails(
-                Math.abs(balanceTransaction.getFee()),
-                stripeDisputeData.getEvidenceDetails().getDueByTimestamp(),
+                stripeDisputeData.getEvidenceDetails().getEvidenceDueByDate(),
                 transaction.getGatewayAccountId(),
                 stripeDisputeData.getAmount(),
-                balanceTransaction.getNetAmount(),
                 stripeDisputeData.getReason());
 
         return new DisputeCreated(

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/EvidenceDetails.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/EvidenceDetails.java
@@ -3,6 +3,10 @@ package uk.gov.pay.connector.queue.tasks.dispute;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.time.ZonedDateTime;
+
+import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EvidenceDetails {
     @JsonProperty("due_by")
@@ -16,7 +20,7 @@ public class EvidenceDetails {
         this.dueByTimestamp = dueByTimestamp;
     }
 
-    public Long getDueByTimestamp() {
-        return dueByTimestamp;
+    public ZonedDateTime getEvidenceDueByDate() {
+        return toUTCZonedDateTime(dueByTimestamp);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
@@ -11,9 +11,7 @@ import java.util.List;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.pay.connector.events.model.dispute.DisputeCreated.from;
 import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
 import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
@@ -21,7 +19,7 @@ import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 class DisputeCreatedTest {
 
     @Test
-    public void shouldBuildAndSerialiseEventDetailsCorrectly() throws JsonProcessingException {
+    void shouldBuildAndSerialiseEventDetailsCorrectly() throws JsonProcessingException {
         LedgerTransaction transaction = aValidLedgerTransaction()
                 .withExternalId("payment-external-id")
                 .withGatewayAccountId(1234L)
@@ -47,30 +45,7 @@ class DisputeCreatedTest {
         assertThat(disputeCreatedJson, hasJsonPath("$.parent_resource_external_id", equalTo("payment-external-id")));
 
         assertThat(disputeCreatedJson, hasJsonPath("$.event_details.gateway_account_id", equalTo("1234")));
-        assertThat(disputeCreatedJson, hasJsonPath("$.event_details.evidence_due_date", equalTo(1642679160)));
-        assertThat(disputeCreatedJson, hasJsonPath("$.event_details.net_amount", equalTo(-8000)));
+        assertThat(disputeCreatedJson, hasJsonPath("$.event_details.evidence_due_date", equalTo("2022-01-20T11:46:00.000000Z")));
         assertThat(disputeCreatedJson, hasJsonPath("$.event_details.amount", equalTo(6500)));
-        assertThat(disputeCreatedJson, hasJsonPath("$.event_details.fee", equalTo(1500)));
-    }
-
-    @Test
-    void shouldThrowExceptionWhenMoreThanOneBalanceTransactionPresent() {
-        LedgerTransaction transaction = aValidLedgerTransaction()
-                .withExternalId("payment-external-id")
-                .withGatewayAccountId(1234L)
-                .withGatewayTransactionId("payment-intent-id")
-                .withServiceId("service-id")
-                .isLive(true)
-                .build();
-        BalanceTransaction balanceTransaction = new BalanceTransaction(6500L, 1500L, -8000L);
-        BalanceTransaction balanceTransaction2 = new BalanceTransaction(6500L, 1500L, 8000L);
-        EvidenceDetails evidenceDetails = new EvidenceDetails(1642679160L);
-        StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
-                "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction,
-                balanceTransaction2), evidenceDetails, null);
-
-        var thrown = assertThrows(RuntimeException.class, () ->
-                from(stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L)));
-        assertThat(thrown.getMessage(), is("Dispute data has too many balance_transactions"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java
@@ -68,7 +68,7 @@ class DisputeLostTest {
                 balanceTransaction2), evidenceDetails, null);
 
         var thrown = assertThrows(RuntimeException.class, () ->
-                DisputeCreated.from(stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L)));
+                DisputeLost.from(stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction));
         assertThat(thrown.getMessage(), is("Dispute data has too many balance_transactions"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -346,7 +346,7 @@ public class QueueMessageContractTest {
 
         var gateway3dsExemptionResultObtained = new Gateway3dsExemptionResultObtained(
                 charge.getServiceId(),
-                charge.getGatewayAccount().isLive(), 
+                charge.getGatewayAccount().isLive(),
                 resourceId,
                 Gateway3dsExemptionResultObtainedEventDetails.from(charge),
                 ZonedDateTime.now()
@@ -398,7 +398,7 @@ public class QueueMessageContractTest {
                 .withStatus(ChargeStatus.CAPTURED)
                 .withFee(Fee.of(null, 42L))
                 .build();
-        
+
         ChargeEventEntity chargeEventEntity = aValidChargeEventEntity()
                 .withCharge(chargeEntity)
                 .withGatewayEventDate(ZonedDateTime.now())
@@ -423,7 +423,7 @@ public class QueueMessageContractTest {
                 .withFee(Fee.of(FeeType.RADAR, 4L))
                 .withFee(Fee.of(FeeType.THREE_D_S, 5L))
                 .build();
-        
+
         var feeIncurredEvent = FeeIncurredEvent.from(chargeEntity);
 
         return feeIncurredEvent.toJsonString();
@@ -432,8 +432,8 @@ public class QueueMessageContractTest {
     @PactVerifyProvider("a dispute created event")
     public String verifyDisputeCreatedEvent() throws JsonProcessingException {
         DisputeCreatedEventDetails eventDetails =
-                new DisputeCreatedEventDetails(1500L, 1644883199L, "a-gateway-account-id",
-                        6500L, -8000L, "duplicate");
+                new DisputeCreatedEventDetails(parse("2022-02-14T23:59:59.000Z"), "a-gateway-account-id",
+                        6500L, "duplicate");
         DisputeCreated disputeCreated =
                 new DisputeCreated("resource-external-id", "external-id", "service-id",
                         true, eventDetails, toUTCZonedDateTime(1642579160L));


### PR DESCRIPTION
## WHAT YOU DID
- Updated DISPUTE_CREATED event for the following
    - Removed `net_amount` and `fee` from dispute_created event as these are included as part of DISPUTE_LOST event and when service is charged for lost dispute
    - Updated evidence_due_date format to ZonedDateTime
    - Removed tests not required

