### PR TITLE
PP-10173 Use Instant in PaymentEvent

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -101,8 +101,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static java.time.ZoneOffset.UTC;
-import static java.time.ZonedDateTime.now;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
@@ -393,7 +391,7 @@ public class ChargeService {
                 .map(chargeEntity -> {
                     if (chargePatchRequest.getPath().equals(ChargesApiResource.EMAIL_KEY)) {
                         chargeEntity.setEmail(chargePatchRequest.getValue());
-                        eventService.emitAndRecordEvent(UserEmailCollected.from(chargeEntity, now(UTC)));
+                        eventService.emitAndRecordEvent(UserEmailCollected.from(chargeEntity, Instant.now()));
                     }
                     return Optional.of(chargeEntity);
                 })
@@ -686,7 +684,7 @@ public class ChargeService {
             }
 
             if (auth3dsRequiredDetails != null && isNotBlank(auth3dsRequiredDetails.getThreeDsVersion())) {
-                eventService.emitAndRecordEvent(Gateway3dsInfoObtained.from(charge, ZonedDateTime.now()));
+                eventService.emitAndRecordEvent(Gateway3dsInfoObtained.from(charge, Instant.now()));
             }
 
             return charge;
@@ -1015,7 +1013,7 @@ public class ChargeService {
         }
     }
     
