### PR TITLE
PP-7862 Respond to notification with 500 when ledger returns error

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
@@ -131,6 +131,24 @@ public class WorldpayNotificationResourceIT extends ChargingITestBase {
     }
 
     @Test
+    public void shouldReturn500_whenChargeNotInConnectorAndLedgerReturnsAnError() throws Exception {
+        String gatewayTransactionId = RandomIdGenerator.newId();
+        String refundExternalId = String.valueOf(nextLong());
+        String chargeExternalId = randomAlphanumeric(26);
+
+        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(getTestAccount())
+                .withExternalChargeId(chargeExternalId)
+                .withTransactionId(gatewayTransactionId);
+
+        ledgerStub.return500ForFindByProviderAndGatewayTransactionId(getPaymentProvider(), testCharge.getTransactionId());
+
+        notifyConnector(gatewayTransactionId, "REFUNDED", refundExternalId)
+                .statusCode(500);
+    }
+
+    @Test
     public void shouldIgnoreAuthorisedNotification() {
 
         String transactionId = RandomIdGenerator.newId();

--- a/src/test/java/uk/gov/pay/connector/rules/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/rules/LedgerStub.java
@@ -89,6 +89,12 @@ public class LedgerStub {
                 null, 404);
     }
 
+    public void return500ForFindByProviderAndGatewayTransactionId(String paymentProvider,
+                                                                       String gatewayTransactionId) throws JsonProcessingException {
+        stubResponseForProviderAndGatewayTransactionId(gatewayTransactionId, paymentProvider,
+                null, 500);
+    }
+    
     public void returnLedgerTransactionForProviderAndGatewayTransactionId(DatabaseFixtures.TestCharge testCharge,
                                                                           String paymentProvider) throws JsonProcessingException {
         Map<String, Object> ledgerTransactionFields = testChargeToLedgerTransactionJson(testCharge, null);


### PR DESCRIPTION
When attempting to get a transaction from ledger and ledger returns a response other than 200 - OK or 404 - NOT FOUND, throw an exception and log an error. When ledger returns a non-success code other that 404 that indicates an issue that should be investigated.

Throwing a LedgerException will cause the HTTP request to connector to respond with a 500 status code. This includes for the HTTP request from gateways. In this case, we want to return a 500 response so Worldpay will retry sending the notification at a later time.

The other places where connector attempts to get transactions from ledger is for parity checking and for handling Stripe webhooks. In both these places, returning a 500 when ledger returns an error is also sensible behaviour.