### PR TITLE
Convert ContractTestSuite to JUnit 4.x

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/AdminusersQueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/AdminusersQueueMessageContractTest.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.provider.junit.loader.PactBroker;
 import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
 import org.junit.runner.RunWith;
 
+@Tag("contract")
 @RunWith(PactRunner.class)
 @Provider("connector")
 @PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTestSuite.java
@@ -1,22 +1,15 @@
 package uk.gov.pay.connector.pact;
 
-import com.google.common.collect.ImmutableSetMultimap;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.TestSuite;
 import org.junit.runner.RunWith;
-import org.junit.runners.AllTests;
-import uk.gov.service.payments.commons.testing.pact.provider.CreateTestSuite;
+import org.junit.runners.Suite;
 
-@RunWith(AllTests.class)
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        FrontendContractTest.class,
+        LedgerQueueMessageContractTest.class,
+        AdminusersQueueMessageContractTest.class,
+        PublicApiContractTest.class,
+        SelfServiceContractTest.class
+})
 public class ContractTestSuite {
-    
-    public static TestSuite suite() {
-        ImmutableSetMultimap<String, JUnit4TestAdapter> consumerToJUnitTest = ImmutableSetMultimap.of(
-                "frontend", new JUnit4TestAdapter(FrontendContractTest.class),
-                "ledger", new JUnit4TestAdapter(LedgerQueueMessageContractTest.class),
-                "adminusers", new JUnit4TestAdapter(AdminusersQueueMessageContractTest.class),
-                "publicapi", new JUnit4TestAdapter(PublicApiContractTest.class),
-                "selfservice", new JUnit4TestAdapter(SelfServiceContractTest.class));
-        return CreateTestSuite.create(consumerToJUnitTest);
-    }
 }


### PR DESCRIPTION
The JUnit 5.x way of doing this would probably involve switching to using the @Tag annotation, but this at least drops JUnit 3.x.