### PR TITLE
PP-9671 Return error when refund unavailable for disputed payment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.10</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.13.3</jackson.version>
-        <pay-java-commons.version>1.0.20220720153401</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20220722152412</pay-java-commons.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <jooq.version>3.17.2</jooq.version>
         <postgresql.version>42.4.0</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -25,10 +25,12 @@ public class Charge {
     private boolean historic;
     private String serviceId;
     private boolean live;
+    private Boolean disputed;
 
     public Charge(String externalId, Long amount, String status, String externalStatus, String gatewayTransactionId,
                   String credentialExternalId, Long corporateSurcharge, String refundAvailabilityStatus, String reference,
-                  String description, Instant createdDate, String email, Long gatewayAccountId, String paymentGatewayName, boolean historic, String serviceId, boolean live) {
+                  String description, Instant createdDate, String email, Long gatewayAccountId, String paymentGatewayName,
+                  boolean historic, String serviceId, boolean live, Boolean disputed) {
         this.externalId = externalId;
         this.amount = amount;
         this.status = status;
@@ -46,6 +48,7 @@ public class Charge {
         this.historic = historic;
         this.serviceId = serviceId;
         this.live = live;
+        this.disputed = disputed;
     }
 
     public static Charge from(ChargeEntity chargeEntity) {
@@ -73,7 +76,8 @@ public class Charge {
                 chargeEntity.getPaymentGatewayName().getName(),
                 false,
                 chargeEntity.getServiceId(),
-                chargeEntity.getGatewayAccount().isLive());
+                chargeEntity.getGatewayAccount().isLive(), 
+                null);
     }
 
     public static Charge from(LedgerTransaction transaction) {
@@ -105,7 +109,8 @@ public class Charge {
                 transaction.getPaymentProvider(),
                 true,
                 transaction.getServiceId(),
-                transaction.getLive()
+                transaction.getLive(),
+                transaction.isDisputed()
         );
     }
 
@@ -183,6 +188,10 @@ public class Charge {
 
     public boolean isLive(){
         return live;
+    }
+
+    public Boolean getDisputed() {
+        return disputed;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
@@ -51,6 +51,7 @@ public class LedgerTransaction {
     private String parentTransactionId;
     private String serviceId;
     private AuthorisationSummary authorisationSummary;
+    private boolean disputed;
 
     public LedgerTransaction() {
 
@@ -304,5 +305,13 @@ public class LedgerTransaction {
 
     public void setAuthorisationSummary(AuthorisationSummary authorisationSummary) {
         this.authorisationSummary = authorisationSummary;
+    }
+
+    public boolean isDisputed() {
+        return disputed;
+    }
+
+    public void setDisputed(boolean disputed) {
+        this.disputed = disputed;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/exception/RefundException.java
+++ b/src/main/java/uk/gov/pay/connector/refund/exception/RefundException.java
@@ -1,8 +1,8 @@
 package uk.gov.pay.connector.refund.exception;
 
-import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -12,6 +12,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_NOT_AVAILABLE;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE;
 
 public class RefundException extends WebApplicationException {
 
@@ -26,6 +27,10 @@ public class RefundException extends WebApplicationException {
     public static RefundException notAvailableForRefundException(String chargeId, ExternalChargeRefundAvailability currentAvailability) {
         return new RefundException(format("Charge with id [%s] not available for refund.", chargeId),
                 REFUND_NOT_AVAILABLE, BAD_REQUEST, currentAvailability.getStatus());
+    }
+    
+    public static RefundException unavailableDueToChargeDisputed() {
+        return new RefundException("Refund not available as the charge is disputed", REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE, BAD_REQUEST, null);
     }
 
     private RefundException(String message, ErrorIdentifier errorIdentifier, Response.Status status, String reason) {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
@@ -244,6 +244,6 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     private Charge getCharge(boolean isHistoric){
         return new Charge("external-id", 10L, null, null, "transaction-id",
                 "credential-external-id", 10L, null, "ref-1", "desc", Instant.now(),
-                "test@example.org", 123L, "epdq", isHistoric, "service-id", true);
+                "test@example.org", 123L, "epdq", isHistoric, "service-id", true, false);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.client.ledger.model.SettlementSummary;
 import uk.gov.pay.connector.client.ledger.model.ThreeDSecure;
 import uk.gov.pay.connector.client.ledger.model.TransactionState;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
@@ -56,7 +57,7 @@ public class LedgerTransactionFixture {
     private ZonedDateTime createdDate = ZonedDateTime.now();
     private boolean live;
     private Long gatewayAccountId;
-    private String paymentProvider;
+    private String paymentProvider = PaymentGatewayName.SANDBOX.getName();
     private String walletType;
     private Long netAmount;
     private Source source;
@@ -73,6 +74,7 @@ public class LedgerTransactionFixture {
     private String refundedByUserEmail;
     private AuthorisationSummary authorisationSummary;
     private String serviceId;
+    private boolean disputed;
 
     public static LedgerTransactionFixture aValidLedgerTransaction() {
         return new LedgerTransactionFixture();
@@ -230,6 +232,7 @@ public class LedgerTransactionFixture {
         ledgerTransaction.setRefundedByUserEmail(refundedByUserEmail);
 
         ledgerTransaction.setAuthorisationSummary(authorisationSummary);
+        ledgerTransaction.setDisputed(disputed);
 
         return ledgerTransaction;
     }
@@ -386,6 +389,11 @@ public class LedgerTransactionFixture {
 
     public LedgerTransactionFixture withServiceId(String serviceId) {
         this.serviceId = serviceId;
+        return this;
+    }
+    
+    public LedgerTransactionFixture withDisputed(boolean disputed) {
+        this.disputed = disputed;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
@@ -156,6 +156,6 @@ public class DefaultExternalRefundAvailabilityCalculatorTest {
     private Charge getHistoricCharge(ExternalChargeRefundAvailability availability) {
         return new Charge("external-id", 500L, null, "success", "transaction-id",
                 "credentials_external_id", 0L, availability.getStatus(), "ref-1", "desc", Instant.now(),
-                "test@example.org", 123L, "epdq", true, "service-id", true);
+                "test@example.org", 123L, "epdq", true, "service-id", true, false);
     }
 }

--- a/src/test/resources/pacts/connector-ledger-get-payment-transaction.json
+++ b/src/test/resources/pacts/connector-ledger-get-payment-transaction.json
@@ -51,6 +51,7 @@
           "moto": false,
           "live": false,
           "transaction_id": "e8eq11mi2ndmauvb51qsg8hccn",
+          "disputed": false
         },
         "matchingRules": {
           "body": {


### PR DESCRIPTION
When a request is made to refund a payment, and the refund status is calculated as "unavailable" and the payment is disputed, return an error response with identifier REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE.

We only know whether a payment is disputed when we get the payment from ledger. This means that if the payment is still in the connector database, we will attempt to refund the payment if we calculate that it can be refunded, and this will result in a refund error when attempting to make the refund with Stripe.

Update the pact test with ledger to expect the "disputed" field to be present for a payment.