### PR TITLE
PP-9677 Process dispute transfers included in payouts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -545,7 +545,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java",
         "hashed_secret": "f182dd26dca3b13579d94c83c1d8cccba160ff77",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 104
       }
     ],
     "src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java": [
@@ -892,5 +892,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-20T10:55:37Z"
+  "generated_at": "2022-07-20T17:12:47Z"
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeEvent.java
@@ -7,15 +7,20 @@ import uk.gov.pay.connector.events.model.ResourceType;
 import java.time.ZonedDateTime;
 
 public class DisputeEvent extends Event {
-    private final String parentResourceExternalId;
-    private final String serviceId;
-    private final Boolean live;
+    private String parentResourceExternalId;
+    private String serviceId;
+    private Boolean live;
+    
     public DisputeEvent(String resourceExternalId, String parentResourceExternalId, String serviceId, Boolean live,
-                        EventDetails eventDetails, ZonedDateTime disputeCreated) {
-        super(resourceExternalId, eventDetails, disputeCreated);
+                        EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(resourceExternalId, eventDetails, timestamp);
         this.parentResourceExternalId = parentResourceExternalId;
         this.serviceId = serviceId;
         this.live = live;
+    }
+
+    public DisputeEvent(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(resourceExternalId, eventDetails, timestamp);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeIncludedInPayout.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeIncludedInPayout.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.events.model.dispute;
+
+import uk.gov.pay.connector.events.eventdetails.TransactionIncludedInPayoutEventDetails;
+
+import java.time.ZonedDateTime;
+
+public class DisputeIncludedInPayout extends DisputeEvent {
+    public DisputeIncludedInPayout(String disputeExternalId, String gatewayPayoutId, ZonedDateTime payoutCreatedDate) {
+        super(disputeExternalId, new TransactionIncludedInPayoutEventDetails(gatewayPayoutId), payoutCreatedDate);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReason.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReason.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 
 public enum StripeTransferMetadataReason {
     NOT_DEFINED,
+    UNRECOGNISED,
     TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT,
     TRANSFER_REFUND_AMOUNT,
     TRANSFER_PAYMENT_AMOUNT,
@@ -24,6 +25,6 @@ public enum StripeTransferMetadataReason {
         return Arrays.stream(StripeTransferMetadataReason.values())
                 .filter(stripeTransferMetadataReason -> StringUtils.equalsIgnoreCase(stripeTransferMetadataReason.name(), value))
                 .findFirst()
-                .orElse(NOT_DEFINED);
+                .orElse(UNRECOGNISED);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeIncludedInPayoutTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeIncludedInPayoutTest.java
@@ -1,6 +1,7 @@
-package uk.gov.pay.connector.events.model.refund;
+package uk.gov.pay.connector.events.model.dispute;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.events.model.refund.RefundIncludedInPayout;
 
 import java.time.ZonedDateTime;
 
@@ -9,20 +10,20 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-class RefundIncludedInPayoutTest {
-
+class DisputeIncludedInPayoutTest {
+    
     @Test
     void serializesEventDetails() throws Exception {
-        var refundExternalId = "refund-id";
+        var disputeExternalId = "dispute-id";
         var gatewayPayoutId = "payout-id";
         String eventDateStr = "2020-05-10T10:30:00.000000Z";
-        var event = new RefundIncludedInPayout(refundExternalId, gatewayPayoutId, ZonedDateTime.parse(eventDateStr));
+        var event = new DisputeIncludedInPayout(disputeExternalId, gatewayPayoutId, ZonedDateTime.parse(eventDateStr));
 
         var json = event.toJsonString();
 
-        assertThat(json, hasJsonPath("$.event_type", equalTo("REFUND_INCLUDED_IN_PAYOUT")));
-        assertThat(json, hasJsonPath("$.resource_type", equalTo("refund")));
-        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(refundExternalId)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("DISPUTE_INCLUDED_IN_PAYOUT")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("dispute")));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(disputeExternalId)));
         assertThat(json, hasJsonPath("$.timestamp", equalTo(eventDateStr)));
         assertThat(json, hasNoJsonPath("$.live"));
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReasonTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReasonTest.java
@@ -22,8 +22,8 @@ class StripeTransferMetadataReasonTest {
     }
 
     @Test
-    void shouldResolveDefaultValueWhenNotExists() {
-        assertThat(StripeTransferMetadataReason.fromString("BLAH"), is(StripeTransferMetadataReason.NOT_DEFINED));
+    void shouldResolveUnrecognisedValueWhenNotRecognisedEnumValue() {
+        assertThat(StripeTransferMetadataReason.fromString("BLAH"), is(StripeTransferMetadataReason.UNRECOGNISED));
     }
 
     @Test


### PR DESCRIPTION
Handle Stripe BalanceTransactions which have a source of type Transfer, and metadata "reason" field `transfer_dispute_amount` by emitting a DISPUTE_INCLUDED_IN_PAYOUT event. The event_details for this event contains the gateway_payout_id, which ledger will use to associate the dispute with the payout.

When a Transfer has a "reason" metadata field that is unrecognised or not handled, make the payout processing fail. This is to prevent us from wrongly reconciling any future Transfer types we add as refunds before we add the logic to the payout reconcile process to deal with them.

Use the MDC to add the payout id and connect account id to all log lines for the payout being processed.
