### PR TITLE
PP-10173 Make captureSubmitTime in SettlementSummary an Instant

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -565,9 +565,10 @@ public class ChargeResponse {
     @JsonFormat(shape = JsonFormat.Shape.OBJECT)
     @Schema(description = "Provides a settlement summary of the charge containing date and time of capture, if present")
     public static class SettlementSummary {
-        private ZonedDateTime captureSubmitTime, capturedTime;
+        private Instant captureSubmitTime;
+        private ZonedDateTime capturedTime;
 
-        public void setCaptureSubmitTime(ZonedDateTime captureSubmitTime) {
+        public void setCaptureSubmitTime(Instant captureSubmitTime) {
             this.captureSubmitTime = captureSubmitTime;
         }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -869,7 +869,7 @@ public class ChargeService {
     private ChargeResponse.SettlementSummary buildSettlementSummary(ChargeEntity charge) {
         ChargeResponse.SettlementSummary settlement = new ChargeResponse.SettlementSummary();
 
-        settlement.setCaptureSubmitTime(charge.getCaptureSubmitTime());
+        settlement.setCaptureSubmitTime(Optional.ofNullable(charge.getCaptureSubmitTime()).map(ZonedDateTime::toInstant).orElse(null));
         settlement.setCapturedTime(charge.getCapturedTime());
 
         return settlement;


### PR DESCRIPTION
In `ChargeResponse.SettlementSummary`, change the type of `captureSubmitTime` from a `ZonedDateTime` to an `Instant`.