### PR TITLE
PP-9671 Update payment when dispute is raised

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -154,7 +154,98 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "423e3dd3782e3527b4f9af75dd9faf9ebbb7889c",
         "is_verified": false,
-        "line_number": 90
+        "line_number": 362
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
+        "is_verified": false,
+        "line_number": 775
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
+        "is_verified": false,
+        "line_number": 3006
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
+        "is_verified": false,
+        "line_number": 3374
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
+        "is_verified": false,
+        "line_number": 3709
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
+        "is_verified": false,
+        "line_number": 3757
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
+        "is_verified": false,
+        "line_number": 4366
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
+        "is_verified": false,
+        "line_number": 4433
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
+        "is_verified": false,
+        "line_number": 4455
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
+        "is_verified": false,
+        "line_number": 4634
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
+        "is_verified": false,
+        "line_number": 4637
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
+        "is_verified": false,
+        "line_number": 4640
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
+        "is_verified": false,
+        "line_number": 5225
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
+        "is_verified": false,
+        "line_number": 5236
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -181,7 +272,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java",
         "hashed_secret": "423e3dd3782e3527b4f9af75dd9faf9ebbb7889c",
         "is_verified": false,
-        "line_number": 91
+        "line_number": 94
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java": [
@@ -892,5 +983,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-20T17:12:47Z"
+  "generated_at": "2022-07-26T09:13:55Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -281,6 +281,33 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Missing required fields
       summary: Create an agreement
+  /v1/api/accounts/{accountId}/agreements/{agreementId}/cancel:
+    post:
+      operationId: cancelAgreement
+      parameters:
+      - description: Gateway account ID
+        example: 1
+        in: path
+        name: accountId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - in: path
+        name: agreementId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgreementCancelRequest'
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
   /v1/api/accounts/{accountId}/charges:
     post:
       operationId: createNewCharge
@@ -2340,6 +2367,13 @@ components:
         postcode:
           type: string
           example: AB1 2CD
+    AgreementCancelRequest:
+      type: object
+      properties:
+        user_email:
+          type: string
+        user_external_id:
+          type: string
     AgreementCreateRequest:
       type: object
       properties:
@@ -2862,6 +2896,7 @@ components:
           - CAPTURE SUBMITTED
           - CAPTURE ERROR
           - CAPTURE QUEUED
+          - AUTHORISATION USER NOT PRESENT QUEUED
           - EXPIRE CANCEL READY
           - EXPIRE CANCEL FAILED
           - EXPIRE CANCEL SUBMITTED
@@ -3006,6 +3041,7 @@ components:
           - CAPTURE SUBMITTED
           - CAPTURE ERROR
           - CAPTURE QUEUED
+          - AUTHORISATION USER NOT PRESENT QUEUED
           - EXPIRE CANCEL READY
           - EXPIRE CANCEL FAILED
           - EXPIRE CANCEL SUBMITTED
@@ -3063,6 +3099,7 @@ components:
           - CAPTURE SUBMITTED
           - CAPTURE ERROR
           - CAPTURE QUEUED
+          - AUTHORISATION USER NOT PRESENT QUEUED
           - EXPIRE CANCEL READY
           - EXPIRE CANCEL FAILED
           - EXPIRE CANCEL SUBMITTED
@@ -3350,6 +3387,7 @@ components:
           - GENERIC
           - REFUND_NOT_AVAILABLE
           - REFUND_AMOUNT_AVAILABLE_MISMATCH
+          - REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE
           - ZERO_AMOUNT_NOT_ALLOWED
           - MOTO_NOT_ALLOWED
           - CANCEL_CHARGE_FAILURE_DUE_TO_CONFLICTING_TERMINAL_STATE_AT_GATEWAY_CHARGE_STATE_FORCIBLY_TRANSITIONED
@@ -3368,6 +3406,7 @@ components:
           - AUTHORISATION_ERROR
           - AUTHORISATION_TIMEOUT
           - AGREEMENT_NOT_ACTIVE
+          - INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT
           - MISSING_MANDATORY_ATTRIBUTE
           - UNEXPECTED_ATTRIBUTE
           - ACCOUNT_DISABLED
@@ -4510,6 +4549,7 @@ components:
           - CAPTURE SUBMITTED
           - CAPTURE ERROR
           - CAPTURE QUEUED
+          - AUTHORISATION USER NOT PRESENT QUEUED
           - EXPIRE CANCEL READY
           - EXPIRE CANCEL FAILED
           - EXPIRE CANCEL SUBMITTED
@@ -4555,6 +4595,7 @@ components:
           - CAPTURE SUBMITTED
           - CAPTURE ERROR
           - CAPTURE QUEUED
+          - AUTHORISATION USER NOT PRESENT QUEUED
           - EXPIRE CANCEL READY
           - EXPIRE CANCEL FAILED
           - EXPIRE CANCEL SUBMITTED
@@ -4655,6 +4696,7 @@ components:
           enum:
           - CREATED
           - ACTIVE
