### PR TITLE
PP-10488 Add additional logging for recurring payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
@@ -14,6 +14,9 @@ import javax.inject.Inject;
 import java.time.Clock;
 import java.util.List;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_INSTRUMENT_EXTERNAL_ID;
+
 public class LinkPaymentInstrumentToAgreementService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LinkPaymentInstrumentToAgreementService.class);
@@ -40,6 +43,8 @@ public class LinkPaymentInstrumentToAgreementService {
                             AgreementSetUp.from(agreementEntity, clock.instant()),
                             PaymentInstrumentConfirmed.from(agreementEntity, clock.instant())
                     ));
+                    LOGGER.info("Agreement successfully set up with payment instrument",
+                            kv(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrumentEntity.getExternalId()));
                 }, () -> LOGGER.error("Charge {} references agreement {} but that agreement does not exist", chargeEntity.getExternalId(), agreementId));
             }, () -> LOGGER.error("Expected charge {} to have an agreement but it does not have one", chargeEntity.getExternalId()));
         }, () -> LOGGER.error("Expected charge {} to have a payment instrument but it does not have one", chargeEntity.getExternalId()));

--- a/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
@@ -19,6 +19,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
@@ -110,6 +111,9 @@ public class LedgerService {
     }
     
     private Response postEvents(List<Event> events) {
+        String eventsList = events.stream().map(Event::getEventType).collect(Collectors.joining(", "));
+        logger.info("Making POST request to send events to ledger for: [" + eventsList + "]", 
+                kv("events", events.stream().map(Event::toString).collect(Collectors.toList())));
         var response = postEventClient.target(eventUri)
                 .request()
                 .accept(MediaType.APPLICATION_JSON)

--- a/src/main/java/uk/gov/pay/connector/events/model/Event.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/Event.java
@@ -14,6 +14,7 @@ import uk.gov.service.payments.commons.api.json.ApiResponseInstantWithMicrosecon
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Objects;
+import java.util.Optional;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -78,8 +79,8 @@ public abstract class Event {
     @Override
     public String toString() {
         return "Event{" +
-                "resourceExternalId='" + resourceExternalId + '\'' +
-                ", eventDetails=" + eventDetails.getClass().getCanonicalName() +
+                "eventType=" + getEventType() +
+                ", resourceExternalId='" + resourceExternalId + '\'' +
                 ", timestamp=" + timestamp +
                 '}';
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AgreementEvent.java
@@ -34,13 +34,4 @@ public class AgreementEvent extends Event {
     public String getServiceId() {
         return serviceId;
     }
-
-    @Override
-    public String toString() {
-        return "AgreementEvent{" +
-                "resourceExternalId='" + getResourceExternalId() + '\'' +
-                ", eventDetails=" + getEventDetails() +
-                ", timestamp=" + getTimestamp() +
-                '}';
-    }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
@@ -38,13 +38,4 @@ public class PaymentEvent extends Event {
     public String getServiceId() {
         return serviceId;
     }
-
-    @Override
-    public String toString() {
-        return "PaymentEvent{" +
-                "resourceExternalId='" + getResourceExternalId() + '\'' +
-                ", eventDetails=" + getEventDetails() +
-                ", timestamp=" + getTimestamp() +
-                '}';
-    }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentInstrumentEvent.java
@@ -34,13 +34,4 @@ public class PaymentInstrumentEvent extends Event {
     public String getServiceId() {
         return serviceId;
     }
-
-    @Override
-    public String toString() {
-        return "PaymentInstrument{" +
-                "resourceExternalId='" + getResourceExternalId() + '\'' +
-                ", eventDetails=" + getEventDetails() +
-                ", timestamp=" + getTimestamp() +
-                '}';
-    }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutEvent.java
@@ -32,13 +32,4 @@ public class PayoutEvent extends Event {
     public String getServiceId() {
         return serviceId;
     }
-
-    @Override
-    public String toString() {
-        return "PayoutEvent{" +
-                "resourceExternalId=" + getResourceExternalId() +
-                ", eventDetails=" + getEventDetails() +
-                ", timestamp=" + getTimestamp() +
-                '}';
-    }
 }


### PR DESCRIPTION
- Log when the status of a payment instrument is updated
- Log when we make a HTTP request to ledger to send events for recurring payments
- Log when the agreement is set up with a payment instrument

Remove overridden `toString` method on subclasses of `Event` as they didn't add any additional
useful information, and:
  - Add the `eventType` to the `toString` so this is logged when we make the POST
request to send events to ledger.
  - Remove `eventDetails` as logging the className of the eventDetails associated with an event
isn't particularly useful and throws a NullPointerException unless a null check is done.