### PR TITLE
PP-10198 Exclude RETIRED credentials when deriving state post Flex credentials update

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -175,11 +175,11 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     @Column(name = "recurring_enabled")
     private boolean recurringEnabled;
-    
-    @Column(name ="disabled")
+
+    @Column(name = "disabled")
     private boolean disabled;
-    
-    @Column(name="disabled_reason")
+
+    @Column(name = "disabled_reason")
     private String disabledReason;
 
     public GatewayAccountEntity() {
@@ -256,6 +256,17 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return gatewayAccountCredentials.stream()
                 .filter(entity -> entity.getPaymentProvider().equals(paymentProvider))
                 .findFirst()
+                .orElseThrow(() -> new WebApplicationException(serviceErrorResponse(
+                        format("Credentials not found for gateway account [%s] and payment_provider [%s] ",
+                                getId(), paymentProvider))));
+    }
+
+    @JsonIgnore
+    public GatewayAccountCredentialsEntity getRecentNonRetiredGatewayAccountCredentialsEntity(String paymentProvider) {
+        return gatewayAccountCredentials.stream()
+                .filter(entity -> entity.getPaymentProvider().equals(paymentProvider))
+                .filter(entity -> entity.getState() != RETIRED)
+                .max(comparing(GatewayAccountCredentialsEntity::getCreatedDate))
                 .orElseThrow(() -> new WebApplicationException(serviceErrorResponse(
                         format("Credentials not found for gateway account [%s] and payment_provider [%s] ",
                                 getId(), paymentProvider))));
@@ -626,7 +637,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     public void setDisabledReason(String disabledReason) {
         this.disabledReason = disabledReason;
     }
-    
+
     public class Views {
         public class ApiView {
         }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -167,10 +167,11 @@ public class GatewayAccountCredentialsService {
     @Transactional
     public void updateStatePostFlexCredentialsUpdate(GatewayAccountEntity gatewayAccountEntity) {
         // Flex credentials are currently set at the Gateway account level, and it is not possible to get the Worldpay
-        // credentials entity for which Flex credentials are updated if multiple exist. So get any Worldpay credential entity.
+        // credentials entity for which Flex credentials are updated if multiple exist. So get latest non-retired Worldpay credential entity.
         // Flex credentials should be moved to the Gateway credentials level to support multiple Flex credentials and
         // get the correct credential entity here.
-        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = gatewayAccountEntity.getGatewayAccountCredentialsEntity(WORLDPAY.getName());
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity =
+                gatewayAccountEntity.getRecentNonRetiredGatewayAccountCredentialsEntity(WORLDPAY.getName());
 
         updateStateForCredentials(gatewayAccountCredentialsEntity);
     }


### PR DESCRIPTION
## WHAT YOU DID

- Exclude RETIRED credentials if any exist when getting a gateway credential to update post Flex credentials update.
- Also gets the latest creds, so this works if any service switches from Worldpay to Worldpay and enters Flex credentials as part of switching PSP

