### PR TITLE
PP-9899 extend logging information

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
@@ -111,8 +111,9 @@ public class StripeWebhookTaskHandler {
                 StripeDisputeStatus disputeStatus = byStatus(stripeDisputeData.getStatus());
 
                 if (disputeStatus == WARNING_NEEDS_RESPONSE || disputeStatus == WARNING_UNDER_REVIEW || disputeStatus == WARNING_CLOSED) {
-                    logger.warn("Skipping dispute notification: [status: {}, type: {}, payment_intent: {}]",
-                            stripeDisputeData.getStatus(), stripeNotificationType, stripeDisputeData.getPaymentIntentId());
+                    logger.warn("Skipping dispute notification: [status: {}, type: {}, payment_intent: {}, reason: {}]",
+                            stripeDisputeData.getStatus(), stripeNotificationType, stripeDisputeData.getPaymentIntentId(),
+                            stripeDisputeData.getReason());
                     return;
                 }
                 

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
@@ -167,7 +167,7 @@ public class StripeWebhookTaskHandlerTest {
         verify(mockLogAppender).doAppend(loggingEventArgumentCaptor.capture());
 
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
-        String expectedLogMessage = "Skipping dispute notification: [status: warning_needs_response, type: charge.dispute.created, payment_intent: pi_1111111111]";
+        String expectedLogMessage = "Skipping dispute notification: [status: warning_needs_response, type: charge.dispute.created, payment_intent: pi_1111111111, reason: general]";
 
         assertThat(logStatement.get(0).getFormattedMessage(), Is.is(expectedLogMessage));
 
@@ -430,7 +430,7 @@ public class StripeWebhookTaskHandlerTest {
         verify(mockLogAppender).doAppend(loggingEventArgumentCaptor.capture());
 
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
-        String expectedLogMessage = "Skipping dispute notification: [status: warning_closed, type: charge.dispute.closed, payment_intent: pi_1111111111]";
+        String expectedLogMessage = "Skipping dispute notification: [status: warning_closed, type: charge.dispute.closed, payment_intent: pi_1111111111, reason: general]";
 
         assertThat(logStatement.get(0).getFormattedMessage(), Is.is(expectedLogMessage));
 
@@ -486,7 +486,7 @@ public class StripeWebhookTaskHandlerTest {
         verify(mockLogAppender).doAppend(loggingEventArgumentCaptor.capture());
 
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
-        String expectedLogMessage = "Skipping dispute notification: [status: warning_under_review, type: charge.dispute.updated, payment_intent: pi_1111111111]";
+        String expectedLogMessage = "Skipping dispute notification: [status: warning_under_review, type: charge.dispute.updated, payment_intent: pi_1111111111, reason: general]";
 
         assertThat(logStatement.get(0).getFormattedMessage(), Is.is(expectedLogMessage));
 


### PR DESCRIPTION
## WHAT YOU DID
- extend the logging information with `reason` for dispute inquiry Stripe notification
- update tests