-    public RefundAvailabilityUpdated createRefundAvailabilityUpdatedEvent(Charge charge, ZonedDateTime eventTimestamp) {
+    public RefundAvailabilityUpdated createRefundAvailabilityUpdatedEvent(Charge charge, Instant eventTimestamp) {
         List<Refund> refundList = refundService.findRefunds(charge);
         ExternalChargeRefundAvailability refundAvailability;
 

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -41,6 +41,7 @@ import uk.gov.pay.connector.refund.service.RefundService;
 
 import javax.inject.Inject;
 import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -102,7 +103,7 @@ public class EventFactory {
 
         Optional<Event> refundAvailabilityEvent = createRefundAvailabilityUpdatedEvent(
                 Charge.from(chargeEvent.getChargeEntity()),
-                chargeEvent.getUpdated(),
+                chargeEvent.getUpdated().toInstant(),
                 paymentStateTransition.getStateTransitionEventClass()
         );
 
@@ -123,7 +124,7 @@ public class EventFactory {
                 charge);
         Optional<Event> refundAvailabilityEvent = createRefundAvailabilityUpdatedEvent(
                 charge,
-                refundHistory.getHistoryStartDate(),
+                refundHistory.getHistoryStartDate().toInstant(),
                 refundStateTransition.getStateTransitionEventClass()
         );
 
@@ -156,11 +157,11 @@ public class EventFactory {
                 return CancelledWithGatewayAfterAuthorisationError.from(chargeEvent);
             } else {
                 return eventClass.getConstructor(String.class,
-                        boolean.class, String.class, ZonedDateTime.class).newInstance(
+                        boolean.class, String.class, Instant.class).newInstance(
                         chargeEvent.getChargeEntity().getServiceId(),
                         chargeEvent.getChargeEntity().getGatewayAccount().isLive(),
                         chargeEvent.getChargeEntity().getExternalId(),
-                        chargeEvent.getUpdated()
+                        chargeEvent.getUpdated().toInstant()
                 );
             }
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
@@ -189,7 +190,7 @@ public class EventFactory {
         }
     }
 
-    private Optional<Event> createRefundAvailabilityUpdatedEvent(Charge charge, ZonedDateTime eventTimestamp, Class eventClass) {
+    private Optional<Event> createRefundAvailabilityUpdatedEvent(Charge charge, Instant eventTimestamp, Class eventClass) {
         if (EVENTS_AFFECTING_REFUNDABILITY.contains(eventClass) || EVENTS_LEADING_TO_TERMINAL_STATE.contains(eventClass)) {
             RefundAvailabilityUpdated refundAvailabilityUpdatedEvent = chargeService.createRefundAvailabilityUpdatedEvent(charge, eventTimestamp);
             return Optional.of(refundAvailabilityUpdatedEvent);

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationCancelled.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationCancelled.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 // Semantically same as auth rejected
 public class AuthorisationCancelled extends PaymentEventWithoutDetails {
-    public AuthorisationCancelled(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public AuthorisationCancelled(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasMissing.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasMissing.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class AuthorisationErrorCheckedWithGatewayChargeWasMissing extends PaymentEventWithoutDetails {
-    public AuthorisationErrorCheckedWithGatewayChargeWasMissing(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public AuthorisationErrorCheckedWithGatewayChargeWasMissing(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasRejected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasRejected.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class AuthorisationErrorCheckedWithGatewayChargeWasRejected extends PaymentEventWithoutDetails {
-    public AuthorisationErrorCheckedWithGatewayChargeWasRejected(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public AuthorisationErrorCheckedWithGatewayChargeWasRejected(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationRejected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationRejected.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 /**
  * Payment has been rejected
@@ -8,7 +8,7 @@ import java.time.ZonedDateTime;
  *
  */
 public class AuthorisationRejected extends PaymentEventWithoutDetails {
-    public AuthorisationRejected(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public AuthorisationRejected(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationSucceeded.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationSucceeded.java
@@ -1,13 +1,13 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 /**
  * Payment has moved to a success state where the request has been submitted
  *
  */
 public class AuthorisationSucceeded extends PaymentEventWithoutDetails {
-    public AuthorisationSucceeded(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public AuthorisationSucceeded(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerGatewayTransactionIdSet.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerGatewayTransactionIdSet.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.BackFillerGatewayTransactionIdSetEventDetails;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
@@ -15,7 +16,7 @@ public class BackfillerGatewayTransactionIdSet extends PaymentEvent {
                                              boolean live,
                                              String resourceExternalId,
                                              BackFillerGatewayTransactionIdSetEventDetails eventDetails,
-                                             ZonedDateTime timestamp) {
+                                             Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
@@ -31,6 +32,6 @@ public class BackfillerGatewayTransactionIdSet extends PaymentEvent {
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 BackFillerGatewayTransactionIdSetEventDetails.from(charge),
-                lastEventDate);
+                lastEventDate.toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollected.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.UserEmailCollectedEventDetails;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -22,7 +23,7 @@ public class BackfillerRecreatedUserEmailCollected extends PaymentEvent {
                                                  boolean live,
                                                  String resourceExternalId,
                                                  UserEmailCollectedEventDetails eventDetails,
-                                                 ZonedDateTime timestamp) {
+                                                 Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
@@ -38,6 +39,6 @@ public class BackfillerRecreatedUserEmailCollected extends PaymentEvent {
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 UserEmailCollectedEventDetails.from(charge),
-                lastEventDate);
+                lastEventDate.toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationFailed.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CancelByExpirationFailed extends PaymentEventWithoutDetails {
-    public CancelByExpirationFailed(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public CancelByExpirationFailed(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationSubmitted.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CancelByExpirationSubmitted extends PaymentEventWithoutDetails {
-    public CancelByExpirationSubmitted(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public CancelByExpirationSubmitted(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceFailed.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CancelByExternalServiceFailed extends PaymentEventWithoutDetails {
-    public CancelByExternalServiceFailed(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public CancelByExternalServiceFailed(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceSubmitted.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CancelByExternalServiceSubmitted extends PaymentEventWithoutDetails {
-    public CancelByExternalServiceSubmitted(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public CancelByExternalServiceSubmitted(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserFailed.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CancelByUserFailed extends PaymentEventWithoutDetails {
-    public CancelByUserFailed(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public CancelByUserFailed(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserSubmitted.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CancelByUserSubmitted extends PaymentEventWithoutDetails {
-    public CancelByUserSubmitted(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public CancelByUserSubmitted(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExpiration.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExpiration.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CancelledByExpiration extends PaymentEventWithoutDetails {
-    public CancelledByExpiration(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public CancelledByExpiration(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExternalService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExternalService.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CancelledByExternalService extends PaymentEventWithoutDetails {
-    public CancelledByExternalService(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public CancelledByExternalService(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByUser.java
@@ -4,15 +4,16 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.CancelledByUserEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CancelledByUser extends PaymentEvent {
-    public CancelledByUser(String serviceId, boolean live, String resourceExternalId, CancelledByUserEventDetails eventDetails, ZonedDateTime timestamp) {
+    public CancelledByUser(String serviceId, boolean live, String resourceExternalId, CancelledByUserEventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
     public static CancelledByUser from(ChargeEventEntity chargeEvent) {
         ChargeEntity charge = chargeEvent.getChargeEntity();
-        return new CancelledByUser(charge.getServiceId(), charge.getGatewayAccount().isLive(), charge.getExternalId(), CancelledByUserEventDetails.from(charge), chargeEvent.getUpdated());
+        return new CancelledByUser(charge.getServiceId(), charge.getGatewayAccount().isLive(), charge.getExternalId(),
+                CancelledByUserEventDetails.from(charge), chargeEvent.getUpdated().toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledWithGatewayAfterAuthorisationError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledWithGatewayAfterAuthorisationError.java
@@ -4,12 +4,12 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.CancelledWithGatewayAfterAuthorisationErrorEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CancelledWithGatewayAfterAuthorisationError extends PaymentEvent {
     public CancelledWithGatewayAfterAuthorisationError(String serviceId, boolean live, String resourceExternalId,
                                                        CancelledWithGatewayAfterAuthorisationErrorEventDetails eventDetails, 
-                                                       ZonedDateTime timestamp) {
+                                                       Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
     
@@ -21,7 +21,7 @@ public class CancelledWithGatewayAfterAuthorisationError extends PaymentEvent {
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 CancelledWithGatewayAfterAuthorisationErrorEventDetails.from(charge),
-                chargeEvent.getUpdated()
+                chargeEvent.getUpdated().toInstant()
         );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureAbandonedAfterTooManyRetries.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureAbandonedAfterTooManyRetries.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CaptureAbandonedAfterTooManyRetries extends PaymentEventWithoutDetails {
-    public CaptureAbandonedAfterTooManyRetries(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public CaptureAbandonedAfterTooManyRetries(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmed.java
@@ -4,13 +4,14 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.CaptureConfirmedEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 /**
  *  Confirmed by notification from payment gateway
  **/
 public class CaptureConfirmed extends PaymentEvent {
-    public CaptureConfirmed(String serviceId, boolean live, String resourceExternalId, CaptureConfirmedEventDetails captureConfirmedEventDetails, ZonedDateTime timestamp) {
+    public CaptureConfirmed(String serviceId, boolean live, String resourceExternalId,
+                            CaptureConfirmedEventDetails captureConfirmedEventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, captureConfirmedEventDetails, timestamp);
     }
 
@@ -22,7 +23,7 @@ public class CaptureConfirmed extends PaymentEvent {
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 CaptureConfirmedEventDetails.from(chargeEvent),
-                chargeEvent.getUpdated()
+                chargeEvent.getUpdated().toInstant()
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotification.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotification.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CaptureConfirmedByGatewayNotification extends PaymentEventWithoutDetails {
-    public CaptureConfirmedByGatewayNotification(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public CaptureConfirmedByGatewayNotification(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureErrored.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureErrored.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 // In rare circumstances.. only smartpay?
 public class CaptureErrored extends PaymentEventWithoutDetails {
-    public CaptureErrored(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public CaptureErrored(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureSubmitted.java
@@ -5,10 +5,10 @@ import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.events.eventdetails.charge.CaptureSubmittedEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CaptureSubmitted extends PaymentEvent {
-    public CaptureSubmitted(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+    public CaptureSubmitted(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
@@ -20,7 +20,7 @@ public class CaptureSubmitted extends PaymentEvent {
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 CaptureSubmittedEventDetails.from(chargeEvent),
-                chargeEvent.getUpdated()
+                chargeEvent.getUpdated().toInstant()
         );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/FeeIncurredEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/FeeIncurredEvent.java
@@ -7,11 +7,9 @@ import uk.gov.pay.connector.events.eventdetails.charge.FeeIncurredEventDetails;
 import uk.gov.pay.connector.events.exception.EventCreationException;
 
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 
 public class FeeIncurredEvent extends PaymentEvent {
-    public FeeIncurredEvent(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+    public FeeIncurredEvent(String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(resourceExternalId, eventDetails, timestamp);
     }
 
@@ -22,12 +20,10 @@ public class FeeIncurredEvent extends PaymentEvent {
                 .min(Instant::compareTo)
                 .orElseThrow(() -> new EventCreationException(charge.getExternalId(), "Failed to create FeeIncurredEvent due to no fees present on charge"));
 
-        ZonedDateTime earliestCreatedDate = ZonedDateTime.ofInstant(earliestInstant, ZoneId.of("UTC"));
-
         return new FeeIncurredEvent(
                 charge.getExternalId(),
                 FeeIncurredEventDetails.from(charge),
-                earliestCreatedDate
+                earliestInstant
         );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsExemptionResultObtained.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsExemptionResultObtained.java
@@ -3,16 +3,16 @@ package uk.gov.pay.connector.events.model.charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.Gateway3dsExemptionResultObtainedEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class Gateway3dsExemptionResultObtained extends PaymentEvent {
 
     public Gateway3dsExemptionResultObtained(String serviceId, boolean live, String resourceExternalId,
-                                             Gateway3dsExemptionResultObtainedEventDetails eventDetails, ZonedDateTime timestamp) {
+                                             Gateway3dsExemptionResultObtainedEventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static Gateway3dsExemptionResultObtained from(ChargeEntity charge, ZonedDateTime eventDate) {
+    public static Gateway3dsExemptionResultObtained from(ChargeEntity charge, Instant eventDate) {
         return new Gateway3dsExemptionResultObtained(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtained.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtained.java
@@ -3,16 +3,16 @@ package uk.gov.pay.connector.events.model.charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.Gateway3dsInfoObtainedEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class Gateway3dsInfoObtained extends PaymentEvent {
 
     public Gateway3dsInfoObtained(String serviceId, boolean live, String resourceExternalId,
-                                  Gateway3dsInfoObtainedEventDetails eventDetails, ZonedDateTime timestamp) {
+                                  Gateway3dsInfoObtainedEventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static Gateway3dsInfoObtained from(ChargeEntity charge, ZonedDateTime eventDate) {
+    public static Gateway3dsInfoObtained from(ChargeEntity charge, Instant eventDate) {
         return new Gateway3dsInfoObtained(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayErrorDuringAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayErrorDuringAuthorisation.java
@@ -1,13 +1,13 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 /**
  * Payment has moved to a gateway error state during the authorisation process
  *
  */
 public class GatewayErrorDuringAuthorisation extends PaymentEventWithoutDetails {
-    public GatewayErrorDuringAuthorisation(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public GatewayErrorDuringAuthorisation(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisation.java
@@ -4,12 +4,12 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.GatewayRequires3dsAuthorisationEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class GatewayRequires3dsAuthorisation extends PaymentEvent {
     public GatewayRequires3dsAuthorisation(String serviceId, boolean live, String resourceExternalId,
                                            GatewayRequires3dsAuthorisationEventDetails eventDetails,
-                                           ZonedDateTime timestamp) {
+                                           Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
@@ -17,6 +17,6 @@ public class GatewayRequires3dsAuthorisation extends PaymentEvent {
         ChargeEntity charge = chargeEvent.getChargeEntity();
         return new GatewayRequires3dsAuthorisation(charge.getServiceId(), charge.getGatewayAccount().isLive(),
                 charge.getExternalId(), GatewayRequires3dsAuthorisationEventDetails.from(charge),
-                chargeEvent.getUpdated());
+                chargeEvent.getUpdated().toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayTimeoutDuringAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayTimeoutDuringAuthorisation.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class GatewayTimeoutDuringAuthorisation extends PaymentEventWithoutDetails {
-    public GatewayTimeoutDuringAuthorisation(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public GatewayTimeoutDuringAuthorisation(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentCreated.java
@@ -4,12 +4,11 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentCreatedEventDetails;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PaymentCreated extends PaymentEvent {
 
-    public PaymentCreated(String serviceId, boolean live, String resourceExternalId, PaymentCreatedEventDetails eventDetails, ZonedDateTime timestamp) {
+    public PaymentCreated(String serviceId, boolean live, String resourceExternalId, PaymentCreatedEventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
@@ -19,7 +18,7 @@ public class PaymentCreated extends PaymentEvent {
                 event.getChargeEntity().getGatewayAccount().isLive(),
                 event.getChargeEntity().getExternalId(),
                 PaymentCreatedEventDetails.from(event.getChargeEntity()),
-                event.getUpdated()
+                event.getUpdated().toInstant()
         );
     }
 
@@ -29,7 +28,7 @@ public class PaymentCreated extends PaymentEvent {
                 charge.getGatewayAccount().isLive(), 
                 charge.getExternalId(),
                 PaymentCreatedEventDetails.from(charge),
-                ZonedDateTime.ofInstant(charge.getCreatedDate(), ZoneOffset.UTC)
+                charge.getCreatedDate()
         );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEntered.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEntered.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentDetailsEnteredEventDetails;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 /**
@@ -19,7 +20,7 @@ public class PaymentDetailsEntered extends PaymentEvent {
                                  boolean live,
                                  String resourceExternalId,
                                  PaymentDetailsEnteredEventDetails eventDetails,
-                                 ZonedDateTime timestamp) {
+                                 Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
@@ -35,7 +36,7 @@ public class PaymentDetailsEntered extends PaymentEvent {
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 PaymentDetailsEnteredEventDetails.from(charge),
-                lastEventDate);
+                lastEventDate.toInstant());
     }
 
     public static PaymentDetailsEntered from (ChargeEventEntity chargeEvent) {
@@ -46,7 +47,7 @@ public class PaymentDetailsEntered extends PaymentEvent {
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 PaymentDetailsEnteredEventDetails.from(charge),
-                chargeEvent.getUpdated()
+                chargeEvent.getUpdated().toInstant()
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsSubmittedByAPI.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsSubmittedByAPI.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentDetailsSubmittedByAPIEventDetails;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 public class PaymentDetailsSubmittedByAPI extends PaymentEvent {
@@ -14,7 +15,7 @@ public class PaymentDetailsSubmittedByAPI extends PaymentEvent {
                                         boolean live,
                                         String resourceExternalId,
                                         PaymentDetailsSubmittedByAPIEventDetails eventDetails,
-                                        ZonedDateTime timestamp) {
+                                        Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
@@ -30,7 +31,7 @@ public class PaymentDetailsSubmittedByAPI extends PaymentEvent {
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 PaymentDetailsSubmittedByAPIEventDetails.from(charge),
-                lastEventDate);
+                lastEventDate.toInstant());
     }
 
     public static PaymentDetailsSubmittedByAPI from(ChargeEventEntity chargeEventEntity) {
@@ -41,7 +42,7 @@ public class PaymentDetailsSubmittedByAPI extends PaymentEvent {
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 PaymentDetailsSubmittedByAPIEventDetails.from(charge),
-                chargeEventEntity.getUpdated()
+                chargeEventEntity.getUpdated().toInstant()
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDisputed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDisputed.java
@@ -4,14 +4,14 @@ import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentDisputedEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PaymentDisputed extends PaymentEvent {
-    private PaymentDisputed(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+    private PaymentDisputed(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
     
-    public static PaymentDisputed from(LedgerTransaction ledgerTransaction, ZonedDateTime disputeCreatedDate) {
+    public static PaymentDisputed from(LedgerTransaction ledgerTransaction, Instant disputeCreatedDate) {
         return new PaymentDisputed(
                 ledgerTransaction.getServiceId(),
                 ledgerTransaction.getLive(),

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
@@ -4,24 +4,24 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.ResourceType;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PaymentEvent extends Event {
     private String serviceId;
     private Boolean live;
     
-    public PaymentEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+    public PaymentEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(timestamp, resourceExternalId, eventDetails);
         this.serviceId = serviceId;
         this.live = live;
     }
 
-    public PaymentEvent(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+    public PaymentEvent(String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(timestamp, resourceExternalId, eventDetails);
     }
 
-    public PaymentEvent(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
-        super(resourceExternalId, timestamp);
+    public PaymentEvent(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
+        super(timestamp, resourceExternalId);
         this.serviceId = serviceId;
         this.live = live;
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEventWithoutDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEventWithoutDetails.java
@@ -2,11 +2,11 @@ package uk.gov.pay.connector.events.model.charge;
 
 import uk.gov.pay.connector.events.eventdetails.EmptyEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PaymentEventWithoutDetails extends PaymentEvent {
 
-    public PaymentEventWithoutDetails(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public PaymentEventWithoutDetails(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, new EmptyEventDetails(), timestamp);
         
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentExpired.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentExpired.java
@@ -1,13 +1,13 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 /**
  * Payment has been processed by the `ChargeExpiryProcess`, this can result in the payment
  * succeeding or failing to expire.
  */
 public class PaymentExpired extends PaymentEventWithoutDetails {
-    public PaymentExpired(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public PaymentExpired(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentIncludedInPayout.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentIncludedInPayout.java
@@ -2,10 +2,10 @@ package uk.gov.pay.connector.events.model.charge;
 
 import uk.gov.pay.connector.events.eventdetails.TransactionIncludedInPayoutEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PaymentIncludedInPayout extends PaymentEvent {
-    public PaymentIncludedInPayout(String paymentExternalId, String gatewayPayoutId, ZonedDateTime payoutCreatedDate) {
+    public PaymentIncludedInPayout(String paymentExternalId, String gatewayPayoutId, Instant payoutCreatedDate) {
         super(paymentExternalId, new TransactionIncludedInPayoutEventDetails(gatewayPayoutId), payoutCreatedDate);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreated.java
@@ -4,10 +4,11 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentNotificationCreatedEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PaymentNotificationCreated extends PaymentEvent {
-    public PaymentNotificationCreated(String serviceId, boolean live, String resourceExternalId, PaymentNotificationCreatedEventDetails eventDetails, ZonedDateTime timestamp) {
+    public PaymentNotificationCreated(String serviceId, boolean live, String resourceExternalId,
+                                      PaymentNotificationCreatedEventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
@@ -17,6 +18,6 @@ public class PaymentNotificationCreated extends PaymentEvent {
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 PaymentNotificationCreatedEventDetails.from(charge),
-                chargeEvent.getUpdated());
+                chargeEvent.getUpdated().toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentRefundCreatedByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentRefundCreatedByUser.java
@@ -2,10 +2,10 @@ package uk.gov.pay.connector.events.model.charge;
 
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PaymentRefundCreatedByUser extends PaymentEvent {
-    public PaymentRefundCreatedByUser(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+    public PaymentRefundCreatedByUser(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentStarted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentStarted.java
@@ -1,13 +1,13 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 /**
  * Payment has moved to a success state where it has started
  *
  */
 public class PaymentStarted extends PaymentEventWithoutDetails {
-    public PaymentStarted(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public PaymentStarted(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForAuthorisationWithUserNotPresent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForAuthorisationWithUserNotPresent.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class QueuedForAuthorisationWithUserNotPresent extends PaymentEventWithoutDetails {
-    public QueuedForAuthorisationWithUserNotPresent(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public QueuedForAuthorisationWithUserNotPresent(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForCapture.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForCapture.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class QueuedForCapture extends PaymentEventWithoutDetails {
-    public QueuedForCapture(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public QueuedForCapture(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
@@ -4,15 +4,17 @@ import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class RefundAvailabilityUpdated extends PaymentEvent {
 
-    public RefundAvailabilityUpdated(String serviceId, boolean live, String resourceExternalId, RefundAvailabilityUpdatedEventDetails eventDetails, ZonedDateTime timestamp) {
+    public RefundAvailabilityUpdated(String serviceId, boolean live, String resourceExternalId,
+                                     RefundAvailabilityUpdatedEventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static RefundAvailabilityUpdated from(LedgerTransaction ledgerTransaction, ExternalChargeRefundAvailability externalChargeRefundAvailability, ZonedDateTime timestamp) {
+    public static RefundAvailabilityUpdated from(LedgerTransaction ledgerTransaction,
+                                                 ExternalChargeRefundAvailability externalChargeRefundAvailability, Instant timestamp) {
         var eventDetails = RefundAvailabilityUpdatedEventDetails.from(externalChargeRefundAvailability);
         return new RefundAvailabilityUpdated(ledgerTransaction.getServiceId(), ledgerTransaction.getLive(),
                 ledgerTransaction.getTransactionId(), eventDetails, timestamp);

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/ServiceApprovedForCapture.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/ServiceApprovedForCapture.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class ServiceApprovedForCapture extends PaymentEventWithoutDetails {
-    public ServiceApprovedForCapture(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public ServiceApprovedForCapture(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationErrorToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationErrorToMatchGatewayStatus.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class StatusCorrectedToAuthorisationErrorToMatchGatewayStatus extends PaymentEventWithoutDetails {
-    public StatusCorrectedToAuthorisationErrorToMatchGatewayStatus(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public StatusCorrectedToAuthorisationErrorToMatchGatewayStatus(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus extends PaymentEventWithoutDetails {
-    public StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToCapturedToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToCapturedToMatchGatewayStatus.java
@@ -4,10 +4,11 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.CaptureConfirmedEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class StatusCorrectedToCapturedToMatchGatewayStatus extends PaymentEvent {
-    public StatusCorrectedToCapturedToMatchGatewayStatus(String serviceId, boolean live, String resourceExternalId, CaptureConfirmedEventDetails eventDetails, ZonedDateTime timestamp) {
+    public StatusCorrectedToCapturedToMatchGatewayStatus(String serviceId, boolean live, String resourceExternalId,
+                                                         CaptureConfirmedEventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
     
@@ -19,7 +20,7 @@ public class StatusCorrectedToCapturedToMatchGatewayStatus extends PaymentEvent 
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 CaptureConfirmedEventDetails.from(chargeEvent),
-                chargeEvent.getUpdated()
+                chargeEvent.getUpdated().toInstant()
         );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/SystemCancelled.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/SystemCancelled.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 
 /**
@@ -17,7 +17,7 @@ import java.time.ZonedDateTime;
  *
  */
 public class SystemCancelled extends PaymentEventWithoutDetails {
-    public SystemCancelled(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public SystemCancelled(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UnexpectedGatewayErrorDuringAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UnexpectedGatewayErrorDuringAuthorisation.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class UnexpectedGatewayErrorDuringAuthorisation extends PaymentEventWithoutDetails {
-    public UnexpectedGatewayErrorDuringAuthorisation(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public UnexpectedGatewayErrorDuringAuthorisation(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCapture.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCapture.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class UserApprovedForCapture extends PaymentEventWithoutDetails {
-    public UserApprovedForCapture(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public UserApprovedForCapture(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCaptureAwaitingServiceApproval.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCaptureAwaitingServiceApproval.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class UserApprovedForCaptureAwaitingServiceApproval extends PaymentEventWithoutDetails {
-    public UserApprovedForCaptureAwaitingServiceApproval(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+    public UserApprovedForCaptureAwaitingServiceApproval(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UserEmailCollected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UserEmailCollected.java
@@ -3,17 +3,17 @@ package uk.gov.pay.connector.events.model.charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.UserEmailCollectedEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class UserEmailCollected extends PaymentEvent {
 
     public UserEmailCollected(String serviceId, boolean live, String resourceExternalId,
                               UserEmailCollectedEventDetails eventDetails,
-                              ZonedDateTime timestamp) {
+                              Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static UserEmailCollected from(ChargeEntity charge, ZonedDateTime eventDate) {
+    public static UserEmailCollected from(ChargeEntity charge, Instant eventDate) {
         return new UserEmailCollected(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import javax.inject.Inject;
 import javax.persistence.OptimisticLockException;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 import static java.lang.String.format;
@@ -103,7 +104,7 @@ public class ChargeNotificationProcessor {
                 kv(GATEWAY_ACCOUNT_ID, gatewayAccount.getId()),
                 kv(PROVIDER, charge.getPaymentGatewayName()));
         
-        Event event = new CaptureConfirmedByGatewayNotification(charge.getServiceId(), charge.isLive(), charge.getExternalId(), ZonedDateTime.now());
+        Event event = new CaptureConfirmedByGatewayNotification(charge.getServiceId(), charge.isLive(), charge.getExternalId(), Instant.now());
         eventService.emitEvent(event);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -45,13 +45,12 @@ import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import java.net.HttpCookie;
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static java.time.ZoneOffset.UTC;
-import static java.time.ZonedDateTime.now;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
@@ -267,7 +266,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
         charge.setExemption3ds(exemption3ds);
         LOGGER.info("Updated exemption_3ds of charge to {} - charge_external_id={}", exemption3ds, charge.getExternalId());
         chargeDao.merge(charge);
-        eventService.emitAndRecordEvent(Gateway3dsExemptionResultObtained.from(charge, now(UTC)));
+        eventService.emitAndRecordEvent(Gateway3dsExemptionResultObtained.from(charge, Instant.now()));
     }
 
     private boolean isExemptionEngineEnabled(CardAuthorisationGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
@@ -205,7 +205,7 @@ public class PayoutReconcileProcess {
     private void emitPaymentEvent(PayoutReconcileMessage payoutReconcileMessage, String paymentExternalId) {
         var paymentEvent = new PaymentIncludedInPayout(paymentExternalId,
                 payoutReconcileMessage.getGatewayPayoutId(),
-                payoutReconcileMessage.getCreatedDate());
+                payoutReconcileMessage.getCreatedDate().toInstant());
         emitEvent(paymentEvent, payoutReconcileMessage, paymentExternalId);
 
         LOGGER.info(format("Emitted event for payment [%s] included in payout [%s]",

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -59,6 +59,7 @@ import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.token.dao.TokenDao;
 
 import javax.ws.rs.core.UriInfo;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -467,8 +468,7 @@ class ChargeServiceTest {
         when(mockedProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.getExternalChargeRefundAvailability(charge, List.of(refund))).thenReturn(EXTERNAL_AVAILABLE);
         
-        ZonedDateTime timestamp = ZonedDateTime.now();
-        RefundAvailabilityUpdated refundAvailabilityUpdated = chargeService.createRefundAvailabilityUpdatedEvent(charge, timestamp);
+        RefundAvailabilityUpdated refundAvailabilityUpdated = chargeService.createRefundAvailabilityUpdatedEvent(charge, Instant.now());
         
         assertThat(refundAvailabilityUpdated.getResourceExternalId(), is(charge.getExternalId()));
         assertThat(refundAvailabilityUpdated.getResourceType(), is(ResourceType.PAYMENT));

--- a/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
@@ -18,7 +18,7 @@ import uk.gov.pay.connector.events.model.charge.GatewayErrorDuringAuthorisation;
 import uk.gov.pay.connector.events.model.charge.PaymentExpired;
 import uk.gov.pay.connector.events.model.charge.PaymentNotificationCreated;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
@@ -85,8 +85,10 @@ public class PaymentGatewayStateTransitionsTest {
 
     @Test
     public void isValidTransition_deniesTransitionWithInvalidEvent() {
-        assertThat(PaymentGatewayStateTransitions.isValidTransition(CAPTURE_READY, CAPTURE_SUBMITTED, new CaptureSubmitted("id", true, "a", new EmptyEventDetails(), ZonedDateTime.now())), is(true));
-        assertThat(PaymentGatewayStateTransitions.isValidTransition(CAPTURE_READY, CAPTURE_SUBMITTED, new CaptureErrored("id", true, "a", ZonedDateTime.now())), is(false));
+        assertThat(PaymentGatewayStateTransitions.isValidTransition(CAPTURE_READY, CAPTURE_SUBMITTED,
+                new CaptureSubmitted("id", true, "a", new EmptyEventDetails(), Instant.now())), is(true));
+        assertThat(PaymentGatewayStateTransitions.isValidTransition(CAPTURE_READY, CAPTURE_SUBMITTED,
+                new CaptureErrored("id", true, "a", Instant.now())), is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
@@ -13,8 +13,8 @@ import uk.gov.service.payments.commons.queue.exception.QueueException;
 
 import java.time.ZonedDateTime;
 
+import static java.time.Instant.now;
 import static java.time.ZoneOffset.UTC;
-import static java.time.ZonedDateTime.now;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -72,7 +72,7 @@ public class EventServiceTest {
     @Test
     public void emitAndRecordEvent_shouldRecordEmissionWithDoNotRetryEmitUntilDate() throws QueueException {
         Event event = new PaymentEvent("service-id", true,"external-id", now());
-        ZonedDateTime doNotRetryEmitUntilDate = now(UTC);
+        ZonedDateTime doNotRetryEmitUntilDate = ZonedDateTime.now(UTC);
         eventService.emitAndRecordEvent(event, doNotRetryEmitUntilDate);
 
         verify(emittedEventDao).recordEmission(event, doNotRetryEmitUntilDate);

--- a/src/test/java/uk/gov/pay/connector/events/StateTransitionEmitterProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/StateTransitionEmitterProcessTest.java
@@ -12,10 +12,10 @@ import uk.gov.pay.connector.events.model.EventFactory;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.model.charge.PaymentEvent;
 import uk.gov.pay.connector.queue.statetransition.PaymentStateTransition;
-import uk.gov.service.payments.commons.queue.exception.QueueException;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionQueue;
+import uk.gov.service.payments.commons.queue.exception.QueueException;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -54,7 +54,7 @@ public class StateTransitionEmitterProcessTest {
                 new PaymentCreated("service-id", true,
                         "id",
                         mock(PaymentCreatedEventDetails.class),
-                        ZonedDateTime.now()
+                        Instant.now()
                 )));
         when(stateTransitionQueue.poll(anyLong(), any(TimeUnit.class))).thenReturn(paymentStateTransition);
 
@@ -84,7 +84,7 @@ public class StateTransitionEmitterProcessTest {
                 new PaymentCreated("service-id", true,
                         "id",
                         mock(PaymentCreatedEventDetails.class),
-                        ZonedDateTime.now()
+                        Instant.now()
                 )));
         doThrow(QueueException.class).when(mockEventService).emitAndMarkEventAsEmitted(any());
 

--- a/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
@@ -210,7 +210,8 @@ public class EmittedEventDaoIT extends DaoITestBase {
                 .withDelayedCapture(false)
                 .withLive(false)
                 .build();
-        return new PaymentCreated("service-id", true, "my-resource-external-id", eventDetails, ZonedDateTime.parse("2019-01-01T14:00:00Z"));
+        return new PaymentCreated("service-id", true, "my-resource-external-id", eventDetails,
+                Instant.parse("2019-01-01T14:00:00Z"));
     }
 
     private RefundSubmitted aRefundSubmittedEvent(ZonedDateTime eventTimestamp) {

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByUserTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByUserTest.java
@@ -9,7 +9,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.events.eventdetails.charge.CancelledByUserEventDetails;
 
 import java.time.Instant;
-import java.time.ZonedDateTime;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
@@ -40,7 +39,8 @@ public class CancelledByUserTest {
     public void whenAllTheDataIsAvailable() throws JsonProcessingException {
         ChargeEntity chargeEntity = chargeEntityFixture.build();
 
-        String actual = new CancelledByUser(chargeEntity.getServiceId(), chargeEntity.getGatewayAccount().isLive(), transactionId, CancelledByUserEventDetails.from(chargeEntity), ZonedDateTime.parse(time)).toJsonString();
+        String actual = new CancelledByUser(chargeEntity.getServiceId(), chargeEntity.getGatewayAccount().isLive(), transactionId,
+                CancelledByUserEventDetails.from(chargeEntity), Instant.parse(time)).toJsonString();
 
         assertThat(actual, hasJsonPath("$.event_type", equalTo("CANCELLED_BY_USER")));
         assertThat(actual, hasJsonPath("event_details.gateway_transaction_id", equalTo(gatewayTransactionId)));
@@ -51,7 +51,8 @@ public class CancelledByUserTest {
         ChargeEntity charge = new ChargeEntity();
         charge.setExternalId(transactionId);
         charge.setGatewayTransactionId(null);
-        String actual = new CancelledByUser(charge.getServiceId(), live, transactionId, CancelledByUserEventDetails.from(charge), ZonedDateTime.parse(time)).toJsonString();
+        String actual = new CancelledByUser(charge.getServiceId(), live, transactionId,
+                CancelledByUserEventDetails.from(charge), Instant.parse(time)).toJsonString();
 
         assertThat(actual, hasJsonPath("$.event_type", equalTo("CANCELLED_BY_USER")));
         assertThat(actual, hasNoJsonPath("event_details.gateway_transaction_id"));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/Gateway3dsExemptionResultObtainedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/Gateway3dsExemptionResultObtainedTest.java
@@ -5,11 +5,10 @@ import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
-import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer.MICROSECOND_FORMATTER;
@@ -19,7 +18,7 @@ class Gateway3dsExemptionResultObtainedTest {
     @Test
     void serializesEventDetailsWithExemption3dsHonoured() throws JsonProcessingException {
         var chargeEntity = ChargeEntityFixture.aValidChargeEntity().withExemption3ds(Exemption3ds.EXEMPTION_HONOURED).build();
-        var eventDate = ZonedDateTime.now(UTC);
+        var eventDate = Instant.now();
         String actual = Gateway3dsExemptionResultObtained.from(chargeEntity, eventDate).toJsonString();
 
         assertThat(actual, hasJsonPath("$.timestamp", equalTo(MICROSECOND_FORMATTER.format(eventDate))));
@@ -32,7 +31,7 @@ class Gateway3dsExemptionResultObtainedTest {
     @Test
     void serializesEventDetailsWithExemption3dsNull() throws JsonProcessingException {
         var chargeEntity = ChargeEntityFixture.aValidChargeEntity().withExemption3ds(null).build();
-        var eventDate = ZonedDateTime.now(UTC);
+        var eventDate = Instant.now();
         String actual = Gateway3dsExemptionResultObtained.from(chargeEntity, eventDate).toJsonString();
 
         assertThat(actual, hasJsonPath("$.timestamp", equalTo(MICROSECOND_FORMATTER.format(eventDate))));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtainedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtainedTest.java
@@ -5,11 +5,10 @@ import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
-import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer.MICROSECOND_FORMATTER;
@@ -21,7 +20,7 @@ class Gateway3dsInfoObtainedTest {
         Auth3dsRequiredEntity auth3dsRequiredEntity = new Auth3dsRequiredEntity();
         auth3dsRequiredEntity.setThreeDsVersion("2.1.0");
         var chargeEntity = ChargeEntityFixture.aValidChargeEntity().withAuth3dsDetailsEntity(auth3dsRequiredEntity).build();
-        var eventDate = ZonedDateTime.now(UTC);
+        var eventDate = Instant.now();
         String actual = Gateway3dsInfoObtained.from(chargeEntity, eventDate).toJsonString();
 
         assertThat(actual, hasJsonPath("$.timestamp", equalTo(MICROSECOND_FORMATTER.format(eventDate))));
@@ -34,7 +33,7 @@ class Gateway3dsInfoObtainedTest {
     @Test
     void serializesEventDetailsWithVersion3dsNull() throws JsonProcessingException {
         var chargeEntity = ChargeEntityFixture.aValidChargeEntity().withAuth3dsDetailsEntity(new Auth3dsRequiredEntity()).build();
-        var eventDate = ZonedDateTime.now(UTC);
+        var eventDate = Instant.now();
         String actual = Gateway3dsInfoObtained.from(chargeEntity, eventDate).toJsonString();
 
         assertThat(actual, hasJsonPath("$.timestamp", equalTo(MICROSECOND_FORMATTER.format(eventDate))));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDisputedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDisputedTest.java
@@ -5,7 +5,7 @@ import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,7 +24,7 @@ class PaymentDisputedTest {
                 .isLive(true)
                 .build();
         String timestampString = "2022-01-19T07:59:20.000000Z";
-        ZonedDateTime timestamp = ZonedDateTime.parse(timestampString);
+        Instant timestamp = Instant.parse(timestampString);
         
         var paymentDisputed = PaymentDisputed.from(transaction, timestamp);
         

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentIncludedInPayoutTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentIncludedInPayoutTest.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.events.model.charge;
 
 import org.junit.Test;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
@@ -16,7 +16,7 @@ public class PaymentIncludedInPayoutTest {
         var paymentExternalId = "payment-id";
         var gatewayPayoutId = "payout-id";
         String eventDateStr = "2020-05-10T10:30:00.000000Z";
-        var event = new PaymentIncludedInPayout(paymentExternalId, gatewayPayoutId, ZonedDateTime.parse(eventDateStr));
+        var event = new PaymentIncludedInPayout(paymentExternalId, gatewayPayoutId, Instant.parse(eventDateStr));
         
         var json = event.toJsonString();
 

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
@@ -29,7 +29,7 @@ public class RefundAvailabilityUpdatedTest {
                 charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 RefundAvailabilityUpdatedEventDetails.from(Charge.from(charge), List.of(), ExternalChargeRefundAvailability.EXTERNAL_FULL),
-                ZonedDateTime.now()
+                Instant.now()
         ).toJsonString();
         
         assertThat(event, hasJsonPath("$.event_type", equalTo("REFUND_AVAILABILITY_UPDATED")));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/UserEmailCollectedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/UserEmailCollectedTest.java
@@ -5,23 +5,22 @@ import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
-import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer.MICROSECOND_FORMATTER;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MICROSECOND_PRECISION;
 
 public class UserEmailCollectedTest {
 
     @Test
     public void serializesEventDetailsForChargeAndEventDate() throws JsonProcessingException {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
-        ZonedDateTime eventDate = ZonedDateTime.now(UTC);
+        Instant eventDate = Instant.now();
         String actual = UserEmailCollected.from(chargeEntity, eventDate).toJsonString();
 
-        assertThat(actual, hasJsonPath("$.timestamp", equalTo(MICROSECOND_FORMATTER.format(eventDate))));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(ISO_INSTANT_MICROSECOND_PRECISION.format(eventDate))));
         assertThat(actual, hasJsonPath("$.event_type", equalTo("USER_EMAIL_COLLECTED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -134,7 +134,7 @@ public class EventFactoryTest {
         ).thenReturn(Optional.of(refundCreatedHistory));
 
         RefundAvailabilityUpdated refundAvailabilityUpdated = mock(RefundAvailabilityUpdated.class);
-        when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(chargeEntity), refundCreatedHistory.getHistoryStartDate()))
+        when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(chargeEntity), refundCreatedHistory.getHistoryStartDate().toInstant()))
                 .thenReturn(refundAvailabilityUpdated);
 
         StateTransition refundStateTransition = new RefundStateTransition(
@@ -237,7 +237,7 @@ public class EventFactoryTest {
         ).thenReturn(Optional.of(refundErrorHistory));
 
         RefundAvailabilityUpdated refundAvailabilityUpdated = mock(RefundAvailabilityUpdated.class);
-        when(chargeService.createRefundAvailabilityUpdatedEvent(charge, refundErrorHistory.getHistoryStartDate()))
+        when(chargeService.createRefundAvailabilityUpdatedEvent(charge, refundErrorHistory.getHistoryStartDate().toInstant()))
                 .thenReturn(refundAvailabilityUpdated);
 
         StateTransition refundStateTransition = new RefundStateTransition(
@@ -273,7 +273,7 @@ public class EventFactoryTest {
         PaymentStateTransition paymentStateTransition = new PaymentStateTransition(chargeEventEntityId, PaymentCreated.class);
 
         RefundAvailabilityUpdated refundAvailabilityUpdated = mock(RefundAvailabilityUpdated.class);
-        when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(chargeEntity), chargeEventEntity.getUpdated()))
+        when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(chargeEntity), chargeEventEntity.getUpdated().toInstant()))
                 .thenReturn(refundAvailabilityUpdated);
         
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
@@ -301,7 +301,7 @@ public class EventFactoryTest {
         PaymentStateTransition paymentStateTransition = new PaymentStateTransition(chargeEventEntityId, CancelByExternalServiceSubmitted.class);
 
         RefundAvailabilityUpdated refundAvailabilityUpdated = mock(RefundAvailabilityUpdated.class);
-        when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(chargeEntity), chargeEventEntity.getUpdated()))
+        when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(chargeEntity), chargeEventEntity.getUpdated().toInstant()))
                 .thenReturn(refundAvailabilityUpdated);
         
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
@@ -360,7 +360,7 @@ public class EventFactoryTest {
         PaymentStateTransition paymentStateTransition = new PaymentStateTransition(chargeEventEntityId, eventClass);
 
         RefundAvailabilityUpdated refundAvailabilityUpdated = mock(RefundAvailabilityUpdated.class);
-        when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(chargeEntity), chargeEventEntity.getUpdated()))
+        when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(chargeEntity), chargeEventEntity.getUpdated().toInstant()))
                 .thenReturn(refundAvailabilityUpdated);
         
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
@@ -402,7 +402,7 @@ public class EventFactoryTest {
         ).thenReturn(Optional.of(refundErrorHistory));
 
         RefundAvailabilityUpdated refundAvailabilityUpdated = mock(RefundAvailabilityUpdated.class);
-        when(chargeService.createRefundAvailabilityUpdatedEvent(chargeFromTransaction, refundErrorHistory.getHistoryStartDate()))
+        when(chargeService.createRefundAvailabilityUpdatedEvent(chargeFromTransaction, refundErrorHistory.getHistoryStartDate().toInstant()))
                 .thenReturn(refundAvailabilityUpdated);
 
         StateTransition refundStateTransition = new RefundStateTransition(
@@ -535,7 +535,7 @@ public class EventFactoryTest {
         PaymentStateTransition paymentStateTransition = new PaymentStateTransition(chargeEventEntityId,
                 CancelledWithGatewayAfterAuthorisationError.class);
         RefundAvailabilityUpdated refundAvailabilityUpdated = mock(RefundAvailabilityUpdated.class);
-        when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(charge), chargeEventEntity.getUpdated()))
+        when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(charge), chargeEventEntity.getUpdated().toInstant()))
                 .thenReturn(refundAvailabilityUpdated);
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
 

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -59,6 +59,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
@@ -95,7 +96,7 @@ public class QueueMessageContractTest {
                 charge.getGatewayAccount().isLive(),
                 resourceId,
                 PaymentCreatedEventDetails.from(charge),
-                ZonedDateTime.now()
+                Instant.now()
         );
 
         return paymentCreatedEvent.toJsonString();
@@ -119,7 +120,7 @@ public class QueueMessageContractTest {
                 chargeEventEntity.getChargeEntity().getGatewayAccount().isLive(),
                 resourceId,
                 CaptureConfirmedEventDetails.from(chargeEventEntity),
-                ZonedDateTime.now()
+                Instant.now()
         );
 
         return captureConfirmedEvent.toJsonString();
@@ -138,7 +139,7 @@ public class QueueMessageContractTest {
                 charge.getGatewayAccount().isLive(),
                 resourceId,
                 PaymentDetailsEnteredEventDetails.from(charge),
-                ZonedDateTime.now()
+                Instant.now()
         );
 
         return captureConfirmedEvent.toJsonString();
@@ -157,7 +158,7 @@ public class QueueMessageContractTest {
                 charge.getGatewayAccount().isLive(),
                 resourceId,
                 PaymentDetailsSubmittedByAPIEventDetails.from(charge),
-                ZonedDateTime.now()
+                Instant.now()
         );
 
         return paymentDetailsSubmittedByAPIEvent.toJsonString();
@@ -174,7 +175,7 @@ public class QueueMessageContractTest {
                 charge.getGatewayAccount().isLive(),
                 resourceId,
                 UserEmailCollectedEventDetails.from(charge),
-                ZonedDateTime.now()
+                Instant.now()
         );
 
         return userEmailCollected.toJsonString();
@@ -191,7 +192,7 @@ public class QueueMessageContractTest {
                 chargeEventEntity.getChargeEntity().getGatewayAccount().isLive(),
                 resourceId,
                 CaptureSubmittedEventDetails.from(chargeEventEntity),
-                ZonedDateTime.now()
+                Instant.now()
         );
 
         return captureSubmittedEvent.toJsonString();
@@ -300,7 +301,7 @@ public class QueueMessageContractTest {
 
     @PactVerifyProvider("a payment included in payout message")
     public String verifyPaymentIncludedInPayoutEvent() throws JsonProcessingException {
-        PaymentIncludedInPayout event = new PaymentIncludedInPayout(resourceId, "po_1234567890", ZonedDateTime.now());
+        PaymentIncludedInPayout event = new PaymentIncludedInPayout(resourceId, "po_1234567890", Instant.now());
 
         return event.toJsonString();
     }
@@ -337,7 +338,7 @@ public class QueueMessageContractTest {
                 charge.getGatewayAccount().isLive(),
                 resourceId,
                 Gateway3dsExemptionResultObtainedEventDetails.from(charge),
-                ZonedDateTime.now()
+                Instant.now()
         );
 
         return gateway3dsExemptionResultObtained.toJsonString();
@@ -356,7 +357,7 @@ public class QueueMessageContractTest {
                 charge.getGatewayAccount().isLive(),
                 resourceId,
                 Gateway3dsInfoObtainedEventDetails.from(charge),
-                ZonedDateTime.now()
+                Instant.now()
         );
 
         return gateway3dsInfoObtained.toJsonString();
@@ -375,7 +376,7 @@ public class QueueMessageContractTest {
                 charge.getGatewayAccount().isLive(),
                 resourceId,
                 GatewayRequires3dsAuthorisationEventDetails.from(charge),
-                ZonedDateTime.now());
+                Instant.now());
 
         return gatewayRequires3dsAuthorisation.toJsonString();
     }
@@ -397,7 +398,7 @@ public class QueueMessageContractTest {
                 chargeEventEntity.getChargeEntity().getGatewayAccount().isLive(),
                 resourceId,
                 CaptureConfirmedEventDetails.from(chargeEventEntity),
-                ZonedDateTime.now()
+                Instant.now()
         );
 
         return event.toJsonString();

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -129,9 +129,9 @@ public class PayoutReconcileProcessTest {
 
     @Test
     public void shouldEmitEventsForMessageAndMarkAsProcessed() throws Exception {
-        var paymentEvent = new PaymentIncludedInPayout(paymentExternalId, payoutId, payoutCreatedDate);
+        var paymentEvent = new PaymentIncludedInPayout(paymentExternalId, payoutId, payoutCreatedDate.toInstant());
         var refundEvent = new RefundIncludedInPayout(refundExternalId, payoutId, payoutCreatedDate);
-        var feeCollectionEvent = new PaymentIncludedInPayout(failedPaymentWithFeeExternalId, payoutId, payoutCreatedDate);
+        var feeCollectionEvent = new PaymentIncludedInPayout(failedPaymentWithFeeExternalId, payoutId, payoutCreatedDate.toInstant());
         var disputeEvent = new DisputeIncludedInPayout(disputeExternalId, payoutId, payoutCreatedDate);
         var stripePayout = new StripePayout("po_123", 1213L, 1589395533L,
                 1589395500L, "pending", "card", "statement_desc");

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
@@ -51,7 +51,6 @@ import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -138,9 +137,9 @@ public class StripeWebhookTaskHandlerTest {
 
         String resourceExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeData.getId());
         var disputeCreated = DisputeCreated.from(resourceExternalId, stripeDisputeData, transaction, stripeDisputeData.getDisputeCreated());
-        var paymentDisputed = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated());
+        var paymentDisputed = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated().toInstant());
         var refundAvailabilityUpdated = RefundAvailabilityUpdated.from(
-                transaction, ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE, ZonedDateTime.parse(fixedClockDateTime));
+                transaction, ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE, Instant.parse(fixedClockDateTime));
 
         verify(eventService).emitEvent(disputeCreated);
         verify(eventService).emitEvent(paymentDisputed);
@@ -190,7 +189,7 @@ public class StripeWebhookTaskHandlerTest {
         String resourceExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeData.getId());
         when(ledgerService.getTransactionForProviderAndGatewayTransactionId(any(), any()))
                 .thenReturn(Optional.of(transaction));
-        when(chargeService.createRefundAvailabilityUpdatedEvent(charge, stripeNotification.getCreated())).thenReturn(refundAvailabilityUpdated);
+        when(chargeService.createRefundAvailabilityUpdatedEvent(charge, stripeNotification.getCreated().toInstant())).thenReturn(refundAvailabilityUpdated);
         stripeWebhookTaskHandler.process(stripeNotification);
         ArgumentCaptor<DisputeWon> argumentCaptor = ArgumentCaptor.forClass(DisputeWon.class);
 
@@ -215,7 +214,7 @@ public class StripeWebhookTaskHandlerTest {
         String resourceExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeData.getId());
         when(ledgerService.getTransactionForProviderAndGatewayTransactionId(any(), any()))
                 .thenReturn(Optional.of(transaction));
-        when(chargeService.createRefundAvailabilityUpdatedEvent(charge, stripeNotification.getCreated().plusSeconds(1))).thenReturn(refundAvailabilityUpdated);
+        when(chargeService.createRefundAvailabilityUpdatedEvent(charge, stripeNotification.getCreated().plusSeconds(1).toInstant())).thenReturn(refundAvailabilityUpdated);
         stripeWebhookTaskHandler.process(stripeNotification);
         ArgumentCaptor<DisputeWon> argumentCaptor = ArgumentCaptor.forClass(DisputeWon.class);
 
@@ -567,9 +566,9 @@ public class StripeWebhookTaskHandlerTest {
 
         String resourceExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeData.getId());
         var disputeCreated = DisputeCreated.from(resourceExternalId, stripeDisputeData, transaction, stripeDisputeData.getDisputeCreated());
-        var paymentDisputed = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated());
+        var paymentDisputed = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated().toInstant());
         var refundAvailabilityUpdated = RefundAvailabilityUpdated.from(
-                transaction, ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE, ZonedDateTime.parse(fixedClockDateTime));
+                transaction, ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE, Instant.parse(fixedClockDateTime));
 
         verify(eventService).emitEvent(disputeCreated);
         verify(eventService).emitEvent(paymentDisputed);


### PR DESCRIPTION
Make `PaymentEvent` and its subclasses take an `Instant`, rather than a `ZonedDateTime`, for the timestamp in the constructor.