### PR TITLE
PP-9292 Add queue message provider tests with adminusers as consumer

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/AdminusersQueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/AdminusersQueueMessageContractTest.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.connector.pact;
+
+import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junit.PactRunner;
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
+import org.junit.runner.RunWith;
+
+@RunWith(PactRunner.class)
+@Provider("connector")
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},
+        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
+        consumers = {"adminusers"})
+@IgnoreNoPactsToVerify
+public class AdminusersQueueMessageContractTest extends QueueMessageContractTest {
+}

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTestSuite.java
@@ -13,7 +13,8 @@ public class ContractTestSuite {
     public static TestSuite suite() {
         ImmutableSetMultimap<String, JUnit4TestAdapter> consumerToJUnitTest = ImmutableSetMultimap.of(
                 "frontend", new JUnit4TestAdapter(FrontendContractTest.class),
-                "ledger", new JUnit4TestAdapter(QueueMessageContractTest.class),
+                "ledger", new JUnit4TestAdapter(LedgerQueueMessageContractTest.class),
+                "adminusers", new JUnit4TestAdapter(AdminusersQueueMessageContractTest.class),
                 "publicapi", new JUnit4TestAdapter(PublicApiContractTest.class),
                 "selfservice", new JUnit4TestAdapter(SelfServiceContractTest.class));
         return CreateTestSuite.create(consumerToJUnitTest);

--- a/src/test/java/uk/gov/pay/connector/pact/LedgerQueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/LedgerQueueMessageContractTest.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.connector.pact;
+
+import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junit.PactRunner;
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
+import org.junit.runner.RunWith;
+
+@RunWith(PactRunner.class)
+@Provider("connector")
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},
+        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
+        consumers = {"ledger"})
+@IgnoreNoPactsToVerify
+public class LedgerQueueMessageContractTest extends QueueMessageContractTest {
+}

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -1,17 +1,11 @@
 package uk.gov.pay.connector.pact;
 
 import au.com.dius.pact.provider.PactVerifyProvider;
-import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
-import au.com.dius.pact.provider.junit.PactRunner;
-import au.com.dius.pact.provider.junit.Provider;
-import au.com.dius.pact.provider.junit.loader.PactBroker;
-import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
 import au.com.dius.pact.provider.junit.target.AmqpTarget;
 import au.com.dius.pact.provider.junit.target.Target;
 import au.com.dius.pact.provider.junit.target.TestTarget;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.runner.RunWith;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
 import uk.gov.pay.connector.charge.model.domain.Charge;
@@ -80,12 +74,6 @@ import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 import static uk.gov.service.payments.commons.model.Source.CARD_API;
 import static uk.gov.service.payments.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 
-@RunWith(PactRunner.class)
-@Provider("connector")
-@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},
-        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
-        consumers = {"ledger"})
-@IgnoreNoPactsToVerify
 public class QueueMessageContractTest {
 
     @TestTarget


### PR DESCRIPTION
Add configuration to run the queue message contract tests that test the
contract for the event messages sent to ledger and then received by
adminusers after they are sent on via SNS.