### PR TITLE
PP-9676 refactor determining live account

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeDisputeData.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeDisputeData.java
@@ -35,6 +35,9 @@ public class StripeDisputeData {
     @JsonProperty("status")
     private String status;
 
+    @JsonProperty("livemode")
+    private Boolean liveMode;
+
     public StripeDisputeData() {
         // for  jackson
     }
@@ -43,7 +46,7 @@ public class StripeDisputeData {
                              Long amount, String reason, Long created,
                              List<BalanceTransaction> balanceTransactionList,
                              EvidenceDetails evidenceDetails,
-                             Evidence evidence
+                             Evidence evidence, Boolean liveMode
     ) {
         this.id = id;
         this.status = status;
@@ -54,6 +57,7 @@ public class StripeDisputeData {
         this.balanceTransactionList = balanceTransactionList;
         this.evidenceDetails = evidenceDetails;
         this.evidence = evidence;
+        this.liveMode = liveMode;
     }
 
     public String getResourceType() {
@@ -94,5 +98,9 @@ public class StripeDisputeData {
 
     public Evidence getEvidence() {
         return evidence;
+    }
+
+    public Boolean getLiveMode() {
+        return liveMode;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
@@ -86,7 +86,7 @@ public class StripeWebhookTaskHandler {
                 case DISPUTE_CREATED:
                     DisputeCreated disputeCreatedEvent = DisputeCreated.from(stripeDisputeData, transaction, stripeDisputeData.getDisputeCreated());
                     emitEvent(disputeCreatedEvent, stripeDisputeData.getId());
-                    if (!transaction.getLive()) {
+                    if(!stripeDisputeData.getLiveMode()) {
                         submitEvidenceForTestAccount(stripeDisputeData, transaction);
                     }
                     break;

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
@@ -31,7 +31,7 @@ class DisputeCreatedTest {
         EvidenceDetails evidenceDetails = new EvidenceDetails(1642679160L);
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
                 "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction),
-                evidenceDetails, null);
+                evidenceDetails, null, true);
 
         DisputeCreated disputeCreated = from(stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L));
 

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java
@@ -25,7 +25,7 @@ public class DisputeEvidenceSubmittedTest {
                 .build();
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
                 "pi_123456789", "under_review", 6500L, "fradulent",
-                1642579160L, null, null, null);
+                1642579160L, null, null, null, true);
 
         DisputeEvidenceSubmitted disputeEvidenceSubmitted = from(stripeDisputeData.getId(), toUTCZonedDateTime(1642579160L), transaction);
 

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java
@@ -33,7 +33,7 @@ class DisputeLostTest {
         BalanceTransaction balanceTransaction = new BalanceTransaction(6500L, 1500L, -8000L);
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
                 "pi_123456789", "lost", 6500L, "fradulent", 1642579160L,
-                List.of(balanceTransaction), null, null);
+                List.of(balanceTransaction), null, null, true);
 
         DisputeLost disputeLost = from(stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, true);
 
@@ -64,7 +64,7 @@ class DisputeLostTest {
         BalanceTransaction balanceTransaction = new BalanceTransaction(6500L, 1500L, -8000L);
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
                 "pi_123456789", "lost", 6500L, "fradulent", 1642579160L,
-                List.of(balanceTransaction), null, null);
+                List.of(balanceTransaction), null, null, false);
 
         DisputeLost disputeLost = from(stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, false);
 
@@ -97,7 +97,7 @@ class DisputeLostTest {
         EvidenceDetails evidenceDetails = new EvidenceDetails(1642679160L);
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
                 "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction,
-                balanceTransaction2), evidenceDetails, null);
+                balanceTransaction2), evidenceDetails, null, false);
 
         var thrown = assertThrows(RuntimeException.class, () ->
                 DisputeLost.from(stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, true));

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java
@@ -24,7 +24,8 @@ public class DisputeWonTest {
                 .isLive(true)
                 .build();
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
-                "pi_123456789", "won", 6500L, "fradulent", 1642579160L, null, null, null);
+                "pi_123456789", "won", 6500L, "fradulent", 1642579160L,
+                null, null, null, false);
 
         DisputeWon disputeWon = from(stripeDisputeData.getId(), toUTCZonedDateTime(1642579160L), transaction);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -313,7 +313,7 @@ class StripePaymentProviderTest {
         EvidenceDetails evidenceDetails = new EvidenceDetails(1642679160L);
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
                 "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction,
-                balanceTransaction2), evidenceDetails, null);
+                balanceTransaction2), evidenceDetails, null, true);
         
         var gatewayAccountEntity = buildTestGatewayAccountEntity();
         ChargeEntity chargeEntity = buildTestCharge(gatewayAccountEntity);
@@ -331,7 +331,7 @@ class StripePaymentProviderTest {
         String paymentIntentId = "pi_123456789";
         StripeDisputeData stripeDisputeData = new StripeDisputeData(stripeDisputeId,
                 paymentIntentId, "needs_response", 6500L, "fradulent", 
-                1642579160L, List.of(balanceTransaction), evidenceDetails, null);
+                1642579160L, List.of(balanceTransaction), evidenceDetails, null, false);
         String disputeExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeId);
 
         var gatewayAccountEntity = buildTestGatewayAccountEntity();

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
@@ -117,7 +117,11 @@ public class StripeWebhookTaskHandlerTest {
                 .withGatewayTransactionId("gateway-transaction-id")
                 .isLive(true)
                 .build();
-        StripeNotification stripeNotification = getDisputeNotification("charge.dispute.created", "needs_response");
+        String finalPayload = payload
+                .replace(PLACEHOLDER_TYPE, "charge.dispute.created")
+                .replace(PLACEHOLDER_STATUS, "needs_response");
+        finalPayload = finalPayload.replaceAll("\"livemode\": false", "\"livemode\": true");
+        StripeNotification stripeNotification = objectMapper.readValue(finalPayload, StripeNotification.class);
         StripeDisputeData stripeDisputeData = objectMapper.readValue(stripeNotification.getObject(), StripeDisputeData.class);
         when(ledgerService.getTransactionForProviderAndGatewayTransactionId(any(), any()))
                 .thenReturn(Optional.of(transaction));

--- a/src/test/resources/templates/stripe/charge_dispute.json
+++ b/src/test/resources/templates/stripe/charge_dispute.json
@@ -11,7 +11,7 @@
     "object": {
       "id": "du_1111111111",
       "object": "dispute",
-      "livemode": true,
+      "livemode": false,
       "payment_intent": "pi_1111111111",
       "status": "{{status}}",
       "amount": 6500,


### PR DESCRIPTION
## WHAT YOU DID
- instead of using transaction.isLive to determine whether an account is test, use the Stripe object's `livemode` field. This is because we have Stripe test account marked as `live` on our test environment.
