### PR TITLE
PP-10488 Add logging fields for recurring payments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -257,7 +257,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 198
+        "line_number": 200
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java": [
@@ -1074,5 +1074,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-19T15:06:20Z"
+  "generated_at": "2023-01-27T10:58:06Z"
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -68,6 +68,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.fromString;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_SUCCESS;
 import static uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions.isValidTransition;
 import static uk.gov.service.payments.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
+import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.AUTHORISATION_MODE;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_TYPE;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
@@ -407,12 +409,15 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     @JsonIgnore
     public Object[] getStructuredLoggingArgs() {
-        return new StructuredArgument[]{
+        ArrayList<StructuredArgument> structuredArguments = new ArrayList<>(List.of(
                 kv(PAYMENT_EXTERNAL_ID, externalId),
                 kv(GATEWAY_ACCOUNT_ID, getGatewayAccount().getId()),
                 kv(PROVIDER, paymentProvider),
-                kv(GATEWAY_ACCOUNT_TYPE, getGatewayAccount().getType())
-        };
+                kv(GATEWAY_ACCOUNT_TYPE, getGatewayAccount().getType()),
+                kv(AUTHORISATION_MODE, authorisationMode)
+        ));
+        getAgreementId().ifPresent(agreementExternalId -> structuredArguments.add(kv(AGREEMENT_EXTERNAL_ID, agreementExternalId)));
+        return structuredArguments.toArray();
     }
 
     public void setAmount(Long amount) {

--- a/src/main/java/uk/gov/pay/connector/filters/LoggingMDCRequestFilter.java
+++ b/src/main/java/uk/gov/pay/connector/filters/LoggingMDCRequestFilter.java
@@ -13,6 +13,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import java.util.Optional;
 
+import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER_PAYMENT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.REFUND_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.SECURE_TOKEN;
@@ -44,6 +45,9 @@ public class LoggingMDCRequestFilter implements ContainerRequestFilter {
 
         getPathParameterFromRequest("gatewayTransactionId", requestContext)
                 .ifPresent(gatewayTxId -> MDC.put(PROVIDER_PAYMENT_ID, gatewayTxId));
+        
+        getPathParameterFromRequest("agreementId", requestContext)
+                .ifPresent(agreementId -> MDC.put(AGREEMENT_EXTERNAL_ID, agreementId));
     }
 
     private Optional<ChargeEntity> getChargeFromRequest(ContainerRequestContext requestContext) {

--- a/src/main/java/uk/gov/pay/connector/filters/LoggingMDCResponseFilter.java
+++ b/src/main/java/uk/gov/pay/connector/filters/LoggingMDCResponseFilter.java
@@ -7,6 +7,7 @@ import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import java.util.List;
 
+import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_TYPE;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
@@ -19,6 +20,6 @@ public class LoggingMDCResponseFilter implements ContainerResponseFilter {
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
         List.of(PAYMENT_EXTERNAL_ID, GATEWAY_ACCOUNT_ID, PROVIDER, GATEWAY_ACCOUNT_TYPE, REFUND_EXTERNAL_ID, 
-                SECURE_TOKEN, PROVIDER_PAYMENT_ID).forEach(MDC::remove);
+                SECURE_TOKEN, PROVIDER_PAYMENT_ID, AGREEMENT_EXTERNAL_ID).forEach(MDC::remove);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/util/MDCUtils.java
+++ b/src/main/java/uk/gov/pay/connector/util/MDCUtils.java
@@ -4,6 +4,8 @@ import org.slf4j.MDC;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.AUTHORISATION_MODE;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_TYPE;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
@@ -13,6 +15,9 @@ public class MDCUtils {
     public static void addChargeAndGatewayAccountDetailsToMDC(ChargeEntity charge) {
         MDC.put(PAYMENT_EXTERNAL_ID, charge.getExternalId());
         MDC.put(PROVIDER, charge.getPaymentProvider());
+        MDC.put(AUTHORISATION_MODE, charge.getAuthorisationMode().getName());
+        charge.getAgreementId().ifPresent(agreementId -> MDC.put(AGREEMENT_EXTERNAL_ID, agreementId));
+        
         addGatewayAccountDetailsToMDC(charge.getGatewayAccount());
     }
     
@@ -24,6 +29,8 @@ public class MDCUtils {
     public static void removeChargeAndGatewayAccountDetailsFromMDC() {
         MDC.remove(PAYMENT_EXTERNAL_ID);
         MDC.remove(PROVIDER);
+        MDC.remove(AUTHORISATION_MODE);
+        MDC.remove(AGREEMENT_EXTERNAL_ID);
         removeGatewayAccountDetailsFromMDC();
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -66,7 +66,7 @@ public class ChargeEntityFixture {
     private Exemption3ds exemption3ds;
     private String paymentProvider = "sandbox";
     private String serviceId = randomUuid();
-    private String agreementId = randomUuid().substring(26);
+    private String agreementId;
     private boolean savePaymentInstrumentToAgreement = false;
     private PaymentInstrumentEntity paymentInstrument = null;
     private AuthorisationMode authorisationMode = AuthorisationMode.WEB;

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
@@ -51,7 +51,8 @@ class PaymentCreatedTest {
             .withEmail(null)
             .withSource(Source.CARD_API)
             .withExternalMetadata(new ExternalMetadata(ImmutableMap.of("key1", "value1", "key2", "value2")))
-            .withAuthorisationMode(AuthorisationMode.WEB);
+            .withAuthorisationMode(AuthorisationMode.WEB)
+            .withAgreementId(AGREEMENT_EXTERNAL_ID);
     private ChargeEntity chargeEntity;
 
     private String preparePaymentCreatedEvent() throws JsonProcessingException {

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -88,6 +88,7 @@ public class QueueMessageContractTest {
                 .withCorporateSurcharge(55L)
                 .withSource(CARD_API)
                 .withCardDetails(anAuthCardDetails().getCardDetailsEntity())
+                .withAgreementId("an-agreement-id")
                 .build();
 
         PaymentCreated paymentCreatedEvent = new PaymentCreated(
@@ -167,6 +168,7 @@ public class QueueMessageContractTest {
     public String verifyUserEmailCollectedEvent() throws JsonProcessingException {
         ChargeEntity charge = aValidChargeEntity()
                 .withEmail("test@example.org")
+                .withAgreementId("an-agreement-id")
                 .build();
 
         UserEmailCollected userEmailCollected = new UserEmailCollected(

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -86,10 +86,12 @@ import java.util.stream.Collectors;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static junit.framework.TestCase.assertTrue;
+import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItemInArray;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThrows;
@@ -371,7 +373,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
         assertThat(loggingEvents.stream().map(LoggingEvent::getFormattedMessage).collect(Collectors.toList()),
                 hasItems("Applied corporate card surcharge for charge"));
-        assertThat(loggingEvents.get(0).getArgumentArray().length, CoreMatchers.is(5));
+        assertThat(loggingEvents.get(0).getArgumentArray(), hasItemInArray(kv("corporate_card_surcharge", 250L)));
     }
 
     @Test


### PR DESCRIPTION
For all request contexts where a charge is present, add to the MDC:
- the authorisation_mode
- the agreement_external_id if one is set for the charge

For requests that include an "agreementId" as a path parameter, add the agreement_external_id to the MDC

Where we are logging using the `ChargeEntity$getStructuredLoggingArgs` method, include the authorisation_mode, and the agreement_external_id if one is set for the charge.