### PR TITLE
PP-10173 Use Instant not ZonedDateTime for timestamp in Event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/EventService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EventService.java
@@ -67,7 +67,7 @@ public class EventService {
             emittedEventDao.recordEmission(event, doNotRetryEmitUntilDate);
         } catch (QueueException e) {
             emittedEventDao.recordEmission(event.getResourceType(), event.getResourceExternalId(),
-                    event.getEventType(), event.getTimestamp().toInstant(), doNotRetryEmitUntilDate);
+                    event.getEventType(), event.getTimestamp(), doNotRetryEmitUntilDate);
             logger.error("Failed to emit event {} due to {} [externalId={}]",
                     event.getEventType(), e.getMessage(), event.getResourceExternalId());
         }

--- a/src/main/java/uk/gov/pay/connector/events/dao/EmittedEventDao.java
+++ b/src/main/java/uk/gov/pay/connector/events/dao/EmittedEventDao.java
@@ -34,7 +34,7 @@ public class EmittedEventDao extends JpaDao<EmittedEventEntity> {
                 .setParameter("resource_type", event.getResourceType().getLowercase())
                 .setParameter("resource_external_id", event.getResourceExternalId())
                 .setParameter("event_type", event.getEventType())
-                .setParameter("event_date", event.getTimestamp().toInstant())
+                .setParameter("event_date", event.getTimestamp())
                 .getResultList();
         return !singleResult.isEmpty();
     }
