### PR TITLE
PP-10137 Don't allow web payments for MOTO API payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
@@ -97,7 +97,8 @@ public class PaymentCreatedEventDetails extends EventDetails {
         charge.getAgreementId().ifPresent(builder::withAgreementId);
         charge.getPaymentInstrument().map(PaymentInstrumentEntity::getExternalId).ifPresent(builder::withPaymentInstrumentId);
 
-        if (isInCreatedState(charge) || hasNotGoneThroughAuthorisation(charge)) {
+        if (isAMotoAPIPayment(charge.getAuthorisationMode()) ||
+                (isInCreatedState(charge) || hasNotGoneThroughAuthorisation(charge))) {
             addCardDetailsIfExist(charge, builder);
         }
 
@@ -110,6 +111,10 @@ public class PaymentCreatedEventDetails extends EventDetails {
 
     private static boolean isInCreatedState(ChargeEntity charge) {
         return ChargeStatus.CREATED.equals(ChargeStatus.fromString(charge.getStatus()));
+    }
+
+    private static boolean isAMotoAPIPayment(AuthorisationMode chargeAuthorisationMode) {
+        return AuthorisationMode.MOTO_API == chargeAuthorisationMode;
     }
 
     private static boolean hasNotGoneThroughAuthorisation(ChargeEntity charge) {
@@ -420,12 +425,12 @@ public class PaymentCreatedEventDetails extends EventDetails {
             this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
             return this;
         }
-        
+
         public Builder withCredentialExternalId(String credentialExternalId) {
             this.credentialExternalId = credentialExternalId;
             return this;
         }
-        
+
         public Builder withAuthorisationMode(AuthorisationMode authorisationMode) {
             this.authorisationMode = authorisationMode;
             return this;

--- a/src/main/java/uk/gov/pay/connector/token/resource/SecurityTokensResource.java
+++ b/src/main/java/uk/gov/pay/connector/token/resource/SecurityTokensResource.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenResponse;
 import uk.gov.pay.connector.util.ResponseUtil;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
@@ -30,6 +31,7 @@ import java.util.Optional;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.util.ResponseUtil.noContentResponse;
 import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 
 @Path("/")
 @Tag(name = "Secure token")
@@ -60,6 +62,7 @@ public class SecurityTokensResource {
                              @PathParam("chargeTokenId") String chargeTokenId) {
         logger.debug("get token {}", chargeTokenId);
         return tokenDao.findByTokenId(chargeTokenId)
+                .filter(tokenEntity -> tokenEntity.getChargeEntity().getAuthorisationMode() != MOTO_API)
                 .map(tokenEntity -> new TokenResponse(tokenEntity.isUsed(), tokenEntity.getChargeEntity()))
                 .map(ResponseUtil::successResponseWithEntity)
                 .orElseGet(() -> notFoundResponse("Token invalid!"));
@@ -81,6 +84,7 @@ public class SecurityTokensResource {
         logger.debug("get charge for token {}", chargeTokenId);
         Optional<ChargeEntity> chargeOpt = chargeDao.findByTokenId(chargeTokenId);
         return chargeOpt
+                .filter(chargeEntity -> chargeEntity.getAuthorisationMode() != MOTO_API)
                 .map(ResponseUtil::successResponseWithEntity)
                 .orElseGet(() -> notFoundResponse("Token invalid!"));
     }


### PR DESCRIPTION
## WHAT YOU DID
- For MOTO API payments, the `one_time_token` generated should only be used by Auth API (`{publicapi)/v1/auth`). But currently, the token can be used by visiting the `/secure/` redirect URL and then payment can be completed using web pages. So return 404 (for MOTO API payments) for `GET one token/charge for token` endpoints which is used by the Frontend app.
- Also for MOTO_API payments, the `PaymentCreated` event should include prefilled billing details all the time and not just when the charge is in the `CREATED` state. This is because automated tests can create a payment and authorise it immediately. In these cases, it is likely that the charge is in an authorised state at the time PAYMENT_CREATED is emitted and prefilled details will not be included in the payment created event or any other event (for MOTO API payments).

