### PR TITLE
PP-10024 fix missing gateway transaction id

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CancelledWithGatewayAfterAuthorisationErrorEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CancelledWithGatewayAfterAuthorisationErrorEventDetails.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.events.eventdetails.charge;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+public class CancelledWithGatewayAfterAuthorisationErrorEventDetails extends EventDetails {
+
+    private String gatewayTransactionId;
+
+    public CancelledWithGatewayAfterAuthorisationErrorEventDetails(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
+    }
+    
+    public static CancelledWithGatewayAfterAuthorisationErrorEventDetails from(ChargeEntity charge) {
+        return new CancelledWithGatewayAfterAuthorisationErrorEventDetails(charge.getGatewayTransactionId());
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledWithGatewayAfterAuthorisationError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledWithGatewayAfterAuthorisationError.java
@@ -1,9 +1,27 @@
 package uk.gov.pay.connector.events.model.charge;
 
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.charge.CancelledWithGatewayAfterAuthorisationErrorEventDetails;
+
 import java.time.ZonedDateTime;
 
-public class CancelledWithGatewayAfterAuthorisationError extends PaymentEventWithoutDetails {
-    public CancelledWithGatewayAfterAuthorisationError(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+public class CancelledWithGatewayAfterAuthorisationError extends PaymentEvent {
+    public CancelledWithGatewayAfterAuthorisationError(String serviceId, boolean live, String resourceExternalId,
+                                                       CancelledWithGatewayAfterAuthorisationErrorEventDetails eventDetails, 
+                                                       ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+    
+    public static CancelledWithGatewayAfterAuthorisationError from(ChargeEventEntity chargeEvent) {
+        ChargeEntity charge = chargeEvent.getChargeEntity();
+        
+        return new CancelledWithGatewayAfterAuthorisationError(
+                charge.getServiceId(),
+                charge.getGatewayAccount().isLive(),
+                charge.getExternalId(),
+                CancelledWithGatewayAfterAuthorisationErrorEventDetails.from(charge),
+                chargeEvent.getUpdated()
+        );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeQueryPaymentStatusHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeQueryPaymentStatusHandler.java
@@ -53,7 +53,7 @@ public class StripeQueryPaymentStatusHandler {
                 throw new ChargeNotFoundRuntimeException(request.getChargeExternalId());
             }
             return new ChargeQueryResponse(StripeChargeStatus.mapToChargeStatus(StripeChargeStatus.fromString(paymentIntentList.get(0).getStatus())),
-                    new StripeQueryResponse(request.getChargeExternalId()));
+                    new StripeQueryResponse(paymentIntentList.get(0).getId()));
         } catch (GatewayException.GatewayErrorException ex) {
             if ((ex.getStatus().isPresent() && ex.getStatus().get() == SC_UNAUTHORIZED) || ex.getFamily() == SERVER_ERROR) {
                 LOGGER.info("Querying payment status failed due to an internal error. Reason: {}. Status code from Stripe: {}.",

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeQueryPaymentStatusHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeQueryPaymentStatusHandlerTest.java
@@ -98,6 +98,16 @@ public class StripeQueryPaymentStatusHandlerTest {
         assertThat(response.getMappedStatus().isPresent(), is(true));
         assertThat(response.getMappedStatus().get(), is(ChargeStatus.AUTHORISATION_CANCELLED));
     }
+    
+    @Test
+    public void shouldReturnGatewayTransactionIdInTheResponse() throws GatewayException {
+        chargeEntity.setGatewayTransactionId(null);
+        when(gatewayClient.getRequestFor(any(StripeQueryPaymentStatusRequest.class))).thenReturn(paymentSearchResponse);
+        when(paymentSearchResponse.getEntity()).thenReturn(searchResponse().replace("succeeded", "canceled"));
+        ChargeQueryResponse response = handler.queryPaymentStatus(queryGatewayRequest);
+        
+        assertThat(response.getRawGatewayResponse().get().getTransactionId(), is("pi_1FJMFKDv3CZEaFO2UhknVpXZ"));
+    }
 
     @Test
     public void shouldReturnError_whenQueryingByMetadataFindsNoCharge() throws GatewayException {


### PR DESCRIPTION
## WHAT YOU DID
- When we try to cancel some Stripe charges, the gatewayTransactionId might be missing from the charge. Set gatewayTransactionId on charge after querying Stripe for the payment intent.
- Use payment intent id to instantiate StripeQueryResponse, instead of our externalid
- update / add relevant tests
