### PR TITLE
PP-10486 Check RCP Enabled on setup agreement or recurring payment

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -4,6 +4,7 @@ import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
+import uk.gov.pay.connector.agreement.exception.RecurringCardPaymentsNotAllowedException;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.app.CaptureProcessConfig;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
@@ -268,7 +269,7 @@ public class ChargeService {
                 checkIfMotoPaymentsAllowed(chargeRequest.isMoto(), gatewayAccount);
             }
 
-            checkAgreementOptions(chargeRequest);
+            checkAgreementOptions(chargeRequest, gatewayAccount);
 
             chargeRequest.getReturnUrl().ifPresent(returnUrl -> {
                 if (gatewayAccount.isLive() && !returnUrl.startsWith("https://")) {
@@ -972,10 +973,15 @@ public class ChargeService {
         }
     }
 
-    private void checkAgreementOptions(ChargeCreateRequest chargeCreateRequest) {
+    private void checkAgreementOptions(ChargeCreateRequest chargeCreateRequest, GatewayAccountEntity gatewayAccount) {
         switch (chargeCreateRequest.getAuthorisationMode()) {
             case AGREEMENT:
-                if (chargeCreateRequest.getAgreementId() == null) {
+                if (!gatewayAccount.isRecurringEnabled()) {
+                    throw new RecurringCardPaymentsNotAllowedException(
+                            "Attempt to use authorisation mode 'agreement' for gateway account " +
+                             gatewayAccount.getId() +
+                            ", which does not have recurring card payments enabled");
+                } else if (chargeCreateRequest.getAgreementId() == null) {
                     throw new MissingMandatoryAttributeException("agreement_id");
                 } else if (chargeCreateRequest.getSavePaymentInstrumentToAgreement()) {
                     throw new IncorrectAuthorisationModeForSavePaymentToAgreementException();
@@ -991,6 +997,11 @@ public class ChargeService {
                 if (chargeCreateRequest.getAgreementId() != null) {
                     if (!chargeCreateRequest.getSavePaymentInstrumentToAgreement()) {
                         throw new UnexpectedAttributeException("agreement_id");
+                    } else if (!gatewayAccount.isRecurringEnabled()) {
+                        throw new RecurringCardPaymentsNotAllowedException(
+                                "Attempt to save payment instrument to agreement for gateway account " +
+                                        gatewayAccount.getId() +
+                                        ", which does not have recurring card payments enabled");
                     }
                 } else {
                     if (chargeCreateRequest.getSavePaymentInstrumentToAgreement()) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
@@ -79,6 +79,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
 
     @Test
     public void shouldCreatePaymentWithAgreementIdAndSavePaymentInstrumentToAgreementTrue() {
+        databaseTestHelper.enableRecurring(Long.valueOf(accountId));
         AddAgreementParams agreementParams = anAddAgreementParams()
                 .withGatewayAccountId(accountId)
                 .withExternalAgreementId(JSON_VALID_AGREEMENT_ID_VALUE)
@@ -107,6 +108,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
 
     @Test
     public void shouldCreatePaymentWithAgreementIdAndAuthorisationModeAgreement() {
+        databaseTestHelper.enableRecurring(Long.valueOf(accountId));
         Long paymentInstrumentId = RandomUtils.nextLong();
 
         AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
@@ -154,6 +156,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
+                .withRecurringEnabled(true)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 
@@ -180,6 +183,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
+                .withRecurringEnabled(true)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 
@@ -205,6 +209,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
+                .withRecurringEnabled(true)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 
@@ -229,6 +234,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("sandbox")
                 .withAccountId(accountId)
+                .withRecurringEnabled(true)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 
@@ -255,6 +261,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
                 .withPaymentGateway("sandbox")
                 .withAccountId(accountId)
                 .withAllowMoto(true)
+                .withRecurringEnabled(true)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 
@@ -281,6 +288,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("sandbox")
                 .withAccountId(accountId)
+                .withRecurringEnabled(true)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 
@@ -307,6 +315,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("sandbox")
                 .withAccountId(accountId)
+                .withRecurringEnabled(true)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 
@@ -342,6 +351,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
+                .withRecurringEnabled(true)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 
@@ -366,6 +376,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
+                .withRecurringEnabled(true)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 
@@ -396,6 +407,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
+                .withRecurringEnabled(true)
                 .build();
         long paymentInstrumentId = 11L;
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
@@ -463,6 +475,7 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
+                .withRecurringEnabled(true)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 
@@ -592,7 +605,64 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
                 .statusCode(SC_UNPROCESSABLE_ENTITY)
                 .contentType(JSON);
     }
+    
+    @Test
+    public void shouldReturn422OnSavePaymentToInstrumentRequestWhenRecurringNotEnabledForGatewayAccount() {
+        AddAgreementParams agreementParams = anAddAgreementParams()
+                .withGatewayAccountId(accountId)
+                .withExternalAgreementId(JSON_VALID_AGREEMENT_ID_VALUE)
+                .build();
+        databaseTestHelper.addAgreement(agreementParams);
+        
+        String postBody = toJson(Map.of(
+                JSON_AMOUNT_KEY, AMOUNT,
+                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
+                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
+                JSON_RETURN_URL_KEY, RETURN_URL,
+                JSON_AGREEMENT_ID_KEY, JSON_VALID_AGREEMENT_ID_VALUE,
+                JSON_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT_KEY, "true"
+                ));
+        
+        connectorRestApiClient
+                .postCreateCharge(postBody)
+                .statusCode(SC_UNPROCESSABLE_ENTITY)
+                .contentType(JSON)
+                .body("message", contains("Recurring payment agreements are not enabled on this account"))
+                .body("error_identifier", is(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED.toString()));
+        }
 
+    @Test
+    public void shouldReturn422OnRecurringPaymentRequestWhenRecurringNotEnabledForGatewayAccount() {
+        Long paymentInstrumentId = RandomUtils.nextLong();
+
+        AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
+                .withPaymentInstrumentId(paymentInstrumentId)
+                .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE).build();
+        databaseTestHelper.addPaymentInstrument(paymentInstrumentParams);
+
+        AddAgreementParams agreementParams = anAddAgreementParams()
+                .withGatewayAccountId(accountId)
+                .withExternalAgreementId(JSON_VALID_AGREEMENT_ID_VALUE)
+                .withPaymentInstrumentId(paymentInstrumentId)
+                .build();
+        databaseTestHelper.addAgreement(agreementParams);
+
+        String postBody = toJson(Map.of(
+                JSON_AMOUNT_KEY, AMOUNT,
+                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
+                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
+                JSON_AGREEMENT_ID_KEY, JSON_VALID_AGREEMENT_ID_VALUE,
+                JSON_AUTH_MODE_KEY, JSON_AUTH_MODE_AGREEMENT
+        ));
+
+        connectorRestApiClient
+                .postCreateCharge(postBody)
+                .statusCode(SC_UNPROCESSABLE_ENTITY)
+                .contentType(JSON)
+                .body("message", contains("Recurring payment agreements are not enabled on this account"))
+                .body("error_identifier", is(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED.toString()));
+    }
+        
     @After
     public void tearDown() {
         databaseTestHelper.truncateAllData();

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
@@ -631,38 +631,6 @@ public class ChargesApiResourceCreateAgreementIT extends ChargingITestBase {
                 .body("error_identifier", is(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED.toString()));
         }
 
-    @Test
-    public void shouldReturn422OnRecurringPaymentRequestWhenRecurringNotEnabledForGatewayAccount() {
-        Long paymentInstrumentId = RandomUtils.nextLong();
-
-        AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
-                .withPaymentInstrumentId(paymentInstrumentId)
-                .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE).build();
-        databaseTestHelper.addPaymentInstrument(paymentInstrumentParams);
-
-        AddAgreementParams agreementParams = anAddAgreementParams()
-                .withGatewayAccountId(accountId)
-                .withExternalAgreementId(JSON_VALID_AGREEMENT_ID_VALUE)
-                .withPaymentInstrumentId(paymentInstrumentId)
-                .build();
-        databaseTestHelper.addAgreement(agreementParams);
-
-        String postBody = toJson(Map.of(
-                JSON_AMOUNT_KEY, AMOUNT,
-                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
-                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_AGREEMENT_ID_KEY, JSON_VALID_AGREEMENT_ID_VALUE,
-                JSON_AUTH_MODE_KEY, JSON_AUTH_MODE_AGREEMENT
-        ));
-
-        connectorRestApiClient
-                .postCreateCharge(postBody)
-                .statusCode(SC_UNPROCESSABLE_ENTITY)
-                .contentType(JSON)
-                .body("message", contains("Recurring payment agreements are not enabled on this account"))
-                .body("error_identifier", is(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED.toString()));
-    }
-        
     @After
     public void tearDown() {
         databaseTestHelper.truncateAllData();

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
@@ -162,6 +162,7 @@ public class ChargesFrontendResourceIT {
         var agreementServiceId = "service-id";
         var agreementDescription = "a valid description";
         var agreementUserIdentifier = "a-valid-user-identifier";
+        databaseTestHelper.enableRecurring(Long.valueOf(accountId));
         databaseTestHelper.addAgreement(anAddAgreementParams().withServiceId(agreementServiceId).withExternalAgreementId(AGREEMENT_ID)
                 .withReference(agreementReference).withDescription(agreementDescription).withUserIdentifier(agreementUserIdentifier)
                 .withCreatedDate(Instant.now()).withLive(false).withGatewayAccountId(accountId).build());

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/AuthoriseWithUserNotPresentTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/AuthoriseWithUserNotPresentTaskHandlerIT.java
@@ -66,6 +66,7 @@ public class AuthoriseWithUserNotPresentTaskHandlerIT extends ChargingITestBase 
         Logger root = (Logger) LoggerFactory.getLogger(CaptureQueue.class);
         root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
+        databaseTestHelper.enableRecurring(Long.valueOf(accountId));
     }
 
     @Test


### PR DESCRIPTION
Context: requests to setup an agreement by taking the first payment, or taking further payments, should only be allowed when recurring_enabled=true for the gateway account
- Add check for recurring_enabled on first charge request, when authorisation mode is 'web' because user is present, and the payment details are being saved to the agreement to set it up
- Add check for recurring_enabled for subsequent charges on an existing agreement where authorisation mode is 'agreement'
- In each case, throw RCP Exception if recurring_enabled is false
- Update existing unit and integration tests to reflect that test accounts need to have recurring_enabled in relevant scenarios
- Add new unit and integration tests for the above logic