### PR TITLE
PP-9671 Emit refund availability updated event when dispute won

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/dispute/DisputeEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/dispute/DisputeEventDetails.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.events.eventdetails.dispute;
 
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
+import java.util.Objects;
+
 abstract class DisputeEventDetails extends EventDetails {
     protected final String gatewayAccountId;
 
@@ -11,5 +13,18 @@ abstract class DisputeEventDetails extends EventDetails {
 
     public String getGatewayAccountId() {
         return gatewayAccountId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DisputeEventDetails that = (DisputeEventDetails) o;
+        return Objects.equals(gatewayAccountId, that.gatewayAccountId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(gatewayAccountId);
     }
 }


### PR DESCRIPTION
When we receive a notification from Stripe informing us that a dispute was won, emit a REFUND_AVAILABILITY_UPDATED event to ledger to update the refund status.

We do this as we will update the refund status to "unavailable" when a new dispute is raised. When the dispute is won be the service, the availability should then be reset to the status it would be if there was no dispute.

Fix some use of optionals in EventFactory.java while refactoring to re-use some code.