@@ -43,7 +43,7 @@ public class EmittedEventDao extends JpaDao<EmittedEventEntity> {
         final EmittedEventEntity emittedEvent = new EmittedEventEntity(event.getResourceType().getLowercase(),
                 event.getResourceExternalId(),
                 event.getEventType(),
-                event.getTimestamp().toInstant(),
+                event.getTimestamp(),
                 Instant.now(),
                 doNotRetryEmitUntilDate
         );
@@ -78,7 +78,7 @@ public class EmittedEventDao extends JpaDao<EmittedEventEntity> {
                 .setParameter("resource_external_id", event.getResourceExternalId())
                 .setParameter("event_type", event.getEventType())
                 .setParameter("emittedDate", Instant.now())
-                .setParameter("eventDate", event.getTimestamp().toInstant());
+                .setParameter("eventDate", event.getTimestamp());
 
         query.executeUpdate();
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/Event.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/Event.java
@@ -7,10 +7,11 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.dropwizard.jackson.Jackson;
-import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
 import uk.gov.pay.connector.events.eventdetails.EmptyEventDetails;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.service.payments.commons.api.json.ApiResponseInstantWithMicrosecondPrecisionSerializer;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
@@ -20,18 +21,26 @@ public abstract class Event {
     private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
     private String resourceExternalId;
     private EventDetails eventDetails;
-    private ZonedDateTime timestamp;
+    private Instant timestamp;
 
-    public Event(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+    public Event(Instant timestamp, String resourceExternalId, EventDetails eventDetails) {
+        this.timestamp = timestamp;
         this.resourceExternalId = resourceExternalId;
         this.eventDetails = eventDetails;
-        this.timestamp = timestamp;
     }
 
+    public Event(Instant timestamp, String resourceExternalId) {
+        this(timestamp, resourceExternalId, new EmptyEventDetails());
+    }
+
+    @Deprecated
+    public Event(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        this(timestamp.toInstant(), resourceExternalId, eventDetails);
+    }
+
+    @Deprecated
     public Event(String resourceExternalId, ZonedDateTime timestamp) {
-        this.resourceExternalId = resourceExternalId;
-        this.timestamp = timestamp;
-        this.eventDetails = new EmptyEventDetails();
+        this(timestamp.toInstant(), resourceExternalId);
     }
 
     public abstract ResourceType getResourceType();
@@ -44,8 +53,8 @@ public abstract class Event {
         return eventDetails;
     }
 
-    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
-    public ZonedDateTime getTimestamp() {
+    @JsonSerialize(using = ApiResponseInstantWithMicrosecondPrecisionSerializer.class)
+    public Instant getTimestamp() {
         return timestamp;
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/UnspecifiedEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/UnspecifiedEvent.java
@@ -2,16 +2,12 @@ package uk.gov.pay.connector.events.model;
 
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class UnspecifiedEvent extends Event {
 
     public UnspecifiedEvent() {
-        super(null, null);
-    }
-
-    public UnspecifiedEvent(String resourceExternalId, ZonedDateTime timestamp) {
-        super(resourceExternalId, timestamp);
+        super((Instant) null, null);
     }
 
     @Override
@@ -35,7 +31,7 @@ public class UnspecifiedEvent extends Event {
     }
 
     @Override
-    public ZonedDateTime getTimestamp() {
+    public Instant getTimestamp() {
         return null;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
@@ -118,6 +118,6 @@ public class StateTransitionService {
                                      ZonedDateTime doNotRetryEmitUntilDate) {
         stateTransitionQueue.offer(stateTransition);
         eventService.recordOfferedEvent(event.getResourceType(), event.getResourceExternalId(),
-                event.getEventType(), event.getTimestamp().toInstant(), doNotRetryEmitUntilDate);
+                event.getEventType(), event.getTimestamp(), doNotRetryEmitUntilDate);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
@@ -88,7 +88,7 @@ public class EventServiceTest {
         verify(eventQueue).emitEvent(event);
         verify(emittedEventDao, never()).recordEmission(event, null);
         verify(emittedEventDao).recordEmission(event.getResourceType(), event.getResourceExternalId(), event.getEventType(),
-                event.getTimestamp().toInstant(), null);
+                event.getTimestamp(), null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
@@ -95,7 +95,7 @@ public class EmittedEventDaoIT extends DaoITestBase {
         final PaymentCreated eventToRecord = aPaymentCreatedEvent();
         ZonedDateTime doNotRetryEmitUntilDate = ZonedDateTime.parse("2019-01-02T13:00:00Z");
         emittedEventDao.recordEmission(eventToRecord.getResourceType(), eventToRecord.getResourceExternalId(),
-                eventToRecord.getEventType(), eventToRecord.getTimestamp().toInstant(), doNotRetryEmitUntilDate);
+                eventToRecord.getEventType(), eventToRecord.getTimestamp(), doNotRetryEmitUntilDate);
 
         final List<Map<String, Object>> events = databaseTestHelper.readEmittedEvents();
 
@@ -113,7 +113,7 @@ public class EmittedEventDaoIT extends DaoITestBase {
         final RefundSubmitted eventToRecord = aRefundSubmittedEvent(ZonedDateTime.parse("2018-01-01T12:00:00Z"));
 
         emittedEventDao.recordEmission(eventToRecord.getResourceType(), eventToRecord.getResourceExternalId(),
-                eventToRecord.getEventType(), eventToRecord.getTimestamp().toInstant(), null);
+                eventToRecord.getEventType(), eventToRecord.getTimestamp(), null);
 
         List<Map<String, Object>> events = databaseTestHelper.readEmittedEvents();
         Map<String, Object> event = events.get(0);
@@ -149,7 +149,7 @@ public class EmittedEventDaoIT extends DaoITestBase {
     public void findNotEmittedEventsOlderThan_shouldReturnEventsWithEmptyEmittedDate() {
         final PaymentCreated paymentCreatedEvent = aPaymentCreatedEvent();
         emittedEventDao.recordEmission(paymentCreatedEvent.getResourceType(), paymentCreatedEvent.getResourceExternalId(),
-                paymentCreatedEvent.getEventType(), paymentCreatedEvent.getTimestamp().toInstant(), null);
+                paymentCreatedEvent.getEventType(), paymentCreatedEvent.getTimestamp(), null);
 
         Optional<Long> maxId = emittedEventDao.findNotEmittedEventMaxIdOlderThan(Instant.parse("2019-01-01T14:00:01Z"),
                 ZonedDateTime.now(UTC));
@@ -170,12 +170,12 @@ public class EmittedEventDaoIT extends DaoITestBase {
         final PaymentCreated paymentCreatedEvent = aPaymentCreatedEvent();
         final RefundSubmitted refundSubmittedEvent = aRefundSubmittedEvent(ZonedDateTime.parse("2019-01-01T14:00:00Z"));
         emittedEventDao.recordEmission(paymentCreatedEvent.getResourceType(), paymentCreatedEvent.getResourceExternalId(),
-                paymentCreatedEvent.getEventType(), paymentCreatedEvent.getTimestamp().toInstant(), null);
+                paymentCreatedEvent.getEventType(), paymentCreatedEvent.getTimestamp(), null);
         ZonedDateTime doNotRetryEmitUntil = ZonedDateTime.now(UTC).minusSeconds(120);
         emittedEventDao.recordEmission(refundSubmittedEvent.getResourceType(), refundSubmittedEvent.getResourceExternalId(),
-                refundSubmittedEvent.getEventType(), refundSubmittedEvent.getTimestamp().toInstant(), doNotRetryEmitUntil);
+                refundSubmittedEvent.getEventType(), refundSubmittedEvent.getTimestamp(), doNotRetryEmitUntil);
         emittedEventDao.recordEmission(paymentCreatedEvent.getResourceType(), paymentCreatedEvent.getResourceExternalId(),
-                paymentCreatedEvent.getEventType(), paymentCreatedEvent.getTimestamp().toInstant(), ZonedDateTime.now(UTC).plusSeconds(120));
+                paymentCreatedEvent.getEventType(), paymentCreatedEvent.getTimestamp(), ZonedDateTime.now(UTC).plusSeconds(120));
 
         Optional<Long> maxId = emittedEventDao.findNotEmittedEventMaxIdOlderThan(Instant.parse("2019-01-01T14:00:01Z"), ZonedDateTime.now(UTC));
         assertThat(maxId.isPresent(), is(true));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MICROSECOND_PRECISION;
 
 public class CaptureConfirmedTest {
 
@@ -65,6 +66,7 @@ public class CaptureConfirmedTest {
         assertThat(actual, hasJsonPath("$.event_type", equalTo("CAPTURE_CONFIRMED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEvent.getChargeEntity().getExternalId())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(ISO_INSTANT_MICROSECOND_PRECISION.format(updated))));
 
         assertThat(actual, hasJsonPath("$.event_details.gateway_event_date", equalTo("2018-03-12T16:25:01.123456Z")));
         assertThat(actual, hasNoJsonPath("$.event_details.fee"));
@@ -74,7 +76,9 @@ public class CaptureConfirmedTest {
 
     @Test
     public void serializesEventGivenNoDetailValues() throws JsonProcessingException {
+        ZonedDateTime updated = ZonedDateTime.parse("2018-03-12T16:25:02.123456Z");
         ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
+        when(chargeEvent.getUpdated()).thenReturn(updated);
         when(chargeEvent.getChargeEntity()).thenReturn(chargeEntity.build());
         when(chargeEvent.getGatewayEventDate()).thenReturn(Optional.empty());
 
@@ -83,6 +87,7 @@ public class CaptureConfirmedTest {
         assertThat(actual, hasJsonPath("$.event_type", equalTo("CAPTURE_CONFIRMED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEvent.getChargeEntity().getExternalId())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(ISO_INSTANT_MICROSECOND_PRECISION.format(updated))));
 
         assertThat(actual, hasNoJsonPath("$.event_details.gateway_event_date"));
         assertThat(actual, hasNoJsonPath("$.event_details.fee"));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisationTest.java
@@ -38,6 +38,8 @@ public class GatewayRequires3dsAuthorisationTest {
         assertThat(actual, hasJsonPath("$.event_type", equalTo("GATEWAY_REQUIRES_3DS_AUTHORISATION")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEvent.getChargeEntity().getExternalId())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo("2018-03-12T16:25:02.123456Z")));
+
 
         assertThat(actual, hasJsonPath("$.event_details.requires_3ds", equalTo(true)));
         assertThat(actual, hasJsonPath("$.event_details.version_3ds", equalTo("2.1.0")));
@@ -45,8 +47,11 @@ public class GatewayRequires3dsAuthorisationTest {
 
     @Test
     public void serializesEventCorrectlyWhenVersion3dsIsNotAvailable() throws JsonProcessingException {
+        ZonedDateTime updated = ZonedDateTime.parse("2018-03-12T16:25:02.123456Z");
+
         ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
         when(chargeEvent.getChargeEntity()).thenReturn(chargeEntity.build());
+        when(chargeEvent.getUpdated()).thenReturn(updated);
         when(chargeEvent.getGatewayEventDate()).thenReturn(Optional.empty());
 
         String actual = GatewayRequires3dsAuthorisation.from(chargeEvent).toJsonString();
@@ -54,6 +59,7 @@ public class GatewayRequires3dsAuthorisationTest {
         assertThat(actual, hasJsonPath("$.event_type", equalTo("GATEWAY_REQUIRES_3DS_AUTHORISATION")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEvent.getChargeEntity().getExternalId())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo("2018-03-12T16:25:02.123456Z")));
 
         assertThat(actual, hasJsonPath("$.event_details.requires_3ds", equalTo(true)));
         assertThat(actual, hasNoJsonPath("$.event_details.version_3ds"));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
@@ -20,12 +21,14 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MICROSECOND_PRECISION;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.EXTERNAL;
 import static uk.gov.service.payments.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 
 public class PaymentNotificationCreatedTest {
 
     private final String providerId = "validTransactionId";
+    private final ZonedDateTime notificationTimestamp = ZonedDateTime.parse("2022-10-06T15:00:00.123456Z");
 
     private ChargeEntityFixture chargeEntityFixture;
 
@@ -57,12 +60,14 @@ public class PaymentNotificationCreatedTest {
         ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
         ChargeEntity chargeEntity = chargeEntityFixture.build();
         when(chargeEvent.getChargeEntity()).thenReturn(chargeEntity);
+        when(chargeEvent.getUpdated()).thenReturn(notificationTimestamp);
 
         String actual = PaymentNotificationCreated.from(chargeEvent).toJsonString();
 
         assertThat(actual, hasJsonPath("$.event_type", equalTo("PAYMENT_NOTIFICATION_CREATED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(ISO_INSTANT_MICROSECOND_PRECISION.format(notificationTimestamp))));
 
         assertThat(actual, hasJsonPath("$.event_details.amount", equalTo(100)));
         assertThat(actual, hasJsonPath("$.event_details.live", equalTo(false)));
@@ -93,12 +98,14 @@ public class PaymentNotificationCreatedTest {
         ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
         ChargeEntity chargeEntity = chargeEntityFixture.build();
         when(chargeEvent.getChargeEntity()).thenReturn(chargeEntity);
+        when(chargeEvent.getUpdated()).thenReturn(notificationTimestamp);
 
         String actual = PaymentNotificationCreated.from(chargeEvent).toJsonString();
 
         assertThat(actual, hasJsonPath("$.event_type", equalTo("PAYMENT_NOTIFICATION_CREATED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(ISO_INSTANT_MICROSECOND_PRECISION.format(notificationTimestamp))));
         assertThat(actual, hasJsonPath("$.event_details.live", equalTo(false)));
 
         assertThat(actual, hasJsonPath("$.event_details.amount", equalTo(100)));
@@ -130,12 +137,14 @@ public class PaymentNotificationCreatedTest {
         ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
         ChargeEntity chargeEntity = chargeEntityFixture.build();
         when(chargeEvent.getChargeEntity()).thenReturn(chargeEntity);
+        when(chargeEvent.getUpdated()).thenReturn(notificationTimestamp);
 
         String actual = PaymentNotificationCreated.from(chargeEvent).toJsonString();
 
         assertThat(actual, hasJsonPath("$.event_type", equalTo("PAYMENT_NOTIFICATION_CREATED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(ISO_INSTANT_MICROSECOND_PRECISION.format(notificationTimestamp))));
         assertThat(actual, hasJsonPath("$.event_details.live", equalTo(false)));
 
         assertThat(actual, hasJsonPath("$.event_details.amount", equalTo(100)));

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessorTest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.processor;
 
 import junitparams.JUnitParamsRunner;
-import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
+import org.exparity.hamcrest.date.InstantMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,9 +20,9 @@ import uk.gov.pay.connector.events.model.ResourceType;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
+import java.time.Instant;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.verify;
@@ -68,7 +68,7 @@ public class ChargeNotificationProcessorTest {
         Event event = eventArgumentCaptor.getValue();
 
         assertThat(event.getEventType(), is("CAPTURE_CONFIRMED_BY_GATEWAY_NOTIFICATION"));
-        assertThat(event.getTimestamp(), ZonedDateTimeMatchers.within(5, ChronoUnit.SECONDS, ZonedDateTime.now()));
+        assertThat(event.getTimestamp(), InstantMatchers.within(5, SECONDS, Instant.now()));
         assertThat(event.getResourceType(), is(ResourceType.PAYMENT));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
@@ -253,7 +253,7 @@ public class StripeWebhookTaskHandlerTest {
         DisputeLost disputeLost = argumentCaptor.getValue();
         assertThat(disputeLost.getEventType(), is("DISPUTE_LOST"));
         assertThat(disputeLost.getResourceType(), is(ResourceType.DISPUTE));
-        assertThat(disputeLost.getTimestamp(), is(stripeNotification.getCreated()));
+        assertThat(disputeLost.getTimestamp(), is(stripeNotification.getCreated().toInstant()));
 
         DisputeLostEventDetails eventDetails = (DisputeLostEventDetails) disputeLost.getEventDetails();
         assertThat(eventDetails.getGatewayAccountId(), is("1000"));
@@ -298,7 +298,7 @@ public class StripeWebhookTaskHandlerTest {
         DisputeLost disputeLost = argumentCaptor.getValue();
         assertThat(disputeLost.getEventType(), is("DISPUTE_LOST"));
         assertThat(disputeLost.getResourceType(), is(ResourceType.DISPUTE));
-        assertThat(disputeLost.getTimestamp(), is(stripeNotification.getCreated().plusSeconds(1)));
+        assertThat(disputeLost.getTimestamp(), is(stripeNotification.getCreated().plusSeconds(1).toInstant()));
 
         DisputeLostEventDetails eventDetails = (DisputeLostEventDetails) disputeLost.getEventDetails();
         assertThat(eventDetails.getGatewayAccountId(), is("1000"));
@@ -334,7 +334,7 @@ public class StripeWebhookTaskHandlerTest {
         DisputeLost disputeLost = argumentCaptor.getValue();
         assertThat(disputeLost.getEventType(), is("DISPUTE_LOST"));
         assertThat(disputeLost.getResourceType(), is(ResourceType.DISPUTE));
-        assertThat(disputeLost.getTimestamp(), is(stripeNotification.getCreated()));
+        assertThat(disputeLost.getTimestamp(), is(stripeNotification.getCreated().toInstant()));
 
         DisputeLostEventDetails eventDetails = (DisputeLostEventDetails) disputeLost.getEventDetails();
         assertThat(eventDetails.getGatewayAccountId(), is("1000"));
@@ -368,7 +368,7 @@ public class StripeWebhookTaskHandlerTest {
         DisputeLost disputeLost = argumentCaptor.getValue();
         assertThat(disputeLost.getEventType(), is("DISPUTE_LOST"));
         assertThat(disputeLost.getResourceType(), is(ResourceType.DISPUTE));
-        assertThat(disputeLost.getTimestamp(), is(stripeNotification.getCreated()));
+        assertThat(disputeLost.getTimestamp(), is(stripeNotification.getCreated().toInstant()));
 
         DisputeLostEventDetails eventDetails = (DisputeLostEventDetails) disputeLost.getEventDetails();
         assertThat(eventDetails.getGatewayAccountId(), is("1000"));
@@ -457,7 +457,7 @@ public class StripeWebhookTaskHandlerTest {
         DisputeEvidenceSubmitted disputeEvidenceSubmitted = argumentCaptor.getValue();
         assertThat(disputeEvidenceSubmitted.getEventType(), is("DISPUTE_EVIDENCE_SUBMITTED"));
         assertThat(disputeEvidenceSubmitted.getResourceType(), is(ResourceType.DISPUTE));
-        assertThat(disputeEvidenceSubmitted.getTimestamp(), is(stripeNotification.getCreated()));
+        assertThat(disputeEvidenceSubmitted.getTimestamp(), is(stripeNotification.getCreated().toInstant()));
 
         DisputeEvidenceSubmittedEventDetails eventDetails = (DisputeEvidenceSubmittedEventDetails) disputeEvidenceSubmitted.getEventDetails();
         assertThat(eventDetails.getGatewayAccountId(), is("1000"));


### PR DESCRIPTION
Make the timestamp field in `Event` (the superclass of the events that get emitted to ledger) be an `Instant` rather than a `ZonedDateTime`.

This does not change how a subclass of `Event` is serialised to JSON.

Keep the existing constructors that use `ZonedDateTime` so we can migrate the subclasses gradually.

This may change how the timestamp is stringified in the `toString()` method for subclasses of `Event` in some circumstances but not in a significant way.

To avoid `NullPointerException`s triggered by some new conversions from `ZonedDateTime` to `Instant`, some tests were updated to include a timestamp in an `Event` where there previously was not one. This is fine as in reality all events have timestamps (except for `UnspecifiedEvent`).