### PR TITLE
PP-10498 add authorisation mode to ledger payment pact test

### DIFF
--- a/src/test/resources/pacts/connector-ledger-get-payment-transaction.json
+++ b/src/test/resources/pacts/connector-ledger-get-payment-transaction.json
@@ -51,7 +51,8 @@
           "moto": false,
           "live": false,
           "transaction_id": "e8eq11mi2ndmauvb51qsg8hccn",
-          "disputed": false
+          "disputed": false,
+          "authorisation_mode": "web"
         },
         "matchingRules": {
           "body": {


### PR DESCRIPTION
## WHAT YOU DID
- we are now using authorisation_mode from Ledger, thus we need to check if it comes when getting a payment.

with @alan-gds
