### PR TITLE
PP-10173 Use Instant in PayoutEvent, DisputeEvent, AgreementEvent

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -73,6 +73,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -486,14 +490,14 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java",
         "hashed_secret": "c2baab12724c0f29014dc172042a17ebbd9b60d4",
         "is_verified": false,
-        "line_number": 119
+        "line_number": 117
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java",
         "hashed_secret": "4991aba1cb28cabc042aa415f2689cf359bb4af2",
         "is_verified": false,
-        "line_number": 120
+        "line_number": 118
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java": [
@@ -974,5 +978,5 @@
       }
     ]
   },
-  "generated_at": "2022-09-28T10:31:58Z"
+  "generated_at": "2022-10-07T13:36:14Z"
 }

--- a/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
@@ -18,8 +18,7 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 
 import javax.inject.Inject;
 import java.time.Clock;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Optional;
 
 import static uk.gov.pay.connector.agreement.model.AgreementEntity.AgreementEntityBuilder.anAgreementEntity;
@@ -91,9 +90,9 @@ public class AgreementService {
                     paymentInstrument.setPaymentInstrumentStatus(PaymentInstrumentStatus.CANCELLED);
 
                     if (agreementCancelRequest != null && agreementCancelRequest.getUserEmail() != null && agreementCancelRequest.getUserExternalId() != null) {
-                        ledgerService.postEvent(AgreementCancelledByUser.from(agreement, agreementCancelRequest, ZonedDateTime.now(ZoneOffset.UTC)));
+                        ledgerService.postEvent(AgreementCancelledByUser.from(agreement, agreementCancelRequest, Instant.now()));
                     } else {
-                        ledgerService.postEvent(AgreementCancelledByService.from(agreement, ZonedDateTime.now(ZoneOffset.UTC)));
+                        ledgerService.postEvent(AgreementCancelledByService.from(agreement, Instant.now()));
                     }
                 }, () -> {
                     throw new PaymentInstrumentNotActiveException("Payment instrument not active.");

--- a/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
@@ -12,7 +12,6 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 
 import javax.inject.Inject;
 import java.time.Clock;
-import java.time.ZonedDateTime;
 import java.util.List;
 
 public class LinkPaymentInstrumentToAgreementService {
@@ -38,8 +37,8 @@ public class LinkPaymentInstrumentToAgreementService {
                     agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
                     paymentInstrumentEntity.setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
                     ledgerService.postEvent(List.of(
-                            AgreementSetup.from(agreementEntity, ZonedDateTime.now(clock)),
-                            PaymentInstrumentConfirmed.from(agreementEntity, ZonedDateTime.now(clock))
+                            AgreementSetup.from(agreementEntity, clock.instant()),
+                            PaymentInstrumentConfirmed.from(agreementEntity, clock.instant())
                     ));
                 }, () -> LOGGER.error("Charge {} references agreement {} but that agreement does not exist", chargeEntity.getExternalId(), agreementId));
             }, () -> LOGGER.error("Expected charge {} to have an agreement but it does not have one", chargeEntity.getExternalId()));

--- a/src/main/java/uk/gov/pay/connector/events/model/Event.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/Event.java
@@ -33,16 +33,6 @@ public abstract class Event {
         this(timestamp, resourceExternalId, new EmptyEventDetails());
     }
 
