### PR TITLE
PP-10116 update secrets baseline, pre-commit conf

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,14 @@ permissions:
   contents: read
 
 jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - name: Detect secrets
+        uses: alphagov/pay-ci/actions/detect-secrets@master
+
   integration-tests:
     name: Unit and Integration tests
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
-- repo: https://github.com/Yelp/detect-secrets
-  rev: 70e6cf69f2d544a49729039a374d86d7b3e472d9
-  hooks:
-    - id: detect-secrets
-      args: ['--baseline', '.secrets.baseline']
-      exclude: package.lock.json
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: [ '--baseline', '.secrets.baseline' ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -19,6 +19,9 @@
     },
     {
       "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
     },
     {
       "name": "GitHubTokenDetector"
@@ -73,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -109,15 +108,6 @@
     }
   ],
   "results": {
-    ".pre-commit-config.yaml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "7480301177f005722b05b9c2b80ec86d9d74b9fd",
-        "is_verified": false,
-        "line_number": 3
-      }
-    ],
     "dev.yml": [
       {
         "type": "Base64 High Entropy String",
@@ -402,6 +392,42 @@
         "line_number": 26
       }
     ],
+    "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java",
+        "hashed_secret": "0f95fda055818f350f3daf93e80654be7ea2ec8f",
+        "is_verified": false,
+        "line_number": 35
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeEvidenceSubmittedTest.java",
+        "hashed_secret": "0f95fda055818f350f3daf93e80654be7ea2ec8f",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java",
+        "hashed_secret": "0f95fda055818f350f3daf93e80654be7ea2ec8f",
+        "is_verified": false,
+        "line_number": 37
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java",
+        "hashed_secret": "0f95fda055818f350f3daf93e80654be7ea2ec8f",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
     "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationTest.java": [
       {
         "type": "Hex High Entropy String",
@@ -500,6 +526,15 @@
         "line_number": 118
       }
     ],
+    "src/test/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationServiceTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationServiceTest.java",
+        "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
+        "is_verified": false,
+        "line_number": 218
+      }
+    ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java": [
       {
         "type": "Base64 High Entropy String",
@@ -513,9 +548,30 @@
       {
         "type": "Hex High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java",
+        "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java",
         "hashed_secret": "a0d988a5c9ccfb53b1e1604eab338ecba25b3485",
         "is_verified": false,
         "line_number": 20
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java",
+        "hashed_secret": "455151f5f2ca3b6b2d441e67eb1aa52a57c26a3d",
+        "is_verified": false,
+        "line_number": 27
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java",
+        "hashed_secret": "379f1968f09d8a343338667844e01a2f433f0a3f",
+        "is_verified": false,
+        "line_number": 32
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3dsFlexJwtMacKeyValidatorTest.java": [
@@ -621,6 +677,15 @@
         "line_number": 143
       }
     ],
+    "src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java",
+        "hashed_secret": "5128e0897a5f54c370ff0e1a6b8217ec4ea8b026",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
     "src/test/java/uk/gov/pay/connector/model/domain/googlepay/GooglePayAuthRequestFixture.java": [
       {
         "type": "Base64 High Entropy String",
@@ -628,6 +693,33 @@
         "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
         "is_verified": false,
         "line_number": 26
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/pact/ContractTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/pact/ContractTest.java",
+        "hashed_secret": "d5662d7353c6257f68cab2a3b0f758cc79b1ac5e",
+        "is_verified": false,
+        "line_number": 322
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java",
+        "hashed_secret": "aa4f63822a427d27308ddef0e735bc21f8f2f7f7",
+        "is_verified": false,
+        "line_number": 102
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java",
+        "hashed_secret": "41e54d60d97545b6b9941f4ddf147f9efb74e7d4",
+        "is_verified": false,
+        "line_number": 18
       }
     ],
     "src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java": [
@@ -648,13 +740,13 @@
         "line_number": 148
       }
     ],
-    "src/test/java/uk/gov/pay/connector/util/PostgresContainer.java": [
+    "src/test/java/uk/gov/pay/connector/util/RandomIdGeneratorTest.java": [
       {
-        "type": "Secret Keyword",
-        "filename": "src/test/java/uk/gov/pay/connector/util/PostgresContainer.java",
-        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/util/RandomIdGeneratorTest.java",
+        "hashed_secret": "3a765b5dd17a80a147bfc1211664c2326f2659a5",
         "is_verified": false,
-        "line_number": 34
+        "line_number": 72
       }
     ],
     "src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java": [
@@ -978,5 +1070,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-03T17:10:49Z"
+  "generated_at": "2022-11-08T12:03:25Z"
 }


### PR DESCRIPTION
### WHAT

- added a new github action to run `detect-secrets`
- updated the pre-commit config to update the detect-secrets hook to version `1.4`
- rebaselined the repository's secrets baseline

#### For reviewers

- ensure your local version of `detect-secrets` matches the latest version in use on this branch
- run `detect-secrets scan` and ensure output matches the latest `.secrets.baseline`, the only change should be the generated timestamp