### PR TITLE
PP-10424 Return ONE_TIME_TOKEN_INVALID identier for invalid token usage

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenUsageInvalidForMotoApiExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/motoapi/OneTimeTokenUsageInvalidForMotoApiExceptionMapper.java
@@ -11,6 +11,7 @@ import java.util.List;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.ONE_TIME_TOKEN_INVALID;
 
 public class OneTimeTokenUsageInvalidForMotoApiExceptionMapper implements ExceptionMapper<OneTimeTokenUsageInvalidForMotoApiException> {
 
@@ -20,7 +21,7 @@ public class OneTimeTokenUsageInvalidForMotoApiExceptionMapper implements Except
     public Response toResponse(OneTimeTokenUsageInvalidForMotoApiException exception) {
         LOGGER.info(exception.getMessage());
 
-        ErrorResponse errorResponse = new ErrorResponse(GENERIC, List.of(exception.getMessage()));
+        ErrorResponse errorResponse = new ErrorResponse(ONE_TIME_TOKEN_INVALID, List.of(exception.getMessage()));
 
         return Response.status(BAD_REQUEST)
                 .entity(errorResponse)

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceTest.java
@@ -270,7 +270,7 @@ class CardResourceTest {
 
         ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
         assertThat(errorResponse.getMessages(), hasItem("The one_time_token is not a valid moto api token"));
-        assertThat(errorResponse.getIdentifier(), is(GENERIC));
+        assertThat(errorResponse.getIdentifier(), is(ONE_TIME_TOKEN_INVALID));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- Connector currently returns a GENERIC error identifier when `one_time_token` created for web payment is used to authorise payment using MOTO API (v1/auth). Public API returns a 500 error response as the GENERIC identifier is not mapped to a specific P code.
- Returns ONE_TIME_TOKEN_INVALID instead which is already handled by public API and returns P1211 error code.
