### PR TITLE
PP-9677 Create transfer request for dispute

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandler.java
@@ -95,7 +95,7 @@ public class StripeFailedPaymentFeeCollectionHandler {
     private void transferFeeFromConnectAccount(long feeAmount,
                                                ChargeEntity charge)
             throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
-        StripeTransferInRequest transferInRequest = StripeTransferInRequest.of(
+        StripeTransferInRequest transferInRequest = StripeTransferInRequest.createFeesForFailedPaymentTransferRequest(
                 String.valueOf(feeAmount),
                 charge.getGatewayAccount(),
                 charge.getGatewayAccountCredentialsEntity(),

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
@@ -109,7 +109,7 @@ public class StripeRefundHandler {
     }
 
     private StripeTransferResponse transferFromConnectAccount(RefundGatewayRequest request, String stripeChargeId) throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
-        String transferResponse = client.postRequestFor(StripeTransferInRequest.of(request, stripeChargeId, stripeGatewayConfig)).getEntity();
+        String transferResponse = client.postRequestFor(StripeTransferInRequest.createRefundTransferRequest(request, stripeChargeId, stripeGatewayConfig)).getEntity();
         StripeTransferResponse stripeTransferResponse = jsonObjectMapper.getObject(transferResponse, StripeTransferResponse.class);
         logger.info("As part of refund {} refunding charge id {}, transferred net amount {} - transfer id {} -  from Stripe Connect account id {} in transfer group {}",
                 request.getRefundExternalId(),

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -32,8 +32,8 @@ public class StripeTransferInRequest extends StripeTransferRequest {
         this.transferGroup = transferGroup;
     }
 
-    public static StripeTransferInRequest of(RefundGatewayRequest request, String stripeChargeId,
-                                             StripeGatewayConfig stripeGatewayConfig) {
+    public static StripeTransferInRequest createRefundTransferRequest(RefundGatewayRequest request, String stripeChargeId,
+                                                                      StripeGatewayConfig stripeGatewayConfig) {
         return new StripeTransferInRequest(
                 request.getAmount(),
                 request.getGatewayAccount(),
@@ -46,13 +46,14 @@ public class StripeTransferInRequest extends StripeTransferRequest {
                 StripeTransferMetadataReason.TRANSFER_REFUND_AMOUNT
         );
     }
-    
-    public static StripeTransferInRequest of(String feeAmount,
-                                             GatewayAccountEntity gatewayAccount,
-                                             GatewayAccountCredentialsEntity gatewayAccountCredentials,
-                                             String paymentIntentId,
-                                             String chargeExternalId,
-                                             StripeGatewayConfig stripeGatewayConfig) {
+
+    public static StripeTransferInRequest createFeesForFailedPaymentTransferRequest(
+            String feeAmount,
+            GatewayAccountEntity gatewayAccount,
+            GatewayAccountCredentialsEntity gatewayAccountCredentials,
+            String paymentIntentId,
+            String chargeExternalId,
+            StripeGatewayConfig stripeGatewayConfig) {
         return new StripeTransferInRequest(
                 feeAmount,
                 gatewayAccount,
@@ -64,6 +65,26 @@ public class StripeTransferInRequest extends StripeTransferRequest {
                 chargeExternalId,
                 StripeTransferMetadataReason.TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT);
     }
+    
+    public static StripeTransferInRequest createDisputeTransferRequest(
+            String amount,
+            GatewayAccountEntity gatewayAccount,
+            GatewayAccountCredentialsEntity gatewayAccountCredentials,
+            String paymentIntentId,
+            String disputeExternalId,
+            String chargeExternalId,
+            StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeTransferInRequest(
+                amount,
+                gatewayAccount,
+                paymentIntentId,
+                disputeExternalId,
+                stripeGatewayConfig,
+                disputeExternalId,
+                gatewayAccountCredentials.getCredentials(),
+                chargeExternalId,
+                StripeTransferMetadataReason.TRANSFER_DISPUTE_AMOUNT);
+    }
 
     @Override
     public Map<String, String> params() {
@@ -73,7 +94,7 @@ public class StripeTransferInRequest extends StripeTransferRequest {
                 "transfer_group", transferGroup
         );
         Map<String, String> commonParams = super.params();
-        params.putAll(transferOutParams); 
+        params.putAll(transferOutParams);
         params.putAll(commonParams);
 
         return params;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReason.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReason.java
@@ -9,7 +9,8 @@ public enum StripeTransferMetadataReason {
     NOT_DEFINED,
     TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT,
     TRANSFER_REFUND_AMOUNT,
-    TRANSFER_PAYMENT_AMOUNT;
+    TRANSFER_PAYMENT_AMOUNT,
+    TRANSFER_DISPUTE_AMOUNT;
     
     @Override
     public String toString() {


### PR DESCRIPTION
Add a static method to StripeTransferInRequest to create a StripeTransferInRequest to transfer the funds for a dispute from a Stripe connected account to the platform account.

Rename the existing static methods to make the context of the transfer clearer.

This will create a transfer request with the following payload fields:

```
transfer_group=<chargeExternalId>
amount=<disputeNetAmount>
metadata[stripe_charge_id]=<paymentIntentId>
metadata[reason]=transfer_dispute_amount
metadata[govuk_pay_transaction_external_id]=<disputeExternalId>
destination=<stripePlatformAccountId>
currency=GBP
expand[]=balance_transaction
expand[]=destination_payment
```

The idempotency key for the request is the dispute external ID.