### PR TITLE
PP-9671 Refactor StripeWebhookTaskHandler

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/dispute/DisputeCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/dispute/DisputeCreatedEventDetails.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
 
 public class DisputeCreatedEventDetails extends DisputeEventDetails {
     @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
@@ -35,5 +36,18 @@ public class DisputeCreatedEventDetails extends DisputeEventDetails {
 
     public String getGatewayTransactionId() {
         return gatewayTransactionId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DisputeCreatedEventDetails that = (DisputeCreatedEventDetails) o;
+        return Objects.equals(evidenceDueDate, that.evidenceDueDate) && Objects.equals(amount, that.amount) && Objects.equals(reason, that.reason) && Objects.equals(gatewayTransactionId, that.gatewayTransactionId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(evidenceDueDate, amount, reason, gatewayTransactionId);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeCreated.java
@@ -6,15 +6,13 @@ import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
 import java.time.ZonedDateTime;
 
-import static uk.gov.pay.connector.util.RandomIdGenerator.idFromExternalId;
-
 public class DisputeCreated extends DisputeEvent {
     public DisputeCreated(String resourceExternalId, String parentResourceExternalId, String serviceId,
                           Boolean live, DisputeCreatedEventDetails eventDetails, ZonedDateTime disputeCreated) {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, disputeCreated);
     }
 
-    public static DisputeCreated from(StripeDisputeData stripeDisputeData, LedgerTransaction transaction, ZonedDateTime disputeCreatedDate) {
+    public static DisputeCreated from(String disputeExternalId, StripeDisputeData stripeDisputeData, LedgerTransaction transaction, ZonedDateTime disputeCreatedDate) {
         DisputeCreatedEventDetails eventDetails = new DisputeCreatedEventDetails(
                 stripeDisputeData.getEvidenceDetails().getEvidenceDueByDate(),
                 transaction.getGatewayAccountId(),
@@ -23,7 +21,7 @@ public class DisputeCreated extends DisputeEvent {
                 stripeDisputeData.getId());
 
         return new DisputeCreated(
-                idFromExternalId(stripeDisputeData.getId()),
+                disputeExternalId,
                 transaction.getTransactionId(),
                 transaction.getServiceId(),
                 transaction.getLive(),

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmitted.java
@@ -5,8 +5,6 @@ import uk.gov.pay.connector.events.eventdetails.dispute.DisputeEvidenceSubmitted
 
 import java.time.ZonedDateTime;
 
-import static uk.gov.pay.connector.util.RandomIdGenerator.idFromExternalId;
-
 public class DisputeEvidenceSubmitted extends DisputeEvent {
     public DisputeEvidenceSubmitted(String resourceExternalId, String parentResourceExternalId, String serviceId,
                                     Boolean live, DisputeEvidenceSubmittedEventDetails eventDetails,
@@ -14,9 +12,9 @@ public class DisputeEvidenceSubmitted extends DisputeEvent {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, eventDate);
     }
 
-    public static DisputeEvidenceSubmitted from(String gatewayDisputeId, ZonedDateTime eventDate, LedgerTransaction transaction) {
+    public static DisputeEvidenceSubmitted from(String disputeExternalId, ZonedDateTime eventDate, LedgerTransaction transaction) {
         return new DisputeEvidenceSubmitted(
-                idFromExternalId(gatewayDisputeId),
+                disputeExternalId,
                 transaction.getTransactionId(),
                 transaction.getServiceId(),
                 transaction.getLive(),

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeLost.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeLost.java
@@ -2,12 +2,10 @@ package uk.gov.pay.connector.events.model.dispute;
 
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeLostEventDetails;
-import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
+import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 
 import java.time.ZonedDateTime;
-
-import static uk.gov.pay.connector.util.RandomIdGenerator.idFromExternalId;
 
 public class DisputeLost extends DisputeEvent {
     public DisputeLost(String resourceExternalId, String parentResourceExternalId, String serviceId, Boolean live,
@@ -15,7 +13,7 @@ public class DisputeLost extends DisputeEvent {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, eventDate);
     }
 
-    public static DisputeLost from(StripeDisputeData stripeDisputeData, ZonedDateTime eventDate, LedgerTransaction transaction, boolean rechargedToService) {
+    public static DisputeLost from(String disputeExternalId, StripeDisputeData stripeDisputeData, ZonedDateTime eventDate, LedgerTransaction transaction, boolean rechargedToService) {
         if (stripeDisputeData.getBalanceTransactionList().size() > 1) {
             throw new RuntimeException("Dispute data has too many balance_transactions");
         }
@@ -34,7 +32,7 @@ public class DisputeLost extends DisputeEvent {
             );
         }
         
-        return new DisputeLost(idFromExternalId(stripeDisputeData.getId()),
+        return new DisputeLost(disputeExternalId,
                 transaction.getTransactionId(),
                 transaction.getServiceId(),
                 transaction.getLive(),

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeWon.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeWon.java
@@ -5,17 +5,15 @@ import uk.gov.pay.connector.events.eventdetails.dispute.DisputeWonEventDetails;
 
 import java.time.ZonedDateTime;
 
-import static uk.gov.pay.connector.util.RandomIdGenerator.idFromExternalId;
-
 public class DisputeWon extends DisputeEvent {
     public DisputeWon(String resourceExternalId, String parentResourceExternalId, String serviceId,
                       Boolean live, DisputeWonEventDetails eventDetails, ZonedDateTime eventDate) {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, eventDate);
     }
 
-    public static DisputeWon from(String gatewayDisputeId, ZonedDateTime eventDate,
+    public static DisputeWon from(String disputeExternalId, ZonedDateTime eventDate,
                                   LedgerTransaction transaction) {
-        return new DisputeWon(idFromExternalId(gatewayDisputeId),
+        return new DisputeWon(disputeExternalId,
                 transaction.getTransactionId(),
                 transaction.getServiceId(),
                 transaction.getLive(),

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
@@ -3,9 +3,9 @@ package uk.gov.pay.connector.events.model.dispute;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 import uk.gov.pay.connector.queue.tasks.dispute.EvidenceDetails;
-import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
 import java.util.List;
 
@@ -32,14 +32,15 @@ class DisputeCreatedTest {
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
                 "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction),
                 evidenceDetails, null, true);
+        String disputeExternalId = "fca65e80d2293ee3bf158a0d12";
 
-        DisputeCreated disputeCreated = from(stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L));
+        DisputeCreated disputeCreated = from(disputeExternalId, stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L));
 
         String disputeCreatedJson = disputeCreated.toJsonString();
         assertThat(disputeCreatedJson, hasJsonPath("$.event_type", equalTo("DISPUTE_CREATED")));
         assertThat(disputeCreatedJson, hasJsonPath("$.resource_type", equalTo("dispute")));
         assertThat(disputeCreatedJson, hasJsonPath("$.service_id", equalTo("service-id")));
-        assertThat(disputeCreatedJson, hasJsonPath("$.resource_external_id", equalTo("fca65e80d2293ee3bf158a0d12")));
+        assertThat(disputeCreatedJson, hasJsonPath("$.resource_external_id", equalTo(disputeExternalId)));
         assertThat(disputeCreatedJson, hasJsonPath("$.timestamp", equalTo("2022-01-19T07:59:20.000000Z")));
         assertThat(disputeCreatedJson, hasJsonPath("$.live", equalTo(true)));
         assertThat(disputeCreatedJson, hasJsonPath("$.parent_resource_external_id", equalTo("payment-external-id")));

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java
@@ -27,13 +27,14 @@ public class DisputeEvidenceSubmittedTest {
                 "pi_123456789", "under_review", 6500L, "fradulent",
                 1642579160L, null, null, null, true);
 
-        DisputeEvidenceSubmitted disputeEvidenceSubmitted = from(stripeDisputeData.getId(), toUTCZonedDateTime(1642579160L), transaction);
+        String disputeExternalId = "fca65e80d2293ee3bf158a0d12";
+        DisputeEvidenceSubmitted disputeEvidenceSubmitted = from(disputeExternalId, toUTCZonedDateTime(1642579160L), transaction);
 
         String disputeEvidenceSubmittedJson = disputeEvidenceSubmitted.toJsonString();
         assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.event_type", equalTo("DISPUTE_EVIDENCE_SUBMITTED")));
         assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.resource_type", equalTo("dispute")));
         assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.service_id", equalTo("service-id")));
-        assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.resource_external_id", equalTo("fca65e80d2293ee3bf158a0d12")));
+        assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.resource_external_id", equalTo(disputeExternalId)));
         assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.timestamp", equalTo("2022-01-19T07:59:20.000000Z")));
         assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.live", equalTo(true)));
         assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.parent_resource_external_id", equalTo("payment-external-id")));

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java
@@ -3,9 +3,9 @@ package uk.gov.pay.connector.events.model.dispute;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 import uk.gov.pay.connector.queue.tasks.dispute.EvidenceDetails;
-import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
 import java.util.List;
 
@@ -34,14 +34,15 @@ class DisputeLostTest {
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
                 "pi_123456789", "lost", 6500L, "fradulent", 1642579160L,
                 List.of(balanceTransaction), null, null, true);
+        String disputeExternalId = "fca65e80d2293ee3bf158a0d12";
 
-        DisputeLost disputeLost = from(stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, true);
+        DisputeLost disputeLost = from(disputeExternalId, stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, true);
 
         String disputeLostJson = disputeLost.toJsonString();
         assertThat(disputeLostJson, hasJsonPath("$.event_type", equalTo("DISPUTE_LOST")));
         assertThat(disputeLostJson, hasJsonPath("$.resource_type", equalTo("dispute")));
         assertThat(disputeLostJson, hasJsonPath("$.service_id", equalTo("service-id")));
-        assertThat(disputeLostJson, hasJsonPath("$.resource_external_id", equalTo("fca65e80d2293ee3bf158a0d12")));
+        assertThat(disputeLostJson, hasJsonPath("$.resource_external_id", equalTo(disputeExternalId)));
         assertThat(disputeLostJson, hasJsonPath("$.timestamp", equalTo("2022-01-19T07:59:20.000000Z")));
         assertThat(disputeLostJson, hasJsonPath("$.live", equalTo(true)));
         assertThat(disputeLostJson, hasJsonPath("$.parent_resource_external_id", equalTo("payment-external-id")));
@@ -65,14 +66,15 @@ class DisputeLostTest {
         StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
                 "pi_123456789", "lost", 6500L, "fradulent", 1642579160L,
                 List.of(balanceTransaction), null, null, false);
+        String disputeExternalId = "fca65e80d2293ee3bf158a0d12";
 
-        DisputeLost disputeLost = from(stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, false);
+        DisputeLost disputeLost = from(disputeExternalId, stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, false);
 
         String disputeLostJson = disputeLost.toJsonString();
         assertThat(disputeLostJson, hasJsonPath("$.event_type", equalTo("DISPUTE_LOST")));
         assertThat(disputeLostJson, hasJsonPath("$.resource_type", equalTo("dispute")));
         assertThat(disputeLostJson, hasJsonPath("$.service_id", equalTo("service-id")));
-        assertThat(disputeLostJson, hasJsonPath("$.resource_external_id", equalTo("fca65e80d2293ee3bf158a0d12")));
+        assertThat(disputeLostJson, hasJsonPath("$.resource_external_id", equalTo(disputeExternalId)));
         assertThat(disputeLostJson, hasJsonPath("$.timestamp", equalTo("2022-01-19T07:59:20.000000Z")));
         assertThat(disputeLostJson, hasJsonPath("$.live", equalTo(true)));
         assertThat(disputeLostJson, hasJsonPath("$.parent_resource_external_id", equalTo("payment-external-id")));
@@ -100,7 +102,7 @@ class DisputeLostTest {
                 balanceTransaction2), evidenceDetails, null, false);
 
         var thrown = assertThrows(RuntimeException.class, () ->
-                DisputeLost.from(stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, true));
+                DisputeLost.from("a-dispute-external-id", stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, true));
         assertThat(thrown.getMessage(), is("Dispute data has too many balance_transactions"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java
@@ -27,13 +27,14 @@ public class DisputeWonTest {
                 "pi_123456789", "won", 6500L, "fradulent", 1642579160L,
                 null, null, null, false);
 
-        DisputeWon disputeWon = from(stripeDisputeData.getId(), toUTCZonedDateTime(1642579160L), transaction);
+        String disputeExternalId = "fca65e80d2293ee3bf158a0d12";
+        DisputeWon disputeWon = from(disputeExternalId, toUTCZonedDateTime(1642579160L), transaction);
 
         String disputeWonJson = disputeWon.toJsonString();
         assertThat(disputeWonJson, hasJsonPath("$.event_type", equalTo("DISPUTE_WON")));
         assertThat(disputeWonJson, hasJsonPath("$.resource_type", equalTo("dispute")));
         assertThat(disputeWonJson, hasJsonPath("$.service_id", equalTo("service-id")));
-        assertThat(disputeWonJson, hasJsonPath("$.resource_external_id", equalTo("fca65e80d2293ee3bf158a0d12")));
+        assertThat(disputeWonJson, hasJsonPath("$.resource_external_id", equalTo(disputeExternalId)));
         assertThat(disputeWonJson, hasJsonPath("$.timestamp", equalTo("2022-01-19T07:59:20.000000Z")));
         assertThat(disputeWonJson, hasJsonPath("$.live", equalTo(true)));
         assertThat(disputeWonJson, hasJsonPath("$.parent_resource_external_id", equalTo("payment-external-id")));


### PR DESCRIPTION
- Use MDC to store common logging fields
- Generate the dispute external ID in one place in the StripeWebhookTaskHandler rather than in the constructor for each event. This is to make is slightly clearer where this comes from and reduce duplication. This also allows us to add it to the MDC.

## Review notes

- Hiding whitespace diff will make this easier to review