### PR TITLE
PP-10487 Fix task queue error for RCP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.11</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.14.1</jackson.version>
-        <pay-java-commons.version>1.0.20230109125639</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20230119110903</pay-java-commons.version>
         <surefire.version>3.0.0-M8</surefire.version>
         <jooq.version>3.17.6</jooq.version>
         <postgresql.version>42.5.1</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueue.java
@@ -34,7 +34,7 @@ public class TaskQueue extends AbstractQueue {
 
     public void addTaskToQueue(Task task) throws QueueException, JsonProcessingException {
         String message = objectMapper.writeValueAsString(task);
-        QueueMessage queueMessage = sendMessageToQueue(message);
+        QueueMessage queueMessage = sendMessageToQueueWithDelay(message, 2);
         LOGGER.info("Task added to queue",
                 kv("task_type", task.getTaskType().getName()),
                 kv("message_id", queueMessage.getMessageId()));

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -116,13 +117,13 @@ public class TaskQueueTest {
 
     @Test
     public void shouldSendValidSerialisedChargeToQueue() throws QueueException, JsonProcessingException {
-        when(sqsQueueService.sendMessage(anyString(), anyString())).thenReturn(mock(QueueMessage.class));
+        when(sqsQueueService.sendMessage(anyString(), anyString(), anyInt())).thenReturn(mock(QueueMessage.class));
 
         TaskQueue queue = new TaskQueue(sqsQueueService, connectorConfiguration, objectMapper);
         Task task = new Task("payload data", TaskType.COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT);
         queue.addTaskToQueue(task);
 
         verify(sqsQueueService).sendMessage(connectorConfiguration.getSqsConfig().getTaskQueueUrl(),
-                "{\"data\":\"payload data\",\"task\":\"collect_fee_for_stripe_failed_payment\"}");
+                "{\"data\":\"payload data\",\"task\":\"collect_fee_for_stripe_failed_payment\"}", 2);
     }
 }


### PR DESCRIPTION
- Context: Occasional delays in database transactions are causing an error whereby connector's task queue message handler picks up a new task before the associated database record has been updated
- Add messages to task queue with 2-second delay
- Update associated unit test