### PR TITLE
PP-10439 Only create agreements when RCP enabled

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -176,70 +176,70 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3733
+        "line_number": 3734
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3781
+        "line_number": 3782
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4390
+        "line_number": 4391
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4457
+        "line_number": 4458
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4479
+        "line_number": 4480
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4658
+        "line_number": 4659
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4661
+        "line_number": 4662
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4664
+        "line_number": 4665
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5254
+        "line_number": 5255
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5265
+        "line_number": 5266
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1074,5 +1074,5 @@
       }
     ]
   },
-  "generated_at": "2022-12-02T11:26:15Z"
+  "generated_at": "2022-12-20T17:33:41Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3434,6 +3434,7 @@ components:
           - MISSING_MANDATORY_ATTRIBUTE
           - UNEXPECTED_ATTRIBUTE
           - ACCOUNT_DISABLED
+          - RECURRING_CARD_PAYMENTS_NOT_ALLOWED
           example: GENERIC
         message:
           type: array

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.11</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.14.1</jackson.version>
-        <pay-java-commons.version>1.0.20221205115218</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20221220092453</pay-java-commons.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <jooq.version>3.17.6</jooq.version>
         <postgresql.version>42.5.1</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/agreement/exception/RecurringCardPaymentsNotAllowedException.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/exception/RecurringCardPaymentsNotAllowedException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.agreement.exception;
+
+public class RecurringCardPaymentsNotAllowedException extends RuntimeException{
+    public RecurringCardPaymentsNotAllowedException(Long gatewayAccountId) {
+        super("Attempt to create an agreement for gateway account " + gatewayAccountId +
+                ", which does not have recurring card payments enabled");
+    }
+}
+

--- a/src/main/java/uk/gov/pay/connector/agreement/exception/RecurringCardPaymentsNotAllowedExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/exception/RecurringCardPaymentsNotAllowedExceptionMapper.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.connector.agreement.exception;
+
+import javax.ws.rs.ext.ExceptionMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class RecurringCardPaymentsNotAllowedExceptionMapper 
+        implements ExceptionMapper<RecurringCardPaymentsNotAllowedException> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecurringCardPaymentsNotAllowedExceptionMapper.class);
+
+    private static final String RESPONSE_ERROR_MESSAGE = "Recurring payment agreements are not enabled on this account";
+
+    @Override
+    public Response toResponse(RecurringCardPaymentsNotAllowedException exception) {
+        LOGGER.info(exception.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED, List.of(RESPONSE_ERROR_MESSAGE));
+
+        return Response.status(422)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}
+

--- a/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.agreement.service;
 import com.google.inject.persist.Transactional;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.agreement.exception.AgreementNotFoundException;
+import uk.gov.pay.connector.agreement.exception.RecurringCardPaymentsNotAllowedException;
 import uk.gov.pay.connector.agreement.model.AgreementCancelRequest;
 import uk.gov.pay.connector.agreement.model.AgreementCreateRequest;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
@@ -54,6 +55,9 @@ public class AgreementService {
     @Transactional
     public Optional<AgreementResponse> create(AgreementCreateRequest agreementCreateRequest, long accountId) {
         return gatewayAccountDao.findById(accountId).map(gatewayAccountEntity -> {
+            if(!gatewayAccountEntity.isRecurringEnabled()) {
+                throw new RecurringCardPaymentsNotAllowedException(gatewayAccountEntity.getId());
+            }
             AgreementEntity agreementEntity = anAgreementEntity(clock.instant())
                     .withReference(agreementCreateRequest.getReference())
                     .withDescription(agreementCreateRequest.getDescription())

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -23,6 +23,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import uk.gov.pay.connector.agreement.exception.AgreementNotFoundExceptionMapper;
+import uk.gov.pay.connector.agreement.exception.RecurringCardPaymentsNotAllowedExceptionMapper;
 import uk.gov.pay.connector.agreement.resource.AgreementsApiResource;
 import uk.gov.pay.connector.cardtype.resource.CardTypesResource;
 import uk.gov.pay.connector.charge.exception.AgreementIdWithIncompatibleOtherOptionsExceptionMapper;
@@ -168,6 +169,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new AuthorisationRejectedExceptionMapper());
         environment.jersey().register(new AuthorisationTimedOutExceptionMapper());
         environment.jersey().register(new GatewayAccountDisabledExceptionMapper());
+        environment.jersey().register(new RecurringCardPaymentsNotAllowedExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceIT.java
@@ -20,6 +20,7 @@ import uk.gov.pay.connector.rules.WorldpayMockClient;
 import uk.gov.pay.connector.util.AddAgreementParams;
 import uk.gov.pay.connector.util.AddPaymentInstrumentParams;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.util.Map;
 
@@ -32,6 +33,7 @@ import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -167,7 +169,9 @@ public class AgreementsApiResourceIT {
                 .body(payload)
                 .post(format(CREATE_AGREEMENT_URL, accountId))
                 .then()
-                .statusCode(SC_UNPROCESSABLE_ENTITY);
+                .statusCode(SC_UNPROCESSABLE_ENTITY)
+                .body("message", contains("Recurring payment agreements are not enabled on this account"))
+                .body("error_identifier", is(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED.toString()));
     }
     @Test
     public void shouldReturn204AndCancelAgreement() {

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -353,6 +353,8 @@ public class DatabaseFixtures {
         private boolean motoMaskCardNumberInput;
         private boolean motoMaskCardSecurityCodeInput;
         private boolean allowTelephonePaymentNotifications;
+
+        private boolean recurringEnabled;
         private final Map<String, String> defaultCredentials = Map.of(
                 CREDENTIALS_MERCHANT_ID, "merchant-id",
                 CREDENTIALS_USERNAME, "username",
@@ -415,6 +417,14 @@ public class DatabaseFixtures {
             return allowTelephonePaymentNotifications;
         }
 
+        public boolean isRecurringEnabled() {
+            return recurringEnabled;
+        }
+
+        public void setRecurringEnabled(boolean recurringEnabled) {
+            this.recurringEnabled = recurringEnabled;
+        }
+        
         public TestAccount withAccountId(long accountId) {
             this.accountId = accountId;
             return this;
@@ -524,7 +534,11 @@ public class DatabaseFixtures {
             this.allowTelephonePaymentNotifications = allowTelephonePaymentNotifications;
             return this;
         }
-
+        
+        public TestAccount withRecurringEnabled(boolean recurringEnabled) {
+            this.recurringEnabled = recurringEnabled;
+            return this;
+        }
         public TestAccount withDefaultCredentials() {
             this.credentialsMap = defaultCredentials;
             return this;
@@ -560,6 +574,7 @@ public class DatabaseFixtures {
                     .withMotoMaskCardSecurityCodeInput(motoMaskCardSecurityCodeInput)
                     .withAllowTelephonePaymentNotifications(allowTelephonePaymentNotifications)
                     .withServiceId(serviceId)
+                    .withRecurringEnabled(recurringEnabled)
                     .build());
             for (TestCardType cardType : cardTypes) {
                 databaseTestHelper.addAcceptedCardType(this.getAccountId(), cardType.getId());


### PR DESCRIPTION
- It should only be possible to create agreements when a gateway account has RCP enabled (recurring_enabled = true)
- If account does not have RCP enabled, throw custom exception
- Respond with 422 with error identifier RECURRING_CARD_PAYMENTS_NOT_ALLOWED
- Add unit test for this scenario and update existing
- PACT tests to be added under a separate ticket PP-10443
