### PR TITLE
PP-10144 Stop replacing gateway_transaction_id with null

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -211,7 +211,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                     LOGGER,
                     authorisationRequestSummary,
                     charge,
-                    authorisationService.extractTransactionId(charge.getExternalId(), response)
+                    authorisationService.extractTransactionId(charge.getExternalId(), response, charge.getGatewayTransactionId())
                             .orElse("missing transaction ID"),
                     response,
                     charge.getChargeStatus(),

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
@@ -55,7 +55,7 @@ public class AuthorisationService {
     public <T> T executeAuthoriseSync(Supplier<T> authorisationSupplier) throws AuthorisationExecutorTimedOutException {
         int timeoutInMilliseconds = authorisationConfig.getSynchronousAuthTimeoutInMilliseconds();
         return executeAuthorise(authorisationSupplier, timeoutInMilliseconds);
-    } 
+    }
 
     private <T> T executeAuthorise(Supplier<T> authorisationSupplier, int timeoutInMilliseconds)
             throws AuthorisationExecutorTimedOutException {
@@ -71,13 +71,16 @@ public class AuthorisationService {
         }
     }
 
-    public Optional<String> extractTransactionId(String chargeExternalId, GatewayResponse<? extends BaseAuthoriseResponse> operationResponse) {
+    public Optional<String> extractTransactionId(String chargeExternalId,
+                                                 GatewayResponse<? extends BaseAuthoriseResponse> operationResponse,
+                                                 String currentGatewayTransactionId) {
         Optional<String> transactionId = operationResponse.getBaseResponse()
                 .map(BaseAuthoriseResponse::getTransactionId);
 
         if (transactionId.isEmpty() || StringUtils.isBlank(transactionId.get())) {
             logger.warn("AuthCardDetails authorisation response received with no transaction id. -  charge_external_id={}",
                     chargeExternalId);
+            return Optional.ofNullable(currentGatewayTransactionId);
         }
 
         return transactionId;

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -184,7 +184,7 @@ public class CardAuthoriseService {
     }
 
     private AuthorisationResponse updateChargePostAuthorisation(AuthCardDetails authCardDetails, ChargeEntity charge, GatewayResponse<BaseAuthoriseResponse> operationResponse, ChargeStatus newStatus) {
-        Optional<String> transactionId = authorisationService.extractTransactionId(charge.getExternalId(), operationResponse);
+        Optional<String> transactionId = authorisationService.extractTransactionId(charge.getExternalId(), operationResponse, charge.getGatewayTransactionId());
         Optional<ProviderSessionIdentifier> sessionIdentifier = operationResponse.getSessionIdentifier();
         Optional<Auth3dsRequiredEntity> auth3dsDetailsEntity =
                 operationResponse.getBaseResponse().flatMap(BaseAuthoriseResponse::extractAuth3dsRequiredDetails);

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -82,7 +82,7 @@ public class WalletAuthoriseService {
                 operationResponse = GatewayResponse.GatewayResponseBuilder.responseBuilder().withGatewayError(e.toGatewayError()).build();
             }
 
-            Optional<String> transactionId = authorisationService.extractTransactionId(charge.getExternalId(), operationResponse);
+            Optional<String> transactionId = authorisationService.extractTransactionId(charge.getExternalId(), operationResponse, charge.getGatewayTransactionId());
             Optional<ProviderSessionIdentifier> sessionIdentifier = operationResponse.getSessionIdentifier();
             Optional<Auth3dsRequiredEntity> auth3dsDetailsEntity =
                     operationResponse.getBaseResponse().flatMap(BaseAuthoriseResponse::extractAuth3dsRequiredDetails);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationServiceTest.java
@@ -1,0 +1,72 @@
+package uk.gov.pay.connector.paymentprocessor.service;
+
+import io.dropwizard.setup.Environment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorisationServiceTest {
+    private final static String TRANSACTION_ID = "transaction_id";
+    private final static String CURRENT_TRANSACTION_ID = "current_transaction_id";
+    @Mock
+    CardExecutorService executorService;
+    @Mock
+    Environment environment;
+    @Mock
+    ConnectorConfiguration config;
+
+    AuthorisationService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthorisationService(executorService, environment, config);
+    }
+
+    @Test
+    void  extractTransactionIdShouldReturnTransactionIdFromAuthResponse() {
+        GatewayResponse authResponse = mockAuthResponse(TRANSACTION_ID);
+        Optional<String> optionalTransactionId = authService.extractTransactionId("externalId", authResponse, CURRENT_TRANSACTION_ID);
+        assertThat(optionalTransactionId.isPresent(), is(true));
+        String transactionId = optionalTransactionId.get();
+        assertThat(transactionId, is(TRANSACTION_ID));
+    }
+
+    @Test
+    void extractTransactionIdShouldReturnCurrentTransactionIdIfResponseDoesnotHaveATransactionId() {
+        GatewayResponse authResponse = mockAuthResponse(null);
+        Optional<String> optionalTransactionId = authService.extractTransactionId("externalId", authResponse, CURRENT_TRANSACTION_ID);
+        assertThat(optionalTransactionId.isPresent(), is(true));
+        String transactionId = optionalTransactionId.get();
+        assertThat(transactionId, is(CURRENT_TRANSACTION_ID));
+    }
+
+    @Test
+    void extractTransactionIdShouldNotReturnTransactionId_whenNonPresent() {
+        GatewayResponse authResponse = mockAuthResponse(null);
+        Optional<String> optionalTransactionId = authService.extractTransactionId("externalId", authResponse, null);
+        assertThat(optionalTransactionId.isPresent(), is(false));
+    }
+
+    private GatewayResponse mockAuthResponse(String transactionId) {
+        WorldpayOrderStatusResponse worldpayResponse = mock(WorldpayOrderStatusResponse.class);
+        when(worldpayResponse.getTransactionId()).thenReturn(transactionId);
+        return responseBuilder()
+                .withResponse(worldpayResponse)
+                .build();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
@@ -9,7 +9,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.FeeType;
-import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.fee.model.Fee;
 import uk.gov.pay.connector.gateway.PaymentProvider;
@@ -77,9 +76,13 @@ public abstract class CardServiceTest {
         GatewayAccountEntity gatewayAccountEntity = ChargeEntityFixture.defaultGatewayAccountEntity();
         ChargeEntity entity = ChargeEntityFixture
                 .aValidChargeEntity()
+                .withPaymentProvider(provider)
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .withId(chargeId)
                 .withStatus(status)
+                .withEvents(List.of(
+                        aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(status).withUpdated(ZonedDateTime.now().minusHours(1)).build()
+                ))
                 .build();
         entity.setGatewayTransactionId(gatewayTransactionId);
         return entity;


### PR DESCRIPTION
## WHAT YOU DID
- In certain edge cases, the gateway_transaction_id gets overwritten with a null value when
      authorisations ends up in an unexpected error and the response is missing transaction id.
- For Worldpay, gateway_trasaction_id is set by us on the charge, so this change keeps the gateway_trasaction_id
      set on the charge as is if transaction id is missing in the response