### PR TITLE
PP-10173 Make capturedTime in SettlementSummary an Instant

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -12,7 +12,6 @@ import uk.gov.pay.connector.charge.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 import uk.gov.pay.connector.charge.model.telephone.PaymentOutcome;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
-import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.pay.connector.wallets.WalletType;
 import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
 import uk.gov.service.payments.commons.api.json.ExternalMetadataSerialiser;
@@ -29,6 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+import static uk.gov.pay.connector.common.model.api.ApiResponseUtcDateFormatter.ISO_LOCAL_DATE_IN_UTC;
 import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
 @JsonInclude(Include.NON_NULL)
@@ -566,7 +566,7 @@ public class ChargeResponse {
     @Schema(description = "Provides a settlement summary of the charge containing date and time of capture, if present")
     public static class SettlementSummary {
         private Instant captureSubmitTime;
-        private ZonedDateTime capturedTime;
+        private Instant capturedTime;
 
         public void setCaptureSubmitTime(Instant captureSubmitTime) {
             this.captureSubmitTime = captureSubmitTime;
@@ -579,14 +579,14 @@ public class ChargeResponse {
             return (captureSubmitTime != null) ? ISO_INSTANT_MILLISECOND_PRECISION.format(captureSubmitTime) : null;
         }
 
-        public void setCapturedTime(ZonedDateTime capturedTime) {
+        public void setCapturedTime(Instant capturedTime) {
             this.capturedTime = capturedTime;
         }
 
         @JsonProperty("captured_date")
         @Schema(example = "2022-06-28", description = "Date of the capture event")
         public String getCapturedDate() {
-            return (capturedTime != null) ? DateTimeUtils.toUTCDateString(capturedTime) : null;
+            return (capturedTime != null) ? ISO_LOCAL_DATE_IN_UTC.format(capturedTime) : null;
         }
 
         @Override

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -870,7 +870,7 @@ public class ChargeService {
         ChargeResponse.SettlementSummary settlement = new ChargeResponse.SettlementSummary();
 
         settlement.setCaptureSubmitTime(Optional.ofNullable(charge.getCaptureSubmitTime()).map(ZonedDateTime::toInstant).orElse(null));
-        settlement.setCapturedTime(charge.getCapturedTime());
+        settlement.setCapturedTime(Optional.ofNullable(charge.getCapturedTime()).map(ZonedDateTime::toInstant).orElse(null));
 
         return settlement;
     }

--- a/src/main/java/uk/gov/pay/connector/common/model/api/ApiResponseUtcDateFormatter.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/ApiResponseUtcDateFormatter.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.common.model.api;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+public class ApiResponseUtcDateFormatter {
+
+    /**
+     * DateTimeFormatter that produces a standard ISO-8601 local date in UTC
+     * without an offset, for example 2022-10-04
+     */
+    public static final DateTimeFormatter ISO_LOCAL_DATE_IN_UTC = DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneOffset.UTC);
+
+}

--- a/src/test/java/uk/gov/pay/connector/common/model/api/ApiResponseUtcDateFormatterTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/api/ApiResponseUtcDateFormatterTest.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.connector.common.model.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.common.model.api.ApiResponseUtcDateFormatter.ISO_LOCAL_DATE_IN_UTC;
+
+class ApiResponseUtcDateFormatterTest {
+
+    @Test
+    void shouldConvertInstantToIsoLocalDateInUtc() {
+        var instant = Instant.parse("2022-10-04T12:34:56.789Z");
+
+        String result = ISO_LOCAL_DATE_IN_UTC.format(instant);
+
+        assertThat(result, is("2022-10-04"));
+    }
+
+    @Test
+    void shouldConvertZonedDateTimeInUtcToIsoLocalDateInUtc() {
+        var zonedDateTime = ZonedDateTime.parse("2022-10-04T12:34:56.789Z");
+
+        String result = ISO_LOCAL_DATE_IN_UTC.format(zonedDateTime);
+
+        assertThat(result, is("2022-10-04"));
+    }
+
+    @Test
+    void shouldConvertZonedDateTimeInAnotherTimeZoneWhereItIsAlreadyTomorrowToIsoLocalDateInUtc() {
+        var zonedDateTime = ZonedDateTime.of(LocalDateTime.parse("2022-10-05T06:07:08.123"), ZoneId.of("Pacific/Auckland"));
+
+        String result = ISO_LOCAL_DATE_IN_UTC.format(zonedDateTime);
+
+        assertThat(result, is("2022-10-04"));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -52,6 +52,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
+import static uk.gov.pay.connector.common.model.api.ApiResponseUtcDateFormatter.ISO_LOCAL_DATE_IN_UTC;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_SUBMITTED;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
@@ -71,8 +72,8 @@ public class ChargesApiResourceIT extends ChargingITestBase {
 
     @Test
     public void makeChargeSubmitCaptureAndCheckSettlementSummary() throws QueueException {
-        ZonedDateTime startOfTest = ZonedDateTime.now().withZoneSameInstant(ZoneOffset.UTC);
-        String expectedDayOfCapture = DateTimeUtils.toUTCDateString(startOfTest);
+        Instant startOfTest = Instant.now();
+        String expectedDayOfCapture = ISO_LOCAL_DATE_IN_UTC.format(startOfTest);
 
         String chargeId = authoriseNewCharge();
 


### PR DESCRIPTION
In `ChargeResponse.SettlementSummary`, change the type of `capturedTime` from a `ZonedDateTime` to an `Instant`.