### PR TITLE
PP-10198 Fix updating gateway credentials state

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -609,7 +609,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 333
+        "line_number": 336
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java": [
@@ -1074,5 +1074,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-10T17:01:35Z"
+  "generated_at": "2022-11-15T11:17:53Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsService.java
@@ -4,15 +4,11 @@ import com.google.inject.persist.Transactional;
 import uk.gov.pay.connector.gatewayaccount.dao.Worldpay3dsFlexCredentialsDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsRequest;
-import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 
 import javax.inject.Inject;
-import javax.ws.rs.WebApplicationException;
 
-import static java.lang.String.format;
 import static uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity.Worldpay3dsFlexCredentialsEntityBuilder.aWorldpay3dsFlexCredentialsEntity;
-import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
 
 public class Worldpay3dsFlexCredentialsService {
 
@@ -40,14 +36,10 @@ public class Worldpay3dsFlexCredentialsService {
                     .withJwtMacKey(worldpay3DsFlexCredentialsRequest.getJwtMacKey())
                     .withOrganisationalUnitId(worldpay3DsFlexCredentialsRequest.getOrganisationalUnitId())
                     .build();
+            gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(newWorldpay3dsFlexCredentialsEntity);
             worldpay3dsFlexCredentialsDao.merge(newWorldpay3dsFlexCredentialsEntity);
         });
 
-        //TODO: To move Flex credentials to gateway account credentials level so correct Worldpay credential can be updated (as part of PP-10143)
-        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = gatewayAccountEntity.getCurrentOrActiveGatewayAccountCredential()
-                .orElseThrow(() -> new WebApplicationException(
-                        serviceErrorResponse(format("Active or current credential not found for gateway account [%s]", gatewayAccountEntity.getId()))));
-
-        gatewayAccountCredentialsService.updateStateForCredentials(gatewayAccountCredentialsEntity);
+        gatewayAccountCredentialsService.updateStatePostFlexCredentialsUpdate(gatewayAccountEntity);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -164,7 +164,18 @@ public class GatewayAccountCredentialsService {
         updateStateForCredentials(gatewayAccountCredentialsEntity);
     }
 
-    public void updateStateForCredentials(GatewayAccountCredentialsEntity credentialsEntity) {
+    @Transactional
+    public void updateStatePostFlexCredentialsUpdate(GatewayAccountEntity gatewayAccountEntity) {
+        // Flex credentials are currently set at the Gateway account level, and it is not possible to get the Worldpay
+        // credentials entity for which Flex credentials are updated if multiple exist. So get any Worldpay credential entity.
+        // Flex credentials should be moved to the Gateway credentials level to support multiple Flex credentials and
+        // get the correct credential entity here.
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = gatewayAccountEntity.getGatewayAccountCredentialsEntity(WORLDPAY.getName());
+
+        updateStateForCredentials(gatewayAccountCredentialsEntity);
+    }
+
+    private void updateStateForCredentials(GatewayAccountCredentialsEntity credentialsEntity) {
         if (credentialsEntity.getState() == CREATED) {
             if (hasRequiredCredentials(credentialsEntity)) {
                 if (credentialsEntity.getGatewayAccountEntity().getGatewayAccountCredentials().size() == 1) {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsServiceTest.java
@@ -12,14 +12,10 @@ import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsReque
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 
-import javax.ws.rs.WebApplicationException;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
@@ -56,23 +52,6 @@ class Worldpay3dsFlexCredentialsServiceTest {
                 gatewayAccountEntity);
 
         verify(mockWorldpay3dsFlexCredentialsDao).merge(any(Worldpay3dsFlexCredentialsEntity.class));
-        verify(mockGatewayAccountCredentialsService).updateStateForCredentials(credentialsEntity);
-    }
-
-    @Test
-    void shouldThrowErrorWhenGatewayCredentialToUpdateStateIsNotFound() {
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().build();
-
-        Worldpay3dsFlexCredentialsRequest worldpay3dsFlexCredentialsRequest
-                = new Worldpay3dsFlexCredentialsRequest();
-
-        WebApplicationException exception = assertThrows(WebApplicationException.class, () -> {
-            worldpay3dsFlexCredentialsService.setGatewayAccountWorldpay3dsFlexCredentials(worldpay3dsFlexCredentialsRequest,
-                    gatewayAccountEntity);
-        });
-
-        assertEquals("HTTP 500 Internal Server Error", exception.getMessage());
-
-        verifyNoInteractions(mockGatewayAccountCredentialsService);
+        verify(mockGatewayAccountCredentialsService).updateStatePostFlexCredentialsUpdate(gatewayAccountEntity);
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- When new Flex credentials are created, set the same on the Gateway account so these can be used further to derive and update the Gateway account credentials state.
- When updating the credentials state after the Flex credentials update, look for a Worldpay credentials entity as Flex will only be applicable for the Worldpay credentials entity
- Fixes integration too which was supposed to test for a LIVE account. For test Worldpay accounts, Flex credentials are not mandatory to set the credentials state to ACTIVE.
