### PR TITLE
PP-9929 Parity between charge and payment instrument table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1927,4 +1927,7 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="drop not null constraint on payment instruments card type" author="">
+        <dropNotNullConstraint tableName="payment_instruments" columnName="card_type" />
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -146,6 +146,7 @@ public class ChargingITestBase {
             );
         }
         databaseTestHelper = testContext.getDatabaseTestHelper();
+        ledgerStub.acceptPostEvent();
 
         credentialParams = anAddGatewayAccountCredentialsParams()
                 .withId(gatewayAccountCredentialsId)


### PR DESCRIPTION
Card type is nullable on charges, currently the enum serialisation for
card types uses null to represent that card id didn't know if the card
number was credit or debit (`CREDIT_OR_DEBIT` -> `null`).

There should be exact parity between the current details stored on
charges and payment instruments to give confidence that running shared
code will work.

Adds a test using a card number with type `CREDIT_OR_DEBIT` that would
fail unless the `card_type` property on payment instruments has been
made nullable.

If we've moved over to payment instruments entirely in the future this
behaviour can be changed but for now it should be consistent with
charges.