### PR TITLE
PP-10487 Send tasks to queue with delay

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -914,7 +918,7 @@
         "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 145
       }
     ],
     "src/test/resources/config/test-it-config.yaml": [
@@ -944,7 +948,7 @@
         "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 145
       }
     ],
     "src/test/resources/googlepay/auth-request-with-empty-last-digits-card-number.json": [
@@ -1070,5 +1074,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-05T17:40:59Z"
+  "generated_at": "2023-01-19T15:06:20Z"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.11</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.14.1</jackson.version>
-        <pay-java-commons.version>1.0.20230116143028</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20230119110903</pay-java-commons.version>
         <surefire.version>3.0.0-M8</surefire.version>
         <jooq.version>3.17.6</jooq.version>
         <postgresql.version>42.5.1</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/app/config/TaskQueueConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/TaskQueueConfig.java
@@ -9,6 +9,7 @@ public class TaskQueueConfig extends Configuration {
     private int queueSchedulerThreadDelayInSeconds;
     private int failedMessageRetryDelayInSeconds;
     private int queueSchedulerShutdownTimeoutInSeconds;
+    private int deliveryDelayInSeconds;
 
     public Boolean getTaskQueueEnabled() {
         return taskQueueEnabled;
@@ -28,5 +29,9 @@ public class TaskQueueConfig extends Configuration {
 
     public int getQueueSchedulerShutdownTimeoutInSeconds() {
         return queueSchedulerShutdownTimeoutInSeconds;
+    }
+
+    public int getDeliveryDelayInSeconds() {
+        return deliveryDelayInSeconds;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueue.java
@@ -23,6 +23,7 @@ public class TaskQueue extends AbstractQueue {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskQueue.class);
     private final int deliveryDelayInSeconds;
+    
     @Inject
     public TaskQueue(SqsQueueService sqsQueueService,
                      ConnectorConfiguration connectorConfiguration,

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -166,6 +166,7 @@ taskQueue:
   queueSchedulerNumberOfThreads: ${TASKS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}
   queueSchedulerThreadDelayInSeconds: ${TASKS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerShutdownTimeoutInSeconds: ${TASKS_QUEUE_SCHEDULER_SHUTDOWN_TIMEOUT_IN_SECONDS:-40}
+  deliveryDelayInSeconds: ${TASK_QUEUE_DELIVERY_DELAY_IN_SECONDS:-2}
 
 jerseyClient:
   # Defines the socket timeout (SO_TIMEOUT), which is the

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -61,6 +62,7 @@ public class TaskQueueTest {
         when(taskQueueConfig.getFailedMessageRetryDelayInSeconds()).thenReturn(3600);
         when(connectorConfiguration.getSqsConfig()).thenReturn(sqsConfig);
         when(connectorConfiguration.getTaskQueueConfig()).thenReturn(taskQueueConfig);
+        when(taskQueueConfig.getDeliveryDelayInSeconds()).thenReturn(2);
         Logger logger = (Logger) LoggerFactory.getLogger(TaskQueue.class);
         logger.setLevel(Level.ERROR);
         logger.addAppender(mockAppender);
@@ -116,13 +118,13 @@ public class TaskQueueTest {
 
     @Test
     public void shouldSendValidSerialisedChargeToQueue() throws QueueException, JsonProcessingException {
-        when(sqsQueueService.sendMessage(anyString(), anyString())).thenReturn(mock(QueueMessage.class));
+        when(sqsQueueService.sendMessage(anyString(), anyString(), anyInt())).thenReturn(mock(QueueMessage.class));
 
         TaskQueue queue = new TaskQueue(sqsQueueService, connectorConfiguration, objectMapper);
         Task task = new Task("payload data", TaskType.COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT);
         queue.addTaskToQueue(task);
 
         verify(sqsQueueService).sendMessage(connectorConfiguration.getSqsConfig().getTaskQueueUrl(),
-                "{\"data\":\"payload data\",\"task\":\"collect_fee_for_stripe_failed_payment\"}");
+                "{\"data\":\"payload data\",\"task\":\"collect_fee_for_stripe_failed_payment\"}", 2);
     }
 }

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -121,6 +121,7 @@ taskQueue:
   queueSchedulerNumberOfThreads: ${TASKS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}
   queueSchedulerThreadDelayInSeconds: ${TASKS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerShutdownTimeoutInSeconds: ${TASKS_QUEUE_SCHEDULER_SHUTDOWN_TIMEOUT_IN_SECONDS:-40}
+  deliveryDelayInSeconds: ${TASK_QUEUE_DELIVERY_DELAY_IN_SECONDS:-2}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -108,6 +108,7 @@ taskQueue:
   queueSchedulerNumberOfThreads: ${TASKS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}
   queueSchedulerThreadDelayInSeconds: ${TASKS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerShutdownTimeoutInSeconds: ${TASKS_QUEUE_SCHEDULER_SHUTDOWN_TIMEOUT_IN_SECONDS:-40}
+  deliveryDelayInSeconds: ${TASK_QUEUE_DELIVERY_DELAY_IN_SECONDS:-2}
 
 sqsConfig:
   nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-true}


### PR DESCRIPTION
- Context: Occasional delays in database transactions are causing an error whereby connector's task queue message handler picks up a new task before the associated database record has been updated
- Added delivery delay as a config setting for task queue
- Applied this delay when adding messages to task queue
- Updated associated unit test
