### PR TITLE
PP-10486 Refactor RCP-Not-Allowed-Exception

### DIFF
--- a/src/main/java/uk/gov/pay/connector/agreement/exception/RecurringCardPaymentsNotAllowedException.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/exception/RecurringCardPaymentsNotAllowedException.java
@@ -1,9 +1,8 @@
 package uk.gov.pay.connector.agreement.exception;
 
 public class RecurringCardPaymentsNotAllowedException extends RuntimeException{
-    public RecurringCardPaymentsNotAllowedException(Long gatewayAccountId) {
-        super("Attempt to create an agreement for gateway account " + gatewayAccountId +
-                ", which does not have recurring card payments enabled");
+    public RecurringCardPaymentsNotAllowedException(String message) {
+        super(message);
     }
 }
 

--- a/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
@@ -56,7 +56,10 @@ public class AgreementService {
     public Optional<AgreementResponse> create(AgreementCreateRequest agreementCreateRequest, long accountId) {
         return gatewayAccountDao.findById(accountId).map(gatewayAccountEntity -> {
             if(!gatewayAccountEntity.isRecurringEnabled()) {
-                throw new RecurringCardPaymentsNotAllowedException(gatewayAccountEntity.getId());
+                throw new RecurringCardPaymentsNotAllowedException(
+                        "Attempt to create an agreement for gateway account " + 
+                        gatewayAccountEntity.getId() + 
+                        ", which does not have recurring card payments enabled");
             }
             AgreementEntity agreementEntity = anAgreementEntity(clock.instant())
                     .withReference(agreementCreateRequest.getReference())


### PR DESCRIPTION
Context: RecurringCardPaymentsNotAllowedException should be generated in response to requests to create or
setup agreements or take recurring payments if the gateway account does not have RCP enabled

- refactor this exception to allow a specific message to be passed as a parameter to cover the different use cases
- update the existing use in AgreementService accordingly
- further changes to cause this exception to be triggered in the other scenarios (setting up agreements and taking recurring payments) will be covered in a separate PR