### PR TITLE
PP-9545 Use commons enums for recurring payment events data

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByService.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.time.ZonedDateTime;
 
@@ -17,19 +18,19 @@ public class AgreementCancelledByService extends AgreementEvent {
                 agreement.getServiceId(),
                 agreement.getGatewayAccount().isLive(),
                 agreement.getExternalId(),
-                new AgreementCancelledByServiceEventDetails(PaymentInstrumentStatus.CANCELLED),
+                new AgreementCancelledByServiceEventDetails(AgreementStatus.CANCELLED),
                 timestamp
         );
     }
 
     static class AgreementCancelledByServiceEventDetails extends EventDetails {
-        private final String status;
+        private final AgreementStatus status;
 
-        public AgreementCancelledByServiceEventDetails(PaymentInstrumentStatus status) {
-            this.status = String.valueOf(status);
+        public AgreementCancelledByServiceEventDetails(AgreementStatus status) {
+            this.status = status;
         }
 
-        public String getStatus() {
+        public AgreementStatus getStatus() {
             return status;
         }
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByUser.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.agreement.model.AgreementCancelRequest;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -19,7 +20,7 @@ public class AgreementCancelledByUser extends AgreementEvent {
                 agreement.getServiceId(),
                 agreement.getGatewayAccount().isLive(),
                 agreement.getExternalId(),
-                new AgreementCancelledByUserEventDetails(agreementCancelRequest, PaymentInstrumentStatus.CANCELLED),
+                new AgreementCancelledByUserEventDetails(agreementCancelRequest, AgreementStatus.CANCELLED),
                 timestamp
         );
     }
@@ -27,12 +28,12 @@ public class AgreementCancelledByUser extends AgreementEvent {
     static class AgreementCancelledByUserEventDetails extends EventDetails {
         private final String userExternalId;
         private final String userEmail;
-        private final String status;
+        private final AgreementStatus status;
 
-        public AgreementCancelledByUserEventDetails(AgreementCancelRequest agreementCancelRequest, PaymentInstrumentStatus status) {
+        public AgreementCancelledByUserEventDetails(AgreementCancelRequest agreementCancelRequest, AgreementStatus status) {
             this.userExternalId = agreementCancelRequest.getUserExternalId();
             this.userEmail = agreementCancelRequest.getUserEmail();
-            this.status = String.valueOf(status);
+            this.status = status;
         }
 
         public String getUserExternalId() {
@@ -43,7 +44,7 @@ public class AgreementCancelledByUser extends AgreementEvent {
             return userEmail;
         }
 
-        public String getStatus() {
+        public AgreementStatus getStatus() {
             return status;
         }
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCreated.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -23,7 +24,7 @@ public class AgreementCreated extends AgreementEvent {
                         agreement.getReference(),
                         agreement.getDescription(),
                         agreement.getUserIdentifier(),
-                        PaymentInstrumentStatus.CREATED
+                        AgreementStatus.CREATED
                 ),
                 ZonedDateTime.ofInstant(agreement.getCreatedDate(), ZoneOffset.UTC)
         );
@@ -34,17 +35,17 @@ public class AgreementCreated extends AgreementEvent {
         private final String reference;
         private final String description;
         private final String userIdentifier;
-        private final String status;
+        private final AgreementStatus status;
 
-        public AgreementCreatedEventDetails(Long gatewayAccountId, String reference, String description, String userIdentifier, PaymentInstrumentStatus status) {
+        public AgreementCreatedEventDetails(Long gatewayAccountId, String reference, String description, String userIdentifier, AgreementStatus status) {
             this.gatewayAccountId = String.valueOf(gatewayAccountId);
             this.reference = reference;
             this.description = description;
             this.userIdentifier = userIdentifier;
-            this.status = String.valueOf(status);
+            this.status = status;
         }
 
-        public String getStatus() {
+        public AgreementStatus getStatus() {
             return status;
         }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementSetup.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementSetup.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
 import java.time.ZonedDateTime;
 import java.util.Objects;
@@ -20,27 +21,27 @@ public class AgreementSetup extends AgreementEvent {
                 agreement.getServiceId(),
                 agreement.getGatewayAccount().isLive(),
                 agreement.getExternalId(),
-                new AgreementSetupEventDetails(agreement.getPaymentInstrument().orElse(null), PaymentInstrumentStatus.ACTIVE),
+                new AgreementSetupEventDetails(agreement.getPaymentInstrument().orElse(null), AgreementStatus.ACTIVE),
                 timestamp
         );
     }
 
     static class AgreementSetupEventDetails extends EventDetails {
         private String paymentInstrumentExternalId;
-        private String status;
+        private AgreementStatus status;
 
-        public AgreementSetupEventDetails(PaymentInstrumentEntity paymentInstrumentEntity, PaymentInstrumentStatus status) {
+        public AgreementSetupEventDetails(PaymentInstrumentEntity paymentInstrumentEntity, AgreementStatus status) {
             this.paymentInstrumentExternalId = Optional.ofNullable(paymentInstrumentEntity)
                     .map(PaymentInstrumentEntity::getExternalId)
                     .orElse(null);
-            this.status = String.valueOf(status);
+            this.status = status;
         }
 
         public String getPaymentInstrumentExternalId() {
             return paymentInstrumentExternalId;
         }
 
-        public String getStatus() {
+        public AgreementStatus getStatus() {
             return status;
         }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
@@ -1,10 +1,13 @@
 package uk.gov.pay.connector.events.model.charge;
 
+import uk.gov.pay.connector.cardtype.model.domain.CardType;
+import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
+import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -21,7 +24,7 @@ public class PaymentInstrumentCreated extends PaymentInstrumentEvent {
                 gatewayAccount.getServiceId(),
                 gatewayAccount.isLive(),
                 paymentInstrument.getExternalId(),
-                new PaymentInstrumentCreatedDetails(paymentInstrument),
+                new PaymentInstrumentCreatedDetails(paymentInstrument, PaymentInstrumentType.CARD),
                 ZonedDateTime.ofInstant(paymentInstrument.getCreatedDate(), ZoneOffset.UTC)
         );
     }
@@ -35,16 +38,21 @@ public class PaymentInstrumentCreated extends PaymentInstrumentEvent {
         private String addressCounty;
         private String addressCountry;
         private String lastDigitsCardNumber;
+        private String firstDigitsCardNumber;
         private String expiryDate;
-        private String cardBrand; 
+        private String cardBrand;
+        private String cardType;
+        private PaymentInstrumentType type;
 
-        public PaymentInstrumentCreatedDetails(PaymentInstrumentEntity paymentInstrument) {
+        public PaymentInstrumentCreatedDetails(PaymentInstrumentEntity paymentInstrument, PaymentInstrumentType type) {
             Optional.ofNullable(paymentInstrument.getCardDetails())
                     .ifPresent(cardDetails -> {
                         this.cardholderName = cardDetails.getCardHolderName();
                         this.lastDigitsCardNumber = Optional.ofNullable(cardDetails.getLastDigitsCardNumber()).map(LastDigitsCardNumber::toString).orElse(null);
+                        this.firstDigitsCardNumber = Optional.ofNullable(cardDetails.getFirstDigitsCardNumber()).map(FirstDigitsCardNumber::toString).orElse(null);
                         this.expiryDate = Optional.ofNullable(cardDetails.getExpiryDate()).map(CardExpiryDate::toString).orElse(null);
                         this.cardBrand = cardDetails.getCardBrand();
+                        this.cardType = Optional.ofNullable(cardDetails.getCardType()).map(CardType::name).orElse(null);
                         
                         cardDetails.getBillingAddress().ifPresent(billingAddress -> {
                             this.addressLine1 = billingAddress.getLine1();
@@ -55,6 +63,7 @@ public class PaymentInstrumentCreated extends PaymentInstrumentEvent {
                             this.addressCountry = billingAddress.getCountry();        
                         });
                     });
+            this.type = type;
         }
 
         public String getCardholderName() {
@@ -95,6 +104,10 @@ public class PaymentInstrumentCreated extends PaymentInstrumentEvent {
 
         public String getCardBrand() {
             return cardBrand;
+        }
+
+        public PaymentInstrumentType getType() {
+            return type;
         }
     }
 }


### PR DESCRIPTION
Use `AgreeementStatus` and `PaymentInstrumentType` enums from java
commons in favour of previous local Connector enum workarounds.

Adds missing first digits and card type to payment instrument payload.

Adds a fixed `CARD` payment instrument type for payment instrument
created events. As this is the only connector creating payment
instruments this will be the only value populated for now.