-    @Deprecated
-    public Event(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
-        this(timestamp.toInstant(), resourceExternalId, eventDetails);
-    }
-
-    @Deprecated
-    public Event(String resourceExternalId, ZonedDateTime timestamp) {
-        this(timestamp.toInstant(), resourceExternalId);
-    }
-
     public abstract ResourceType getResourceType();
 
     public String getResourceExternalId() {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByService.java
@@ -2,18 +2,17 @@ package uk.gov.pay.connector.events.model.charge;
 
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
-import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class AgreementCancelledByService extends AgreementEvent {
 
-    public AgreementCancelledByService(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+    public AgreementCancelledByService(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static AgreementCancelledByService from(AgreementEntity agreement, ZonedDateTime timestamp) {
+    public static AgreementCancelledByService from(AgreementEntity agreement, Instant timestamp) {
         return new AgreementCancelledByService(
                 agreement.getServiceId(),
                 agreement.getGatewayAccount().isLive(),

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCancelledByUser.java
@@ -3,19 +3,17 @@ package uk.gov.pay.connector.events.model.charge;
 import uk.gov.pay.connector.agreement.model.AgreementCancelRequest;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
-import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class AgreementCancelledByUser extends AgreementEvent {
 
-    public AgreementCancelledByUser(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+    public AgreementCancelledByUser(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static AgreementCancelledByUser from(AgreementEntity agreement, AgreementCancelRequest agreementCancelRequest, ZonedDateTime timestamp) {
+    public static AgreementCancelledByUser from(AgreementEntity agreement, AgreementCancelRequest agreementCancelRequest, Instant timestamp) {
         return new AgreementCancelledByUser(
                 agreement.getServiceId(),
                 agreement.getGatewayAccount().isLive(),

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementCreated.java
@@ -2,15 +2,13 @@ package uk.gov.pay.connector.events.model.charge;
 
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
-import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class AgreementCreated extends AgreementEvent {
 
-    public AgreementCreated(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+    public AgreementCreated(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
@@ -26,7 +24,7 @@ public class AgreementCreated extends AgreementEvent {
                         agreement.getUserIdentifier(),
                         AgreementStatus.CREATED
                 ),
-                ZonedDateTime.ofInstant(agreement.getCreatedDate(), ZoneOffset.UTC)
+                agreement.getCreatedDate()
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementEvent.java
@@ -4,20 +4,20 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.ResourceType;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class AgreementEvent extends Event {
     private String serviceId;
     private Boolean live;
     
-    public AgreementEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+    public AgreementEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(timestamp, resourceExternalId, eventDetails);
         this.serviceId = serviceId;
         this.live = live;
     }
 
-    public AgreementEvent(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
-        super(resourceExternalId, timestamp);
+    public AgreementEvent(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
+        super(timestamp, resourceExternalId);
         this.serviceId = serviceId;
         this.live = live;
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementSetup.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementSetup.java
@@ -3,20 +3,19 @@ package uk.gov.pay.connector.events.model.charge;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
-import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
 public class AgreementSetup extends AgreementEvent {
 
-    public AgreementSetup(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+    public AgreementSetup(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static AgreementSetup from(AgreementEntity agreement, ZonedDateTime timestamp) {
+    public static AgreementSetup from(AgreementEntity agreement, Instant timestamp) {
         return new AgreementSetup(
                 agreement.getServiceId(),
                 agreement.getGatewayAccount().isLive(),

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentConfirmed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentConfirmed.java
@@ -4,17 +4,16 @@ import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Objects;
 
 public class PaymentInstrumentConfirmed extends PaymentInstrumentEvent {
 
-    public PaymentInstrumentConfirmed(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+    public PaymentInstrumentConfirmed(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static PaymentInstrumentConfirmed from(AgreementEntity agreement, ZonedDateTime timestamp) {
+    public static PaymentInstrumentConfirmed from(AgreementEntity agreement, Instant timestamp) {
         String paymentInstrumentExternalId = agreement.getPaymentInstrument()
                 .map(PaymentInstrumentEntity::getExternalId)
                 .orElseThrow(() -> new IllegalArgumentException("Agreement " + agreement.getExternalId() + " does not have a payment instrument"));

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentCreated.java
@@ -9,13 +9,12 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.service.payments.commons.model.agreement.PaymentInstrumentType;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Optional;
 
 public class PaymentInstrumentCreated extends PaymentInstrumentEvent {
 
-    public PaymentInstrumentCreated(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+    public PaymentInstrumentCreated(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
@@ -25,7 +24,7 @@ public class PaymentInstrumentCreated extends PaymentInstrumentEvent {
                 gatewayAccount.isLive(),
                 paymentInstrument.getExternalId(),
                 new PaymentInstrumentCreatedDetails(paymentInstrument, PaymentInstrumentType.CARD),
-                ZonedDateTime.ofInstant(paymentInstrument.getCreatedDate(), ZoneOffset.UTC)
+                paymentInstrument.getCreatedDate()
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentEvent.java
@@ -4,20 +4,20 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.ResourceType;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PaymentInstrumentEvent extends Event {
     private String serviceId;
     private Boolean live;
     
-    public PaymentInstrumentEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+    public PaymentInstrumentEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(timestamp, resourceExternalId, eventDetails);
         this.serviceId = serviceId;
         this.live = live;
     }
 
-    public PaymentInstrumentEvent(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
-        super(resourceExternalId, timestamp);
+    public PaymentInstrumentEvent(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
+        super(timestamp, resourceExternalId);
         this.serviceId = serviceId;
         this.live = live;
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeCreated.java
@@ -4,15 +4,16 @@ import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeCreatedEventDetails;
 import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class DisputeCreated extends DisputeEvent {
     public DisputeCreated(String resourceExternalId, String parentResourceExternalId, String serviceId,
-                          Boolean live, DisputeCreatedEventDetails eventDetails, ZonedDateTime disputeCreated) {
+                          Boolean live, DisputeCreatedEventDetails eventDetails, Instant disputeCreated) {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, disputeCreated);
     }
 
-    public static DisputeCreated from(String disputeExternalId, StripeDisputeData stripeDisputeData, LedgerTransaction transaction, ZonedDateTime disputeCreatedDate) {
+    public static DisputeCreated from(String disputeExternalId, StripeDisputeData stripeDisputeData,
+                                      LedgerTransaction transaction, Instant disputeCreatedDate) {
         DisputeCreatedEventDetails eventDetails = new DisputeCreatedEventDetails(
                 stripeDisputeData.getEvidenceDetails().getEvidenceDueByDate(),
                 transaction.getGatewayAccountId(),

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeEvent.java
@@ -4,7 +4,7 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.ResourceType;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class DisputeEvent extends Event {
     private String parentResourceExternalId;
@@ -12,15 +12,15 @@ public class DisputeEvent extends Event {
     private Boolean live;
     
     public DisputeEvent(String resourceExternalId, String parentResourceExternalId, String serviceId, Boolean live,
-                        EventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+                        EventDetails eventDetails, Instant timestamp) {
+        super(timestamp, resourceExternalId, eventDetails);
         this.parentResourceExternalId = parentResourceExternalId;
         this.serviceId = serviceId;
         this.live = live;
     }
 
-    public DisputeEvent(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+    public DisputeEvent(String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(timestamp, resourceExternalId, eventDetails);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmitted.java
@@ -3,16 +3,16 @@ package uk.gov.pay.connector.events.model.dispute;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeEvidenceSubmittedEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class DisputeEvidenceSubmitted extends DisputeEvent {
     public DisputeEvidenceSubmitted(String resourceExternalId, String parentResourceExternalId, String serviceId,
                                     Boolean live, DisputeEvidenceSubmittedEventDetails eventDetails,
-                                    ZonedDateTime eventDate) {
+                                    Instant eventDate) {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, eventDate);
     }
 
-    public static DisputeEvidenceSubmitted from(String disputeExternalId, ZonedDateTime eventDate, LedgerTransaction transaction) {
+    public static DisputeEvidenceSubmitted from(String disputeExternalId, Instant eventDate, LedgerTransaction transaction) {
         return new DisputeEvidenceSubmitted(
                 disputeExternalId,
                 transaction.getTransactionId(),

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeIncludedInPayout.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeIncludedInPayout.java
@@ -2,10 +2,10 @@ package uk.gov.pay.connector.events.model.dispute;
 
 import uk.gov.pay.connector.events.eventdetails.TransactionIncludedInPayoutEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class DisputeIncludedInPayout extends DisputeEvent {
-    public DisputeIncludedInPayout(String disputeExternalId, String gatewayPayoutId, ZonedDateTime payoutCreatedDate) {
+    public DisputeIncludedInPayout(String disputeExternalId, String gatewayPayoutId, Instant payoutCreatedDate) {
         super(disputeExternalId, new TransactionIncludedInPayoutEventDetails(gatewayPayoutId), payoutCreatedDate);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeLost.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeLost.java
@@ -5,15 +5,16 @@ import uk.gov.pay.connector.events.eventdetails.dispute.DisputeLostEventDetails;
 import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class DisputeLost extends DisputeEvent {
     public DisputeLost(String resourceExternalId, String parentResourceExternalId, String serviceId, Boolean live,
-                       DisputeLostEventDetails eventDetails, ZonedDateTime eventDate) {
+                       DisputeLostEventDetails eventDetails, Instant eventDate) {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, eventDate);
     }
 
-    public static DisputeLost from(String disputeExternalId, StripeDisputeData stripeDisputeData, ZonedDateTime eventDate, LedgerTransaction transaction, boolean rechargedToService) {
+    public static DisputeLost from(String disputeExternalId, StripeDisputeData stripeDisputeData, Instant eventDate,
+                                   LedgerTransaction transaction, boolean rechargedToService) {
         if (stripeDisputeData.getBalanceTransactionList().size() > 1) {
             throw new RuntimeException("Dispute data has too many balance_transactions");
         }

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeWon.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeWon.java
@@ -3,15 +3,15 @@ package uk.gov.pay.connector.events.model.dispute;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeWonEventDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class DisputeWon extends DisputeEvent {
     public DisputeWon(String resourceExternalId, String parentResourceExternalId, String serviceId,
-                      Boolean live, DisputeWonEventDetails eventDetails, ZonedDateTime eventDate) {
+                      Boolean live, DisputeWonEventDetails eventDetails, Instant eventDate) {
         super(resourceExternalId, parentResourceExternalId, serviceId, live, eventDetails, eventDate);
     }
 
-    public static DisputeWon from(String disputeExternalId, ZonedDateTime eventDate,
+    public static DisputeWon from(String disputeExternalId, Instant eventDate,
                                   LedgerTransaction transaction) {
         return new DisputeWon(disputeExternalId,
                 transaction.getTransactionId(),

--- a/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutCreated.java
@@ -3,11 +3,11 @@ package uk.gov.pay.connector.events.model.payout;
 import uk.gov.pay.connector.events.eventdetails.payout.PayoutCreatedEventDetails;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PayoutCreated extends PayoutEvent {
 
-    private PayoutCreated(String resourceExternalId, PayoutCreatedEventDetails eventDetails, ZonedDateTime timestamp) {
+    private PayoutCreated(String resourceExternalId, PayoutCreatedEventDetails eventDetails, Instant timestamp) {
         super(resourceExternalId, eventDetails, timestamp);
     }
 
@@ -21,6 +21,6 @@ public class PayoutCreated extends PayoutEvent {
                         payout.getStatus(),
                         payout.getType(),
                         payout.getStatementDescriptor()),
-                payout.getCreated());
+                payout.getCreated().toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutEvent.java
@@ -4,20 +4,20 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.ResourceType;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PayoutEvent extends Event {
     private String serviceId;
     private Boolean live;
 
-    public PayoutEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+    public PayoutEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(timestamp, resourceExternalId, eventDetails);
         this.serviceId = serviceId;
         this.live = live;
     }
 
-    public PayoutEvent(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+    public PayoutEvent(String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(timestamp, resourceExternalId, eventDetails);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutFailed.java
@@ -3,15 +3,15 @@ package uk.gov.pay.connector.events.model.payout;
 import uk.gov.pay.connector.events.eventdetails.payout.PayoutFailedEventDetails;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PayoutFailed extends PayoutEvent {
 
-    public PayoutFailed(String resourceExternalId, PayoutFailedEventDetails eventDetails, ZonedDateTime timestamp) {
+    public PayoutFailed(String resourceExternalId, PayoutFailedEventDetails eventDetails, Instant timestamp) {
         super(resourceExternalId, eventDetails, timestamp);
     }
 
-    public static PayoutFailed from(ZonedDateTime eventTimestamp, StripePayout payout) {
+    public static PayoutFailed from(Instant eventTimestamp, StripePayout payout) {
         return new PayoutFailed(payout.getId(),
                 new PayoutFailedEventDetails(
                         payout.getStatus(),

--- a/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutPaid.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutPaid.java
@@ -3,14 +3,14 @@ package uk.gov.pay.connector.events.model.payout;
 import uk.gov.pay.connector.events.eventdetails.payout.PayoutPaidEventDetails;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PayoutPaid extends PayoutEvent {
-    public PayoutPaid(String resourceExternalId, PayoutPaidEventDetails eventDetails, ZonedDateTime timestamp) {
+    public PayoutPaid(String resourceExternalId, PayoutPaidEventDetails eventDetails, Instant timestamp) {
         super(resourceExternalId, eventDetails, timestamp);
     }
 
-    public static PayoutPaid from(ZonedDateTime eventTimestamp, StripePayout payout) {
+    public static PayoutPaid from(Instant eventTimestamp, StripePayout payout) {
         return new PayoutPaid(payout.getId(),
                 new PayoutPaidEventDetails(payout.getArrivalDate(), payout.getStatus()),
                 eventTimestamp);

--- a/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutUpdated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutUpdated.java
@@ -3,14 +3,14 @@ package uk.gov.pay.connector.events.model.payout;
 import uk.gov.pay.connector.events.eventdetails.payout.PayoutEventWithGatewayStatusDetails;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PayoutUpdated extends PayoutEvent {
-    public PayoutUpdated(String resourceExternalId, PayoutEventWithGatewayStatusDetails eventDetails, ZonedDateTime timestamp) {
+    public PayoutUpdated(String resourceExternalId, PayoutEventWithGatewayStatusDetails eventDetails, Instant timestamp) {
         super(resourceExternalId, eventDetails, timestamp);
     }
 
-    public static PayoutUpdated from(ZonedDateTime eventTimestamp, StripePayout payout) {
+    public static PayoutUpdated from(Instant eventTimestamp, StripePayout payout) {
         return new PayoutUpdated(payout.getId(),
                 new PayoutEventWithGatewayStatusDetails(payout.getStatus()),
                 eventTimestamp);

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
@@ -25,9 +25,9 @@ import uk.gov.pay.connector.paymentprocessor.service.Card3dsResponseAuthService;
 import uk.gov.pay.connector.payout.PayoutEmitterService;
 import uk.gov.pay.connector.queue.payout.Payout;
 import uk.gov.pay.connector.queue.payout.PayoutReconcileQueue;
-import uk.gov.pay.connector.queue.tasks.model.Task;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.queue.tasks.TaskType;
+import uk.gov.pay.connector.queue.tasks.model.Task;
 import uk.gov.pay.connector.util.IpAddressMatcher;
 import uk.gov.service.payments.commons.queue.exception.QueueException;
 
@@ -174,7 +174,7 @@ public class StripeNotificationService {
                             kv(GATEWAY_PAYOUT_ID, stripePayout.getId()),
                             kv(CONNECT_ACCOUNT_ID, notification.getAccount()));
                 } else {
-                    payoutEmitterService.emitPayoutEvent(mayBeEventClass.get(), notification.getCreated(),
+                    payoutEmitterService.emitPayoutEvent(mayBeEventClass.get(), notification.getCreated().toInstant(),
                             notification.getAccount(), stripePayout);
                 }
             }

--- a/src/main/java/uk/gov/pay/connector/payout/PayoutEmitterService.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutEmitterService.java
@@ -16,7 +16,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.service.payments.commons.queue.exception.QueueException;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -44,7 +44,7 @@ public class PayoutEmitterService {
         this.gatewayAccountCredentialsService = gatewayAccountCredentialsService;
     }
 
-    public void emitPayoutEvent(Class<? extends PayoutEvent> eventClass, ZonedDateTime eventDate,
+    public void emitPayoutEvent(Class<? extends PayoutEvent> eventClass, Instant eventDate,
                                 String connectAccount, StripePayout payout) {
         Event event = getPayoutEvent(eventClass, connectAccount, eventDate, payout);
 
@@ -70,7 +70,7 @@ public class PayoutEmitterService {
     }
 
     private Event getPayoutEvent(Class<? extends PayoutEvent> eventClass, String connectAccount,
-                                 ZonedDateTime eventDate, StripePayout payout) {
+                                 Instant eventDate, StripePayout payout) {
         if (eventClass == PayoutCreated.class) {
             return getPayoutCreatedEvent(connectAccount, payout);
         } else if (eventClass == PayoutPaid.class) {

--- a/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
@@ -131,7 +131,7 @@ public class PayoutReconcileProcess {
         Payout payoutObject = (Payout) balanceTransaction.getSourceObject();
         StripePayout stripePayout = StripePayout.from(payoutObject);
 
-        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, stripePayout.getCreated(),
+        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, stripePayout.getCreated().toInstant(),
                 payoutReconcileMessage.getConnectAccountId(), stripePayout);
 
         emitTerminalPayoutEvent(payoutReconcileMessage.getConnectAccountId(), stripePayout);
@@ -148,7 +148,7 @@ public class PayoutReconcileProcess {
         if (stripePayoutStatus.isTerminal()) {
             Optional<Class<? extends PayoutEvent>> mayBeEventClass = stripePayoutStatus.getEventClass();
             mayBeEventClass.ifPresentOrElse(
-                    eventClass -> payoutEmitterService.emitPayoutEvent(eventClass, stripePayout.getCreated(),
+                    eventClass -> payoutEmitterService.emitPayoutEvent(eventClass, stripePayout.getCreated().toInstant(),
                             connectAccountId, stripePayout),
                     () -> LOGGER.warn("Event class is not available for a payout in terminal status. " +
                                     "gateway_payout_id [{}], connect_account_id [{}], status [{}]",
@@ -229,7 +229,7 @@ public class PayoutReconcileProcess {
     private void emitDisputeEvent(PayoutReconcileMessage payoutReconcileMessage, String disputeExternalId) {
         var disputeEvent = new DisputeIncludedInPayout(disputeExternalId,
                 payoutReconcileMessage.getGatewayPayoutId(),
-                payoutReconcileMessage.getCreatedDate());
+                payoutReconcileMessage.getCreatedDate().toInstant());
         emitEvent(disputeEvent, payoutReconcileMessage, disputeExternalId);
 
         LOGGER.info(format("Emitted event for dispute [%s] included in payout [%s]",

--- a/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
@@ -25,7 +25,6 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -91,8 +90,8 @@ class LinkPaymentInstrumentToAgreementServiceTest {
         verify(mockAgreementEntity).setPaymentInstrument(mockPaymentInstrumentEntity);
         verify(mockPaymentInstrumentEntity).setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
         verify(ledgerService).postEvent(List.of(
-                AgreementSetup.from(mockAgreementEntity, ZonedDateTime.now(clock)),
-                PaymentInstrumentConfirmed.from(mockAgreementEntity, ZonedDateTime.now(clock))
+                AgreementSetup.from(mockAgreementEntity, clock.instant()),
+                PaymentInstrumentConfirmed.from(mockAgreementEntity, clock.instant())
         ));
     }
 

--- a/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceTest.java
@@ -21,8 +21,7 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -95,7 +94,7 @@ public class LedgerServiceTest {
     @Test
     void serialiseAndSendEvent() {
         setupMocksForPostRequest();
-        var event = new AgreementCreated("service-id", false, "resource-id", null, ZonedDateTime.now(ZoneOffset.UTC));
+        var event = new AgreementCreated("service-id", false, "resource-id", null, Instant.now());
         when(mockResponse.getStatus()).thenReturn(SC_ACCEPTED);
         ledgerService.postEvent(event);
         verify(mockClientRequestInvocationBuilder).post(Entity.json(List.of(event)));
@@ -104,7 +103,7 @@ public class LedgerServiceTest {
     @Test
     void sendEventShouldThrowExceptionIfResponseIsNotAccepted() {
         setupMocksForPostRequest();
-        var event = new AgreementCreated("service-id", false, "resource-id", null, ZonedDateTime.now(ZoneOffset.UTC));
+        var event = new AgreementCreated("service-id", false, "resource-id", null, Instant.now());
         when(mockResponse.getStatus()).thenReturn(SC_BAD_REQUEST);
         assertThrows(LedgerException.class, () -> ledgerService.postEvent(event));
     }
@@ -112,8 +111,8 @@ public class LedgerServiceTest {
     @Test
     void serialiseAndSendMultipleEvents() {
         setupMocksForPostRequest();
-        var eventOne = new AgreementCreated("service-id", false, "resource-id", null, ZonedDateTime.now(ZoneOffset.UTC));
-        var eventTwo = new AgreementSetup("service-id", false, "resource-id", null, ZonedDateTime.now(ZoneOffset.UTC));
+        var eventOne = new AgreementCreated("service-id", false, "resource-id", null, Instant.now());
+        var eventTwo = new AgreementSetup("service-id", false, "resource-id", null, Instant.now());
         List<Event> list = List.of(eventOne, eventTwo);
         when(mockResponse.getStatus()).thenReturn(SC_ACCEPTED);
         ledgerService.postEvent(list);

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 import uk.gov.pay.connector.queue.tasks.dispute.EvidenceDetails;
 
+import java.time.Instant;
 import java.util.List;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
@@ -14,7 +15,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static uk.gov.pay.connector.events.model.dispute.DisputeCreated.from;
 import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
-import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 
 class DisputeCreatedTest {
 
@@ -34,7 +34,7 @@ class DisputeCreatedTest {
                 evidenceDetails, null, true);
         String disputeExternalId = "fca65e80d2293ee3bf158a0d12";
 
-        DisputeCreated disputeCreated = from(disputeExternalId, stripeDisputeData, transaction, toUTCZonedDateTime(1642579160L));
+        DisputeCreated disputeCreated = from(disputeExternalId, stripeDisputeData, transaction, Instant.ofEpochSecond(1642579160L));
 
         String disputeCreatedJson = disputeCreated.toJsonString();
         assertThat(disputeCreatedJson, hasJsonPath("$.event_type", equalTo("DISPUTE_CREATED")));

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java
@@ -5,12 +5,13 @@ import org.junit.Test;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
+import java.time.Instant;
+
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static uk.gov.pay.connector.events.model.dispute.DisputeEvidenceSubmitted.from;
 import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
-import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 
 public class DisputeEvidenceSubmittedTest {
 
@@ -28,7 +29,7 @@ public class DisputeEvidenceSubmittedTest {
                 1642579160L, null, null, null, true);
 
         String disputeExternalId = "fca65e80d2293ee3bf158a0d12";
-        DisputeEvidenceSubmitted disputeEvidenceSubmitted = from(disputeExternalId, toUTCZonedDateTime(1642579160L), transaction);
+        DisputeEvidenceSubmitted disputeEvidenceSubmitted = from(disputeExternalId, Instant.ofEpochSecond(1642579160L), transaction);
 
         String disputeEvidenceSubmittedJson = disputeEvidenceSubmitted.toJsonString();
         assertThat(disputeEvidenceSubmittedJson, hasJsonPath("$.event_type", equalTo("DISPUTE_EVIDENCE_SUBMITTED")));

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeIncludedInPayoutTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeIncludedInPayoutTest.java
@@ -1,9 +1,8 @@
 package uk.gov.pay.connector.events.model.dispute;
 
 import org.junit.jupiter.api.Test;
-import uk.gov.pay.connector.events.model.refund.RefundIncludedInPayout;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
@@ -17,7 +16,7 @@ class DisputeIncludedInPayoutTest {
         var disputeExternalId = "dispute-id";
         var gatewayPayoutId = "payout-id";
         String eventDateStr = "2020-05-10T10:30:00.000000Z";
-        var event = new DisputeIncludedInPayout(disputeExternalId, gatewayPayoutId, ZonedDateTime.parse(eventDateStr));
+        var event = new DisputeIncludedInPayout(disputeExternalId, gatewayPayoutId, Instant.parse(eventDateStr));
 
         var json = event.toJsonString();
 

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 import uk.gov.pay.connector.queue.tasks.dispute.EvidenceDetails;
 
+import java.time.Instant;
 import java.util.List;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
@@ -17,7 +18,6 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.pay.connector.events.model.dispute.DisputeLost.from;
 import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
-import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 
 class DisputeLostTest {
 
@@ -36,7 +36,7 @@ class DisputeLostTest {
                 List.of(balanceTransaction), null, null, true);
         String disputeExternalId = "fca65e80d2293ee3bf158a0d12";
 
-        DisputeLost disputeLost = from(disputeExternalId, stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, true);
+        DisputeLost disputeLost = from(disputeExternalId, stripeDisputeData, Instant.ofEpochSecond(1642579160L), transaction, true);
 
         String disputeLostJson = disputeLost.toJsonString();
         assertThat(disputeLostJson, hasJsonPath("$.event_type", equalTo("DISPUTE_LOST")));
@@ -68,7 +68,7 @@ class DisputeLostTest {
                 List.of(balanceTransaction), null, null, false);
         String disputeExternalId = "fca65e80d2293ee3bf158a0d12";
 
-        DisputeLost disputeLost = from(disputeExternalId, stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, false);
+        DisputeLost disputeLost = from(disputeExternalId, stripeDisputeData, Instant.ofEpochSecond(1642579160L), transaction, false);
 
         String disputeLostJson = disputeLost.toJsonString();
         assertThat(disputeLostJson, hasJsonPath("$.event_type", equalTo("DISPUTE_LOST")));
@@ -102,7 +102,8 @@ class DisputeLostTest {
                 balanceTransaction2), evidenceDetails, null, false);
 
         var thrown = assertThrows(RuntimeException.class, () ->
-                DisputeLost.from("a-dispute-external-id", stripeDisputeData, toUTCZonedDateTime(1642579160L), transaction, true));
+                DisputeLost.from("a-dispute-external-id", stripeDisputeData, Instant.ofEpochSecond(1642579160L),
+                        transaction, true));
         assertThat(thrown.getMessage(), is("Dispute data has too many balance_transactions"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java
@@ -5,12 +5,13 @@ import org.junit.Test;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 
+import java.time.Instant;
+
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static uk.gov.pay.connector.events.model.dispute.DisputeWon.from;
 import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
-import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 
 public class DisputeWonTest {
 
@@ -28,7 +29,7 @@ public class DisputeWonTest {
                 null, null, null, false);
 
         String disputeExternalId = "fca65e80d2293ee3bf158a0d12";
-        DisputeWon disputeWon = from(disputeExternalId, toUTCZonedDateTime(1642579160L), transaction);
+        DisputeWon disputeWon = from(disputeExternalId, Instant.ofEpochSecond(1642579160L), transaction);
 
         String disputeWonJson = disputeWon.toJsonString();
         assertThat(disputeWonJson, hasJsonPath("$.event_type", equalTo("DISPUTE_WON")));

--- a/src/test/java/uk/gov/pay/connector/events/model/payout/PayoutFailedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/payout/PayoutFailedTest.java
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 
+import java.time.Instant;
+
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
-import static java.time.ZonedDateTime.parse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -14,7 +15,7 @@ public class PayoutFailedTest {
     public void shouldSerializePayoutFailedEventWithCorrectEventDetails() throws JsonProcessingException {
         StripePayout payout = new StripePayout("po_123", "pending", "account_closed",
                 "The bank account has been closed", "ba_1GkZtqDv3CZEaFO2CQhLrluk");
-        String payoutEventJson = PayoutFailed.from(parse("2020-05-13T18:50:00Z"), payout).toJsonString();
+        String payoutEventJson = PayoutFailed.from(Instant.parse("2020-05-13T18:50:00Z"), payout).toJsonString();
 
         assertThat(payoutEventJson, hasJsonPath("$.event_type", equalTo("PAYOUT_FAILED")));
         assertThat(payoutEventJson, hasJsonPath("$.resource_type", equalTo("payout")));

--- a/src/test/java/uk/gov/pay/connector/events/model/payout/PayoutPaidTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/payout/PayoutPaidTest.java
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 
+import java.time.Instant;
+
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
-import static java.time.ZonedDateTime.parse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -15,7 +16,7 @@ public class PayoutPaidTest {
     public void shouldSerializePayoutPaidEventWithCorrectEventDetails() throws JsonProcessingException {
         StripePayout payout = new StripePayout("po_123", 1000L, 1589395533L, 1589395500L,
                 "pending", "card", "SERVICE NAME");
-        String payoutEventJson = PayoutPaid.from(parse("2020-05-13T18:50:00Z"), payout).toJsonString();
+        String payoutEventJson = PayoutPaid.from(Instant.parse("2020-05-13T18:50:00Z"), payout).toJsonString();
 
         assertThat(payoutEventJson, hasJsonPath("$.event_type", equalTo("PAYOUT_PAID")));
         assertThat(payoutEventJson, hasJsonPath("$.resource_type", equalTo("payout")));

--- a/src/test/java/uk/gov/pay/connector/events/model/payout/PayoutUpdatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/payout/PayoutUpdatedTest.java
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 
+import java.time.Instant;
+
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
-import static java.time.ZonedDateTime.parse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -15,7 +16,7 @@ public class PayoutUpdatedTest {
     public void shouldSerializePayoutUpdatedEventWithCorrectEventDetails() throws JsonProcessingException {
         StripePayout payout = new StripePayout("po_123", 1000L, 1589395533L, 1589395500L,
                 "pending", "card", "SERVICE NAME");
-        String payoutEventJson = PayoutUpdated.from(parse("2020-05-13T18:45:33Z"), payout).toJsonString();
+        String payoutEventJson = PayoutUpdated.from(Instant.parse("2020-05-13T18:45:33Z"), payout).toJsonString();
 
         assertThat(payoutEventJson, hasJsonPath("$.event_type", equalTo("PAYOUT_UPDATED")));
         assertThat(payoutEventJson, hasJsonPath("$.resource_type", equalTo("payout")));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
@@ -29,13 +29,13 @@ import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.paymentprocessor.service.Card3dsResponseAuthService;
 import uk.gov.pay.connector.payout.PayoutEmitterService;
-import uk.gov.service.payments.commons.queue.exception.QueueException;
 import uk.gov.pay.connector.queue.payout.Payout;
 import uk.gov.pay.connector.queue.payout.PayoutReconcileQueue;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.util.CidrUtils;
 import uk.gov.pay.connector.util.IpAddressMatcher;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+import uk.gov.service.payments.commons.queue.exception.QueueException;
 
 import javax.ws.rs.WebApplicationException;
 import java.time.Instant;
@@ -45,7 +45,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,7 +70,6 @@ import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.PAYMENT
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.PAYOUT_CREATED;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.UNKNOWN;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.byType;
-import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_NOTIFICATION_ACCOUNT_UPDATED;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_NOTIFICATION_CHARGE_DISPUTE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_NOTIFICATION_CHARGE_REFUND_UPDATED;
@@ -302,7 +300,7 @@ class StripeNotificationServiceTest {
             assertTrue(notificationService.handleNotificationFor(payload, signPayload(payload), FORWARDED_IP_ADDRESSES));
 
             verify(mockPayoutEmitterService).emitPayoutEvent(stripeNotificationType.getEventClass().get(),
-                    toUTCZonedDateTime(1567622603L), "connect_account_id", payout);
+                    Instant.ofEpochSecond(1567622603L), "connect_account_id", payout);
 
             reset(mockPayoutEmitterService);
         });

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -69,7 +69,6 @@ import static uk.gov.pay.connector.events.model.payout.PayoutCreated.from;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 import static uk.gov.pay.connector.pact.ChargeEventEntityFixture.aValidChargeEventEntity;
 import static uk.gov.pay.connector.pact.RefundHistoryEntityFixture.aValidRefundHistoryEntity;
-import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.EXTERNAL;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 import static uk.gov.service.payments.commons.model.Source.CARD_API;
@@ -276,7 +275,7 @@ public class QueueMessageContractTest {
     public String verifyPayoutFailedEvent() throws JsonProcessingException {
         StripePayout payout = new StripePayout("po_failed_1234567890", "failed", "account_closed",
                 "The bank account has been closed", "ba_aaaaaaaaaa");
-        PayoutFailed payoutFailed = PayoutFailed.from(parse("2020-05-13T18:50:00Z"), payout);
+        PayoutFailed payoutFailed = PayoutFailed.from(Instant.parse("2020-05-13T18:50:00Z"), payout);
 
         return payoutFailed.toJsonString();
     }
@@ -285,7 +284,7 @@ public class QueueMessageContractTest {
     public String verifyPayoutPaidEvent() throws JsonProcessingException {
         StripePayout payout = new StripePayout("po_paid_1234567890", 1000L, 1589395533L,
                 1589395500L, "paid", "bank_account", "SERVICE NAME");
-        PayoutPaid payoutPaid = PayoutPaid.from(parse("2020-05-13T18:50:00Z"), payout);
+        PayoutPaid payoutPaid = PayoutPaid.from(Instant.parse("2020-05-13T18:50:00Z"), payout);
 
         return payoutPaid.toJsonString();
     }
@@ -294,7 +293,7 @@ public class QueueMessageContractTest {
     public String verifyPayoutUpdatedEvent() throws JsonProcessingException {
         StripePayout payout = new StripePayout("po_updated_1234567890", 1000L, 1589395533L,
                 1589395500L, "pending", "bank_account", "SERVICE NAME");
-        PayoutUpdated payoutPaid = PayoutUpdated.from(parse("2020-05-13T18:50:00Z"), payout);
+        PayoutUpdated payoutPaid = PayoutUpdated.from(Instant.parse("2020-05-13T18:50:00Z"), payout);
 
         return payoutPaid.toJsonString();
     }
@@ -425,7 +424,7 @@ public class QueueMessageContractTest {
                         6500L, "duplicate", "du_1LIaq8Dv3CZEaFO2MNQJK333");
         DisputeCreated disputeCreated =
                 new DisputeCreated("resource-external-id", "external-id", "service-id",
-                        true, eventDetails, toUTCZonedDateTime(1642579160L));
+                        true, eventDetails, Instant.ofEpochSecond(1642579160L));
         return disputeCreated.toJsonString();
     }
 
@@ -434,7 +433,7 @@ public class QueueMessageContractTest {
         DisputeLostEventDetails eventDetails = new DisputeLostEventDetails("a-gateway-account-id",
                 6500L, -8000L, 1500L);
         DisputeLost disputeLost = new DisputeLost("resource-external-id",
-                "external-id", "service-id", true, eventDetails, toUTCZonedDateTime(1642579160L));
+                "external-id", "service-id", true, eventDetails, Instant.ofEpochSecond(1642579160L));
         return disputeLost.toJsonString();
     }
 
@@ -442,7 +441,7 @@ public class QueueMessageContractTest {
     public String verifyDisputeWonEvent() throws JsonProcessingException {
         DisputeWonEventDetails eventDetails = new DisputeWonEventDetails("a-gateway-account-id");
         DisputeWon disputeWon = new DisputeWon("resource-external-id", "external-id",
-                "service-id", true, eventDetails, toUTCZonedDateTime(1642579160L));
+                "service-id", true, eventDetails, Instant.ofEpochSecond(1642579160L));
         return disputeWon.toJsonString();
     }
 
@@ -450,7 +449,7 @@ public class QueueMessageContractTest {
     public String verifyDisputeEvidenceSubmittedEvent() throws JsonProcessingException {
         DisputeEvidenceSubmittedEventDetails eventDetails = new DisputeEvidenceSubmittedEventDetails("a-gateway-account-id");
         DisputeEvidenceSubmitted disputeEvidenceSubmitted = new DisputeEvidenceSubmitted("resource-external-id",
-                "external-id", "service-id", true, eventDetails, toUTCZonedDateTime(1642579160L));
+                "external-id", "service-id", true, eventDetails, Instant.ofEpochSecond(1642579160L));
         return disputeEvidenceSubmitted.toJsonString();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutEmitterServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutEmitterServiceTest.java
@@ -73,7 +73,7 @@ public class PayoutEmitterServiceTest {
 
     @Test
     public void emitPayoutEventForPayoutCreatedShouldEmitCorrectEvent() throws QueueException {
-        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, eventDate, connectAccount, payout);
+        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, eventDate.toInstant(), connectAccount, payout);
 
         verify(mockEventService).emitEvent(payoutArgumentCaptor.capture(), anyBoolean());
 
@@ -90,7 +90,7 @@ public class PayoutEmitterServiceTest {
 
     @Test
     public void shouldEmitPayoutUpdatedEventCorrectly() throws QueueException {
-        payoutEmitterService.emitPayoutEvent(PayoutUpdated.class, eventDate, connectAccount, payout);
+        payoutEmitterService.emitPayoutEvent(PayoutUpdated.class, eventDate.toInstant(), connectAccount, payout);
 
         verify(mockEventService).emitEvent(payoutArgumentCaptor.capture(), anyBoolean());
         PayoutUpdated payoutEvent = (PayoutUpdated) payoutArgumentCaptor.getValue();
@@ -104,7 +104,7 @@ public class PayoutEmitterServiceTest {
     public void shouldEmitPayoutFailedEventCorrectly() throws QueueException {
         payout = new StripePayout("po_123", "pending", "account_closed",
                 "The bank account has been closed", "ba_1GkZtqDv3CZEaFO2CQhLrluk");
-        payoutEmitterService.emitPayoutEvent(PayoutFailed.class, eventDate, "connect-account", payout);
+        payoutEmitterService.emitPayoutEvent(PayoutFailed.class, eventDate.toInstant(), "connect-account", payout);
 
         verify(mockEventService).emitEvent(payoutArgumentCaptor.capture(), anyBoolean());
         PayoutFailed payoutEvent = (PayoutFailed) payoutArgumentCaptor.getValue();
@@ -119,7 +119,7 @@ public class PayoutEmitterServiceTest {
 
     @Test
     public void shouldEmitPayoutPaidEventCorrectly() throws QueueException {
-        payoutEmitterService.emitPayoutEvent(PayoutPaid.class, eventDate, connectAccount, payout);
+        payoutEmitterService.emitPayoutEvent(PayoutPaid.class, eventDate.toInstant(), connectAccount, payout);
 
         verify(mockEventService).emitEvent(payoutArgumentCaptor.capture(), anyBoolean());
         PayoutPaid payoutEvent = (PayoutPaid) payoutArgumentCaptor.getValue();
@@ -139,7 +139,7 @@ public class PayoutEmitterServiceTest {
 
     @Test
     public void emitPayoutEventShouldEmitEventIfFeatureFlagToEmitEventsIsEnabled() throws QueueException {
-        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, eventDate, connectAccount, payout);
+        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, eventDate.toInstant(), connectAccount, payout);
         verify(mockEventService).emitEvent(any(), anyBoolean());
     }
 
@@ -147,13 +147,13 @@ public class PayoutEmitterServiceTest {
     public void emitPayoutEventShouldNotEmitEventIfFeatureFlagToEmitEventsIsDisabled() throws QueueException {
         when(mockConnectorConfiguration.getEmitPayoutEvents()).thenReturn(false);
         payoutEmitterService = new PayoutEmitterService(mockEventService, mockConnectorConfiguration, mockGatewayAccountCredentialsService);
-        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, eventDate, connectAccount, payout);
+        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, eventDate.toInstant(), connectAccount, payout);
         verify(mockEventService, never()).emitEvent(any(), anyBoolean());
     }
 
     @Test
     public void emitPayoutEventShouldNotEmitEventForAnUnknownPayoutEvent() throws QueueException {
-        payoutEmitterService.emitPayoutEvent(PayoutEvent.class, eventDate, null, payout);
+        payoutEmitterService.emitPayoutEvent(PayoutEvent.class, eventDate.toInstant(), null, payout);
         verify(mockEventService, never()).emitEvent(any(), anyBoolean());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -132,7 +132,7 @@ public class PayoutReconcileProcessTest {
         var paymentEvent = new PaymentIncludedInPayout(paymentExternalId, payoutId, payoutCreatedDate.toInstant());
         var refundEvent = new RefundIncludedInPayout(refundExternalId, payoutId, payoutCreatedDate.toInstant());
         var feeCollectionEvent = new PaymentIncludedInPayout(failedPaymentWithFeeExternalId, payoutId, payoutCreatedDate.toInstant());
-        var disputeEvent = new DisputeIncludedInPayout(disputeExternalId, payoutId, payoutCreatedDate);
+        var disputeEvent = new DisputeIncludedInPayout(disputeExternalId, payoutId, payoutCreatedDate.toInstant());
         var stripePayout = new StripePayout("po_123", 1213L, 1589395533L,
                 1589395500L, "pending", "card", "statement_desc");
         PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage();
@@ -145,7 +145,7 @@ public class PayoutReconcileProcessTest {
         verify(eventService).emitEvent(feeCollectionEvent, false);
         verify(eventService).emitEvent(disputeEvent, false);
         verifyNoMoreInteractions(eventService);
-        verify(payoutEmitterService).emitPayoutEvent(PayoutCreated.class, stripePayout.getCreated(),
+        verify(payoutEmitterService).emitPayoutEvent(PayoutCreated.class, stripePayout.getCreated().toInstant(),
                 stripeAccountId, stripePayout);
         verify(payoutReconcileQueue).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
     }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
@@ -136,7 +136,8 @@ public class StripeWebhookTaskHandlerTest {
         stripeWebhookTaskHandler.process(stripeNotification);
 
         String resourceExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeData.getId());
-        var disputeCreated = DisputeCreated.from(resourceExternalId, stripeDisputeData, transaction, stripeDisputeData.getDisputeCreated());
+        var disputeCreated = DisputeCreated.from(resourceExternalId, stripeDisputeData, transaction,
+                stripeDisputeData.getDisputeCreated().toInstant());
         var paymentDisputed = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated().toInstant());
         var refundAvailabilityUpdated = RefundAvailabilityUpdated.from(
                 transaction, ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE, Instant.parse(fixedClockDateTime));
@@ -193,7 +194,7 @@ public class StripeWebhookTaskHandlerTest {
         stripeWebhookTaskHandler.process(stripeNotification);
         ArgumentCaptor<DisputeWon> argumentCaptor = ArgumentCaptor.forClass(DisputeWon.class);
 
-        var disputeWon = DisputeWon.from(resourceExternalId, stripeNotification.getCreated(), transaction);
+        var disputeWon = DisputeWon.from(resourceExternalId, stripeNotification.getCreated().toInstant(), transaction);
         verify(eventService).emitEvent(disputeWon);
         verify(eventService).emitEvent(refundAvailabilityUpdated);
     }
@@ -218,7 +219,7 @@ public class StripeWebhookTaskHandlerTest {
         stripeWebhookTaskHandler.process(stripeNotification);
         ArgumentCaptor<DisputeWon> argumentCaptor = ArgumentCaptor.forClass(DisputeWon.class);
 
-        var disputeWon = DisputeWon.from(resourceExternalId, stripeNotification.getCreated().plusSeconds(1), transaction);
+        var disputeWon = DisputeWon.from(resourceExternalId, stripeNotification.getCreated().plusSeconds(1).toInstant(), transaction);
         verify(eventService).emitEvent(disputeWon);
         verify(eventService).emitEvent(refundAvailabilityUpdated);
     }
@@ -565,7 +566,8 @@ public class StripeWebhookTaskHandlerTest {
         stripeWebhookTaskHandler.process(stripeNotification);
 
         String resourceExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeData.getId());
-        var disputeCreated = DisputeCreated.from(resourceExternalId, stripeDisputeData, transaction, stripeDisputeData.getDisputeCreated());
+        var disputeCreated = DisputeCreated.from(resourceExternalId, stripeDisputeData, transaction,
+                stripeDisputeData.getDisputeCreated().toInstant());
         var paymentDisputed = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated().toInstant());
         var refundAvailabilityUpdated = RefundAvailabilityUpdated.from(
                 transaction, ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE, Instant.parse(fixedClockDateTime));


### PR DESCRIPTION
Make `PayoutEvent`, `DisputeEvent`, `AgreementEvent` and `PaymentInstrumentEvent` and their subclasses take an `Instant`, rather than a `ZonedDateTime`, for the timestamp in the constructor.