### PR TITLE
PP-9498 Use correct error identifier for incorrect auth mode

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/exception/AgreementIdWithIncompatibleOtherOptionsException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/AgreementIdWithIncompatibleOtherOptionsException.java
@@ -2,12 +2,10 @@ package uk.gov.pay.connector.charge.exception;
 
 import javax.ws.rs.WebApplicationException;
 
-import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
-
 public class AgreementIdWithIncompatibleOtherOptionsException extends WebApplicationException {
 
     public AgreementIdWithIncompatibleOtherOptionsException(String message) {
-        super(badRequestResponse(message));
+        super(message);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/charge/exception/AuthorisationModeAgreementRequiresAgreementIdException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/AuthorisationModeAgreementRequiresAgreementIdException.java
@@ -2,12 +2,10 @@ package uk.gov.pay.connector.charge.exception;
 
 import javax.ws.rs.WebApplicationException;
 
-import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
-
 public class AuthorisationModeAgreementRequiresAgreementIdException extends WebApplicationException {
 
     public AuthorisationModeAgreementRequiresAgreementIdException(String message) {
-        super(badRequestResponse(message));
+        super(message);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/charge/exception/IncorrectAuthorisationModeForSavePaymentToAgreementException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/IncorrectAuthorisationModeForSavePaymentToAgreementException.java
@@ -2,12 +2,10 @@ package uk.gov.pay.connector.charge.exception;
 
 import javax.ws.rs.WebApplicationException;
 
-import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
-
 public class IncorrectAuthorisationModeForSavePaymentToAgreementException extends WebApplicationException {
 
     public IncorrectAuthorisationModeForSavePaymentToAgreementException() {
-        super(badRequestResponse("If [save_payment_instrument_to_agreement] is true, [authorisation_mode] must be [web]"));
+        super("If [save_payment_instrument_to_agreement] is true, [authorisation_mode] must be [web]");
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/charge/exception/SavePaymentInstrumentToAgreementRequiresAgreementIdException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/SavePaymentInstrumentToAgreementRequiresAgreementIdException.java
@@ -2,12 +2,10 @@ package uk.gov.pay.connector.charge.exception;
 
 import javax.ws.rs.WebApplicationException;
 
-import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
-
 public class SavePaymentInstrumentToAgreementRequiresAgreementIdException extends WebApplicationException {
 
     public SavePaymentInstrumentToAgreementRequiresAgreementIdException() {
-        super(badRequestResponse("If [save_payment_instrument_to_agreement] is true, [agreement_id] must be specified"));
+        super("If [save_payment_instrument_to_agreement] is true, [agreement_id] must be specified");
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
@@ -29,16 +29,14 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static io.restassured.http.ContentType.JSON;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_USER_NOT_PRESENT_QUEUED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -482,7 +480,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
                 .statusCode(SC_BAD_REQUEST)
                 .contentType(JSON)
                 .body("message", contains("If [save_payment_instrument_to_agreement] is true, [authorisation_mode] must be [web]"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT.toString()));
     }
 
     @Test


### PR DESCRIPTION
When we receive a create charge request containing `"authorisation_mode": "agreement"`, `"save_payment_instrument_to_agreement": true` and an `"agreement_id"`, we return a 400 error (because
`"save_payment_instrument_to_agreement": true` cannot be used with `"authorisation_mode": "agreement"`).

This 400 response should have the error identifier `INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT` but it was actually using `GENERIC` because the `IncorrectAuthorisationModeForSavePaymentToAgreementException` constructor was directly calling `RequestUtil.badRequestResponse(String)` — which always constructs a 400 response with a `GENERIC` error identifier — rather than allowing the registered exception mapper for `IncorrectAuthorisationModeForSavePaymentToAgreementException` to do its thing.

In addition to fixing `IncorrectAuthorisationModeForSavePaymentToAgreementException`, also fix a couple of other exceptions that directly called `RequestUtil.badRequestResponse(String)` even though they have registered exception mappers.