### PR TITLE
PP-10173 Use Instant not ZonedDateTime in TransactionEvent

### DIFF
--- a/src/main/java/uk/gov/pay/connector/chargeevent/model/TransactionEvent.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/model/TransactionEvent.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
@@ -94,9 +94,9 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
     private String userExternalId;
     private State state;
     private Long amount;
-    private ZonedDateTime updated;
+    private Instant updated;
 
-    public TransactionEvent(Type type, String extChargeId, State state, Long amount, ZonedDateTime updated) {
+    public TransactionEvent(Type type, String extChargeId, State state, Long amount, Instant updated) {
         this.type = type;
         this.extChargeId = extChargeId;
         this.state = state;
@@ -104,7 +104,8 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
         this.updated = updated;
     }
 
-    public TransactionEvent(Type type, String extChargeId, String refundGatewayTransactionId, State state, Long amount, ZonedDateTime updated, String userExternalId) {
+    public TransactionEvent(Type type, String extChargeId, String refundGatewayTransactionId,
+                            State state,Long amount, Instant updated, String userExternalId) {
         this.type = type;
         this.refundGatewayTransactionId = refundGatewayTransactionId;
         this.extChargeId = extChargeId;
@@ -157,7 +158,7 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
     }
 
     @JsonIgnore
-    public ZonedDateTime getTimeUpdate() {
+    public Instant getTimeUpdate() {
         return updated;
     }
 

--- a/src/main/java/uk/gov/pay/connector/chargeevent/resource/ChargeEventsResource.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/resource/ChargeEventsResource.java
@@ -87,7 +87,7 @@ public class ChargeEventsResource {
                         event.getChargeEntity().getExternalId(),
                         extractState(event.getStatus().toExternal()),
                         event.getChargeEntity().getAmount(),
-                        event.getUpdated()
+                        event.getUpdated().toInstant()
                 ))
                 .collect(toList());
     }
@@ -100,7 +100,7 @@ public class ChargeEventsResource {
                         event.getGatewayTransactionId(),
                         extractState(event.getStatus().toExternal()),
                         event.getAmount(),
-                        event.getHistoryStartDate(),
+                        event.getHistoryStartDate().toInstant(),
                         event.getUserExternalId()
                 ))
                 .collect(toList());

--- a/src/test/java/uk/gov/pay/connector/model/TransactionEventTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/TransactionEventTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 import uk.gov.pay.connector.chargeevent.model.TransactionEvent;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -20,7 +20,8 @@ public class TransactionEventTest {
     @Test
     public void equals_shouldReturnTrue_whenSameInstance() {
 
-        TransactionEvent event = new TransactionEvent(Type.PAYMENT, "charge", extractState(ExternalChargeState.EXTERNAL_CREATED), 100L, ZonedDateTime.now());
+        TransactionEvent event = new TransactionEvent(Type.PAYMENT, "charge", extractState(ExternalChargeState.EXTERNAL_CREATED),
+                100L, Instant.now());
 
         assertEquals(event, event);
     }
@@ -28,8 +29,10 @@ public class TransactionEventTest {
     @Test
     public void equals_shouldReturnTrue_whenFieldsAreTheSame() {
 
-        TransactionEvent event1 = new TransactionEvent(Type.PAYMENT, "charge", extractState(ExternalChargeState.EXTERNAL_CREATED), 100L, ZonedDateTime.now());
-        TransactionEvent event2 = new TransactionEvent(Type.PAYMENT, "charge", extractState(ExternalChargeState.EXTERNAL_CREATED), 100L, ZonedDateTime.now());
+        TransactionEvent event1 = new TransactionEvent(Type.PAYMENT, "charge", extractState(ExternalChargeState.EXTERNAL_CREATED),
+                100L, Instant.now());
+        TransactionEvent event2 = new TransactionEvent(Type.PAYMENT, "charge", extractState(ExternalChargeState.EXTERNAL_CREATED),
+                100L, Instant.now());
 
         assertThat(event1.equals(event2), is(true));
     }
@@ -37,8 +40,10 @@ public class TransactionEventTest {
     @Test
     public void equals_shouldReturnFalse_whenFieldsRefundTransactionIdIsDifferent() {
 
-        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(), USER_EXTERNAL_ID);
-        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", "success", extractState(EXTERNAL_SUBMITTED),
+                100L, Instant.now(), USER_EXTERNAL_ID);
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED),
+                100L, Instant.now(),USER_EXTERNAL_ID);
 
         assertThat(event1.equals(event2), is(false));
     }
@@ -46,8 +51,10 @@ public class TransactionEventTest {
     @Test
     public void equals_shouldReturnFalse_whenFirstObjectRefundTransactionIdIsNull() {
 
-        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
-        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED),
+                100L, Instant.now(),USER_EXTERNAL_ID);
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED),
+                100L, Instant.now(),USER_EXTERNAL_ID);
 
         assertThat(event1.equals(event2), is(false));
     }
@@ -55,8 +62,10 @@ public class TransactionEventTest {
     @Test
     public void equals_shouldReturnFalse_whenSecondObjectRefundTransactionIdIsNull() {
 
-        TransactionEvent event1 = new TransactionEvent(Type.REFUND, null, "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
-        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, null, "success", extractState(EXTERNAL_SUBMITTED),
+                100L, Instant.now(),USER_EXTERNAL_ID);
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED),
+                100L, Instant.now(),USER_EXTERNAL_ID);
 
         assertThat(event1.equals(event2), is(false));
     }


### PR DESCRIPTION
This will not change how `TransactionEvent` is serialised to JSON.