### PR TITLE
PP-10233 include machine cookies generated by us only

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/ClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/ClientFactory.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static org.glassfish.jersey.apache.connector.ApacheClientProperties.CONNECTION_MANAGER;
+import static org.glassfish.jersey.apache.connector.ApacheClientProperties.DISABLE_COOKIES;
 import static org.glassfish.jersey.client.ClientProperties.READ_TIMEOUT;
 
 public class ClientFactory {
@@ -56,7 +57,8 @@ public class ClientFactory {
                 .using(new ApacheConnectorProvider())
                 .using(conf.getClientConfiguration())
                 .withProperty(READ_TIMEOUT, (int) readTimeout.toMilliseconds())
-                .withProperty(CONNECTION_MANAGER, 
+                .withProperty(DISABLE_COOKIES, true)
+                .withProperty(CONNECTION_MANAGER,
                         createConnectionManager(gateway.getName(), metricName, metricRegistry, conf.getCustomJerseyClient().getConnectionTTL()));
 
         if (System.getProperty(PROXY_HOST_PROPERTY) != null && System.getProperty(PROXY_PORT_PROPERTY) != null) {


### PR DESCRIPTION
## WHAT YOU DID

We occasionally get `Could not find order` errors from Worldpay for 3DS authorisation attempts.
As per Worldpay, this is due to invalid machine cookies sent in the request header.
As per Worldpay logs error is Unable to find data in SessionCache for second 3DS request : orderCode=XXX, merchantCode=XXX
We are seeing multiple machine cookies being passed in one string where we would only expect one as HTTP/1.1

- disable automatic cookie setting on clients
- add test to check that we only include our own cookie

    with @james-peacock-gds