### PR TITLE
PP-9671 Filter ledger refunds query

### DIFF
--- a/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
@@ -76,7 +76,8 @@ public class LedgerService {
         var uri = UriBuilder
                 .fromPath(ledgerUrl)
                 .path(format("/v1/transaction/%s/transaction", paymentExternalId))
-                .queryParam("gateway_account_id", gatewayAccountId);
+                .queryParam("gateway_account_id", gatewayAccountId)
+                .queryParam("transaction_type", "REFUND");
 
         Response response = getResponse(uri);
 

--- a/src/test/resources/pacts/connector-ledger-get-refunds-for-payment.json
+++ b/src/test/resources/pacts/connector-ledger-get-refunds-for-payment.json
@@ -10,7 +10,7 @@
       "description": "get a refunds for payment request",
       "providerStates": [
         {
-          "name": "refund transactions for a transaction exist",
+          "name": "refund and dispute transactions for a transaction exist",
           "params": {
             "gateway_account_id": "3",
             "transaction_external_id": "650516the13q5jpfo435f1m1fm"
@@ -23,6 +23,9 @@
         "query": {
           "gateway_account_id": [
             "3"
+          ],
+          "transaction_type": [
+            "REFUND"
           ]
         }
       },


### PR DESCRIPTION
A ledger transaction can now have child transactions that have a type other than "REFUND" since we introduced disputes.

When making a request to ledger to get refunds for a payment using the `/v1/transaction/{parentTransactionExternalId}/transaction` endpoint, provide the query parameter "transaction_type=REFUND" so that only refund transactions are returned.