### PR TITLE
PP-10435 Add gateway transaction id to payment details taken event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetails.java
@@ -22,6 +22,7 @@ public class PaymentDetailsTakenFromPaymentInstrumentEventDetails extends EventD
     private final String addressCounty;
     private final String addressStateProvince;
     private final String addressCountry;
+    private final String gatewayTransactionId;
 
     public PaymentDetailsTakenFromPaymentInstrumentEventDetails(PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder builder) {
         this.cardType = builder.cardType;
@@ -38,11 +39,13 @@ public class PaymentDetailsTakenFromPaymentInstrumentEventDetails extends EventD
         this.addressCounty = builder.addressCounty;
         this.addressStateProvince = builder.addressStateProvince;
         this.addressCountry = builder.addressCountry;
+        this.gatewayTransactionId = builder.gatewayTransactionId;
     }
 
     public static PaymentDetailsTakenFromPaymentInstrumentEventDetails from(ChargeEntity charge) {
         var cardDetails = charge.getCardDetails();
         var builder = new PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder()
+                .setGatewayTransactionId(charge.getGatewayTransactionId())
                 .setCardType(Optional.ofNullable(cardDetails.getCardType()).map(Enum::toString).orElse(null))
                 .setCardBrand(cardDetails.getCardBrand())
                 .setCardBrandLabel(cardDetails.getCardTypeDetails().map(CardBrandLabelEntity::getLabel).orElse(null))
@@ -135,5 +138,9 @@ public class PaymentDetailsTakenFromPaymentInstrumentEventDetails extends EventD
 
     public String getAddressCountry() {
         return addressCountry;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder.java
@@ -15,6 +15,7 @@ public class PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder {
     String addressCounty;
     String addressStateProvince;
     String addressCountry;
+    String gatewayTransactionId;
 
     public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setCardType(String cardType) {
         this.cardType = cardType;
@@ -83,6 +84,11 @@ public class PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder {
 
     public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setAddressCountry(String addressCountry) {
         this.addressCountry = addressCountry;
+        return this;
+    }
+
+    public PaymentDetailsTakenFromPaymentInstrumentEventDetailsBuilder setGatewayTransactionId(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsTakenFromPaymentInstrumentTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsTakenFromPaymentInstrumentTest.java
@@ -40,6 +40,7 @@ class PaymentDetailsTakenFromPaymentInstrumentTest {
                 .withStatus(ChargeStatus.AUTHORISATION_SUCCESS)
                 .withExternalId(paymentId)
                 .withCorporateSurcharge(10L)
+                .withGatewayTransactionId("a-gateway-transaction-id")
                 .withCardDetails(anAuthCardDetails().getCardDetailsEntity())
                 .withAmount(100L)
                 .withEvents(list);
@@ -90,6 +91,7 @@ class PaymentDetailsTakenFromPaymentInstrumentTest {
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
         assertThat(actual, hasJsonPath("$.title", equalTo("Payment details taken from payment instrument")));
         assertThat(actual, hasJsonPath("$.description", equalTo("The event happens when the payment details are taken from a payment instrument during a recurring card payment")));
+        assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo("a-gateway-transaction-id")));
         assertThat(actual, hasJsonPath("$.event_details.card_type", equalTo("DEBIT")));
         assertThat(actual, hasJsonPath("$.event_details.address_line1", equalTo("125 Kingsway")));
         assertThat(actual, hasJsonPath("$.event_details.address_city", equalTo("London")));


### PR DESCRIPTION
It looks like for a happy path payment the only place the gateway transaction id is included is in the payment detail entered event. 

Make sure this also gets propagated for recurring payments.