### PR TITLE
PP-10198 Make flex credentials mandatory for Worlday non-MOTO live accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsService.java
@@ -4,18 +4,26 @@ import com.google.inject.persist.Transactional;
 import uk.gov.pay.connector.gatewayaccount.dao.Worldpay3dsFlexCredentialsDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsRequest;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 
 import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
 
+import static java.lang.String.format;
 import static uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity.Worldpay3dsFlexCredentialsEntityBuilder.aWorldpay3dsFlexCredentialsEntity;
+import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
 
 public class Worldpay3dsFlexCredentialsService {
 
     private Worldpay3dsFlexCredentialsDao worldpay3dsFlexCredentialsDao;
+    private GatewayAccountCredentialsService gatewayAccountCredentialsService;
 
     @Inject
-    public Worldpay3dsFlexCredentialsService(Worldpay3dsFlexCredentialsDao worldpay3dsFlexCredentialsDao) {
+    public Worldpay3dsFlexCredentialsService(Worldpay3dsFlexCredentialsDao worldpay3dsFlexCredentialsDao,
+                                             GatewayAccountCredentialsService gatewayAccountCredentialsService) {
         this.worldpay3dsFlexCredentialsDao = worldpay3dsFlexCredentialsDao;
+        this.gatewayAccountCredentialsService = gatewayAccountCredentialsService;
     }
 
     @Transactional
@@ -34,5 +42,12 @@ public class Worldpay3dsFlexCredentialsService {
                     .build();
             worldpay3dsFlexCredentialsDao.merge(newWorldpay3dsFlexCredentialsEntity);
         });
+
+        //TODO: To move Flex credentials to gateway account credentials level so correct Worldpay credential can be updated (as part of PP-10143)
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = gatewayAccountEntity.getCurrentOrActiveGatewayAccountCredential()
+                .orElseThrow(() -> new WebApplicationException(
+                        serviceErrorResponse(format("Active or current credential not found for gateway account [%s]", gatewayAccountEntity.getId()))));
+
+        gatewayAccountCredentialsService.updateStateForCredentials(gatewayAccountCredentialsEntity);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
@@ -27,6 +27,8 @@ public final class GatewayAccountEntityFixture {
     private boolean requires3ds;
     private boolean allowGooglePay;
     private boolean allowApplePay;
+
+    private boolean allowMoto;
     private long corporateCreditCardSurchargeAmount;
     private long corporateDebitCardSurchargeAmount;
     private long corporatePrepaidDebitCardSurchargeAmount;
@@ -99,6 +101,11 @@ public final class GatewayAccountEntityFixture {
 
     public GatewayAccountEntityFixture withAllowApplePay(boolean allowApplePay) {
         this.allowApplePay = allowApplePay;
+        return this;
+    }
+
+    public GatewayAccountEntityFixture withAllowMoto(boolean allowMoto) {
+        this.allowMoto = allowMoto;
         return this;
     }
 
@@ -213,6 +220,7 @@ public final class GatewayAccountEntityFixture {
         gatewayAccountEntity.setRequiresAdditionalKycData(requiresAdditionalKycData);
         gatewayAccountEntity.setBlockPrepaidCards(blockPrepaidCards);
         gatewayAccountEntity.setDisabled(disabled);
+        gatewayAccountEntity.setAllowMoto(allowMoto);
 
         if (credentials != null && !credentials.isEmpty() && gatewayAccountCredentialsEntities != null
                 && gatewayAccountCredentialsEntities.isEmpty()) {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsServiceTest.java
@@ -1,0 +1,78 @@
+package uk.gov.pay.connector.gatewayaccount.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gatewayaccount.dao.Worldpay3dsFlexCredentialsDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsRequest;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
+
+@ExtendWith(MockitoExtension.class)
+class Worldpay3dsFlexCredentialsServiceTest {
+
+    private Worldpay3dsFlexCredentialsService worldpay3dsFlexCredentialsService;
+    @Mock
+    private Worldpay3dsFlexCredentialsDao mockWorldpay3dsFlexCredentialsDao;
+    @Mock
+    private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
+
+    @BeforeEach
+    public void setup() {
+        worldpay3dsFlexCredentialsService = new Worldpay3dsFlexCredentialsService(
+                mockWorldpay3dsFlexCredentialsDao,
+                mockGatewayAccountCredentialsService);
+    }
+
+    @Test
+    void shouldUpdateFlexCredentialsAndCredentialsState() {
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().build();
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(gatewayAccountEntity)
+                .withState(CREATED)
+                .build();
+        gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntity));
+
+        Worldpay3dsFlexCredentialsRequest worldpay3dsFlexCredentialsRequest
+                = new Worldpay3dsFlexCredentialsRequest();
+
+        worldpay3dsFlexCredentialsService.setGatewayAccountWorldpay3dsFlexCredentials(worldpay3dsFlexCredentialsRequest,
+                gatewayAccountEntity);
+
+        verify(mockWorldpay3dsFlexCredentialsDao).merge(any(Worldpay3dsFlexCredentialsEntity.class));
+        verify(mockGatewayAccountCredentialsService).updateStateForCredentials(credentialsEntity);
+    }
+
+    @Test
+    void shouldThrowErrorWhenGatewayCredentialToUpdateStateIsNotFound() {
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().build();
+
+        Worldpay3dsFlexCredentialsRequest worldpay3dsFlexCredentialsRequest
+                = new Worldpay3dsFlexCredentialsRequest();
+
+        WebApplicationException exception = assertThrows(WebApplicationException.class, () -> {
+            worldpay3dsFlexCredentialsService.setGatewayAccountWorldpay3dsFlexCredentials(worldpay3dsFlexCredentialsRequest,
+                    gatewayAccountEntity);
+        });
+
+        assertEquals("HTTP 500 Internal Server Error", exception.getMessage());
+
+        verifyNoInteractions(mockGatewayAccountCredentialsService);
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID

- At present, Worldpay gateway_account_credentials record is set to ACTIVE as soon as Worldpay integration credentials are entered. It should still be the case for MOTO accounts and TEST accounts.
- For LIVE accounts, Worldpay Flex is required.
   - So, for these accounts, gateway_account_credentials state is set to ACTIVE only when both integration credentials and Flex credentials are configured