+          - CANCELLED
           - EXPIRED
     PaymentOutcome:
       type: object

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDisputedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDisputedEventDetails.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.events.eventdetails.charge;
+
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+import java.util.Objects;
+
+public class PaymentDisputedEventDetails extends EventDetails {
+    private static final boolean disputed = true;
+    
+    public boolean isDisputed() {
+        return disputed;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(disputed);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/RefundAvailabilityUpdatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/RefundAvailabilityUpdatedEventDetails.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 
 import java.util.List;
+import java.util.Objects;
 
 public class RefundAvailabilityUpdatedEventDetails extends EventDetails {
     private Long amountAvailable;
@@ -27,6 +28,10 @@ public class RefundAvailabilityUpdatedEventDetails extends EventDetails {
                 availability.getStatus()
         );
     }
+    
+    public static RefundAvailabilityUpdatedEventDetails from(ExternalChargeRefundAvailability availability) {
+        return new RefundAvailabilityUpdatedEventDetails(null, null, availability.getStatus());
+    }
 
     public Long getRefundAmountAvailable() {
         return amountAvailable;
@@ -38,5 +43,18 @@ public class RefundAvailabilityUpdatedEventDetails extends EventDetails {
 
     public String getRefundStatus() {
         return availability;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RefundAvailabilityUpdatedEventDetails that = (RefundAvailabilityUpdatedEventDetails) o;
+        return Objects.equals(amountAvailable, that.amountAvailable) && Objects.equals(amountRefunded, that.amountRefunded) && Objects.equals(availability, that.availability);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amountAvailable, amountRefunded, availability);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDisputed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDisputed.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.events.eventdetails.charge.PaymentDisputedEventDetails;
+
+import java.time.ZonedDateTime;
+
+public class PaymentDisputed extends PaymentEvent {
+    private PaymentDisputed(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+    
+    public static PaymentDisputed from(LedgerTransaction ledgerTransaction, ZonedDateTime disputeCreatedDate) {
+        return new PaymentDisputed(
+                ledgerTransaction.getServiceId(),
+                ledgerTransaction.getLive(),
+                ledgerTransaction.getTransactionId(),
+                new PaymentDisputedEventDetails(),
+                disputeCreatedDate
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.events.model.charge;
 
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
 
 import java.time.ZonedDateTime;
@@ -8,5 +10,11 @@ public class RefundAvailabilityUpdated extends PaymentEvent {
 
     public RefundAvailabilityUpdated(String serviceId, boolean live, String resourceExternalId, RefundAvailabilityUpdatedEventDetails eventDetails, ZonedDateTime timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static RefundAvailabilityUpdated from(LedgerTransaction ledgerTransaction, ExternalChargeRefundAvailability externalChargeRefundAvailability, ZonedDateTime timestamp) {
+        var eventDetails = RefundAvailabilityUpdatedEventDetails.from(externalChargeRefundAvailability);
+        return new RefundAvailabilityUpdated(ledgerTransaction.getServiceId(), ledgerTransaction.getLive(),
+                ledgerTransaction.getTransactionId(), eventDetails, timestamp);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDisputedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDisputedTest.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+
+import java.time.ZonedDateTime;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
+
+class PaymentDisputedTest {
+
+    @Test
+    void shouldBuildAndSerialiseEventDetailsCorrectly() throws JsonProcessingException {
+        LedgerTransaction transaction = aValidLedgerTransaction()
+                .withExternalId("payment-external-id")
+                .withGatewayAccountId(1234L)
+                .withGatewayTransactionId("payment-intent-id")
+                .withServiceId("service-id")
+                .isLive(true)
+                .build();
+        String timestampString = "2022-01-19T07:59:20.000000Z";
+        ZonedDateTime timestamp = ZonedDateTime.parse(timestampString);
+        
+        var paymentDisputed = PaymentDisputed.from(transaction, timestamp);
+        
+        String paymentDisputedJson = paymentDisputed.toJsonString();
+        assertThat(paymentDisputedJson, hasJsonPath("$.event_type", equalTo("PAYMENT_DISPUTED")));
+        assertThat(paymentDisputedJson, hasJsonPath("$.resource_type", IsEqual.equalTo("payment")));
+        assertThat(paymentDisputedJson, hasJsonPath("$.service_id", IsEqual.equalTo("service-id")));
+        assertThat(paymentDisputedJson, hasJsonPath("$.resource_external_id", IsEqual.equalTo("payment-external-id")));
+        assertThat(paymentDisputedJson, hasJsonPath("$.timestamp", IsEqual.equalTo("2022-01-19T07:59:20.000000Z")));
+        assertThat(paymentDisputedJson, hasJsonPath("$.live", IsEqual.equalTo(true)));
+
+        assertThat(paymentDisputedJson, hasJsonPath("$.event_details.disputed", IsEqual.equalTo(true)));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
@@ -40,6 +40,4 @@ public class RefundAvailabilityUpdatedTest {
         assertThat(event, hasJsonPath("$.event_details.refund_amount_available", equalTo(500)));
         assertThat(event, hasJsonPath("$.event_details.refund_amount_refunded", equalTo(0)));
     }
-
-
 }


### PR DESCRIPTION
When we get a webhook informing us that a dispute has been raised, emit the following events to ledger for the payment:

PAYMENT_DISPUTED - this has event_details with a `disputed` field set to true
REFUND_AVAILABILITY_UPDATED - the event_details will only contain the `refund_status` field set to "unavailable"

This will not affect the refund availability if the payment still exists in connector, as this is calculated when requested rather than stored.