### PR TITLE
PP-9677 Make transfer in Stripe for lost dispute

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -73,6 +73,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -667,7 +671,7 @@
         "filename": "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 146
       }
     ],
     "src/test/resources/config/client-factory-test-config.yaml": [
@@ -697,7 +701,7 @@
         "filename": "src/test/resources/config/client-factory-test-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 134
+        "line_number": 136
       }
     ],
     "src/test/resources/config/test-config.yaml": [
@@ -727,7 +731,7 @@
         "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 142
+        "line_number": 144
       }
     ],
     "src/test/resources/config/test-it-config.yaml": [
@@ -757,7 +761,7 @@
         "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 142
+        "line_number": 144
       }
     ],
     "src/test/resources/googlepay/auth-request-with-empty-last-digits-card-number.json": [
@@ -888,5 +892,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-04T11:23:47Z"
+  "generated_at": "2022-07-20T10:55:37Z"
 }

--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -5,6 +5,7 @@ import io.dropwizard.Configuration;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,6 +51,12 @@ public class StripeGatewayConfig extends Configuration {
     @Valid
     private int threeDsFeeInPence;
 
+    @Valid
+    private Instant rechargeServicesForLivePaymentDisputesFromDate;
+    
+    @Valid
+    private Instant rechargeServicesForTestPaymentDisputesFromDate;
+
     public String getUrl() {
         return url;
     }
@@ -92,5 +99,13 @@ public class StripeGatewayConfig extends Configuration {
 
     public int getThreeDsFeeInPence() {
         return threeDsFeeInPence;
+    }
+
+    public Instant getRechargeServicesForLivePaymentDisputesFromDate() {
+        return rechargeServicesForLivePaymentDisputesFromDate;
+    }
+
+    public Instant getRechargeServicesForTestPaymentDisputesFromDate() {
+        return rechargeServicesForTestPaymentDisputesFromDate;
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -116,6 +116,8 @@ stripe:
   credentials: ['stripe_account_id']
   radarFeeInPence: ${STRIPE_TRANSACTION_RADAR_FEE_IN_PENCE}
   threeDsFeeInPence: ${STRIPE_TRANSACTION_THREE_DS_FEE_IN_PENCE}
+  rechargeServicesForLivePaymentDisputesFromDate: ${RECHARGE_SERVICES_FOR_LIVE_PAYMENTS_DISPUTES_FROM_DATE:-1659916800} # 8 August 2022 00:00:00
+  rechargeServicesForTestPaymentDisputesFromDate: ${RECHARGE_SERVICES_FOR_TEST_PAYMENTS_DISPUTES_FROM_DATE:-1659916800} # 8 August 2022 00:00:00
 
 executorServiceConfig:
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
@@ -113,7 +113,7 @@ class TaskQueueMessageHandlerTest {
     }
 
     @Test
-    public void shouldProcessDisputeCreatedTask() throws QueueException, JsonProcessingException {
+    public void shouldProcessDisputeCreatedTask() throws Exception {
         TaskMessage taskMessage = setupQueueMessage("{ \"key\": \"value\"}", TaskType.HANDLE_STRIPE_WEBHOOK_NOTIFICATION);
         taskQueueMessageHandler.processMessages();
         verify(stripeWebhookTaskHandler).process(any(StripeNotification.class));

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -81,6 +81,8 @@ stripe:
   credentials: ['stripe_account_id']
   radarFeeInPence: ${STRIPE_TRANSACTION_RADAR_FEE_IN_PENCE:-5}
   threeDsFeeInPence: ${STRIPE_TRANSACTION_THREE_DS_FEE_IN_PENCE:-5}
+  rechargeServicesForLivePaymentDisputesFromDate: ${RECHARGE_SERVICES_FOR_LIVE_PAYMENTS_DISPUTES_FROM_DATE:-1659916800} # 8 August 2022 00:00:00
+  rechargeServicesForTestPaymentDisputesFromDate: ${RECHARGE_SERVICES_FOR_TEST_PAYMENTS_DISPUTES_FROM_DATE:-1659916800} # 8 August 2022 00:00:00
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -71,6 +71,8 @@ stripe:
   credentials: ['stripe_account_id']
   radarFeeInPence: ${STRIPE_TRANSACTION_RADAR_FEE_IN_PENCE:-5}
   threeDsFeeInPence: ${STRIPE_TRANSACTION_THREE_DS_FEE_IN_PENCE:-5}
+  rechargeServicesForLivePaymentDisputesFromDate: ${RECHARGE_SERVICES_FOR_LIVE_PAYMENTS_DISPUTES_FROM_DATE:-1659916800} # 8 August 2022 00:00:00
+  rechargeServicesForTestPaymentDisputesFromDate: ${RECHARGE_SERVICES_FOR_TEST_PAYMENTS_DISPUTES_FROM_DATE:-1659916800} # 8 August 2022 00:00:00
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -77,6 +77,8 @@ stripe:
   credentials: ['stripe_account_id']
   radarFeeInPence: ${STRIPE_TRANSACTION_RADAR_FEE_IN_PENCE:-5}
   threeDsFeeInPence: ${STRIPE_TRANSACTION_THREE_DS_FEE_IN_PENCE:-5}
+  rechargeServicesForLivePaymentDisputesFromDate: ${RECHARGE_SERVICES_FOR_LIVE_PAYMENTS_DISPUTES_FROM_DATE:-1659916800} # 8 August 2022 00:00:00
+  rechargeServicesForTestPaymentDisputesFromDate: ${RECHARGE_SERVICES_FOR_TEST_PAYMENTS_DISPUTES_FROM_DATE:-1659916800} # 8 August 2022 00:00:00
 
 executorServiceConfig:
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -77,6 +77,8 @@ stripe:
   credentials: ['stripe_account_id']
   radarFeeInPence: ${STRIPE_TRANSACTION_RADAR_FEE_IN_PENCE:-5}
   threeDsFeeInPence: ${STRIPE_TRANSACTION_THREE_DS_FEE_IN_PENCE:-6}
+  rechargeServicesForLivePaymentDisputesFromDate: ${RECHARGE_SERVICES_FOR_LIVE_PAYMENTS_DISPUTES_FROM_DATE:-1659916800} # 8 August 2022 00:00:00
+  rechargeServicesForTestPaymentDisputesFromDate: ${RECHARGE_SERVICES_FOR_TEST_PAYMENTS_DISPUTES_FROM_DATE:-1659916800} # 8 August 2022 00:00:00
 
 executorServiceConfig:
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}


### PR DESCRIPTION
When we receive a `charge.dispute.closed` from Stripe with a status of
'lost', make a transfer in Stripe for the net amount for the dispute
from the Connect account to our Platform account if:

- the charge is live, and the dispute was created after the 
RECHARGE_SERVICES_FOR_LIVE_PAYMENTS_DISPUTES_FROM_DATE environment variable
- the charge is test, and the dispute was created after the
RECHARGE_SERVICES_FOR_TEST_PAYMENTS_DISPUTES_FROM_DATE environment variable