### PR TITLE
PP-10173 EmittedEventEntity: use Instant for eventDate/emittedDate

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/EmittedEventBatchIterator.java
+++ b/src/main/java/uk/gov/pay/connector/events/EmittedEventBatchIterator.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.events;
 import uk.gov.pay.connector.app.config.EmittedEventSweepConfig;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Iterator;
 import java.util.List;
@@ -16,7 +17,7 @@ class EmittedEventBatchIterator implements Iterator<EmittedEventBatchIterator.Ev
     private final ZonedDateTime batchStartTime;
     private EventBatch currentBatch;
     private Optional<Long> maybeMaximumIdOfEventsEligibleForReEmission;
-    private ZonedDateTime cutoffDate;
+    private Instant cutoffDate;
 
     EmittedEventBatchIterator(EmittedEventDao emittedEventDao,
                               EmittedEventSweepConfig sweepConfig,
@@ -69,9 +70,9 @@ class EmittedEventBatchIterator implements Iterator<EmittedEventBatchIterator.Ev
         return new EventBatch(emittedEventEntities, startFromId);
     }
 
-    private ZonedDateTime getCutoffDateForProcessingNotEmittedEvents(ZonedDateTime batchStartTime) {
+    private Instant getCutoffDateForProcessingNotEmittedEvents(ZonedDateTime batchStartTime) {
         int notEmittedEventMaxAgeInSeconds = sweepConfig.getNotEmittedEventMaxAgeInSeconds();
-        return batchStartTime.minusSeconds(notEmittedEventMaxAgeInSeconds);
+        return batchStartTime.minusSeconds(notEmittedEventMaxAgeInSeconds).toInstant();
     }
     
 
@@ -100,9 +101,8 @@ class EmittedEventBatchIterator implements Iterator<EmittedEventBatchIterator.Ev
             return events.isEmpty();
         }
 
