### PR TITLE
PP-8693 Respond with 402 on gateway errors for wallets

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
@@ -13,7 +13,8 @@ import javax.inject.Inject;
 import javax.ws.rs.core.Response;
 
 import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
-import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.gatewayErrorResponse;
+
 
 public abstract class WalletService {
 
@@ -55,7 +56,7 @@ public abstract class WalletService {
         switch (error.getErrorType()) {
             case GATEWAY_ERROR:
             case GATEWAY_CONNECTION_TIMEOUT_ERROR:
-                return serviceErrorResponse(error.getMessage());
+                return gatewayErrorResponse(error.getMessage());
             default:
                 LOGGER.error("Charge {}: error {}", chargeId, error.getMessage());
                 return badRequestResponse(error.getMessage());

--- a/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
@@ -87,7 +87,7 @@ public class ApplePayServiceTest {
         Response authorisationResponse = applePayService.authorise(externalChargeId, applePayAuthRequest);
 
         verify(mockedApplePayAuthoriseService).doAuthorise(externalChargeId, validData);
-        assertThat(authorisationResponse.getStatus(), is(500));
+        assertThat(authorisationResponse.getStatus(), is(402));
         ErrorResponse response = (ErrorResponse)authorisationResponse.getEntity();
         assertThat(response.getMessages(), contains("oops"));
     }

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
@@ -97,7 +97,7 @@ public class GooglePayServiceTest {
         Response authorisationResponse = googlePayService.authorise(externalChargeId, googlePayAuthRequest);
 
         verify(mockedWalletAuthoriseService).doAuthorise(externalChargeId, googlePayAuthRequest);
-        assertThat(authorisationResponse.getStatus(), is(500));
+        assertThat(authorisationResponse.getStatus(), is(402));
         ErrorResponse response = (ErrorResponse)authorisationResponse.getEntity();
         assertThat(response.getMessages(), contains("oops"));
     }


### PR DESCRIPTION
## WHAT YOU DID
Currently gateway errors such as timeouts result in 500 response from connector to front end.
This is a misleading response to the front end and results in unnecessary alerts.
This change is for wallet authorisations, ensuring that in cases of gateway errors, 402 responses are sent to the front end.