### PR TITLE
FIX: Dependabot/maven/com.stripe stripe java 21.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
         <dependency>
             <groupId>com.stripe</groupId>
             <artifactId>stripe-java</artifactId>
-            <version>20.136.0</version>
+            <version>21.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/src/main/java/uk/gov/pay/connector/payout/StripeClientWrapper.java
+++ b/src/main/java/uk/gov/pay/connector/payout/StripeClientWrapper.java
@@ -19,6 +19,6 @@ class StripeClientWrapper {
                 "payout", payoutId,
                 "expand", List.of("data.source", "data.source.source_transfer"));
         
-        return BalanceTransaction.list(params, requestOptions).autoPagingIterable();
+        return BalanceTransaction.list(params, requestOptions).autoPagingIterable(params, requestOptions);
     }
 }


### PR DESCRIPTION
A [breaking interface change](https://github.com/stripe/stripe-java/blob/master/CHANGELOG.md#2100---2022-08-02) in release `21.0.0 - 2022-08-02` means
that the request options specified on the list method will no longer
apply to the auto paging request. Pass the request options into the auto
paging request to provide the Stripe API key.