-        public Optional<ZonedDateTime> oldestEventDate() {
-            return events.stream()
-                    .map(EmittedEventEntity::getEventDate).min(ZonedDateTime::compareTo);
+        public Optional<Instant> oldestEventDate() {
+            return events.stream().map(EmittedEventEntity::getEventDate).min(Instant::compareTo);
         }
         
         public Optional<EmittedEventEntity> last() {

--- a/src/main/java/uk/gov/pay/connector/events/EmittedEventEntity.java
+++ b/src/main/java/uk/gov/pay/connector/events/EmittedEventEntity.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.events;
 
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
+import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
 
 import javax.persistence.Column;
 import javax.persistence.Convert;
@@ -10,6 +11,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 @Entity
@@ -31,13 +33,13 @@ public class EmittedEventEntity {
     @Column(name = "event_type")
     private String eventType;
 
-    @Convert(converter = UTCDateTimeConverter.class)
+    @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
     @Column(name = "event_date")
-    private ZonedDateTime eventDate;
+    private Instant eventDate;
 
-    @Convert(converter = UTCDateTimeConverter.class)
+    @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
     @Column(name = "emitted_date")
-    private ZonedDateTime emittedDate;
+    private Instant emittedDate;
 
     @Convert(converter = UTCDateTimeConverter.class)
     @Column(name = "do_not_retry_emit_until")
@@ -46,8 +48,8 @@ public class EmittedEventEntity {
     protected EmittedEventEntity() {
     }
 
-    public EmittedEventEntity(String resourceType, String resourceExternalId, String eventType, 
-                              ZonedDateTime eventDate, ZonedDateTime emittedDate,
+    public EmittedEventEntity(String resourceType, String resourceExternalId, String eventType,
+                              Instant eventDate, Instant emittedDate,
                               ZonedDateTime doNotRetryEmitUntil) {
         this.resourceType = resourceType;
         this.resourceExternalId = resourceExternalId;
@@ -73,11 +75,11 @@ public class EmittedEventEntity {
         return eventType;
     }
 
-    public ZonedDateTime getEventDate() {
+    public Instant getEventDate() {
         return eventDate;
     }
 
-    public ZonedDateTime getEmittedDate() {
+    public Instant getEmittedDate() {
         return emittedDate;
     }
 
@@ -85,7 +87,7 @@ public class EmittedEventEntity {
         return doNotRetryEmitUntil;
     }
 
-    public void setEmittedDate(ZonedDateTime emittedDate) {
+    public void setEmittedDate(Instant emittedDate) {
         this.emittedDate = emittedDate;
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/EmittedEventsBackfillService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EmittedEventsBackfillService.java
@@ -15,7 +15,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.tasks.HistoricalEventEmitter;
 
 import javax.inject.Inject;
-import java.time.ZoneId;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 import static java.time.ZoneOffset.UTC;
@@ -53,7 +53,7 @@ public class EmittedEventsBackfillService {
                     "Processing not emitted events [lastProcessedId={}, no.of.events={}, oldestDate={}]",
                     batch.getStartId(),
                     batch.getEndId().map(Object::toString).orElse("none"),
-                    batch.oldestEventDate().map(ZonedDateTime::toString).orElse("none")
+                    batch.oldestEventDate().map(Instant::toString).orElse("none")
             );
 
             batch.getEvents().forEach(this::backfillEvent);
@@ -76,7 +76,7 @@ public class EmittedEventsBackfillService {
             } else {
                 historicalEventEmitter.emitEventsForRefund(event.getResourceExternalId(), true);
             }
-            event.setEmittedDate(now(ZoneId.of("UTC")));
+            event.setEmittedDate(Instant.now());
         } catch (Exception e) {
             logger.error(
                     "Failed to process backfill for event {} due to {} [externalId={}] [event_type={}] [event_date={}]",

--- a/src/main/java/uk/gov/pay/connector/events/EventService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EventService.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.events.model.ResourceType;
 import uk.gov.service.payments.commons.queue.exception.QueueException;
 
 import javax.inject.Inject;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 public class EventService {
@@ -66,7 +67,7 @@ public class EventService {
             emittedEventDao.recordEmission(event, doNotRetryEmitUntilDate);
         } catch (QueueException e) {
             emittedEventDao.recordEmission(event.getResourceType(), event.getResourceExternalId(),
-                    event.getEventType(), event.getTimestamp(), doNotRetryEmitUntilDate);
+                    event.getEventType(), event.getTimestamp().toInstant(), doNotRetryEmitUntilDate);
             logger.error("Failed to emit event {} due to {} [externalId={}]",
                     event.getEventType(), e.getMessage(), event.getResourceExternalId());
         }
@@ -81,12 +82,12 @@ public class EventService {
         emittedEventDao.markEventAsEmitted(event);
     }
 
-    public void recordOfferedEvent(ResourceType resourceType, String externalId, String eventType, ZonedDateTime eventDate) {
+    public void recordOfferedEvent(ResourceType resourceType, String externalId, String eventType, Instant eventDate) {
         this.recordOfferedEvent(resourceType, externalId, eventType, eventDate, null);
     }
 
     public void recordOfferedEvent(ResourceType resourceType, String externalId, String eventType,
-                                   ZonedDateTime eventDate, ZonedDateTime doNotRetryEmitUntilDate) {
+                                   Instant eventDate, ZonedDateTime doNotRetryEmitUntilDate) {
         emittedEventDao.recordEmission(resourceType, externalId, eventType, eventDate, doNotRetryEmitUntilDate);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
@@ -17,12 +17,10 @@ import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.refund.service.RefundStateEventMap;
 
 import javax.inject.Inject;
-import java.time.ZoneId;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 import static java.lang.String.format;
-import static java.time.ZonedDateTime.now;
-import static net.logstash.logback.argument.StructuredArguments.e;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
 public class StateTransitionService {
@@ -51,7 +49,7 @@ public class StateTransitionService {
         eventService.recordOfferedEvent(ResourceType.REFUND,
                 refundEntity.getExternalId(),
                 Event.eventTypeForClass(refundEventClass),
-                now(ZoneId.of("UTC")));
+                Instant.now());
     }
 
     @Transactional
@@ -88,7 +86,7 @@ public class StateTransitionService {
         eventService.recordOfferedEvent(ResourceType.PAYMENT,
                 externalId,
                 Event.eventTypeForClass(eventClass),
-                chargeEventEntity.getUpdated());
+                chargeEventEntity.getUpdated().toInstant());
     }
 
     private void incrementPerGatewayAccountStateTransitionCounter(ChargeStatus targetChargeState, ChargeEventEntity chargeEventEntity) {
@@ -120,6 +118,6 @@ public class StateTransitionService {
                                      ZonedDateTime doNotRetryEmitUntilDate) {
         stateTransitionQueue.offer(stateTransition);
         eventService.recordOfferedEvent(event.getResourceType(), event.getResourceExternalId(),
-                event.getEventType(), event.getTimestamp(), doNotRetryEmitUntilDate);
+                event.getEventType(), event.getTimestamp().toInstant(), doNotRetryEmitUntilDate);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/EmittedEventFixture.java
+++ b/src/test/java/uk/gov/pay/connector/events/EmittedEventFixture.java
@@ -1,14 +1,14 @@
 package uk.gov.pay.connector.events;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class EmittedEventFixture {
     private Long id = 1L;
     private String resourceType = "payment";
     private String resourceExternalId = "some-external-id";
     private String eventType = "PAYMENT_CREATED";
-    private ZonedDateTime eventDate = ZonedDateTime.parse("2019-09-20T10:00Z");
-    private ZonedDateTime emittedDate;
+    private Instant eventDate = Instant.parse("2019-09-20T10:00:00Z");
+    private Instant emittedDate;
 
     public static EmittedEventFixture anEmittedEventEntity() {
         return new EmittedEventFixture();
@@ -22,12 +22,12 @@ public class EmittedEventFixture {
         return event;
     }
 
-    public EmittedEventFixture withEmittedDate(ZonedDateTime emittedDate) {
+    public EmittedEventFixture withEmittedDate(Instant emittedDate) {
         this.emittedDate = emittedDate;
         return this;
     }
 
-    public EmittedEventFixture withEventDate(ZonedDateTime eventDate) {
+    public EmittedEventFixture withEventDate(Instant eventDate) {
         this.eventDate = eventDate;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
@@ -87,7 +87,8 @@ public class EventServiceTest {
 
         verify(eventQueue).emitEvent(event);
         verify(emittedEventDao, never()).recordEmission(event, null);
-        verify(emittedEventDao).recordEmission(event.getResourceType(), event.getResourceExternalId(), event.getEventType(), event.getTimestamp(), null);
+        verify(emittedEventDao).recordEmission(event.getResourceType(), event.getResourceExternalId(), event.getEventType(),
+                event.getTimestamp().toInstant(), null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
@@ -12,7 +12,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.EventService;
@@ -26,6 +25,7 @@ import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 import static java.time.ZoneOffset.UTC;
@@ -88,7 +88,7 @@ public class StateTransitionServiceTest {
         assertThat(paymentStateTransitionArgumentCaptor.getValue().getChargeEventId(), is(100L));
         assertThat(paymentStateTransitionArgumentCaptor.getValue().getStateTransitionEventClass(), is(PaymentStarted.class));
 
-        verify(mockEventService).recordOfferedEvent(PAYMENT, "external-id", "PAYMENT_STARTED", chargeEvent.getUpdated());
+        verify(mockEventService).recordOfferedEvent(PAYMENT, "external-id", "PAYMENT_STARTED", chargeEvent.getUpdated().toInstant());
     }
 
     @Test
@@ -115,7 +115,7 @@ public class StateTransitionServiceTest {
         assertThat(refundStateTransitionArgumentCaptor.getValue().getRefundExternalId(), is(refundEntity.getExternalId()));
         assertThat(refundStateTransitionArgumentCaptor.getValue().getStateTransitionEventClass(), is(RefundCreatedByUser.class));
 
-        ArgumentCaptor<ZonedDateTime> eventDateArgumentCaptor = forClass(ZonedDateTime.class);
+        ArgumentCaptor<Instant> eventDateArgumentCaptor = forClass(Instant.class);
         ArgumentCaptor<ResourceType> resourceTypeCaptor = forClass(ResourceType.class);
         ArgumentCaptor<String> externalIdCaptor = forClass(String.class);
         ArgumentCaptor<String> eventTypeCaptor = forClass(String.class);
@@ -148,6 +148,6 @@ public class StateTransitionServiceTest {
         assertThat(refundStateTransitionArgumentCaptor.getValue().getStateTransitionEventClass(), is(RefundCreatedByUser.class));
 
         verify(mockEventService).recordOfferedEvent(REFUND, refundHistory.getExternalId(),
-                "REFUND_CREATED_BY_USER", refundHistory.getHistoryStartDate(), doNotEmitRetryUntil);
+                "REFUND_CREATED_BY_USER", refundHistory.getHistoryStartDate().toInstant(), doNotEmitRetryUntil);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -995,7 +995,7 @@ public class DatabaseTestHelper {
                                 " :eventType, :emittedDate, :doNotRetryEmitUntil)")
                         .bind("resourceType", resourceType)
                         .bind("externalId", externalId)
-                        .bind("eventDate", Timestamp.from(eventDate))
+                        .bind("eventDate", LocalDateTime.ofInstant(eventDate, UTC))
                         .bind("eventType", eventType)
                         .bind("emittedDate", emittedDate)
                         .bind("doNotRetryEmitUntil", doNotRetryEmitUntil == null ? null : Timestamp.from(doNotRetryEmitUntil))


### PR DESCRIPTION
In `EmittedEventEntity`, use an `Instant` rather than a `ZonedDateTime` for the `eventDate` and `emittedEventDate` fields.

Leave `doNotRetryEmitUntil` as a `ZonedDateTime` for now because it’s persisted into a database column of type `TIMESTAMP WITH TIME ZONE` (as opposed to `TIMESTAMP WITHOUT TIME ZONE`) so will require more tweaks.

This changes how the `EmittedEventBackfill` service logs timestamps when the time is bang on the minute (it will log
`2019-09-20T10:00:00Z` rather than `2019-09-20T10:00Z`) but I’ll eat my hat if anything is relying on that.

To avoid a `NullPointerException`, a change had to made to the `markEventAsEmitted_shouldRecordEventAndEmittedDate` test in `EmittedEventDaoIT`, adding a timestamp to a `RefundSubmitted` event. I believe all `Event`s (of the
`uk.gov.pay.connector.events.model.Event` kind) have a non-null timestamp (with the exception of `UnspecifiedEvent`, which never gets persisted or emitted) so this should be safe.

In `DatabaseTestHelper`, `addEmittedEvent` had to be changed so that the event date is converted to a `LocalDateTime` in UTC rather than a `Timestamp` because it seemed to be being mangled to be an hour ahead when the tests ran on my machine in the BST time zone, which I think is due to JDBI relying on the default time zone. Not entirely sure what change caused this to become a problem now but I’m fairly certain nothing will be altered in production where we run on UTC all year round.