### PR TITLE
PP-9911 Validate gateway account ID when retrieving agreement

### DIFF
--- a/src/main/java/uk/gov/pay/connector/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/dao/AgreementDao.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.agreement.dao;
 
 import com.google.inject.Provider;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.dao.JpaDao;
 
 import javax.inject.Inject;
@@ -20,14 +19,16 @@ public class AgreementDao extends JpaDao<AgreementEntity> {
         return super.findById(AgreementEntity.class, agreementId);
     }
 
-    public Optional<AgreementEntity> findByExternalId(String externalId) {
+    public Optional<AgreementEntity> findByExternalId(String externalId, long gatewayAccountId) {
 
         String query = "SELECT ae FROM AgreementEntity ae " +
-                "WHERE ae.externalId = :externalId";
+                "WHERE ae.externalId = :externalId " +
+                "AND ae.gatewayAccount.id = :gatewayAccountId";
 
         return entityManager.get()
                 .createQuery(query, AgreementEntity.class)
                 .setParameter("externalId", externalId)
+                .setParameter("gatewayAccountId", gatewayAccountId)
                 .getResultList().stream().findFirst();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java
@@ -69,7 +69,7 @@ public class AgreementsApiResource {
             @PathParam("agreementId") String agreementId,
             @Valid AgreementCancelRequest agreementCancelRequest
     ) {
-        agreementService.cancel(agreementId, agreementCancelRequest);
+        agreementService.cancel(agreementId, accountId, agreementCancelRequest);
         return Response.noContent().build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
@@ -39,8 +39,8 @@ public class AgreementService {
         this.clock = clock;
     }
 
-    public Optional<AgreementResponse> findByExternalId(String externalId) {
-        return agreementDao.findByExternalId(externalId)
+    public Optional<AgreementResponse> findByExternalId(String externalId, long gatewayAccountId) {
+        return agreementDao.findByExternalId(externalId, gatewayAccountId)
                 .map(agreementEntity -> new AgreementResponseBuilder()
                         .withAgreementId(agreementEntity.getExternalId())
                         .withServiceId(agreementEntity.getServiceId())
@@ -81,9 +81,9 @@ public class AgreementService {
     }
 
     @Transactional
-    public void cancel(String agreementExternalId, AgreementCancelRequest agreementCancelRequest) {
+    public void cancel(String agreementExternalId, long gatewayAccountId, AgreementCancelRequest agreementCancelRequest) {
         var agreement = agreementDao
-                .findByExternalId(agreementExternalId)
+                .findByExternalId(agreementExternalId, gatewayAccountId)
                 .orElseThrow(() -> new AgreementNotFoundException("Agreement with ID [" + agreementExternalId + "] not found."));
         agreement.getPaymentInstrument()
                 .filter(paymentInstrument -> paymentInstrument.getPaymentInstrumentStatus() == PaymentInstrumentStatus.ACTIVE)

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -219,8 +219,8 @@ public class ChargesFrontendResource {
                 .map(CardTypeEntity::getLabel);
     }
 
-    private Optional<AgreementResponse> findAgreement(String agreementExternalId) {
-        return agreementService.findByExternalId(agreementExternalId);
+    private Optional<AgreementResponse> findAgreement(String agreementExternalId, long gatewayAccountId) {
+        return agreementService.findByExternalId(agreementExternalId, gatewayAccountId);
     }
 
     private ChargeResponse buildChargeResponse(UriInfo uriInfo, ChargeEntity charge) {
@@ -256,7 +256,7 @@ public class ChargesFrontendResource {
         }
 
         charge.getAgreementId().ifPresent(responseBuilder::withAgreementId);
-        charge.getAgreementId().flatMap(this::findAgreement).ifPresent(responseBuilder::withAgreement);
+        charge.getAgreementId().flatMap(agreementId -> findAgreement(agreementId, charge.getGatewayAccount().getId())).ifPresent(responseBuilder::withAgreement);
 
         if (charge.get3dsRequiredDetails() != null) {
             var auth3dsData = new ChargeResponse.Auth3dsData();

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -309,7 +309,7 @@ public class ChargeService {
                     .ifPresent(chargeEntity::setCardDetails);
 
             if (chargeRequest.getAgreementId() != null) {
-                var agreementEntity = agreementDao.findByExternalId(chargeRequest.getAgreementId())
+                var agreementEntity = agreementDao.findByExternalId(chargeRequest.getAgreementId(), gatewayAccount.getId())
                         .orElseThrow(() -> new AgreementNotFoundBadRequestException("Agreement with ID [" + chargeRequest.getAgreementId() + "] not found."));
                 if (authorisationMode == AuthorisationMode.AGREEMENT) {
                     checkAgreementHasActivePaymentInstrument(agreementEntity);

--- a/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
@@ -12,7 +12,6 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 
 import javax.inject.Inject;
 import java.time.Clock;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -35,7 +34,7 @@ public class LinkPaymentInstrumentToAgreementService {
     public void linkPaymentInstrumentFromChargeToAgreementFromCharge(ChargeEntity chargeEntity) {
         chargeEntity.getPaymentInstrument().ifPresentOrElse(paymentInstrumentEntity -> {
             chargeEntity.getAgreementId().ifPresentOrElse(agreementId -> {
-                agreementDao.findByExternalId(agreementId).ifPresentOrElse(agreementEntity -> {
+                agreementDao.findByExternalId(agreementId, chargeEntity.getGatewayAccount().getId()).ifPresentOrElse(agreementEntity -> {
                     agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
                     paymentInstrumentEntity.setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
                     ledgerService.postEvent(List.of(

--- a/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
@@ -82,8 +82,9 @@ public class AgreementServiceTest {
     @Test
     public void cancelAnAgreement_ThrowsAgreementNotFound() {
         var agreementId = "an-external-id";
-        when(mockedAgreementDao.findByExternalId(agreementId)).thenReturn(Optional.empty());
-        assertThrows(AgreementNotFoundException.class, () -> agreementService.cancel(agreementId, new AgreementCancelRequest()));
+        when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+        when(mockedAgreementDao.findByExternalId(agreementId, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
+        assertThrows(AgreementNotFoundException.class, () -> agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest()));
     }
 
     @Test
@@ -92,8 +93,9 @@ public class AgreementServiceTest {
         var agreementWithoutPaymentInstrument = new AgreementEntity.AgreementEntityBuilder()
                 .withPaymentInstrument(null)
                 .build();
-        when(mockedAgreementDao.findByExternalId(agreementId)).thenReturn(Optional.of(agreementWithoutPaymentInstrument));
-        assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancel(agreementId, new AgreementCancelRequest()));
+        when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+        when(mockedAgreementDao.findByExternalId(agreementId, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreementWithoutPaymentInstrument));
+        assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest()));
     }
 
     @ParameterizedTest()
@@ -106,8 +108,9 @@ public class AgreementServiceTest {
         var agreement = new AgreementEntity.AgreementEntityBuilder()
                 .withPaymentInstrument(paymentInstrument)
                 .build();
-        when(mockedAgreementDao.findByExternalId(agreementId)).thenReturn(Optional.of(agreement));
-        assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancel(agreementId, new AgreementCancelRequest()));
+        when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+        when(mockedAgreementDao.findByExternalId(agreementId, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreement));
+        assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest()));
     }
 
     @Test
@@ -121,8 +124,9 @@ public class AgreementServiceTest {
                 .withGatewayAccount(GatewayAccountEntityFixture.aGatewayAccountEntity().build())
                 .build();
         var cancelRequest = new AgreementCancelRequest("valid-user-external-id", "valid@email.test");
-        when(mockedAgreementDao.findByExternalId(agreementId)).thenReturn(Optional.of(agreement));
-        agreementService.cancel(agreementId, cancelRequest);
+        when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+        when(mockedAgreementDao.findByExternalId(agreementId, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreement));
+        agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, cancelRequest);
         verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByUser.class));
         assertThat(paymentInstrument.getPaymentInstrumentStatus(), is(PaymentInstrumentStatus.CANCELLED));
     }
@@ -137,8 +141,9 @@ public class AgreementServiceTest {
                 .withPaymentInstrument(paymentInstrument)
                 .withGatewayAccount(GatewayAccountEntityFixture.aGatewayAccountEntity().build())
                 .build();
-        when(mockedAgreementDao.findByExternalId(agreementId)).thenReturn(Optional.of(agreement));
-        agreementService.cancel(agreementId, new AgreementCancelRequest());
+        when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+        when(mockedAgreementDao.findByExternalId(agreementId, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreement));
+        agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest());
         verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByService.class));
         assertThat(paymentInstrument.getPaymentInstrumentStatus(), is(PaymentInstrumentStatus.CANCELLED));
     }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
@@ -184,7 +184,7 @@ class ChargeServiceCreateAgreementTest {
 
     @Test
     void shouldCreateChargeWithSavePaymentInstrumentToAgreement() {
-        when(mockAgreementDao.findByExternalId(AGREEMENT_ID)).thenReturn(Optional.of(mockAgreementEntity));
+        when(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockedUriInfo.getBaseUriBuilder()).thenReturn(fromUri(SERVICE_HOST));
         when(mockLinksConfig.getFrontendUrl()).thenReturn(FRONTEND_URL);
         when(mockProviders.byName(PaymentGatewayName.SANDBOX)).thenReturn(mockPaymentProvider);
@@ -209,7 +209,7 @@ class ChargeServiceCreateAgreementTest {
 
     @Test
     void shouldCreateChargeWithAuthorisationModeAgreement() {
-        when(mockAgreementDao.findByExternalId(AGREEMENT_ID)).thenReturn(Optional.of(mockAgreementEntity));
+        when(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
         when(mockPaymentInstrumentEntity.getPaymentInstrumentStatus()).thenReturn(PaymentInstrumentStatus.ACTIVE);
         when(mockedUriInfo.getBaseUriBuilder()).thenReturn(fromUri(SERVICE_HOST));
@@ -412,7 +412,7 @@ class ChargeServiceCreateAgreementTest {
 
         String UNKNOWN_AGREEMENT_ID = "unknownId";
         ChargeCreateRequest request = requestBuilder.withAmount(1000).withAgreementId(UNKNOWN_AGREEMENT_ID).withSavePaymentInstrumentToAgreement(true).build();
-        when(mockAgreementDao.findByExternalId(UNKNOWN_AGREEMENT_ID)).thenReturn(Optional.empty());
+        when(mockAgreementDao.findByExternalId(UNKNOWN_AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
 
         assertThrows(AgreementNotFoundBadRequestException.class, () -> chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo));
 
@@ -437,7 +437,7 @@ class ChargeServiceCreateAgreementTest {
     @Test
     void shouldThrowExceptionWhenAgreementHasNoPaymentInstrumentForAuthorisationModeAgreement() {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
-        when(mockAgreementDao.findByExternalId(AGREEMENT_ID)).thenReturn(Optional.of(mockAgreementEntity));
+        when(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.empty());
 
         final ChargeCreateRequest request = requestBuilder.withAmount(1000)
@@ -455,7 +455,7 @@ class ChargeServiceCreateAgreementTest {
     @EnumSource(mode = EXCLUDE, names = "ACTIVE")
     void shouldThrowExceptionWhenAgreementHasPaymentInstrumentInIncorrectStateForAuthorisationModeAgreement(PaymentInstrumentStatus paymentInstrumentStatus) {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
-        when(mockAgreementDao.findByExternalId(AGREEMENT_ID)).thenReturn(Optional.of(mockAgreementEntity));
+        when(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
         when(mockPaymentInstrumentEntity.getPaymentInstrumentStatus()).thenReturn(paymentInstrumentStatus);
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -42,6 +41,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aVali
 class LinkPaymentInstrumentToAgreementServiceTest {
 
     private static final String AGREEMENT_ID = "I am very agreeable";
+    private static final long GATEWAY_ACCOUNT_ID = 1;
 
     @Mock
     private AgreementDao mockAgreementDao;
@@ -54,6 +54,9 @@ class LinkPaymentInstrumentToAgreementServiceTest {
 
     @Mock
     private PaymentInstrumentEntity mockPaymentInstrumentEntity;
+    
+    @Mock
+    private GatewayAccountEntity mockGatewayAccountEntity;
 
     @Mock
     private Appender<ILoggingEvent> mockAppender;
@@ -77,8 +80,8 @@ class LinkPaymentInstrumentToAgreementServiceTest {
 
     @Test
     void linksPaymentInstrumentFromChargeToAgreementFromChargeAndSetsPaymentInstrumentToActive() {
-        given(mockAgreementDao.findByExternalId(AGREEMENT_ID)).willReturn(Optional.of(mockAgreementEntity));
-        when(mockAgreementEntity.getGatewayAccount()).thenReturn(mock(GatewayAccountEntity.class));
+        when(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
+        when(mockAgreementEntity.getGatewayAccount()).thenReturn(mockGatewayAccountEntity);
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
         when(mockPaymentInstrumentEntity.getExternalId()).thenReturn("payment instrument external ID");
         var chargeEntity = aValidChargeEntity().withPaymentInstrument(mockPaymentInstrumentEntity).withAgreementId(AGREEMENT_ID).build();
@@ -129,7 +132,7 @@ class LinkPaymentInstrumentToAgreementServiceTest {
 
     @Test
     void logsErrorIfChargeHasPaymentInstrumentAndAgreementIdButAgreementNotFound() {
-        given(mockAgreementDao.findByExternalId(AGREEMENT_ID)).willReturn(Optional.empty());
+        given(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).willReturn(Optional.empty());
         var chargeEntity = aValidChargeEntity().withPaymentInstrument(mockPaymentInstrumentEntity).withAgreementId(AGREEMENT_ID).build();
 
         linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreementFromCharge(chargeEntity);

--- a/src/test/java/uk/gov/pay/connector/it/dao/AgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/AgreementDaoIT.java
@@ -8,83 +8,85 @@ import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
-import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
-import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
-import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 
 public class AgreementDaoIT extends DaoITestBase {
 
     private AgreementDao agreementDao;
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private DatabaseFixtures.TestCardDetails defaultTestCardDetails;
-    private GatewayAccountEntity gatewayAccount;
-    private GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity;
+    private GatewayAccountEntity gatewayAccount1, gatewayAccount2;
+    private GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity1, gatewayAccountCredentialsEntity2;
 
+    private static final long GATEWAY_ACCOUNT_ID_1 = 1;
+    private static final long GATEWAY_ACCOUNT_ID_2 = 2;
+    
     private static final String AGREEMENT_EXTERNAL_ID_ONE = "12345678901234567890123456";
     private static final String AGREEMENT_EXTERNAL_ID_TWO = "65432109876543210987654321";
     
     @Before
     public void setUp() {
         agreementDao = env.getInstance(AgreementDao.class);
-        defaultTestCardDetails = new DatabaseFixtures(databaseTestHelper).validTestCardDetails();
-        insertTestAccount();
 
-        gatewayAccount = new GatewayAccountEntity(TEST);
-        gatewayAccount.setId(defaultTestAccount.getAccountId());
+        DatabaseFixtures.TestAccount testAccount1 = insertTestAccount();
+        gatewayAccount1 = new GatewayAccountEntity(TEST);
+        gatewayAccount1.setId(testAccount1.getAccountId());
 
-        gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
-                .withCredentials(Map.of())
-                .withGatewayAccountEntity(gatewayAccount)
-                .withPaymentProvider(defaultTestAccount.getPaymentProvider())
-                .withState(ACTIVE)
-                .build();
-        gatewayAccountCredentialsEntity.setId(defaultTestAccount.getCredentials().get(0).getId());
+        DatabaseFixtures.TestAccount testAccount2 = insertTestAccount();
+        gatewayAccount2 = new GatewayAccountEntity(TEST);
+        gatewayAccount2.setId(testAccount2.accountId);
     }
+
+    @Test
+    public void findByExternalId_shouldFindAnAgreementEntityForGatewayAccount() {
+        insertTestAgreement(AGREEMENT_EXTERNAL_ID_ONE, gatewayAccount1.getId());
+        insertTestAgreement(AGREEMENT_EXTERNAL_ID_TWO, gatewayAccount1.getId());
+        Optional<AgreementEntity> agreement = agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID_ONE, gatewayAccount1.getId());
+        assertThat(agreement.isPresent(), is(true));
+        assertThat(agreement.get().getExternalId(), is(AGREEMENT_EXTERNAL_ID_ONE));
+    }
+
+    @Test
+    public void findByExternalId_shouldNotFindAgreementEntityForDifferentGatewayAccount() {
+        insertTestAgreement(AGREEMENT_EXTERNAL_ID_ONE, gatewayAccount1.getId());
+        Optional<AgreementEntity> agreement = agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID_ONE, gatewayAccount2.getId());
+        assertThat(agreement.isPresent(), is(false));
+    }
+
+    @Test
+    public void findByExternalId_shouldNotFindAnAgreementEntity() {
+        Optional<AgreementEntity> agreement = agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID_TWO, gatewayAccount1.getId());
+        assertThat(agreement.isPresent(), is(false));
+    }
+
 
     @After
     public void clear() {
         databaseTestHelper.truncateAllData();
     }
     
-    @Test
-    public void findByExternalId_shouldFindAnAgreementEntity() {
-        insertTestAgreement(AGREEMENT_EXTERNAL_ID_ONE);
-        insertTestAgreement(AGREEMENT_EXTERNAL_ID_TWO);
-        Optional<AgreementEntity> agreement = agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID_ONE);
-        assertThat(agreement.isPresent(), is(true));
-        assertThat(agreement.get().getExternalId(), is(AGREEMENT_EXTERNAL_ID_ONE));
-    }
-
-    @Test
-    public void findByExternalId_shouldNotFindAnAgreementEntity() {
-        //insertTestAgreement(AGREEMENT_EXTERNAL_ID_ONE);
-        Optional<AgreementEntity> agreement = agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID_TWO);
-        assertThat(agreement.isPresent(), is(false));
-    }
-    
-    private void insertTestAgreement(String agreementExternalId) {
+    private void insertTestAgreement(String agreementExternalId, long gatewayAccountId) {
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAgreement()
                 .withAgreementId(nextLong())
                 .withExternalId(agreementExternalId)
                 .withReference("ref9876")
-                .withGatewayAccountId(defaultTestAccount.getAccountId())
+                .withGatewayAccountId(gatewayAccountId)
                 .insert();
     }
 
-    private void insertTestAccount() {
-        this.defaultTestAccount = DatabaseFixtures
+    private DatabaseFixtures.TestAccount insertTestAccount() {
+        return DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
                 .withAccountId(nextLong())
                 .insert();
     }
-    
+
 }


### PR DESCRIPTION
When retrieving an agreement from the DAO by its external ID, only return agreements that belong to the appropriate gateway account.

with @sfount