### PR TITLE
BAU make Dockerfiles multistage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-*/*
-!newrelic/*
-!docker-startup.sh
-!target/pay-*-allinone.jar
-!target/*.yaml
+target/
+.idea/
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
-FROM eclipse-temurin:11-jre-alpine@sha256:dc28ac69ce6118cb9a4da85de8de7592d3a006af971cf398f1280590d30e82bc
+FROM maven:3.8.6-eclipse-temurin-11 as builder
+WORKDIR /home/build
+COPY . .
+RUN ["mvn", "clean", "package", "-DskipTests"]
 
+FROM eclipse-temurin:11-jre-alpine@sha256:dc28ac69ce6118cb9a4da85de8de7592d3a006af971cf398f1280590d30e82bc as final
 RUN ["apk", "--no-cache", "upgrade"]
-
 ARG DNS_TTL=15
-
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
-
 RUN echo networkaddress.cache.ttl=$DNS_TTL >> "$JAVA_HOME/conf/security/java.security"
-
 # Add RDS CA certificates to the default truststore
 RUN wget -qO - https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem       | keytool -importcert -noprompt -cacerts -storepass changeit -alias rds-ca-2019-root \
  && wget -qO - https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem | keytool -importcert -noprompt -cacerts -storepass changeit -alias rds-combined-ca-bundle
-
 RUN ["apk", "add", "--no-cache", "bash", "tini"]
 
 ENV PORT 8080
@@ -23,10 +22,9 @@ EXPOSE 8081
 
 WORKDIR /app
 
-ADD docker-startup.sh .
-ADD target/*.yaml .
-ADD target/pay-*-allinone.jar .
+COPY --from=builder /home/build/docker-startup.sh .
+COPY --from=builder /home/build/target/*.yaml .
+COPY --from=builder /home/build/target/pay-*-allinone.jar .
 
 ENTRYPOINT ["tini", "-e", "143", "--"]
-
 CMD ["bash", "./docker-startup.sh"]

--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -1,4 +1,9 @@
-FROM eclipse-temurin:11-jre@sha256:08a2a85a8c948146f8e052216c5450b5290fe13ab5d3922aeb829b3bf61e08c1
+FROM maven:3.8.6-eclipse-temurin-11 as builder
+WORKDIR /home/build
+COPY . .
+RUN ["mvn", "clean", "package", "-DskipTests"]
+
+FROM eclipse-temurin:11-jre@sha256:08a2a85a8c948146f8e052216c5450b5290fe13ab5d3922aeb829b3bf61e08c1 as final
 
 ARG DNS_TTL=15
 
@@ -23,9 +28,9 @@ EXPOSE 8081
 
 WORKDIR /app
 
-COPY docker-startup.sh /app/docker-startup.sh
-COPY target/*.yaml /app/
-COPY target/pay-*-allinone.jar /app/
+COPY --from=builder /home/build/docker-startup.sh .
+COPY --from=builder /home/build/target/*.yaml .
+COPY --from=builder /home/build/target/pay-*-allinone.jar .
 
 ENTRYPOINT ["tini", "-e", "143", "--"]
 


### PR DESCRIPTION
## WHAT YOU DID

- update java Dockerfiles to include a `build` stage, this allows us to simplify our CI pipeline as it is no longer necessary to build jars separately to images
