### PR TITLE
PP-10255 Check if there are uncommitted changes to OpenApi file

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,5 +33,13 @@ jobs:
       - name: Pull docker image dependencies
         run: |
           docker pull govukpay/postgres:11.1
+      - name: Compile
+        run: mvn clean compile
+      - name: Check for OpenApi file changes
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            echo "Changes to the OpenApi file have not been committed. Run \`mvn compile\` on your branch to regenerate the file and then commit the changes."
+            exit 1
+          fi
       - name: Run unit and integration tests
-        run: mvn clean verify
+        run: mvn verify

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # pay-connector
 The GOV.UK Pay Connector in Java (Dropwizard).
 
+## API Specification
 
+The [Open API Specification](/openapi/connector_spec.yaml) provides details on the paths and operations including examples.
+
+[View the API specification for connector in Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/alphagov/pay-connector/master/openapi/connector_spec.yaml). 
+
+Alternatively, docs can be generated using [Pay API Docs generator](https://github.com/alphagov/pay-api-docs-generator)
 
 ## Environment Variables
 
@@ -144,14 +150,6 @@ The command to run all the tests is:
 ```
     mvn verify
 ```
-
-## API Specification
-
-The [Open API Specification](/openapi/connector_spec.yaml) provides details on the paths and operations including examples.
-
-API docs can be viewed in browser using [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/alphagov/pay-connector/master/openapi/connector_spec.yaml) 
-
-Alternatively, docs can be generated using [Pay API Docs generator](https://github.com/alphagov/pay-api-docs-generator)
 
 ## Command line tasks
 


### PR DESCRIPTION
Add a check in the GitHub actions workflow that runs on PR builds to check whether there are uncommitted changes after running `mvn compile`. If there are, this suggests that there have been changes to the API specification and the OpenApi file has not been regenerated. Fail the build when uncommitted changes are detected.

Edit README to move API specification section to the top, as it has a useful link to view the specification in Swagger Editor that it would be good to be able to quickly access.