### PR TITLE
PP-10198 Gateway account credentials: Merge when state is updated

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -609,7 +609,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 308
+        "line_number": 333
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java": [
@@ -1074,5 +1074,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-10T12:23:14Z"
+  "generated_at": "2022-11-10T17:01:35Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
@@ -96,7 +96,6 @@ public class GatewayAccountCredentialsResource {
                 .orElseGet(() -> notFoundResponse("Not a Worldpay gateway account"));
     }
 
-
     @POST
     @Path("/v1/api/accounts/{accountId}/worldpay/check-3ds-flex-config")
     @Produces(APPLICATION_JSON)

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -160,7 +160,7 @@ public class GatewayAccountCredentialsService {
         HashMap<String, String> updatableMap = new HashMap<>(gatewayAccountCredentialsEntity.getCredentials());
         patchRequest.valueAsObject().forEach(updatableMap::put);
         gatewayAccountCredentialsEntity.setCredentials(updatableMap);
-        
+
         updateStateForCredentials(gatewayAccountCredentialsEntity);
     }
 
@@ -173,6 +173,7 @@ public class GatewayAccountCredentialsService {
                 } else {
                     credentialsEntity.setState(ENTERED);
                 }
+                gatewayAccountCredentialsDao.merge(credentialsEntity);
             }
         }
     }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsServiceTest.java
@@ -239,7 +239,7 @@ public class GatewayAccountCredentialsServiceTest {
 
             gatewayAccountCredentialsService.updateGatewayAccountCredentials(credentialsEntity, patchRequests);
 
-            verify(mockGatewayAccountCredentialsDao).merge(credentialsEntity);
+            verify(mockGatewayAccountCredentialsDao, times(2)).merge(credentialsEntity);
             assertThat(credentialsEntity.getCredentials(), hasEntry("merchant_id", "new-merchant-id"));
             assertThat(credentialsEntity.getLastUpdatedByUserExternalId(), is("new-user-external-id"));
             assertThat(credentialsEntity.getState(), is(VERIFIED_WITH_LIVE_PAYMENT));


### PR DESCRIPTION
## WHAT YOU DID
- Merge gatway_account_credentials when the `state` is updated.
- When updating the `gatway_account_credentials` state as part of flex credentials changes, GatewayAccountCredentials are derived from GatewayAccountEntity and GatewayAccountCredentials entity is not attached to the persistence context. Thus JPA is not synchronizing changes for state changes.

