### PR TITLE
PP-9947 Update required number of capture retries

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -128,10 +128,9 @@ captureProcessConfig:
 
   # The below effectively get multiplied together. In order to handle how
   # certain payment gateways do things, it is extremely desirable to keep these
-  # values such that we will continue retrying for at least two nights after
-  # the initial attempt. See PP-2627 or commit
-  # e931b4dab25284acedeb6d59d4bfd3d29e454b82 for more details.
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
+  # values such that we will continue retrying for at least 24 hours after
+  # the initial attempt. See PP-9947 for more details.
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-26}
   failedCaptureRetryDelayInSeconds: ${CAPTURE_PROCESS_FAILED_CAPTURE_RETRY_DELAY_IN_SECONDS:-3600}
 
   queueSchedulerThreadDelayInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}

--- a/src/test/java/uk/gov/pay/connector/app/ConnectorConfigurationIT.java
+++ b/src/test/java/uk/gov/pay/connector/app/ConnectorConfigurationIT.java
@@ -6,17 +6,16 @@ import io.dropwizard.util.Duration;
 import org.junit.Rule;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
 
 public class ConnectorConfigurationIT {
 
     @Rule
     public final DropwizardAppRule<ConnectorConfiguration> RULE =
             new DropwizardAppRule<>(ConnectorApp.class, ResourceHelpers.resourceFilePath("config/test-config.yaml"));
-
 
     @Test
     public void shouldParseConfiguration() {
@@ -27,7 +26,7 @@ public class ConnectorConfigurationIT {
 
         CaptureProcessConfig captureProcessConfig = RULE.getConfiguration().getCaptureProcessConfig();
         assertThat(captureProcessConfig.getChargesConsideredOverdueForCaptureAfter(), is(60));
-        assertThat(captureProcessConfig.getMaximumRetries(), is(48));
+        assertThat(captureProcessConfig.getMaximumRetries(), is(26));
         assertThat(RULE.getConfiguration().getLedgerBaseUrl(), is(not(emptyString())));
         assertThat(RULE.getConfiguration().getRestClientConfig().isDisabledSecureConnection(), is(true));
         assertThat(RULE.getConfiguration().getEmittedEventSweepConfig().getNotEmittedEventMaxAgeInSeconds(), is(1800));

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -104,7 +104,7 @@ executorServiceConfig:
 captureProcessConfig:
   backgroundProcessingEnabled: ${BACKGROUND_PROCESSING_ENABLED:-false}
   chargesConsideredOverdueForCaptureAfter: 60
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-26}
   failedCaptureRetryDelayInSeconds: ${CAPTURE_PROCESS_FAILED_CAPTURE_RETRY_DELAY_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -106,7 +106,7 @@ executorServiceConfig:
 captureProcessConfig:
   backgroundProcessingEnabled: ${BACKGROUND_PROCESSING_ENABLED:-false}
   chargesConsideredOverdueForCaptureAfter: 60
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-26}
   failedCaptureRetryDelayInSeconds: ${CAPTURE_PROCESS_FAILED_CAPTURE_RETRY_DELAY_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -96,7 +96,7 @@ executorServiceConfig:
 captureProcessConfig:
   backgroundProcessingEnabled: ${BACKGROUND_PROCESSING_ENABLED:-false}
   chargesConsideredOverdueForCaptureAfter: 60
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-26}
   failedCaptureRetryDelayInSeconds: ${CAPTURE_PROCESS_FAILED_CAPTURE_RETRY_DELAY_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -86,7 +86,7 @@ executorServiceConfig:
 captureProcessConfig:
   backgroundProcessingEnabled: ${BACKGROUND_PROCESSING_ENABLED:-false}
   chargesConsideredOverdueForCaptureAfter: 60
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-26}
   failedCaptureRetryDelayInSeconds: ${CAPTURE_PROCESS_FAILED_CAPTURE_RETRY_DELAY_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -86,7 +86,7 @@ executorServiceConfig:
 captureProcessConfig:
   backgroundProcessingEnabled: ${BACKGROUND_PROCESSING_ENABLED:-false}
   chargesConsideredOverdueForCaptureAfter: 60
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-26}
   failedCaptureRetryDelayInSeconds: ${CAPTURE_PROCESS_FAILED_CAPTURE_RETRY_DELAY_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}


### PR DESCRIPTION
- Currently, the capture process retries charges that failed capture for up to 48 hours. This is due to ePDQ behaviour https://github.com/alphagov/pay-connector/commit/e931b4dab25284acedeb6d59d4bfd3d29e454b82. Since we longer have any services with ePDQ this could be reduced. 

- Based on the past 6 months' data, below is the behaviour of capture retries for current payment providers we support (see PP-9947 for details)
  - **Worldpay**: Most live payments are captured immediately. Very few remaining payments are captured after 1 or 2 retry attempts.
  - **Stripe**: Most payments are captured immediately or after 1 or 2 retries. A few exceptions are below
    - **Low-value payments**: Payments with low value cause negative transfer amounts so capture fails. These payments will always fail irrespective of the number of retry attempts
    - **Payments failed due to Stripe's internal error**: When Stripe returns a 5xx error, subsequent requests will return the same 5xx error due to idempotency requests (https://stripe.com/docs/api/idempotent_requests). Note that this is different to connection timeout where requests are successful on Stripe but timed out on our side which is fixed by https://github.com/alphagov/pay-connector/pull/3962. When Stripe responds with internal error / API error, payments won't be captured or transfer won't take place.

For the payments that failed due to idempotency (rare and happened for 33 payments in the last 6 months), Stripe processes requests after 24 hours. We make two requests (capture request + transfer) at the time of capture, so adding some buffer takes the desired number of capture retries config to **26**. 
