### PR TITLE
PP-9671 Adjust event date for refund availability event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
@@ -148,7 +148,7 @@ public class StripeWebhookTaskHandler {
                         if (disputeStatus == WON) {
                             disputeEvent = DisputeWon.from(disputeExternalId, disputeClosedEventTimestamp, transaction);
                             Charge charge = Charge.from(transaction);
-                            RefundAvailabilityUpdated refundAvailabilityUpdatedEvent = chargeService.createRefundAvailabilityUpdatedEvent(charge, stripeNotification.getCreated());
+                            RefundAvailabilityUpdated refundAvailabilityUpdatedEvent = chargeService.createRefundAvailabilityUpdatedEvent(charge, disputeClosedEventTimestamp);
                             emitEvent(refundAvailabilityUpdatedEvent);
                         } else if (disputeStatus == LOST) {
                             disputeEvent = handleDisputeLost(stripeDisputeData, transaction, disputeExternalId, disputeClosedEventTimestamp);


### PR DESCRIPTION
For Stripe test payments, we add on a second to the dispute won and lost
events to ensure the events appear in the correct order in the payment
timeline - as Stripe sends the webhook for this at the same time as the
evidence submitted webhook.

When the dispute is won, we emit a REFUND_AVAILABILITY_UPDATED event.
Make this use the same timestamp as the DISPUTE_WON event so it is
easier to associate these.

Add a test to check that the events we emit when a dispute is won for a
test payment use the expected timestamps.