### PR TITLE
PP-9328 Cancel agreement endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/connector/agreement/model/AgreementCancelRequest.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/model/AgreementCancelRequest.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.agreement.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AgreementCancelRequest {
+    private String userExternalId;
+    private String userEmail;
+
+    public AgreementCancelRequest() {
+    }
+
+    public AgreementCancelRequest(String userExternalId, String userEmail) {
+        this.userExternalId = userExternalId;
+        this.userEmail = userEmail;
+    }
+
+    public String getUserExternalId() {
+        return userExternalId;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/agreement/model/AgreementEntity.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/model/AgreementEntity.java
@@ -69,7 +69,7 @@ public class AgreementEntity {
     }
     
     private AgreementEntity(GatewayAccountEntity gatewayAccount, String serviceId, String reference,
-                            String description, String userIdentifier, boolean live, Instant createdDate) {
+                            String description, String userIdentifier, boolean live, Instant createdDate, PaymentInstrumentEntity paymentInstrument) {
         this.externalId = RandomIdGenerator.newId();
         this.gatewayAccount = gatewayAccount;
         this.serviceId = serviceId;
@@ -78,6 +78,7 @@ public class AgreementEntity {
         this.createdDate = createdDate;
         this.description = description;
         this.userIdentifier = userIdentifier;
+        this.paymentInstrument = paymentInstrument;
     }
 
     public Long getId() {
@@ -168,6 +169,7 @@ public class AgreementEntity {
         private String userIdentifier;
         private String serviceId;
         private boolean live;
+        private PaymentInstrumentEntity paymentInstrument;
 
         public static AgreementEntityBuilder anAgreementEntity(Instant createdDate) {
             var agreementEntityBuilder = new AgreementEntityBuilder();
@@ -210,8 +212,13 @@ public class AgreementEntity {
             return this;
         }
 
+        public AgreementEntityBuilder withPaymentInstrument(PaymentInstrumentEntity paymentInstrument) {
+            this.paymentInstrument = paymentInstrument;
+            return this;
+        }
+
         public AgreementEntity build() {
-            return new AgreementEntity(gatewayAccount, serviceId, reference, description, userIdentifier, live, createdDate);
+            return new AgreementEntity(gatewayAccount, serviceId, reference, description, userIdentifier, live, createdDate, paymentInstrument);
         }
         
     }

--- a/src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.agreement.model.AgreementCancelRequest;
 import uk.gov.pay.connector.agreement.model.AgreementCreateRequest;
 import uk.gov.pay.connector.agreement.model.AgreementResponse;
 import uk.gov.pay.connector.agreement.service.AgreementService;
@@ -56,5 +57,19 @@ public class AgreementsApiResource {
         LOGGER.info("Creating new agreement for gateway account ID {}", accountId);
         AgreementResponse agreementResponse = agreementService.create(agreementCreateRequest, accountId).orElseThrow(NotFoundException::new);
         return Response.status(SC_CREATED).entity(agreementResponse).build();
+    }
+
+    @POST
+    @Path("/v1/api/accounts/{accountId}/agreements/{agreementId}/cancel")
+    @Produces("application/json")
+    @Consumes("application/json")
+    public Response cancelAgreement(
+            @Parameter(example = "1", description = "Gateway account ID")
+            @PathParam("accountId") Long accountId,
+            @PathParam("agreementId") String agreementId,
+            @Valid AgreementCancelRequest agreementCancelRequest
+    ) {
+        agreementService.cancel(agreementId, agreementCancelRequest);
+        return Response.noContent().build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByService.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+
+import java.time.ZonedDateTime;
+
+public class AgreementCancelledByService extends AgreementEvent {
+
+    public AgreementCancelledByService(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static AgreementCancelledByService from(AgreementEntity agreement, ZonedDateTime timestamp) {
+        return new AgreementCancelledByService(
+                agreement.getServiceId(),
+                agreement.getGatewayAccount().isLive(),
+                agreement.getExternalId(),
+                new AgreementCancelledByServiceEventDetails(PaymentInstrumentStatus.CANCELLED),
+                timestamp
+        );
+    }
+
+    static class AgreementCancelledByServiceEventDetails extends EventDetails {
+        private final String status;
+
+        public AgreementCancelledByServiceEventDetails(PaymentInstrumentStatus status) {
+            this.status = String.valueOf(status);
+        }
+
+        public String getStatus() {
+            return status;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByUser.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.agreement.model.AgreementCancelRequest;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class AgreementCancelledByUser extends AgreementEvent {
+
+    public AgreementCancelledByUser(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static AgreementCancelledByUser from(AgreementEntity agreement, AgreementCancelRequest agreementCancelRequest, ZonedDateTime timestamp) {
+        return new AgreementCancelledByUser(
+                agreement.getServiceId(),
+                agreement.getGatewayAccount().isLive(),
+                agreement.getExternalId(),
+                new AgreementCancelledByUserEventDetails(agreementCancelRequest, PaymentInstrumentStatus.CANCELLED),
+                timestamp
+        );
+    }
+
+    static class AgreementCancelledByUserEventDetails extends EventDetails {
+        private final String userExternalId;
+        private final String userEmail;
+        private final String status;
+
+        public AgreementCancelledByUserEventDetails(AgreementCancelRequest agreementCancelRequest, PaymentInstrumentStatus status) {
+            this.userExternalId = agreementCancelRequest.getUserExternalId();
+            this.userEmail = agreementCancelRequest.getUserEmail();
+            this.status = String.valueOf(status);
+        }
+
+        public String getUserExternalId() {
+            return userExternalId;
+        }
+
+        public String getUserEmail() {
+            return userEmail;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentStatus.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentStatus.java
@@ -3,5 +3,6 @@ package uk.gov.pay.connector.paymentinstrument.model;
 public enum PaymentInstrumentStatus {
     CREATED,
     ACTIVE,
+    CANCELLED,
     EXPIRED
 }

--- a/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.agreement.service;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 
@@ -10,19 +12,28 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.agreement.model.AgreementCreateRequest;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.agreement.model.AgreementResponse;
+import uk.gov.pay.connector.charge.exception.AgreementNotFoundException;
+import uk.gov.pay.connector.charge.exception.PaymentInstrumentNotActiveException;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AgreementServiceTest {
 
     private static final String SERVICE_ID = "TestAgreementServiceID";
@@ -39,13 +50,13 @@ public class AgreementServiceTest {
 
     private LedgerService mockedLedgerService = mock(LedgerService.class);
 
-    private AgreementService service;
+    private AgreementService agreementService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         String instantExpected = "2022-03-03T10:15:30Z";
         Clock clock = Clock.fixed(Instant.parse(instantExpected), ZoneOffset.UTC);
-        service = new AgreementService(mockedAgreementDao, mockedGatewayAccountDao, mockedLedgerService, clock);
+        agreementService = new AgreementService(mockedAgreementDao, mockedGatewayAccountDao, mockedLedgerService, clock);
     }
 
     @Test
@@ -57,12 +68,57 @@ public class AgreementServiceTest {
         when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
 
         AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, description, userIdentifier);
-        Optional<AgreementResponse> response = service.create(agreementCreateRequest, GATEWAY_ACCOUNT_ID);
+        Optional<AgreementResponse> response = agreementService.create(agreementCreateRequest, GATEWAY_ACCOUNT_ID);
 
         assertThat(response.isPresent(), is(true));
         assertThat(response.get().getReference(), is(REFERENCE_ID));
         assertThat(response.get().getServiceId(), is(SERVICE_ID));
         assertThat(response.get().getDescription(), is(description));
         assertThat(response.get().getUserIdentifier(), is(userIdentifier));
+    }
+
+    @Test
+    public void cancelAnAgreement_ThrowsAgreementNotFound() {
+        var agreementId = "an-external-id";
+        when(mockedAgreementDao.findByExternalId(agreementId)).thenReturn(Optional.empty());
+        assertThrows(AgreementNotFoundException.class, () -> agreementService.cancel(agreementId, null));
+    }
+
+    @Test
+    public void cancelAnAgreement_ThrowsPaymentInstrumentNotActiveWhenNoPaymentInstrument() {
+        var agreementId = "an-external-id";
+        var agreementWithoutPaymentInstrument = new AgreementEntity.AgreementEntityBuilder()
+                .withPaymentInstrument(null)
+                .build();
+        when(mockedAgreementDao.findByExternalId(agreementId)).thenReturn(Optional.of(agreementWithoutPaymentInstrument));
+        assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancel(agreementId, null));
+    }
+
+    @ParameterizedTest()
+    @EnumSource(mode = EnumSource.Mode.EXCLUDE, names = "ACTIVE")
+    public void cancelAnAgreement_ThrowsPaymentInstrumentNotActiveWhenNonActiveStates(PaymentInstrumentStatus status) {
+        var agreementId = "an-external-id";
+        var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
+                .withStatus(status)
+                .build();
+        var agreement = new AgreementEntity.AgreementEntityBuilder()
+                .withPaymentInstrument(paymentInstrument)
+                .build();
+        when(mockedAgreementDao.findByExternalId(agreementId)).thenReturn(Optional.of(agreement));
+        assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancel(agreementId, null));
+    }
+
+    @Test
+    public void cancelAnAgreement_ShouldMoveToCancelStatusForActivePaymentInstrument() {
+        var agreementId = "an-external-id";
+        var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
+                .withStatus(PaymentInstrumentStatus.ACTIVE)
+                .build();
+        var agreement = new AgreementEntity.AgreementEntityBuilder()
+                .withPaymentInstrument(paymentInstrument)
+                .build();
+        when(mockedAgreementDao.findByExternalId(agreementId)).thenReturn(Optional.of(agreement));
+        agreementService.cancel(agreementId, null);
+        assertThat(paymentInstrument.getPaymentInstrumentStatus(), is(PaymentInstrumentStatus.CANCELLED));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -1102,6 +1102,14 @@ public class DatabaseTestHelper {
                         .list());
     }
 
+    public Map<String, Object> getPaymentInstrument(Long paymentInstrumentId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT * from payment_instruments where id = :id")
+                        .bind("id", paymentInstrumentId)
+                        .mapToMap()
+                        .first());
+    }
+
     public void insertGatewayAccountCredentials(AddGatewayAccountCredentialsParams params) {
         PGobject credentialsJson = buildCredentialsJson(params);
 


### PR DESCRIPTION
Add `/v1/api/account/:id/agreements/:id/cancel` endpoint.

This will move the payment instrument for a given agreement into the
cancelled state.

If no payment instrument is associated with the agreement, uniformly
throw agreement not active error.

404 if the agreement attempting to be cancelled doesn't exist.

---

Add agreement cancelled by service/ user events to mirror the event
structure of refunds (also processed through the admin tool or the API).

If user details are provided (generally by the admin tool) send the
cancelled by user event. If user details are no provided (generally
through the API) send the cancelled by service event.

with @alexbishop1 