### PR TITLE
PP-9671 Add magic cardholder name to skip submitting dispute evidence

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeFullTestCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeFullTestCardNumbers.java
@@ -8,8 +8,12 @@ public class StripeFullTestCardNumbers {
 
     private static final String STRIPE_LOSING_EVIDENCE_CARD_NUMBER = "4000000000000259";
     private static final String STRIPE_WINNING_EVIDENCE_CARD_NUMBER = "4000000000002685";
+    private static final String SKIP_SUBMITTING_EVIDENCE_CARDHOLDER_NAME = "skip_evidence";
 
-    public static Optional<String> getSubmitTestDisputeEvidenceText(String firstSixDigits, String lastFourDigits) {
+    public static Optional<String> getSubmitTestDisputeEvidenceText(String firstSixDigits, String lastFourDigits, String cardholderName) {
+        if (SKIP_SUBMITTING_EVIDENCE_CARDHOLDER_NAME.equals(cardholderName)) {
+            return Optional.empty();
+        }
         if (StringUtils.left(STRIPE_LOSING_EVIDENCE_CARD_NUMBER, 6).equals(firstSixDigits)) {
             if (StringUtils.right(STRIPE_LOSING_EVIDENCE_CARD_NUMBER, 4).equals(lastFourDigits)) {
                 return Optional.of("losing_evidence");

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
@@ -200,7 +200,7 @@ public class StripeWebhookTaskHandler {
         }
         Optional<String> evidenceText =
                 StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(transaction.getCardDetails().getFirstDigitsCardNumber(),
-                        transaction.getCardDetails().getLastDigitsCardNumber());
+                        transaction.getCardDetails().getLastDigitsCardNumber(), transaction.getCardDetails().getCardholderName());
         evidenceText.ifPresent(submitEvidenceText -> {
             try {
                 StripeDisputeData dispute = stripePaymentProvider.submitTestDisputeEvidence(stripeDisputeData.getId(),

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeFullTestCardNumbersTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeFullTestCardNumbersTest.java
@@ -11,21 +11,34 @@ class StripeFullTestCardNumbersTest {
 
     @Test
     void shouldReturnLosingEvidenceText() {
-        var evidenceText = StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(firstSixDigits, "0259");
+        var evidenceText = StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(firstSixDigits, "0259", "A cardholder name");
         assertThat(evidenceText.isPresent(), is(true));
         assertThat(evidenceText.get(), is("losing_evidence"));
     }
 
     @Test
     void shouldReturnWinningEvidenceText() {
-        var evidenceText = StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(firstSixDigits, "2685");
+        var evidenceText = StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(firstSixDigits, "2685", "A cardholder name");
+        assertThat(evidenceText.isPresent(), is(true));
+        assertThat(evidenceText.get(), is("winning_evidence"));
+    }
+
+    @Test
+    void shouldHandleNullCardholderName() {
+        var evidenceText = StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(firstSixDigits, "2685", null);
         assertThat(evidenceText.isPresent(), is(true));
         assertThat(evidenceText.get(), is("winning_evidence"));
     }
 
     @Test
     void shouldReturnEmpty_whenLastFourDigitsDoNotMatch() {
-        var evidenceText = StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(firstSixDigits, "1976");
+        var evidenceText = StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(firstSixDigits, "1976", "A cardholder name");
+        assertThat(evidenceText.isPresent(), is(false));
+    }
+    
+    @Test
+    void shouldReturnEmpty_whenCardholderNameMatchesSkipEvidenceReservedValue() {
+        var evidenceText = StripeFullTestCardNumbers.getSubmitTestDisputeEvidenceText(firstSixDigits, "2685", "skip_evidence");
         assertThat(evidenceText.isPresent(), is(false));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
@@ -456,7 +456,7 @@ public class StripeWebhookTaskHandlerTest {
                 .withExternalId("external-id")
                 .withGatewayAccountId(1000L)
                 .withGatewayTransactionId("gateway-transaction-id")
-                .withCardDetails(new CardDetails(null, null, null,
+                .withCardDetails(new CardDetails("John Doe", null, null,
                         "0259", "400000", null, null))
                 .isLive(false)
                 .build();


### PR DESCRIPTION
Stripe provide 2 test card numbers which will create a dispute as soon as they are captured. On receiving the dispute created webhook, we automatically submit either winning or losing evidence to Stripe for these card numbers.

So that we can internally test the state of a payment when the dispute is still open, add a magic cardholder name: 'skip_evidence', which when used will cause evidence not to be automatically uploaded. This is necessary as there is not a different card number we can use to create the dispute.