### PR TITLE
PP-10435 Use appropriate state for capturing user not present payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeEligibleForCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeEligibleForCaptureService.java
@@ -16,10 +16,13 @@ import uk.gov.service.payments.commons.queue.exception.QueueException;
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 
+import java.util.List;
+
 import static java.lang.String.format;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_QUEUED;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.AGREEMENT;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 
 public class ChargeEligibleForCaptureService {
@@ -75,7 +78,7 @@ public class ChargeEligibleForCaptureService {
     }
 
     private ChargeStatus deriveCaptureStatusForChargeAuthorisationMode(ChargeEntity charge) {
-        return charge.getAuthorisationMode() == MOTO_API ? CAPTURE_QUEUED : CAPTURE_APPROVED;
+        return List.of(MOTO_API, AGREEMENT).contains(charge.getAuthorisationMode()) ? CAPTURE_QUEUED : CAPTURE_APPROVED;
     }
 
     private void addChargeToCaptureQueue(ChargeEntity charge) {

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/AuthoriseWithUserNotPresentTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/AuthoriseWithUserNotPresentTaskHandlerIT.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_USER_NOT_PRESENT_QUEUED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_QUEUED;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_ERROR_GATEWAY;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_FAILED_REJECTED;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_STARTED;
@@ -78,7 +78,7 @@ public class AuthoriseWithUserNotPresentTaskHandlerIT extends ChargingITestBase 
 
         taskHandler.process(chargeWithValidAgreementAndPaymentInstrument);
 
-        assertFrontendChargeStatusIs(chargeWithValidAgreementAndPaymentInstrument, CAPTURE_APPROVED.getValue());
+        assertFrontendChargeStatusIs(chargeWithValidAgreementAndPaymentInstrument, CAPTURE_QUEUED.getValue());
         assertApiStateIs(chargeWithValidAgreementAndPaymentInstrument, EXTERNAL_SUCCESS.getStatus());
 
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());


### PR DESCRIPTION
The default state for marking a charge as eligible for capture moves the charge into the `CAPTURE_APPROVED` state, this transition is annotated by the `UserApprovedForCapture` event.

As there are no users directly involved in recurring (agreement) payments, update the method to determine what state to move to also check for agreement authorisation mode. The `CAPTURE_QUEUED` state indicates the charge will be captured but instead uses the `QeuedForCapture` event which doesn't refer to a paying user (rather a system call).