### PR TITLE
PP-10435 Add payment details taken from payment instrument event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -59,10 +59,12 @@ import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
 import uk.gov.pay.connector.common.model.domain.PrefilledAddress;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.events.EventService;
+import uk.gov.pay.connector.events.eventdetails.charge.PaymentDetailsTakenFromPaymentInstrumentEventDetails;
 import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
 import uk.gov.pay.connector.events.model.charge.Gateway3dsInfoObtained;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsSubmittedByAPI;
+import uk.gov.pay.connector.events.model.charge.PaymentDetailsTakenFromPaymentInstrument;
 import uk.gov.pay.connector.events.model.charge.RefundAvailabilityUpdated;
 import uk.gov.pay.connector.events.model.charge.UserEmailCollected;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
@@ -119,6 +121,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.PAYMENT_NOTIFICATION_CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.fromString;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.AGREEMENT;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 
 public class ChargeService {
@@ -613,6 +616,8 @@ public class ChargeService {
         ChargeEntity chargeEntity = findChargeByExternalId(chargeExternalId);
         if (chargeEntity.getAuthorisationMode() == MOTO_API) {
             eventService.emitAndRecordEvent(PaymentDetailsSubmittedByAPI.from(chargeEntity));
+        } else if (chargeEntity.getAuthorisationMode() == AGREEMENT) {
+            eventService.emitAndRecordEvent(PaymentDetailsTakenFromPaymentInstrument.from(chargeEntity));
         } else {
             eventService.emitAndRecordEvent(PaymentDetailsEntered.from(chargeEntity));
         }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetails.java
@@ -78,4 +78,60 @@ public class PaymentDetailsTakenFromPaymentInstrumentEventDetails extends EventD
     public int hashCode() {
         return Objects.hash(cardType, cardBrand, firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, expiryDate);
     }
+
+    public String getCardType() {
+        return cardType;
+    }
+
+    public String getCardBrand() {
+        return cardBrand;
+    }
+
+    public String getCardBrandLabel() {
+        return cardBrandLabel;
+    }
+
+    public String getFirstDigitsCardNumber() {
+        return firstDigitsCardNumber;
+    }
+
+    public String getLastDigitsCardNumber() {
+        return lastDigitsCardNumber;
+    }
+
+    public String getCardholderName() {
+        return cardholderName;
+    }
+
+    public String getExpiryDate() {
+        return expiryDate;
+    }
+
+    public String getAddressLine1() {
+        return addressLine1;
+    }
+
+    public String getAddressLine2() {
+        return addressLine2;
+    }
+
+    public String getAddressPostcode() {
+        return addressPostcode;
+    }
+
+    public String getAddressCity() {
+        return addressCity;
+    }
+
+    public String getAddressCounty() {
+        return addressCounty;
+    }
+
+    public String getAddressStateProvince() {
+        return addressStateProvince;
+    }
+
+    public String getAddressCountry() {
+        return addressCountry;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetails.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
 import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
-import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
@@ -24,41 +23,44 @@ public class PaymentDetailsTakenFromPaymentInstrumentEventDetails extends EventD
     private final String addressStateProvince;
     private final String addressCountry;
 
-    private PaymentDetailsTakenFromPaymentInstrumentEventDetails(String cardType, String cardBrand, String cardBrandLabel, String firstDigitsCardNumber, String lastDigitsCardNumber, String cardholderName, String expiryDate, String addressLine1, String addressLine2, String addressPostcode, String addressCity, String addressCounty, String addressStateProvince, String addressCountry) {
-        this.cardType = cardType;
-        this.cardBrand = cardBrand;
-        this.cardBrandLabel = cardBrandLabel;
-        this.firstDigitsCardNumber = firstDigitsCardNumber;
-        this.lastDigitsCardNumber = lastDigitsCardNumber;
-        this.cardholderName = cardholderName;
-        this.expiryDate = expiryDate;
-        this.addressLine1 = addressLine1;
-        this.addressLine2 = addressLine2;
-        this.addressPostcode = addressPostcode;
-        this.addressCity = addressCity;
-        this.addressCounty = addressCounty;
-        this.addressStateProvince = addressStateProvince;
-        this.addressCountry = addressCountry;
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetails(PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder builder) {
+        this.cardType = builder.cardType;
+        this.cardBrand = builder.cardBrand;
+        this.cardBrandLabel = builder.cardBrandLabel;
+        this.firstDigitsCardNumber = builder.firstDigitsCardNumber;
+        this.lastDigitsCardNumber = builder.lastDigitsCardNumber;
+        this.cardholderName = builder.cardholderName;
+        this.expiryDate = builder.expiryDate;
+        this.addressLine1 = builder.addressLine1;
+        this.addressLine2 = builder.addressLine2;
+        this.addressPostcode = builder.addressPostcode;
+        this.addressCity = builder.addressCity;
+        this.addressCounty = builder.addressCounty;
+        this.addressStateProvince = builder.addressStateProvince;
+        this.addressCountry = builder.addressCountry;
     }
 
     public static PaymentDetailsTakenFromPaymentInstrumentEventDetails from(ChargeEntity charge) {
         var cardDetails = charge.getCardDetails();
-        return new PaymentDetailsTakenFromPaymentInstrumentEventDetails(
-                Optional.ofNullable(cardDetails.getCardType()).map(Enum::toString).orElse(null),
-                cardDetails.getCardBrand(),
-                cardDetails.getCardTypeDetails().map(CardBrandLabelEntity::getLabel).orElse(null),
-                cardDetails.getFirstDigitsCardNumber().toString(),
-                cardDetails.getLastDigitsCardNumber().toString(),
-                cardDetails.getCardHolderName(),
-                cardDetails.getExpiryDate().toString(),
-                cardDetails.getBillingAddress().map(AddressEntity::getLine1).orElse(null),
-                cardDetails.getBillingAddress().map(AddressEntity::getLine2).orElse(null),
-                cardDetails.getBillingAddress().map(AddressEntity::getPostcode).orElse(null),
-                cardDetails.getBillingAddress().map(AddressEntity::getCity).orElse(null),
-                cardDetails.getBillingAddress().map(AddressEntity::getCounty).orElse(null),
-                cardDetails.getBillingAddress().map(AddressEntity::getStateOrProvince).orElse(null),
-                cardDetails.getBillingAddress().map(AddressEntity::getCountry).orElse(null)
-        );
+        var builder = new PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder()
+                .setCardType(Optional.ofNullable(cardDetails.getCardType()).map(Enum::toString).orElse(null))
+                .setCardBrand(cardDetails.getCardBrand())
+                .setCardBrandLabel(cardDetails.getCardTypeDetails().map(CardBrandLabelEntity::getLabel).orElse(null))
+                .setFirstDigitsCardNumber(cardDetails.getFirstDigitsCardNumber().toString())
+                .setLastDigitsCardNumber(cardDetails.getLastDigitsCardNumber().toString())
+                .setCardholderName(cardDetails.getCardHolderName())
+                .setExpiryDate(cardDetails.getExpiryDate().toString());
+
+        cardDetails.getBillingAddress().ifPresent(billingAddress -> {
+            builder.setAddressLine1(billingAddress.getLine1())
+                    .setAddressLine2(billingAddress.getLine2())
+                    .setAddressPostcode(billingAddress.getPostcode())
+                    .setAddressCity(billingAddress.getCity())
+                    .setAddressCounty(billingAddress.getCounty())
+                    .setAddressStateProvince(billingAddress.getStateOrProvince())
+                    .setAddressCountry(billingAddress.getCountry());
+        });
+        return builder.createPaymentDetailsTakenFromPaymentInstrumentEventDetails();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetails.java
@@ -1,0 +1,81 @@
+package uk.gov.pay.connector.events.eventdetails.charge;
+
+import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
+import uk.gov.pay.connector.charge.model.AddressEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class PaymentDetailsTakenFromPaymentInstrumentEventDetails extends EventDetails {
+    private final String cardType;
+    private final String cardBrand;
+    private final String cardBrandLabel;
+    private final String firstDigitsCardNumber;
+    private final String lastDigitsCardNumber;
+    private final String cardholderName;
+    private final String expiryDate;
+    private final String addressLine1;
+    private final String addressLine2;
+    private final String addressPostcode;
+    private final String addressCity;
+    private final String addressCounty;
+    private final String addressStateProvince;
+    private final String addressCountry;
+
+    private PaymentDetailsTakenFromPaymentInstrumentEventDetails(String cardType, String cardBrand, String cardBrandLabel, String firstDigitsCardNumber, String lastDigitsCardNumber, String cardholderName, String expiryDate, String addressLine1, String addressLine2, String addressPostcode, String addressCity, String addressCounty, String addressStateProvince, String addressCountry) {
+        this.cardType = cardType;
+        this.cardBrand = cardBrand;
+        this.cardBrandLabel = cardBrandLabel;
+        this.firstDigitsCardNumber = firstDigitsCardNumber;
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+        this.cardholderName = cardholderName;
+        this.expiryDate = expiryDate;
+        this.addressLine1 = addressLine1;
+        this.addressLine2 = addressLine2;
+        this.addressPostcode = addressPostcode;
+        this.addressCity = addressCity;
+        this.addressCounty = addressCounty;
+        this.addressStateProvince = addressStateProvince;
+        this.addressCountry = addressCountry;
+    }
+
+    public static PaymentDetailsTakenFromPaymentInstrumentEventDetails from(ChargeEntity charge) {
+        var cardDetails = charge.getCardDetails();
+        return new PaymentDetailsTakenFromPaymentInstrumentEventDetails(
+                Optional.ofNullable(cardDetails.getCardType()).map(Enum::toString).orElse(null),
+                cardDetails.getCardBrand(),
+                cardDetails.getCardTypeDetails().map(CardBrandLabelEntity::getLabel).orElse(null),
+                cardDetails.getFirstDigitsCardNumber().toString(),
+                cardDetails.getLastDigitsCardNumber().toString(),
+                cardDetails.getCardHolderName(),
+                cardDetails.getExpiryDate().toString(),
+                cardDetails.getBillingAddress().map(AddressEntity::getLine1).orElse(null),
+                cardDetails.getBillingAddress().map(AddressEntity::getLine2).orElse(null),
+                cardDetails.getBillingAddress().map(AddressEntity::getPostcode).orElse(null),
+                cardDetails.getBillingAddress().map(AddressEntity::getCity).orElse(null),
+                cardDetails.getBillingAddress().map(AddressEntity::getCounty).orElse(null),
+                cardDetails.getBillingAddress().map(AddressEntity::getStateOrProvince).orElse(null),
+                cardDetails.getBillingAddress().map(AddressEntity::getCountry).orElse(null)
+        );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PaymentDetailsTakenFromPaymentInstrumentEventDetails that = (PaymentDetailsTakenFromPaymentInstrumentEventDetails) o;
+        return Objects.equals(cardType, that.cardType) &&
+                Objects.equals(cardBrand, that.cardBrand) &&
+                Objects.equals(firstDigitsCardNumber, that.firstDigitsCardNumber) &&
+                Objects.equals(lastDigitsCardNumber, that.lastDigitsCardNumber) &&
+                Objects.equals(cardholderName, that.cardholderName) &&
+                Objects.equals(expiryDate, that.expiryDate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cardType, cardBrand, firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, expiryDate);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder.java
@@ -1,0 +1,92 @@
+package uk.gov.pay.connector.events.eventdetails.charge;
+
+public class PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder {
+    String cardType;
+    String cardBrand;
+    String cardBrandLabel;
+    String firstDigitsCardNumber;
+    String lastDigitsCardNumber;
+    String cardholderName;
+    String expiryDate;
+    String addressLine1;
+    String addressLine2;
+    String addressPostcode;
+    String addressCity;
+    String addressCounty;
+    String addressStateProvince;
+    String addressCountry;
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setCardType(String cardType) {
+        this.cardType = cardType;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setCardBrand(String cardBrand) {
+        this.cardBrand = cardBrand;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setCardBrandLabel(String cardBrandLabel) {
+        this.cardBrandLabel = cardBrandLabel;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setFirstDigitsCardNumber(String firstDigitsCardNumber) {
+        this.firstDigitsCardNumber = firstDigitsCardNumber;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setLastDigitsCardNumber(String lastDigitsCardNumber) {
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setCardholderName(String cardholderName) {
+        this.cardholderName = cardholderName;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setExpiryDate(String expiryDate) {
+        this.expiryDate = expiryDate;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setAddressLine1(String addressLine1) {
+        this.addressLine1 = addressLine1;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setAddressLine2(String addressLine2) {
+        this.addressLine2 = addressLine2;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setAddressPostcode(String addressPostcode) {
+        this.addressPostcode = addressPostcode;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setAddressCity(String addressCity) {
+        this.addressCity = addressCity;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setAddressCounty(String addressCounty) {
+        this.addressCounty = addressCounty;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setAddressStateProvince(String addressStateProvince) {
+        this.addressStateProvince = addressStateProvince;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setAddressCountry(String addressCountry) {
+        this.addressCountry = addressCountry;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetails createPaymentDetailsTakenFromPaymentInstrumentEventDetails() {
+        return new PaymentDetailsTakenFromPaymentInstrumentEventDetails(this);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsTakenFromPaymentInstrument.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsTakenFromPaymentInstrument.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.charge.exception.ChargeEventNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.charge.PaymentDetailsTakenFromPaymentInstrumentEventDetails;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+
+public class PaymentDetailsTakenFromPaymentInstrument extends PaymentEvent {
+
+    public PaymentDetailsTakenFromPaymentInstrument(String serviceId,
+                                                    boolean live,
+                                                    String resourceExternalId,
+                                                    PaymentDetailsTakenFromPaymentInstrumentEventDetails eventDetails,
+                                                    Instant timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static PaymentDetailsTakenFromPaymentInstrument from(ChargeEntity charge) {
+        ZonedDateTime lastEventDate = charge.getEvents().stream()
+                .filter(e -> e.getStatus() == ChargeStatus.fromString(charge.getStatus()))
+                .map(ChargeEventEntity::getUpdated)
+                .max(ZonedDateTime::compareTo)
+                .orElseThrow(() -> new ChargeEventNotFoundRuntimeException(charge.getExternalId()));
+
+        return new PaymentDetailsTakenFromPaymentInstrument(
+                charge.getServiceId(),
+                charge.getGatewayAccount().isLive(),
+                charge.getExternalId(),
+                PaymentDetailsTakenFromPaymentInstrumentEventDetails.from(charge),
+                lastEventDate.toInstant());
+    }
+
+    public static PaymentDetailsTakenFromPaymentInstrument from(ChargeEventEntity chargeEventEntity) {
+        ChargeEntity charge = chargeEventEntity.getChargeEntity();
+
+        return new PaymentDetailsTakenFromPaymentInstrument(
+                charge.getServiceId(),
+                charge.getGatewayAccount().isLive(),
+                charge.getExternalId(),
+                PaymentDetailsTakenFromPaymentInstrumentEventDetails.from(charge),
+                chargeEventEntity.getUpdated().toInstant()
+        );
+    }
+
+    public String getTitle() {
+        return "Payment details taken from payment instrument";
+    }
+
+    public String getDescription() {
+        return "The event happens when the payment details are taken from a payment instrument during a recurring card payment";
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsTakenFromPaymentInstrumentTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsTakenFromPaymentInstrumentTest.java
@@ -1,0 +1,104 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity.ChargeEventEntityBuilder.aChargeEventEntity;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+
+class PaymentDetailsTakenFromPaymentInstrumentTest {
+
+    private final String time = "2018-03-12T16:25:01.123456Z";
+
+    private ChargeEntityFixture chargeEntityFixture;
+
+    @BeforeEach
+    public void setUp() {
+        ZonedDateTime latestDateTime = ZonedDateTime.parse(time);
+
+        List<ChargeEventEntity> list = List.of(
+                aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.CREATED).withUpdated(latestDateTime.minusHours(3)).build(),
+                aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.AUTHORISATION_SUCCESS).withUpdated(latestDateTime).build()
+        );
+
+        String paymentId = "jweojfewjoifewj";
+        chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(Instant.parse(time))
+                .withStatus(ChargeStatus.AUTHORISATION_SUCCESS)
+                .withExternalId(paymentId)
+                .withCorporateSurcharge(10L)
+                .withCardDetails(anAuthCardDetails().getCardDetailsEntity())
+                .withAmount(100L)
+                .withEvents(list);
+    }
+
+    @Test
+    public void shouldIncludeAllFieldsForTheEvent() throws JsonProcessingException {
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+        String json = PaymentDetailsTakenFromPaymentInstrument.from(chargeEntity).toJsonString();
+
+        assertDetails(json, chargeEntity);
+    }
+
+    @Test
+    public void shouldSerialiseAndIncludeSelectedFieldsForPartialCardDetails() throws JsonProcessingException {
+        var cardDetails = anAuthCardDetails().getCardDetailsEntity();
+        cardDetails.setBillingAddress(null);
+        cardDetails.setCardType(null);
+        ChargeEntity chargeEntity = chargeEntityFixture.withCardDetails(cardDetails).build();
+        String json = PaymentDetailsTakenFromPaymentInstrument.from(chargeEntity).toJsonString();
+
+        assertThat(json, hasJsonPath("$.event_type", equalTo("PAYMENT_DETAILS_TAKEN_FROM_PAYMENT_INSTRUMENT")));
+        assertThat(json, hasJsonPath("$.event_details.card_brand", equalTo("visa")));
+        assertThat(json, hasJsonPath("$.event_details.last_digits_card_number", equalTo("4242")));
+
+        assertThat(json, hasNoJsonPath("$.event_details.card_type"));
+        assertThat(json, hasNoJsonPath("$.event_details.address_line1"));
+        assertThat(json, hasNoJsonPath("$.event_details.address_city"));
+        assertThat(json, hasNoJsonPath("$.event_details.address_country"));
+    }
+
+    @Test
+    public void shouldIncludeAllFieldsForEventEmittedUsingChargeEvent() throws JsonProcessingException {
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+        ChargeEventEntity chargeEventEntity = aChargeEventEntity()
+                .withUpdated(ZonedDateTime.parse(time))
+                .withChargeEntity(chargeEntity)
+                .build();
+        String json = PaymentDetailsTakenFromPaymentInstrument.from(chargeEventEntity).toJsonString();
+
+        assertDetails(json, chargeEntity);
+    }
+
+    private void assertDetails(String actual, ChargeEntity chargeEntity) {
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(time)));
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("PAYMENT_DETAILS_TAKEN_FROM_PAYMENT_INSTRUMENT")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+        assertThat(actual, hasJsonPath("$.title", equalTo("Payment details taken from payment instrument")));
+        assertThat(actual, hasJsonPath("$.description", equalTo("The event happens when the payment details are taken from a payment instrument during a recurring card payment")));
+        assertThat(actual, hasJsonPath("$.event_details.card_type", equalTo("DEBIT")));
+        assertThat(actual, hasJsonPath("$.event_details.address_line1", equalTo("125 Kingsway")));
+        assertThat(actual, hasJsonPath("$.event_details.address_city", equalTo("London")));
+        assertThat(actual, hasJsonPath("$.event_details.address_country", equalTo("GB")));
+        assertThat(actual, hasJsonPath("$.event_details.card_brand", equalTo("visa")));
+        assertThat(actual, hasJsonPath("$.event_details.card_brand_label", equalTo("Visa")));
+        assertThat(actual, hasJsonPath("$.event_details.first_digits_card_number", equalTo("424242")));
+        assertThat(actual, hasJsonPath("$.event_details.last_digits_card_number", equalTo("4242")));
+        assertThat(actual, hasJsonPath("$.event_details.cardholder_name", equalTo("Mr Test")));
+        assertThat(actual, hasJsonPath("$.event_details.expiry_date", equalTo("12/99")));
+    }
+}


### PR DESCRIPTION
Adds a new event/ event details to represent when payment details are
extracted from an existing payment instrument rather than input by a
paying user. 

Common fields are taken from the payment details entered event however 
this isn't extended directly as there are a number of fields that have 
been omitted as not relevant to recurring card payments.

When processing a recurring payment (authorisation mode agreement), be
specific about the type of event describing the payment instrument being
used to populate payment details.

Now that recurring charges use a specific event to represent that the
user is not entering details, make sure this is used when the charge is
being backfilled.