### PR TITLE
PP-9545 Accessors for new payment instrument fields

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
@@ -109,5 +109,13 @@ public class PaymentInstrumentCreated extends PaymentInstrumentEvent {
         public PaymentInstrumentType getType() {
             return type;
         }
+
+        public String getFirstDigitsCardNumber() {
+            return firstDigitsCardNumber;
+        }
+
+        public String getCardType() {
+            return cardType;
+        }
     }
 }


### PR DESCRIPTION
The default setup for event details are to have private attributes, jackson requires an accessor to serialise the event details appropriately. 