### PR TITLE
PP-9677 Only send fee and net when dispute recharged

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/dispute/DisputeLostEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/dispute/DisputeLostEventDetails.java
@@ -5,11 +5,15 @@ public class DisputeLostEventDetails extends DisputeEventDetails {
     private final Long amount;
     private final Long fee;
 
-    public DisputeLostEventDetails(String gatewayAccountId, Long netAmount, Long amount, Long fee) {
+    public DisputeLostEventDetails(String gatewayAccountId, Long amount, Long netAmount, Long fee) {
         super(gatewayAccountId);
         this.netAmount = netAmount;
         this.amount = amount;
         this.fee = fee;
+    }
+    
+    public DisputeLostEventDetails(String gatewayAccountId, Long amount) {
+        this(gatewayAccountId, amount, null, null);
     }
 
     public Long getNetAmount() {

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
@@ -129,8 +129,8 @@ public class StripeWebhookTaskHandler {
 
     private DisputeEvent handleDisputeLost(StripeNotification stripeNotification, StripeDisputeData stripeDisputeData,
                                            LedgerTransaction transaction) throws GatewayException {
-        boolean shouldRechargeDispute = shouldRechargeDispute(stripeDisputeData, transaction);
-        if (shouldRechargeDispute) {
+        boolean rechargeDispute = shouldRechargeDispute(stripeDisputeData, transaction);
+        if (rechargeDispute) {
             Charge charge = Charge.from(transaction);
             GatewayAccountEntity gatewayAccount = gatewayAccountService.getGatewayAccount(Long.valueOf(transaction.getGatewayAccountId()))
                     .orElseThrow(() -> new GatewayAccountNotFoundException(transaction.getGatewayAccountId()));
@@ -141,7 +141,7 @@ public class StripeWebhookTaskHandler {
             logger.info("Skipping recharging for dispute {} for payment {} as it was created before the date we started recharging from",
                     stripeDisputeData.getId(), transaction.getTransactionId());
         }
-        return DisputeLost.from(stripeDisputeData, stripeNotification.getCreated(), transaction);
+        return DisputeLost.from(stripeDisputeData, stripeNotification.getCreated(), transaction, rechargeDispute);
     }
 
     private boolean shouldRechargeDispute(StripeDisputeData stripeDisputeData, LedgerTransaction transaction) {

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -443,7 +443,7 @@ public class QueueMessageContractTest {
     @PactVerifyProvider("a dispute lost event")
     public String verifyDisputeLostEvent() throws JsonProcessingException {
         DisputeLostEventDetails eventDetails = new DisputeLostEventDetails("a-gateway-account-id",
-                -8000L, 6500L, 1500L);
+                6500L, -8000L, 1500L);
         DisputeLost disputeLost = new DisputeLost("resource-external-id",
                 "external-id", "service-id", true, eventDetails, toUTCZonedDateTime(1642579160L));
         return disputeLost.toJsonString();

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
@@ -52,6 +52,7 @@ import java.util.Optional;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -291,9 +292,9 @@ public class StripeWebhookTaskHandlerTest {
 
         DisputeLostEventDetails eventDetails = (DisputeLostEventDetails) disputeLost.getEventDetails();
         assertThat(eventDetails.getGatewayAccountId(), is("1000"));
-        assertThat(eventDetails.getFee(), is(stripeDisputeData.getBalanceTransactionList().get(0).getFee()));
         assertThat(eventDetails.getAmount(), is(stripeDisputeData.getAmount()));
-        assertThat(eventDetails.getNetAmount(), is(stripeDisputeData.getBalanceTransactionList().get(0).getNetAmount()));
+        assertThat(eventDetails.getFee(), is(nullValue()));
+        assertThat(eventDetails.getNetAmount(), is(nullValue()));
 
         verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
@@ -325,9 +326,9 @@ public class StripeWebhookTaskHandlerTest {
 
         DisputeLostEventDetails eventDetails = (DisputeLostEventDetails) disputeLost.getEventDetails();
         assertThat(eventDetails.getGatewayAccountId(), is("1000"));
-        assertThat(eventDetails.getFee(), is(stripeDisputeData.getBalanceTransactionList().get(0).getFee()));
         assertThat(eventDetails.getAmount(), is(stripeDisputeData.getAmount()));
-        assertThat(eventDetails.getNetAmount(), is(stripeDisputeData.getBalanceTransactionList().get(0).getNetAmount()));
+        assertThat(eventDetails.getFee(), is(nullValue()));
+        assertThat(eventDetails.getNetAmount(), is(nullValue()));
 
         verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();


### PR DESCRIPTION
Only send the `fee` and `net_amount` fields in the DISPUTE_LOST event when we have recharged the service for the dispute. This is because these fields in our reports are used for reconcilliation, so should only be included when money has moved into or out of the service's Stripe account.