### PR TITLE
PP-10114 Send CARD-SSL not VISA-SSL for some Worldpay accounts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -506,7 +506,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 643
+        "line_number": 649
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
@@ -978,5 +978,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-07T13:36:14Z"
+  "generated_at": "2022-11-01T16:46:47Z"
 }

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.app;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
@@ -11,12 +12,14 @@ import uk.gov.pay.connector.app.config.EventEmitterConfig;
 import uk.gov.pay.connector.app.config.ExpungeConfig;
 import uk.gov.pay.connector.app.config.PayoutReconcileProcessConfig;
 import uk.gov.pay.connector.app.config.RestClientConfig;
+import uk.gov.pay.connector.app.config.StringToListConverter;
 import uk.gov.pay.connector.app.config.TaskQueueConfig;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.time.Duration;
+import java.util.List;
 
 public class ConnectorConfiguration extends Configuration {
 
@@ -148,6 +151,11 @@ public class ConnectorConfiguration extends Configuration {
     @NotNull
     private Long ledgerPostEventTimeoutInMillis;
 
+    @Valid
+    @JsonDeserialize(converter = StringToListConverter.class)
+    @JsonProperty("worldpayCardSslAccounts")
+    private List<String> worldpayCardSslAccounts;
+
     public String getLedgerBaseUrl() {
         return ledgerBaseUrl;
     }
@@ -266,6 +274,10 @@ public class ConnectorConfiguration extends Configuration {
 
     public Boolean getEmitPayoutEvents() {
         return emitPayoutEvents;
+    }
+
+    public List<String> getWorldpayCardSslAccounts() {
+        return worldpayCardSslAccounts;
     }
 
     public RestClientConfig getRestClientConfig() {

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
@@ -57,6 +58,8 @@ public class AuthCardDetails implements AuthorisationDetails {
     private String jsTimezoneOffsetMins;
     @Schema(example = "fr;q=0.9, fr-CH;q=1.0, en;q=0.8, de;q=0.7, *;q=0.5")
     private String acceptLanguageHeader;
+    @JsonIgnore
+    private boolean useCardSslForWorldpay = false;
 
     public static AuthCardDetails anAuthCardDetails() {
         return new AuthCardDetails();
@@ -252,6 +255,14 @@ public class AuthCardDetails implements AuthorisationDetails {
 
     public Optional<String> getJsNavigatorLanguage() {
         return Optional.ofNullable(jsNavigatorLanguage);
+    }
+
+    public boolean isUseCardSslForWorldpay() {
+        return useCardSslForWorldpay;
+    }
+
+    public void setUseCardSslForWorldpay(boolean useCardSsl) {
+        this.useCardSslForWorldpay = useCardSsl;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
@@ -32,4 +32,8 @@ public interface AuthorisationRequestSummary {
         return null; 
     };
 
+    default Presence worldpayCardSsl() {
+        return NOT_APPLICABLE;
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
@@ -68,6 +68,10 @@ public class AuthorisationRequestSummaryStringifier {
         Optional.ofNullable(authorisationRequestSummary.ipAddress())
                 .map(ipAddress -> stringJoiner.add("with remote IP " + ipAddress));
 
+        if (authorisationRequestSummary.worldpayCardSsl() == AuthorisationRequestSummary.Presence.PRESENT) {
+            stringJoiner.add("using CARD-SSL");
+        }
+
         return stringJoiner.toString();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -13,13 +12,14 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
     private final Presence billingAddress;
     private final Presence dataFor3ds;
     private final Presence deviceDataCollectionResult;
+    private final Presence useCardSsl;
     private String ipAddress;
-    
 
     public WorldpayAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
         deviceDataCollectionResult = authCardDetails.getWorldpay3dsFlexDdcResult().map(address -> PRESENT).orElse(NOT_PRESENT);
         dataFor3ds = (deviceDataCollectionResult == PRESENT || gatewayAccount.isRequires3ds()) ? PRESENT : NOT_PRESENT;
+        useCardSsl = authCardDetails.isUseCardSslForWorldpay() ? PRESENT : NOT_PRESENT;
         ipAddress = authCardDetails.getIpAddress().orElse(null);
     }
 
@@ -36,6 +36,11 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
     @Override
     public Presence deviceDataCollectionResult() {
         return deviceDataCollectionResult;
+    }
+
+    @Override
+    public Presence worldpayCardSsl() {
+        return useCardSsl;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -52,9 +52,9 @@ public interface WorldpayOrderBuilder {
     
     static GatewayOrder buildAuthoriseOrderWithExemptionEngine(CardAuthorisationGatewayRequest request, boolean withExemptionEngine, AcceptLanguageHeaderParser acceptLanguageHeaderParser) {
         if (withExemptionEngine) {
-            return buildAuthoriseOrderWithExemptionEngine(aWorldpayAuthoriseOrderRequestBuilder(), request, acceptLanguageHeaderParser).build();
+            return buildAuthoriseOrderWithExemptionEngine(aWorldpayAuthoriseOrderRequestBuilder(request), request, acceptLanguageHeaderParser).build();
         } else {
-            return buildAuthoriseOrderWithoutExemptionEngine(aWorldpayAuthoriseOrderRequestBuilder(), request, acceptLanguageHeaderParser).build();
+            return buildAuthoriseOrderWithoutExemptionEngine(aWorldpayAuthoriseOrderRequestBuilder(request), request, acceptLanguageHeaderParser).build();
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.OrderRequestBuilder;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.templates.PayloadBuilder;
 import uk.gov.pay.connector.gateway.templates.TemplateBuilder;
 import uk.gov.pay.connector.northamericaregion.NorthAmericaRegion;
@@ -144,6 +145,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     }
 
     public static final TemplateBuilder AUTHORISE_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayAuthoriseOrderTemplate.xml");
+    public static final TemplateBuilder AUTHORISE_ORDER_TEMPLATE_BUILDER_CARD_SSL = new TemplateBuilder("/worldpay/WorldpayAuthoriseOrderTemplate_CARD-SSL.xml");
     public static final TemplateBuilder AUTHORISE_APPLE_PAY_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayAuthoriseApplePayOrderTemplate.xml");
     public static final TemplateBuilder AUTHORISE_GOOGLE_PAY_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml");
     public static final TemplateBuilder AUTH_3DS_RESPONSE_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/Worldpay3dsResponseAuthOrderTemplate.xml");
@@ -155,7 +157,10 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     private final WorldpayTemplateData worldpayTemplateData;
     private final NorthAmericanRegionMapper northAmericanRegionMapper;
 
-    public static WorldpayOrderRequestBuilder aWorldpayAuthoriseOrderRequestBuilder() {
+    public static WorldpayOrderRequestBuilder aWorldpayAuthoriseOrderRequestBuilder(CardAuthorisationGatewayRequest request) {
+        if (request.getAuthCardDetails().isUseCardSslForWorldpay()) {
+            return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), AUTHORISE_ORDER_TEMPLATE_BUILDER_CARD_SSL, OrderRequestType.AUTHORISE);
+        }
         return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), AUTHORISE_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE);
     }
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -287,3 +287,5 @@ authorisation3dsConfig:
 authorisationConfig:
   asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_TIMEOUT_IN_MILLISECONDS::-10000}
+
+worldpayCardSslAccounts: ${WORLDPAY_CARD_SSL_ACCOUNTS}

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate_CARD-SSL.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate_CARD-SSL.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="${merchantCode}">
+    <submit>
+        <order orderCode="${transactionId?xml}">
+            <description>${description?xml}</description>
+            <amount currencyCode="GBP" exponent="2" value="${amount}"/>
+            <paymentDetails>
+                <CARD-SSL>
+                    <cardNumber>${authCardDetails.cardNo}</cardNumber>
+                    <expiryDate>
+                        <date month="${authCardDetails.endDate.twoDigitMonth?xml}" year="${authCardDetails.endDate.fourDigitYear?xml}"/>
+                    </expiryDate>
+                    <cardHolderName>${authCardDetails.cardHolder?xml}</cardHolderName>
+                    <cvc>${authCardDetails.cvc}</cvc>
+                    <#if authCardDetails.address.isPresent()>
+                    <cardAddress>
+                        <address>
+                            <address1>${authCardDetails.address.get().line1?xml}</address1>
+                            <#if authCardDetails.address.get().line2??>
+                            <address2>${authCardDetails.address.get().line2?xml}</address2>
+                            </#if>
+                            <postalCode>${authCardDetails.address.get().postcode?xml}</postalCode>
+                            <city>${authCardDetails.address.get().city?xml}</city>
+                            <#if state??>
+                            <state>${state?xml}</state>
+                            </#if>
+                            <countryCode>${authCardDetails.address.get().country?xml}</countryCode>
+                        </address>
+                    </cardAddress>
+                    </#if>
+                </CARD-SSL>
+                <#if requires3ds>
+                <#if payerIpAddress??>
+                <session id="${sessionId?xml}" shopperIPAddress="${payerIpAddress?xml}"/>
+                <#else>
+                <session id="${sessionId?xml}"/>
+                </#if>
+                </#if>
+            </paymentDetails>
+            <#if requires3ds || payerEmail??>
+            <shopper>
+                <#if payerEmail??>
+                <shopperEmailAddress>${payerEmail?xml}</shopperEmailAddress>
+                </#if>
+                <#if requires3ds>
+                <browser>
+                    <acceptHeader>${authCardDetails.acceptHeader?xml}</acceptHeader>
+                    <userAgentHeader>${authCardDetails.userAgentHeader?xml}</userAgentHeader>
+                    <#if authCardDetails.worldpay3dsFlexDdcResult.isEmpty() && integrationVersion3ds == 2>
+                    <browserLanguage>${browserLanguage?xml}</browserLanguage>
+                    </#if>
+                </browser>
+                </#if>
+            </shopper>
+            </#if>
+            <#if requires3ds>
+            <#if authCardDetails.worldpay3dsFlexDdcResult.isPresent()>
+            <additional3DSData
+                dfReferenceId="${authCardDetails.worldpay3dsFlexDdcResult.get()?xml}"
+                challengeWindowSize="390x400" challengePreference="noPreference"
+            />
+            </#if>
+            <#if authCardDetails.worldpay3dsFlexDdcResult.isEmpty() && integrationVersion3ds == 2>
+            <additional3DSData
+                dfReferenceId=""
+                javaScriptEnabled="false"
+                challengeWindowSize="390x400" challengePreference="noPreference"
+            />
+            </#if>
+            <#if exemptionEngineEnabled>
+            <exemption type="OP" placement="OPTIMISED"/>
+            </#if>
+            </#if>
+        </order>
+    </submit>
+</paymentService>

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
@@ -27,11 +27,12 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
         given(mockAuthorisationRequestSummary.exemptionRequest()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.worldpayCardSsl()).willReturn(PRESENT);
         given(mockAuthorisationRequestSummary.ipAddress()).willReturn("1.1.1.1");
-        
+
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
-        
-        assertThat(result, is(" with billing address and with 3DS data and without device data collection result and with exemption and with remote IP 1.1.1.1"));
+
+        assertThat(result, is(" with billing address and with 3DS data and without device data collection result and with exemption and with remote IP 1.1.1.1 and using CARD-SSL"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
@@ -66,4 +66,11 @@ class WorldpayAuthorisationRequestSummaryTest {
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
     }
 
+    @Test
+    void cardSslPresent() {
+        given(mockAuthCardDetails.isUseCardSslForWorldpay()).willReturn(true);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.worldpayCardSsl(), is(PRESENT));
+    }
+
 }

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -124,6 +124,12 @@ public class ChargingITestBase {
         this.gatewayAccountCredentialsId = RandomUtils.nextInt();
     }
 
+    public ChargingITestBase(String paymentProvider, String gatewayAccountId) {
+        this.paymentProvider = paymentProvider;
+        this.accountId = gatewayAccountId;
+        this.gatewayAccountCredentialsId = RandomUtils.nextInt();
+    }
+
     @Before
     public void setUp() {
         wireMockServer = testContext.getWireMockServer();
@@ -268,12 +274,20 @@ public class ChargingITestBase {
         return createNewChargeWith(status, null);
     }
 
+    protected String createNewChargeWithNoTransactionIdForSpecfiedGatewayAccount(ChargeStatus status, String gatewayAccountId) {
+        return createNewChargeWith(status, null, gatewayAccountId);
+    }
+
     protected String createNewCharge(ChargeStatus status) {
         return createNewChargeWith(status, randomId());
     }
 
     protected String createNewChargeWith(ChargeStatus status, String gatewayTransactionId) {
         return createNewChargeWithAccountId(status, gatewayTransactionId, accountId, databaseTestHelper, paymentProvider, credentialParams.getId()).toString();
+    }
+
+    protected String createNewChargeWith(ChargeStatus status, String gatewayTransactionId, String gatewayAccountId) {
+        return createNewChargeWithAccountId(status, gatewayTransactionId, gatewayAccountId, databaseTestHelper, paymentProvider, credentialParams.getId()).toString();
     }
 
     protected RequestSpecification givenSetup() {

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -572,7 +572,8 @@ class WorldpayPaymentProviderTest {
                 new AuthorisationService(mockCardExecutorService, mockEnvironment, mockConnectorConfiguration), 
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()), 
                 mock(ChargeDao.class),
-                mock(EventService.class));
+                mock(EventService.class),
+                mock(ConnectorConfiguration.class));
     }
 
     private Map<String, URI> gatewayUrlMap() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceCardSslIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceCardSslIT.java
@@ -1,0 +1,79 @@
+package uk.gov.pay.connector.it.resources.worldpay;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingXPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithFullAddress;
+import static uk.gov.pay.connector.rules.WorldpayMockClient.WORLDPAY_URL;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(
+        app = ConnectorApp.class,
+        config = "config/test-it-config.yaml",
+        withDockerSQS = true
+)
+public class WorldpayCardResourceCardSslIT extends ChargingITestBase {
+    
+    private static String ACCOUNT_ID_THAT_APPEARS_IN_CONFIG_AS_WORLDPAY_CARD_SSL_ACCOUNTS = "42";
+
+    public WorldpayCardResourceCardSslIT() {
+        super("worldpay", ACCOUNT_ID_THAT_APPEARS_IN_CONFIG_AS_WORLDPAY_CARD_SSL_ACCOUNTS);
+    }
+
+    @Test
+    public void shouldAuthoriseUsingCardSsl() {
+        String chargeId = createNewChargeWithNoTransactionIdForSpecfiedGatewayAccount(ENTERING_CARD_DETAILS, ACCOUNT_ID_THAT_APPEARS_IN_CONFIG_AS_WORLDPAY_CARD_SSL_ACCOUNTS);
+        worldpayMockClient.mockAuthorisationSuccess();
+
+        String authDetails = buildJsonAuthorisationDetailsWithFullAddress();
+
+        givenSetup()
+                .body(authDetails)
+                .post(authoriseChargeUrlFor(chargeId))
+                .then()
+                .body("status", is(AUTHORISATION_SUCCESS.toString()))
+                .statusCode(200);
+
+        assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.toString());
+
+        verifyRequestBodyToWorldpay(WORLDPAY_URL);
+    }
+
+    private void verifyRequestBodyToWorldpay(String path) {
+        wireMockServer.verify(
+                postRequestedFor(urlPathEqualTo(path))
+                        .withHeader("Content-Type", equalTo("application/xml"))
+                        .withHeader("Authorization", equalTo("Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ="))
+                        .withRequestBody(matchingXPath(getMatchingXPath("paymentService", "merchantCode", "merchant-id")))
+                        .withRequestBody(matchingXPath(getMatchingXPathForText("description", "Test description")))
+                        .withRequestBody(matchingXPath(getMatchingXPath("amount", "value", "6234")))
+                        .withRequestBody(matchingXPath(getMatchingXPath("amount", "currencyCode", "GBP")))
+                        .withRequestBody(matchingXPath(getMatchingXPathForText("CARD-SSL//cardHolderName", "Scrooge McDuck")))
+                        .withRequestBody(matchingXPath(getMatchingXPathForText("CARD-SSL//cardNumber", "4242424242424242")))
+                        .withRequestBody(matchingXPath(getMatchingXPath("CARD-SSL//date", "month", "11")))
+                        .withRequestBody(matchingXPath(getMatchingXPath("CARD-SSL//date", "year", "2099")))
+                        .withRequestBody(matchingXPath(getMatchingXPathForText("CARD-SSL//cvc", "123")))
+        );
+    }
+
+    public String getMatchingXPath(String path, String attribute, String value) {
+        return format("//%s[@%s=\"%s\"]", path, attribute, value);
+    }
+
+    public String getMatchingXPathForText(String path, String value) {
+        return format("//%s[text()=\"%s\"]", path, value);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -166,11 +166,11 @@ public class WorldpayCardResourceIT extends ChargingITestBase {
                         .withRequestBody(matchingXPath(getMatchingXPathForText("description", "Test description")))
                         .withRequestBody(matchingXPath(getMatchingXPath("amount", "value", "6234")))
                         .withRequestBody(matchingXPath(getMatchingXPath("amount", "currencyCode", "GBP")))
-                        .withRequestBody(matchingXPath(getMatchingXPathForText("cardHolderName", "Scrooge McDuck")))
-                        .withRequestBody(matchingXPath(getMatchingXPathForText("cardNumber", "4242424242424242")))
-                        .withRequestBody(matchingXPath(getMatchingXPath("date", "month", "11")))
-                        .withRequestBody(matchingXPath(getMatchingXPath("date", "year", "2099")))
-                        .withRequestBody(matchingXPath(getMatchingXPathForText("cvc", "123")))
+                        .withRequestBody(matchingXPath(getMatchingXPathForText("VISA-SSL//cardHolderName", "Scrooge McDuck")))
+                        .withRequestBody(matchingXPath(getMatchingXPathForText("VISA-SSL//cardNumber", "4242424242424242")))
+                        .withRequestBody(matchingXPath(getMatchingXPath("VISA-SSL//date", "month", "11")))
+                        .withRequestBody(matchingXPath(getMatchingXPath("VISA-SSL//date", "year", "2099")))
+                        .withRequestBody(matchingXPath(getMatchingXPathForText("VISA-SSL//cvc", "123")))
         );
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -21,6 +21,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_AUTHORISATION_PARES_PARSE_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-pares-parse-error-response.xml";
     public static final String WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS = WORLDPAY_BASE_NAME + "/special-char-valid-authorise-worldpay-request-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-min-address.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS_CARD_SSL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-min-address-CARD-SSL.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-including-state.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-excluding-3ds.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-excluding-3ds-with-email.xml";

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -225,3 +225,5 @@ authorisation3dsConfig:
 authorisationConfig:
   asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}
+
+worldpayCardSslAccounts: ${WORLDPAY_CARD_SSL_ACCOUNTS:-42}

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-3ds-request-min-address-CARD-SSL.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-3ds-request-min-address-CARD-SSL.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <CARD-SSL>
+                    <cardNumber>4111111111111111</cardNumber>
+                    <expiryDate>
+                        <date month="12" year="2015"/>
+                    </expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cvc>123</cvc>
+                    <cardAddress>
+                        <address>
+                            <address1>123 My Street</address1>
+                            <postalCode>SW8URR</postalCode>
+                            <city>London</city>
+                            <countryCode>GB</countryCode>
+                        </address>
+                    </cardAddress>
+                </CARD-SSL>
+                <session id="uniqueSessionId"/>
+            </paymentDetails>
+            <shopper>
+                <browser>
+                    <acceptHeader>text/html</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0</userAgentHeader>
+                </browser>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
If a Worldpay gateway account ID appears in the comma-separated value of the `WORLDPAY_CARD_SSL_ACCOUNTS` environment variable, use `CARD-SSL` instead of `VISA-SSL` in the XML when sending an authorisation request to Worldpay.