### PR TITLE
PP-10173 Use Instant in RefundEvent

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -42,7 +42,6 @@ import uk.gov.pay.connector.refund.service.RefundService;
 import javax.inject.Inject;
 import java.lang.reflect.InvocationTargetException;
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -176,13 +175,14 @@ public class EventFactory {
             } else if (eventClass == RefundCreatedByUser.class) {
                 return RefundCreatedByUser.from(refundHistory, charge);
             } else {
-                return eventClass.getConstructor(String.class, boolean.class, String.class, String.class, RefundEventWithGatewayTransactionIdDetails.class, ZonedDateTime.class).newInstance(
+                return eventClass.getConstructor(String.class, boolean.class, String.class, String.class,
+                        RefundEventWithGatewayTransactionIdDetails.class, Instant.class).newInstance(
                         charge.getServiceId(),
                         charge.isLive(),
                         refundHistory.getExternalId(),
                         refundHistory.getChargeExternalId(),
                         new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),
-                        refundHistory.getHistoryStartDate()
+                        refundHistory.getHistoryStartDate().toInstant()
                 );
             }
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
@@ -4,11 +4,12 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundCreatedByServiceEventDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class RefundCreatedByService extends RefundEvent {
 
-    private RefundCreatedByService(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId, RefundCreatedByServiceEventDetails eventDetails, ZonedDateTime timestamp) {
+    private RefundCreatedByService(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
+                                   RefundCreatedByServiceEventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
     }
 
@@ -21,7 +22,7 @@ public class RefundCreatedByService extends RefundEvent {
                 new RefundCreatedByServiceEventDetails(
                         refundHistory.getAmount(),
                         charge.getGatewayAccountId().toString()),
-                refundHistory.getHistoryStartDate()
+                refundHistory.getHistoryStartDate().toInstant()
         );
 
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
@@ -4,11 +4,12 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundCreatedByUserEventDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class RefundCreatedByUser extends RefundEvent {
 
-    private RefundCreatedByUser(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId, RefundCreatedByUserEventDetails eventDetails, ZonedDateTime timestamp) {
+    private RefundCreatedByUser(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
+                                RefundCreatedByUserEventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
     }
 
@@ -23,6 +24,6 @@ public class RefundCreatedByUser extends RefundEvent {
                         refundHistory.getUserExternalId(),
                         charge.getGatewayAccountId().toString(),
                         refundHistory.getUserEmail()),
-                refundHistory.getHistoryStartDate());
+                refundHistory.getHistoryStartDate().toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
@@ -4,12 +4,12 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class RefundError extends RefundEvent {
 
     public RefundError(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
-                       RefundEventWithGatewayTransactionIdDetails referenceDetails, ZonedDateTime timestamp) {
+                       RefundEventWithGatewayTransactionIdDetails referenceDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
@@ -20,6 +20,6 @@ public class RefundError extends RefundEvent {
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),
-                refundHistory.getHistoryStartDate());
+                refundHistory.getHistoryStartDate().toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
@@ -4,22 +4,23 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.ResourceType;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public abstract class RefundEvent extends Event {
     private String serviceId;
     private Boolean live;
     private String parentResourceExternalId;
 
-    public RefundEvent(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+    public RefundEvent(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
+                       EventDetails eventDetails, Instant timestamp) {
+        super(timestamp, resourceExternalId, eventDetails);
         this.parentResourceExternalId = parentResourceExternalId;
         this.serviceId = serviceId;
         this.live = live;
     }
-    
-    public RefundEvent(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+
+    public RefundEvent(String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(timestamp, resourceExternalId, eventDetails);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundIncludedInPayout.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundIncludedInPayout.java
@@ -2,10 +2,10 @@ package uk.gov.pay.connector.events.model.refund;
 
 import uk.gov.pay.connector.events.eventdetails.TransactionIncludedInPayoutEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class RefundIncludedInPayout extends RefundEvent {
-    public RefundIncludedInPayout(String refundExternalId, String gatewayPayoutId, ZonedDateTime payoutCreatedDate) {
+    public RefundIncludedInPayout(String refundExternalId, String gatewayPayoutId, Instant payoutCreatedDate) {
         super(refundExternalId, new TransactionIncludedInPayoutEventDetails(gatewayPayoutId), payoutCreatedDate);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
@@ -4,12 +4,12 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class RefundSubmitted extends RefundEvent {
 
     public RefundSubmitted(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
-                           RefundEventWithGatewayTransactionIdDetails referenceDetails, ZonedDateTime timestamp) {
+                           RefundEventWithGatewayTransactionIdDetails referenceDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
@@ -20,6 +20,6 @@ public class RefundSubmitted extends RefundEvent {
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),
-                refundHistory.getHistoryStartDate());
+                refundHistory.getHistoryStartDate().toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
@@ -4,12 +4,12 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class RefundSucceeded extends RefundEvent {
 
     public RefundSucceeded(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
-                           RefundEventWithGatewayTransactionIdDetails referenceDetails, ZonedDateTime timestamp) {
+                           RefundEventWithGatewayTransactionIdDetails referenceDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
@@ -19,6 +19,6 @@ public class RefundSucceeded extends RefundEvent {
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),
-                refundHistory.getHistoryStartDate());
+                refundHistory.getHistoryStartDate().toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
@@ -217,7 +217,7 @@ public class PayoutReconcileProcess {
     private void emitRefundEvent(PayoutReconcileMessage payoutReconcileMessage, String refundExternalId) {
         var refundEvent = new RefundIncludedInPayout(refundExternalId,
                 payoutReconcileMessage.getGatewayPayoutId(),
-                payoutReconcileMessage.getCreatedDate());
+                payoutReconcileMessage.getCreatedDate().toInstant());
         emitEvent(refundEvent, payoutReconcileMessage, refundExternalId);
 
         LOGGER.info(format("Emitted event for refund [%s] included in payout [%s]",

--- a/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
@@ -110,7 +110,7 @@ public class EmittedEventDaoIT extends DaoITestBase {
 
     @Test
     public void markEventAsEmitted_shouldRecordEventAndEmittedDate() {
-        final RefundSubmitted eventToRecord = aRefundSubmittedEvent(ZonedDateTime.parse("2018-01-01T12:00:00Z"));
+        final RefundSubmitted eventToRecord = aRefundSubmittedEvent(Instant.parse("2018-01-01T12:00:00Z"));
 
         emittedEventDao.recordEmission(eventToRecord.getResourceType(), eventToRecord.getResourceExternalId(),
                 eventToRecord.getEventType(), eventToRecord.getTimestamp(), null);
@@ -120,7 +120,7 @@ public class EmittedEventDaoIT extends DaoITestBase {
         assertThat(event.get("emitted_date"), is(nullValue()));
         assertThat(event.get("event_date").toString(), is("2018-01-01 12:00:00.0"));
 
-        final RefundSubmitted eventToUpdate = aRefundSubmittedEvent(ZonedDateTime.parse("2019-01-01T14:00:00Z"));
+        final RefundSubmitted eventToUpdate = aRefundSubmittedEvent(Instant.parse("2019-01-01T14:00:00Z"));
         emittedEventDao.markEventAsEmitted(eventToUpdate);
         events = databaseTestHelper.readEmittedEvents();
         event = events.get(0);
@@ -168,7 +168,7 @@ public class EmittedEventDaoIT extends DaoITestBase {
     @Test
     public void findNotEmittedEventsOlderThan_shouldNotReturnRecordsWithDoNotRetryEmitUntilValueInFuture() {
         final PaymentCreated paymentCreatedEvent = aPaymentCreatedEvent();
-        final RefundSubmitted refundSubmittedEvent = aRefundSubmittedEvent(ZonedDateTime.parse("2019-01-01T14:00:00Z"));
+        final RefundSubmitted refundSubmittedEvent = aRefundSubmittedEvent(Instant.parse("2019-01-01T14:00:00Z"));
         emittedEventDao.recordEmission(paymentCreatedEvent.getResourceType(), paymentCreatedEvent.getResourceExternalId(),
                 paymentCreatedEvent.getEventType(), paymentCreatedEvent.getTimestamp(), null);
         ZonedDateTime doNotRetryEmitUntil = ZonedDateTime.now(UTC).minusSeconds(120);
@@ -214,7 +214,7 @@ public class EmittedEventDaoIT extends DaoITestBase {
                 Instant.parse("2019-01-01T14:00:00Z"));
     }
 
-    private RefundSubmitted aRefundSubmittedEvent(ZonedDateTime eventTimestamp) {
+    private RefundSubmitted aRefundSubmittedEvent(Instant eventTimestamp) {
         return new RefundSubmitted("service-id", true, "my-resource-external-id",
                 "parent-external-id",
                 null, eventTimestamp);

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundIncludedInPayoutTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundIncludedInPayoutTest.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.events.model.refund;
 
 import org.junit.jupiter.api.Test;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
@@ -16,7 +16,7 @@ class RefundIncludedInPayoutTest {
         var refundExternalId = "refund-id";
         var gatewayPayoutId = "payout-id";
         String eventDateStr = "2020-05-10T10:30:00.000000Z";
-        var event = new RefundIncludedInPayout(refundExternalId, gatewayPayoutId, ZonedDateTime.parse(eventDateStr));
+        var event = new RefundIncludedInPayout(refundExternalId, gatewayPayoutId, Instant.parse(eventDateStr));
 
         var json = event.toJsonString();
 

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -308,7 +308,7 @@ public class QueueMessageContractTest {
 
     @PactVerifyProvider("a refund included in payout message")
     public String verifyRefundIncludedInPayoutEvent() throws JsonProcessingException {
-        RefundIncludedInPayout event = new RefundIncludedInPayout(resourceId, "po_1234567890", ZonedDateTime.now());
+        RefundIncludedInPayout event = new RefundIncludedInPayout(resourceId, "po_1234567890", Instant.now());
 
         return event.toJsonString();
     }

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -130,7 +130,7 @@ public class PayoutReconcileProcessTest {
     @Test
     public void shouldEmitEventsForMessageAndMarkAsProcessed() throws Exception {
         var paymentEvent = new PaymentIncludedInPayout(paymentExternalId, payoutId, payoutCreatedDate.toInstant());
-        var refundEvent = new RefundIncludedInPayout(refundExternalId, payoutId, payoutCreatedDate);
+        var refundEvent = new RefundIncludedInPayout(refundExternalId, payoutId, payoutCreatedDate.toInstant());
         var feeCollectionEvent = new PaymentIncludedInPayout(failedPaymentWithFeeExternalId, payoutId, payoutCreatedDate.toInstant());
         var disputeEvent = new DisputeIncludedInPayout(disputeExternalId, payoutId, payoutCreatedDate);
         var stripePayout = new StripePayout("po_123", 1213L, 1589395533L,
@@ -284,7 +284,7 @@ public class PayoutReconcileProcessTest {
 
         payoutReconcileProcess.processPayouts();
 
-        var refundEvent = new RefundIncludedInPayout(refundExternalId, payoutId, payoutCreatedDate);
+        var refundEvent = new RefundIncludedInPayout(refundExternalId, payoutId, payoutCreatedDate.toInstant());
         verify(eventService).emitEvent(refundEvent, false);
         verifyNoMoreInteractions(eventService);
         verify(payoutReconcileQueue).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());


### PR DESCRIPTION
Make `RefundEvent` and its subclasses take an `Instant`, rather than a `ZonedDateTime`, for the timestamp in the constructor.