### PR TITLE
PP-10078 Submit additional3DSData for GooglePay payments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -73,10 +73,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -238,14 +234,14 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5225
+        "line_number": 5230
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5236
+        "line_number": 5241
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -864,6 +860,15 @@
         "line_number": 9
       }
     ],
+    "src/test/resources/googlepay/example-3ds-auth-request-with-ddc.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/googlepay/example-3ds-auth-request-with-ddc.json",
+        "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
     "src/test/resources/googlepay/example-3ds-auth-request-without-email.json": [
       {
         "type": "Base64 High Entropy String",
@@ -969,5 +974,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-16T10:20:59Z"
+  "generated_at": "2022-09-28T10:31:58Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -5203,6 +5203,11 @@ components:
         user_agent_header:
           type: string
           example: Mozilla/5.0
+        worldpay_3ds_flex_ddc_result:
+          type: string
+          description: SessionId returned by Worldpay/CardinalCommerce as part of
+            device data collection. Applicable for Google Pay payments only
+          example: 1f1154b7-620d-4654-801b-893b5bb22db1
     Worldpay3dsFlexCredentials:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.wallets.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,7 +13,7 @@ import java.util.Optional;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WalletPaymentInfo {
-    
+
     @Schema(description = "last digits card number", example = "4242")
     private String lastDigitsCardNumber;
     @Schema(example = "visa")
@@ -32,6 +33,10 @@ public class WalletPaymentInfo {
     @Schema(example = "203.0.113.1")
     private String ipAddress;
 
+    @Schema(example = "1f1154b7-620d-4654-801b-893b5bb22db1", description = "SessionId returned by Worldpay/CardinalCommerce as part of device data collection. Applicable for Google Pay payments only")
+    @JsonProperty("worldpay_3ds_flex_ddc_result")
+    private String worldpay3dsFlexDdcResult;
+
     public WalletPaymentInfo() {
     }
 
@@ -43,13 +48,13 @@ public class WalletPaymentInfo {
         this.email = email;
     }
 
-    public WalletPaymentInfo(String lastDigitsCardNumber, 
+    public WalletPaymentInfo(String lastDigitsCardNumber,
                              String brand,
-                             PayersCardType cardType, 
+                             PayersCardType cardType,
                              String cardholderName,
                              String email,
-                             String acceptHeader, 
-                             String userAgentHeader, 
+                             String acceptHeader,
+                             String userAgentHeader,
                              String ipAddress) {
         this(lastDigitsCardNumber, brand, cardType, cardholderName, email);
         this.acceptHeader = acceptHeader;
@@ -89,6 +94,10 @@ public class WalletPaymentInfo {
         return ipAddress;
     }
 
+    public Optional<String> getWorldpay3dsFlexDdcResult() {
+        return Optional.ofNullable(worldpay3dsFlexDdcResult);
+    }
+
     @Override
     public String toString() { //this might be logged, so we serialise without PII
         return "WalletPaymentInfo{" +
@@ -98,6 +107,7 @@ public class WalletPaymentInfo {
                 ", acceptHeader=" + acceptHeader +
                 ", userAgentHeader=" + userAgentHeader +
                 ", ipAddress=" + Optional.ofNullable(ipAddress).map(x -> "ipAddress is present").orElse("ipAddress is not present") +
+                ", worldpay3dsFlexDdcResult=" + getWorldpay3dsFlexDdcResult().map(x -> "present").orElse("not present") +
                 '}';
     }
 }

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml
@@ -33,6 +33,12 @@
                 </#if>
             </shopper>
             </#if>
+            <#if walletAuthorisationData.paymentInfo.worldpay3dsFlexDdcResult.isPresent()>
+            <additional3DSData
+                dfReferenceId="${walletAuthorisationData.paymentInfo.worldpay3dsFlexDdcResult.get()?xml}"
+                challengeWindowSize="390x400" challengePreference="noPreference"
+            />
+            </#if>
         </order>
     </submit>
 </paymentService>

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -36,6 +36,8 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-with-email.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay.xml";
+
+    public static final String WORLDPAY_VALID_AUTHORISE_GOOGLE_PAY_3DS_REQUEST_WITH_DDC_RESULT = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-with-ddc.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-with-email.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-without-ip-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-with-ip-address.xml";

--- a/src/test/resources/googlepay/example-3ds-auth-request-with-ddc.json
+++ b/src/test/resources/googlepay/example-3ds-auth-request-with-ddc.json
@@ -1,0 +1,16 @@
+{
+  "payment_info": {
+    "last_digits_card_number": "4242",
+    "brand": "visa",
+    "cardholder_name": "Example Name",
+    "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,/;q=0.8",
+    "user_agent_header": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.183 Safari/537.36",
+    "ip_address": "8.8.8.8",
+    "worldpay_3ds_flex_ddc_result": "1f1154b7-620d-4654-801b-893b5bb22db1"
+  },
+  "encrypted_payment_data": {
+    "signature": "MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl",
+    "protocol_version": "ECv1",
+    "signed_message": "aSignedMessage"
+  }
+}

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-3ds-with-ddc.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-3ds-with-ddc.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!" shopperLanguageCode="en">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <PAYWITHGOOGLE-SSL>
+                    <protocolVersion>ECv1</protocolVersion>
+                    <signature>MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl</signature>
+                    <signedMessage>aSignedMessage</signedMessage>
+                </PAYWITHGOOGLE-SSL>
+                <session id="uniqueSessionId" shopperIPAddress="8.8.8.8"/>
+            </paymentDetails>
+            <shopper>
+                <browser>
+                    <acceptHeader>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,/;q=0.8</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.183 Safari/537.36</userAgentHeader>
+                </browser>
+            </shopper>
+            <additional3DSData
+                    dfReferenceId="1f1154b7-620d-4654-801b-893b5bb22db1"
+                    challengeWindowSize="390x400" challengePreference="noPreference"
+            />
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
## WHAT YOU DID
- Includes `additional3DSData` element with the device data collection result when authorising GooglePay payments with Worldpay. Device data collection is required for GooglePay payments and frontend app does the device data collection.

