### PR TITLE
PP-10486 refactor to use multilevel credentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -176,70 +176,70 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3734
+        "line_number": 3735
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3782
+        "line_number": 3784
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4391
+        "line_number": 4395
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4458
+        "line_number": 4462
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4480
+        "line_number": 4484
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4659
+        "line_number": 4663
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4662
+        "line_number": 4666
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4665
+        "line_number": 4669
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5255
+        "line_number": 5259
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5266
+        "line_number": 5270
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -352,7 +352,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 83
+        "line_number": 84
       }
     ],
     "src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java": [
@@ -1074,5 +1074,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-27T10:58:06Z"
+  "generated_at": "2023-02-08T17:30:03Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3725,8 +3725,9 @@ components:
         credentials:
           type: object
           additionalProperties:
-            type: string
-            example: "{\"stripe_account_id\":\"accnt_id\"}"
+            type: object
+            example:
+              stripe_account_id: accnt_id
           example:
             stripe_account_id: accnt_id
         external_id:
@@ -3773,8 +3774,9 @@ components:
         credentials:
           type: object
           additionalProperties:
-            type: string
-            example: "{\"stripe_account_id\":\"an-id\"}"
+            type: object
+            example:
+              stripe_account_id: an-id
           example:
             stripe_account_id: an-id
         external_id:
@@ -3822,8 +3824,9 @@ components:
         credentials:
           type: object
           additionalProperties:
-            type: string
-            example: "{\"stripe_account_id\":\"an-id\"}"
+            type: object
+            example:
+              stripe_account_id: an-id
           example:
             stripe_account_id: an-id
         external_id:
@@ -3871,8 +3874,9 @@ components:
         credentials:
           type: object
           additionalProperties:
-            type: string
-            example: "{\"stripe_account_id\":\"an-id\"}"
+            type: object
+            example:
+              stripe_account_id: an-id
           example:
             stripe_account_id: an-id
         external_id:

--- a/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryGatewayRequest.java
@@ -48,7 +48,7 @@ public class ChargeQueryGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, String> getGatewayCredentials() {
+    public Map<String, Object> getGatewayCredentials() {
         return gatewayAccountCredentialsEntity.getCredentials();
     }
     

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -50,11 +50,11 @@ public class EpdqCaptureHandler implements CaptureHandler {
 
     private GatewayOrder buildCaptureOrder(CaptureGatewayRequest request) {
         var epdqPayloadDefinitionForCaptureOrder = new EpdqPayloadDefinitionForCaptureOrder();
-        epdqPayloadDefinitionForCaptureOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinitionForCaptureOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinitionForCaptureOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));
+        epdqPayloadDefinitionForCaptureOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME).toString());
+        epdqPayloadDefinitionForCaptureOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD).toString());
+        epdqPayloadDefinitionForCaptureOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString());
         epdqPayloadDefinitionForCaptureOrder.setPayId(request.getGatewayTransactionId());
-        epdqPayloadDefinitionForCaptureOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinitionForCaptureOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE).toString());
         return epdqPayloadDefinitionForCaptureOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationService.java
@@ -207,7 +207,7 @@ public class EpdqNotificationService {
     }
 
     private String getShaOutPassphrase(GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity) {
-        return gatewayAccountCredentialsEntity.getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE);
+        return gatewayAccountCredentialsEntity.getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString();
     }
 
     private static Optional<ChargeStatus> newChargeStateForChargeNotification(String notificationStatus, Charge charge) {

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -291,20 +291,20 @@ public class EpdqPaymentProvider implements PaymentProvider {
     private GatewayOrder buildQueryOrderRequestFor(Auth3dsResponseGatewayRequest request) {
         var epdqPayloadDefinitionForQueryOrder = new EpdqPayloadDefinitionForQueryOrder();
         epdqPayloadDefinitionForQueryOrder.setOrderId(request.getChargeExternalId());
-        epdqPayloadDefinitionForQueryOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinitionForQueryOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinitionForQueryOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));
-        epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinitionForQueryOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD).toString());
+        epdqPayloadDefinitionForQueryOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME).toString());
+        epdqPayloadDefinitionForQueryOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString());
+        epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE).toString());
         return epdqPayloadDefinitionForQueryOrder.createGatewayOrder();
     }
 
     private GatewayOrder buildQueryOrderRequestFor(ChargeQueryGatewayRequest chargeQueryGatewayRequest) {
         var epdqPayloadDefinitionForQueryOrder = new EpdqPayloadDefinitionForQueryOrder();
         epdqPayloadDefinitionForQueryOrder.setOrderId(chargeQueryGatewayRequest.getChargeExternalId());
-        epdqPayloadDefinitionForQueryOrder.setPassword(chargeQueryGatewayRequest.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinitionForQueryOrder.setUserId(chargeQueryGatewayRequest.getGatewayCredentials().get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinitionForQueryOrder.setPspId(chargeQueryGatewayRequest.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));
-        epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(chargeQueryGatewayRequest.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinitionForQueryOrder.setPassword(chargeQueryGatewayRequest.getGatewayCredentials().get(CREDENTIALS_PASSWORD).toString());
+        epdqPayloadDefinitionForQueryOrder.setUserId(chargeQueryGatewayRequest.getGatewayCredentials().get(CREDENTIALS_USERNAME).toString());
+        epdqPayloadDefinitionForQueryOrder.setPspId(chargeQueryGatewayRequest.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString());
+        epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(chargeQueryGatewayRequest.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE).toString());
         return epdqPayloadDefinitionForQueryOrder.createGatewayOrder();
     }
 
@@ -322,12 +322,12 @@ public class EpdqPaymentProvider implements PaymentProvider {
         }
 
         epdqPayloadDefinition.setOrderId(request.getGovUkPayPaymentId());
-        epdqPayloadDefinition.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinition.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinition.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));
+        epdqPayloadDefinition.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD).toString());
+        epdqPayloadDefinition.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME).toString());
+        epdqPayloadDefinition.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString());
         epdqPayloadDefinition.setAmount(request.getAmount());
         epdqPayloadDefinition.setAuthCardDetails(request.getAuthCardDetails());
-        epdqPayloadDefinition.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinition.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE).toString());
         return epdqPayloadDefinition.createGatewayOrder();
     }
 
@@ -337,10 +337,10 @@ public class EpdqPaymentProvider implements PaymentProvider {
                 .ifPresentOrElse(
                         epdqPayloadDefinitionForCancelOrder::setPayId,
                         () -> epdqPayloadDefinitionForCancelOrder.setOrderId(request.getExternalChargeId()));
-        epdqPayloadDefinitionForCancelOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinitionForCancelOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinitionForCancelOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));
-        epdqPayloadDefinitionForCancelOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinitionForCancelOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME).toString());
+        epdqPayloadDefinitionForCancelOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD).toString());
+        epdqPayloadDefinitionForCancelOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString());
+        epdqPayloadDefinitionForCancelOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE).toString());
         return epdqPayloadDefinitionForCancelOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
@@ -52,12 +52,12 @@ public class EpdqRefundHandler implements RefundHandler {
 
     private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
         var epdqPayloadDefinitionForRefundOrder = new EpdqPayloadDefinitionForRefundOrder();
-        epdqPayloadDefinitionForRefundOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinitionForRefundOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinitionForRefundOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));
+        epdqPayloadDefinitionForRefundOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME).toString());
+        epdqPayloadDefinitionForRefundOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD).toString());
+        epdqPayloadDefinitionForRefundOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString());
         epdqPayloadDefinitionForRefundOrder.setPayId(request.getTransactionId());
         epdqPayloadDefinitionForRefundOrder.setAmount(request.getAmount());
-        epdqPayloadDefinitionForRefundOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinitionForRefundOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE).toString());
         return epdqPayloadDefinitionForRefundOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
@@ -51,7 +51,7 @@ public class Auth3dsResponseGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, String> getGatewayCredentials() {
+    public Map<String, Object> getGatewayCredentials() {
         return charge.getGatewayAccountCredentialsEntity().getCredentials();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -20,7 +20,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     private final String description;
     private final ServicePaymentReference reference;
     private final String govUkPayPaymentId;
-    private final Map<String, String> credentials;
+    private final Map<String, Object> credentials;
     private final GatewayAccountEntity gatewayAccount;
 
     protected AuthorisationGatewayRequest(ChargeEntity charge) {
@@ -38,7 +38,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.gatewayAccount = charge.getGatewayAccount();
     }
 
-    public AuthorisationGatewayRequest(String gatewayTransactionId, 
+    public AuthorisationGatewayRequest(String gatewayTransactionId,
                                        String email,
                                        SupportedLanguage language,
                                        boolean moto,
@@ -46,7 +46,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
                                        String description,
                                        ServicePaymentReference reference,
                                        String govUkPayPaymentId,
-                                       Map<String, String> credentials,
+                                       Map<String, Object> credentials,
                                        GatewayAccountEntity gatewayAccount) {
         this.gatewayTransactionId = gatewayTransactionId;
         this.email = email;
@@ -93,7 +93,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, String> getGatewayCredentials() {
+    public Map<String, Object> getGatewayCredentials() {
         return credentials;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CancelGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CancelGatewayRequest.java
@@ -33,7 +33,7 @@ public class CancelGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, String> getGatewayCredentials() {
+    public Map<String, Object> getGatewayCredentials() {
         return charge.getGatewayAccountCredentialsEntity().getCredentials();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
@@ -58,7 +58,7 @@ public class CaptureGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, String> getGatewayCredentials() {
+    public Map<String, Object> getGatewayCredentials() {
         return charge.getGatewayAccountCredentialsEntity().getCredentials();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayRequest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.model.request;
 
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gateway.GatewayOperation;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.util.Map;
 
@@ -10,5 +10,5 @@ public interface GatewayRequest {
 
     GatewayOperation getRequestType();
 
-    Map<String, String> getGatewayCredentials();
+    Map<String, Object> getGatewayCredentials();
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
@@ -51,7 +51,7 @@ public class RefundGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, String> getGatewayCredentials() {
+    public Map<String, Object> getGatewayCredentials() {
         return credentialsEntity.getCredentials();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
@@ -44,7 +44,7 @@ public class SmartpayCaptureHandler implements CaptureHandler {
     private GatewayOrder buildCaptureOrderFor(CaptureGatewayRequest request) {
         return SmartpayOrderRequestBuilder.aSmartpayCaptureOrderRequestBuilder()
                 .withTransactionId(request.getGatewayTransactionId())
-                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString())
                 .withAmount(request.getAmountAsString())
                 .build();
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -213,7 +213,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     private String getMerchantCode(GatewayRequest request) {
-        return request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID);
+        return request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString();
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
@@ -52,6 +52,6 @@ public class SmartpayRefundHandler implements RefundHandler {
     }
 
     private String getMerchantCode(GatewayRequest request) {
-        return request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID);
+        return request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequest.java
@@ -25,7 +25,7 @@ public class StripeAuthoriseRequest extends StripePostRequest {
             GatewayAccountEntity gatewayAccount,
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
-            Map<String, String> credentials) {
+            Map<String, Object> credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.amount = amount;
         this.description = description;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequest.java
@@ -13,7 +13,7 @@ public abstract class StripeCaptureRequest extends StripePostRequest {
             GatewayAccountEntity gatewayAccount,
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
-            Map<String, String> credentials) {
+            Map<String, Object> credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
     }
     

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentCancelRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentCancelRequest.java
@@ -12,7 +12,7 @@ public class StripePaymentIntentCancelRequest extends StripePostRequest {
 
     private StripePaymentIntentCancelRequest(GatewayAccountEntity gatewayAccount, String stripePaymentIntentId,
                                              String idempotencyKey, StripeGatewayConfig stripeGatewayConfig,
-                                             Map<String, String> credentials) {
+                                             Map<String, Object> credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.stripePaymentIntentId = stripePaymentIntentId;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentCaptureRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentCaptureRequest.java
@@ -16,7 +16,7 @@ public class StripePaymentIntentCaptureRequest extends StripeCaptureRequest {
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             String stripeIdentifier,
-            Map<String, String> credentials) {
+            Map<String, Object> credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.stripeIdentifier = stripeIdentifier;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -25,7 +25,7 @@ public class StripePaymentIntentRequest extends StripePostRequest {
     private StripePaymentIntentRequest(
             GatewayAccountEntity gatewayAccount, String idempotencyKey, StripeGatewayConfig stripeGatewayConfig,
             String amount, String paymentMethodId, String transferGroup, String frontendUrl, String chargeExternalId,
-            String description, boolean moto, Map<String, String> credentials) {
+            String description, boolean moto, Map<String, Object> credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.amount = amount;
         this.paymentMethodId = paymentMethodId;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
@@ -21,7 +21,7 @@ public class StripePaymentMethodRequest extends StripePostRequest {
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             AuthCardDetails authCardDetails,
-            Map<String, String> credentials) {
+            Map<String, Object> credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.authCardDetails = authCardDetails;
         this.northAmericanRegionMapper = new NorthAmericanRegionMapper();

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePostRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePostRequest.java
@@ -30,15 +30,15 @@ public abstract class StripePostRequest implements GatewayClientPostRequest {
     protected StripeGatewayConfig stripeGatewayConfig;
     protected String stripeConnectAccountId;
     protected String gatewayAccountType;
-    protected Map<String, String> credentials;
+    protected Map<String, Object> credentials;
 
     protected StripePostRequest(GatewayAccountEntity gatewayAccount, String idempotencyKey,
-                                StripeGatewayConfig stripeGatewayConfig, Map<String, String>  credentials) {
+                                StripeGatewayConfig stripeGatewayConfig, Map<String, Object>  credentials) {
         if (gatewayAccount == null) {
             throw new IllegalArgumentException("Cannot create StripeRequest without a gateway account");
         }
 
-        String stripeAccountId = credentials.get("stripe_account_id");
+        String stripeAccountId = credentials.get("stripe_account_id").toString();
         if (stripeAccountId == null) {
             throw new IllegalArgumentException("Cannot create StripeRequest without a stripe account id in credentials");
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
@@ -17,7 +17,7 @@ public class StripeRefundRequest extends StripePostRequest {
             String idempotencyKey,
             String stripeChargeId,
             StripeGatewayConfig stripeGatewayConfig,
-            Map<String, String> credentials) {
+            Map<String, Object> credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.stripeChargeId = stripeChargeId;
         this.amount = amount;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -24,7 +24,7 @@ public class StripeTransferInRequest extends StripeTransferRequest {
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             String govukPayTransactionExternalId,
-            Map<String, String> credentials,
+            Map<String, Object> credentials,
             String transferGroup,
             StripeTransferMetadataReason reason) {
         super(amount, gatewayAccount, stripeChargeId, idempotencyKey, stripeGatewayConfig,

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
@@ -16,7 +16,7 @@ public class StripeTransferOutRequest extends StripeTransferRequest {
                                      String idempotencyKey,
                                      StripeGatewayConfig stripeGatewayConfig,
                                      String govukPayTransactionExternalId,
-                                     Map<String, String> credentials) {
+                                     Map<String, Object> credentials) {
         super(amount, gatewayAccount, sourceTransactionId, idempotencyKey, stripeGatewayConfig,
                 govukPayTransactionExternalId, credentials, StripeTransferMetadataReason.TRANSFER_PAYMENT_AMOUNT);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
@@ -20,7 +20,7 @@ public abstract class StripeTransferRequest extends StripePostRequest {
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             String govukPayTransactionExternalId,
-            Map<String, String> credentials,
+            Map<String, Object> credentials,
             StripeTransferMetadataReason reason) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.stripeChargeId = stripeChargeId;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferReversalRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferReversalRequest.java
@@ -15,7 +15,7 @@ public class StripeTransferReversalRequest extends StripePostRequest {
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             String transferId,
-            Map<String, String> credentials) {
+            Map<String, Object> credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.transferId = transferId;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.util.Base64;
 import java.util.Map;
@@ -43,8 +44,8 @@ public class AuthUtil {
     }
 
 
-    public static Map<String, String> getGatewayAccountCredentialsAsAuthHeader(Map<String, String> gatewayCredentials) {
-        String value = encode(gatewayCredentials.get(CREDENTIALS_USERNAME), gatewayCredentials.get(CREDENTIALS_PASSWORD));
+    public static Map<String, String> getGatewayAccountCredentialsAsAuthHeader(Map<String, Object> gatewayCredentials) {
+        String value = encode(gatewayCredentials.get(CREDENTIALS_USERNAME).toString(), gatewayCredentials.get(CREDENTIALS_PASSWORD).toString());
         return ImmutableMap.of(AUTHORIZATION, value);
     }
     

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -51,7 +51,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
     private GatewayOrder buildCaptureOrder(CaptureGatewayRequest request) {
         return aWorldpayCaptureOrderRequestBuilder()
                 .withDate(LocalDate.now(ZoneOffset.UTC))
-                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString())
                 .withAmount(request.getAmountAsString())
                 .withTransactionId(request.getGatewayTransactionId())
                 .build();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -43,7 +43,7 @@ public interface WorldpayOrderBuilder {
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getGovUkPayPaymentId()))
                 .with3dsRequired(is3dsRequired)
                 .withTransactionId(request.getTransactionId().orElse(""))
-                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString())
                 .withAmount(request.getAmount())
                 .withAuthorisationDetails(request.getAuthCardDetails())
                 .withIntegrationVersion3ds(request.getGatewayAccount().getIntegrationVersion3ds())

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -185,7 +185,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     private GatewayOrder buildQuery(ChargeQueryGatewayRequest chargeQueryGatewayRequest) {
         return aWorldpayInquiryRequestBuilder()
                 .withTransactionId(chargeQueryGatewayRequest.getTransactionId())
-                .withMerchantCode(chargeQueryGatewayRequest.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(chargeQueryGatewayRequest.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString())
                 .build();
     }
 
@@ -350,14 +350,14 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                 .withPaResponse3ds(request.getAuth3dsResult().getPaResponse())
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
                 .withTransactionId(request.getTransactionId().orElse(""))
-                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString())
                 .build();
     }
 
     private GatewayOrder buildCancelOrder(CancelGatewayRequest request) {
         return aWorldpayCancelOrderRequestBuilder()
                 .withTransactionId(request.getTransactionId())
-                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString())
                 .build();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -49,7 +49,7 @@ public class WorldpayRefundHandler implements RefundHandler {
     private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
         return aWorldpayRefundOrderRequestBuilder()
                 .withReference(request.getRefundExternalId())
-                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString())
                 .withAmount(request.getAmount())
                 .withTransactionId(request.getTransactionId())
                 .build();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
@@ -69,7 +69,7 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
                 .withUserAgentHeader(request.getWalletAuthorisationData().getPaymentInfo().getUserAgentHeader())
                 .withUserAgentHeader(request.getWalletAuthorisationData().getPaymentInfo().getAcceptHeader())
                 .withTransactionId(request.getTransactionId().orElse(""))
-                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString())
                 .withDescription(request.getDescription())
                 .withAmount(request.getAmount())
                 .build();

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
@@ -29,7 +29,7 @@ public class GatewayAccountCredentials {
     @Schema(example = "{" +
             "  \"stripe_account_id\": \"accnt_id\"" +
             "  }")
-    private Map<String, String> credentials;
+    private Map<String, Object> credentials;
 
     @Schema(example = "ACTIVE")
     private GatewayAccountCredentialState state;
@@ -80,7 +80,7 @@ public class GatewayAccountCredentials {
         return paymentProvider;
     }
 
-    public Map<String, String> getCredentials() {
+    public Map<String, Object> getCredentials() {
         return credentials;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -239,7 +239,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         }
     }
 
-    public Map<String, String> getCredentials(String paymentProvider) {
+    public Map<String, Object> getCredentials(String paymentProvider) {
         List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntities = getGatewayAccountCredentials();
 
         return gatewayAccountCredentialsEntities.stream()
@@ -276,8 +276,14 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @JsonView(Views.FrontendView.class)
     public String getGatewayMerchantId() {
         return getCurrentOrActiveGatewayAccountCredential()
-                .map(credentialsEntity -> credentialsEntity.getCredentials().get("gateway_merchant_id"))
-                .orElse(null);
+                .map(credentialsEntity -> {
+                    if (credentialsEntity.getCredentials() != null &&
+                            credentialsEntity.getCredentials().containsKey("gateway_merchant_id") &&
+                            credentialsEntity.getCredentials().get("gateway_merchant_id") != null) {
+                        return credentialsEntity.getCredentials().get("gateway_merchant_id").toString();
+                    }
+                    return null;
+                }).orElse(null);
     }
 
     @JsonProperty("gateway_account_credentials")

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
@@ -11,7 +11,8 @@ public class StripeAccountService {
 
     public Optional<StripeAccountResponse> buildStripeAccountResponse(GatewayAccountEntity gatewayAccountEntity) {
         return Optional.ofNullable(gatewayAccountEntity.getCredentials(STRIPE.getName()))
-                .map(credentials -> credentials.get("stripe_account_id"))
+                .map(credentials -> credentials.get("stripe_account_id") != null ?
+                        credentials.get("stripe_account_id").toString() : null)
                 .map(StripeAccountResponse::new);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/util/CredentialsConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/util/CredentialsConverter.java
@@ -12,12 +12,12 @@ import java.sql.SQLException;
 import java.util.Map;
 
 @Converter
-public class CredentialsConverter implements AttributeConverter<Map<String,String>, PGobject> {
+public class CredentialsConverter implements AttributeConverter<Map<String,Object>, PGobject> {
     
     private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
-    public PGobject convertToDatabaseColumn(Map<String,String> credentials) {
+    public PGobject convertToDatabaseColumn(Map<String,Object> credentials) {
         PGobject pgCredentials = new PGobject();
         pgCredentials.setType("json");
         try {
@@ -29,7 +29,7 @@ public class CredentialsConverter implements AttributeConverter<Map<String,Strin
     }
 
     @Override
-    public Map<String,String> convertToEntityAttribute(PGobject dbCredentials) {
+    public Map<String, Object> convertToEntityAttribute(PGobject dbCredentials) {
         try {
             return objectMapper.readValue(dbCredentials.toString(), new TypeReference<>() {});
         } catch (IOException e) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -28,6 +28,7 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Objects;
 
 @Entity
 @Table(name = "gateway_account_credentials")
@@ -50,7 +51,7 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     @Schema(example = "{" +
             "                \"stripe_account_id\": \"an-id\"" +
             "            }")
-    private Map<String, String> credentials;
+    private Map<String, Object> credentials;
 
     @Column(name = "state", nullable = false)
     @Enumerated(EnumType.STRING)
@@ -87,7 +88,7 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     }
 
     public GatewayAccountCredentialsEntity(GatewayAccountEntity gatewayAccountEntity, String paymentProvider,
-                                           Map<String, String> credentials, GatewayAccountCredentialState state) {
+                                           Map<String, Object> credentials, GatewayAccountCredentialState state) {
         this.paymentProvider = paymentProvider;
         this.gatewayAccountEntity = gatewayAccountEntity;
         this.credentials = credentials;
@@ -105,7 +106,7 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
         return paymentProvider;
     }
 
-    public Map<String, String> getCredentials() {
+    public Map<String, Object> getCredentials() {
         return credentials;
     }
 
@@ -162,7 +163,7 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
         this.activeEndDate = activeEndDate;
     }
 
-    public void setCredentials(Map<String, String> credentials) {
+    public void setCredentials(Map<String, Object> credentials) {
         this.credentials = credentials;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
@@ -81,7 +81,7 @@ public class GatewayAccountCredentialsRequestValidator {
                 .collect(Collectors.toList());
     }
 
-    public void validatePatch(JsonNode patchRequest, String paymentProvider, Map<String, String> credentials) {
+    public void validatePatch(JsonNode patchRequest, String paymentProvider, Map<String, Object> credentials) {
         Map<PatchPathOperation, Consumer<JsonPatchRequest>> operationValidators = Map.of(
                 new PatchPathOperation(FIELD_CREDENTIALS, JsonPatchOp.REPLACE), operation -> validateReplaceCredentialsOperation(operation, paymentProvider),
                 new PatchPathOperation(FIELD_LAST_UPDATED_BY_USER, JsonPatchOp.REPLACE), JsonPatchRequestValidator::throwIfValueNotString,
@@ -110,7 +110,7 @@ public class GatewayAccountCredentialsRequestValidator {
     }
 
     private void validateGatewayMerchantId(JsonPatchRequest request, String paymentProvider,
-                                           Map<String, String> credentials) {
+                                           Map<String, Object> credentials) {
         if (!WORLDPAY.getName().equals(paymentProvider)) {
             throw new ValidationException(List.of(format("Gateway '%s' does not support digital wallets.", paymentProvider)));
         }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -28,6 +28,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -75,8 +76,10 @@ public class GatewayAccountCredentialsService {
                                                                      String paymentProvider,
                                                                      Map<String, String> credentials) {
         GatewayAccountCredentialState state = calculateStateForNewCredentials(gatewayAccountEntity, paymentProvider, credentials);
+        // We refactored the type to <String, Object> for nested credentials. We need to "cast" credentials until we refactor creation as well
+        Map<String, Object> newMap = new HashMap<>(credentials);
         GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity
-                = new GatewayAccountCredentialsEntity(gatewayAccountEntity, paymentProvider, credentials, state);
+                = new GatewayAccountCredentialsEntity(gatewayAccountEntity, paymentProvider, newMap, state);
 
         if (state == ACTIVE) {
             gatewayAccountCredentialsEntity.setActiveStartDate(Instant.now());
@@ -147,7 +150,7 @@ public class GatewayAccountCredentialsService {
                         GatewayAccountCredentialState.valueOf(patchRequest.valueAsString()));
                 break;
             case GATEWAY_MERCHANT_ID_PATH:
-                HashMap<String, String> updatableMap = new HashMap<>(gatewayAccountCredentialsEntity.getCredentials());
+                HashMap<String, Object> updatableMap = new HashMap<>(gatewayAccountCredentialsEntity.getCredentials());
                 updatableMap.put(FIELD_GATEWAY_MERCHANT_ID, patchRequest.valueAsString());
                 gatewayAccountCredentialsEntity.setCredentials(updatableMap);
                 break;
@@ -157,7 +160,7 @@ public class GatewayAccountCredentialsService {
     }
 
     private void updateCredentials(JsonPatchRequest patchRequest, GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity) {
-        HashMap<String, String> updatableMap = new HashMap<>(gatewayAccountCredentialsEntity.getCredentials());
+        HashMap<String, Object> updatableMap = new HashMap<>(gatewayAccountCredentialsEntity.getCredentials());
         patchRequest.valueAsObject().forEach(updatableMap::put);
         gatewayAccountCredentialsEntity.setCredentials(updatableMap);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
@@ -101,7 +101,7 @@ public abstract class BaseEpdqPaymentProviderIT {
 
     private Invocation.Builder mockClientInvocationBuilder;
 
-    private final Map<String, String> credentials = Map.of(
+    private final Map<String, Object> credentials = Map.of(
             CREDENTIALS_MERCHANT_ID, "merchant-id",
             CREDENTIALS_USERNAME, "username",
             CREDENTIALS_PASSWORD, "password",

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -64,7 +64,7 @@ public class WorldpayCaptureHandlerTest {
     @Mock
     private Response response;
 
-    private final Map<String, String> credentials = Map.of(
+    private final Map<String, Object> credentials = Map.of(
             CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
             CREDENTIALS_USERNAME, "worldpay-password",
             CREDENTIALS_PASSWORD, "password"

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -60,7 +60,7 @@ public class WorldpayWalletAuthorisationHandlerTest {
     @Mock
     private GatewayClient mockGatewayClient;
     private GatewayAccountEntity gatewayAccountEntity;
-    private Map<String, String> gatewayAccountCredentials = Map.of(
+    private Map<String, Object> gatewayAccountCredentials = Map.of(
             CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
             CREDENTIALS_USERNAME, "worldpay-password",
             CREDENTIALS_PASSWORD, "password"

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
@@ -20,7 +20,7 @@ public final class GatewayAccountEntityFixture {
     private Long id = 1L;
     private String gatewayName = SANDBOX.getName();
     private GatewayAccountType type = TEST;
-    private Map<String, String> credentials = Map.of();
+    private Map<String, Object> credentials = Map.of();
     private String serviceName = "Test Service";
     private String description;
     private String analyticsId;
@@ -69,7 +69,7 @@ public final class GatewayAccountEntityFixture {
         return this;
     }
 
-    public GatewayAccountEntityFixture withCredentials(Map<String, String> credentials) {
+    public GatewayAccountEntityFixture withCredentials(Map<String, Object> credentials) {
         this.credentials = credentials;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
@@ -137,7 +137,7 @@ class GatewayAccountEntityTest {
                 .build();
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntity, credentialsEntityWorldpay));
 
-        Map<String, String> actualCreds = gatewayAccountEntity.getCredentials("worldpay");
+        Map<String, Object> actualCreds = gatewayAccountEntity.getCredentials("worldpay");
         assertThat(actualCreds, hasEntry("username", "some-user-name"));
     }
 
@@ -155,7 +155,7 @@ class GatewayAccountEntityTest {
                 .build();
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay, credentialsEntityWorldpayLatest));
 
-        Map<String, String> actualCreds = gatewayAccountEntity.getCredentials("worldpay");
+        Map<String, Object> actualCreds = gatewayAccountEntity.getCredentials("worldpay");
         assertThat(actualCreds, hasEntry("username", "latest-creds-user-name"));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
@@ -115,7 +115,7 @@ public class GatewayAccountCredentialsDaoIT extends DaoITestBase {
     @Test
     public void findByCredentialsKeyValue_shouldFindGatewayAccountCredentialEntity() {
         long gatewayAccountId = nextLong();
-        var credMap = Map.of("some_payment_provider_account_id", "accountid");
+        Map<String, Object> credMap = Map.of("some_payment_provider_account_id", "accountid");
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(String.valueOf(gatewayAccountId))
                 .withPaymentGateway("test provider")
@@ -138,7 +138,7 @@ public class GatewayAccountCredentialsDaoIT extends DaoITestBase {
 
         Optional<GatewayAccountCredentialsEntity> maybeGatewayAccountCredentials = gatewayAccountCredentialsDao.findByCredentialsKeyValue("some_payment_provider_account_id", "accountid");
         assertThat(maybeGatewayAccountCredentials.isPresent(), is(true));
-        Map<String, String> credentialsMap = maybeGatewayAccountCredentials.get().getCredentials();
+        Map<String, Object> credentialsMap = maybeGatewayAccountCredentials.get().getCredentials();
         assertThat(credentialsMap, hasEntry("some_payment_provider_account_id", "accountid"));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityFixture.java
@@ -12,7 +12,7 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 public final class GatewayAccountCredentialsEntityFixture {
     private Instant activeStartDate = Instant.now();
     private String paymentProvider = WORLDPAY.getName();
-    private Map<String, String> credentials = Map.of();
+    private Map<String, Object> credentials = Map.of();
     private GatewayAccountCredentialState state = ACTIVE;
     private GatewayAccountEntity gatewayAccountEntity;
     private String externalId = randomUuid();
@@ -40,7 +40,7 @@ public final class GatewayAccountCredentialsEntityFixture {
         return this;
     }
 
-    public GatewayAccountCredentialsEntityFixture withCredentials(Map<String, String> credentials) {
+    public GatewayAccountCredentialsEntityFixture withCredentials(Map<String, Object> credentials) {
         this.credentials = credentials;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
@@ -55,7 +55,7 @@ public class SendRefundEmailIT {
     private static NotifyClientFactory notifyClientFactory = mock(NotifyClientFactory.class);
     private static NotificationClient notificationClient = mock(NotificationClient.class);
     private static DatabaseTestHelper databaseTestHelper;
-    private static Map<String, String> credentials = ImmutableMap.of(
+    private static Map<String, Object> credentials = ImmutableMap.of(
             CREDENTIALS_MERCHANT_ID, "merchant-id",
             CREDENTIALS_USERNAME, "test-user",
             CREDENTIALS_PASSWORD, "test-password",
@@ -90,7 +90,7 @@ public class SendRefundEmailIT {
 
         given().port(testContext.getPort())
                 .header("X-Forwarded-For", EPDQ_IP_ADDRESS)
-                .body(epdqNotificationPayload(transactionId, payIdSub, "8", credentials.get(CREDENTIALS_SHA_OUT_PASSPHRASE)))
+                .body(epdqNotificationPayload(transactionId, payIdSub, "8", credentials.get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString()))
                 .contentType(APPLICATION_FORM_URLENCODED)
                 .post("/v1/api/notifications/epdq");
 

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -106,7 +106,7 @@ public class ChargingITestBase {
     protected RestAssuredClient connectorRestApiClient;
     protected final String accountId;
     protected final int gatewayAccountCredentialsId; 
-    protected Map<String, String> credentials;
+    protected Map<String, Object> credentials;
     private DatabaseFixtures.TestAccount testAccount;
 
     @DropwizardTestContext
@@ -175,7 +175,7 @@ public class ChargingITestBase {
         databaseTestHelper.truncateAllData();
     }
 
-    public Map<String, String> getCredentials() {
+    public Map<String, Object> getCredentials() {
         return credentials;
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -365,7 +365,7 @@ public class EpdqPaymentProviderTest {
     private void epdqSetupWithStatusCheck(boolean require3ds, boolean requires3ds2) {
         try {
             new URL(url).openConnection().connect();
-            Map<String, String> validEpdqCredentials = ImmutableMap.of(
+            Map<String, Object> validEpdqCredentials = ImmutableMap.of(
                     "merchant_id", merchantId,
                     "username", username,
                     "password", password,

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -90,7 +90,7 @@ public class SmartpayPaymentProviderTest {
         }
 
         new URL(url).openConnection().connect();
-        Map<String, String> validSmartPayCredentials = ImmutableMap.of(
+        Map<String, Object> validSmartPayCredentials = ImmutableMap.of(
                 "merchant_id", "DCOTest",
                 "username", username,
                 "password", password);

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -89,8 +89,8 @@ class WorldpayPaymentProviderTest {
 
     private GatewayAccountEntity validGatewayAccount;
     private GatewayAccountEntity validGatewayAccountFor3ds;
-    private Map<String, String> validCredentials;
-    private Map<String, String> validCredentialsFor3ds;
+    private Map<String, Object> validCredentials;
+    private Map<String, Object> validCredentialsFor3ds;
     private GatewayAccountCredentialsEntity validGatewayAccountCredentialsEntity;
     private GatewayAccountCredentialsEntity validGatewayAccountCredentialsEntityFor3ds;
     private ChargeEntity chargeEntity;
@@ -477,7 +477,7 @@ class WorldpayPaymentProviderTest {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
 
         Long gatewayAccountId = 112233L;
-        var credentials = Map.of(
+        Map<String, Object> credentials = Map.of(
                 "merchant_id", "non-existent-id",
                 "username", "non-existent-username",
                 "password", "non-existent-password"

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -330,7 +330,7 @@ public class DatabaseFixtures {
         long accountId = RandomUtils.nextLong(1, 99999);
         String externalId = randomUuid();
         private String paymentProvider = "sandbox";
-        private Map<String, String> credentialsMap = Map.of();
+        private Map<String, Object> credentialsMap = Map.of();
         private List<AddGatewayAccountCredentialsParams> gatewayAccountCredentialsParams;
         private String serviceName = "service_name";
         private String serviceId = "valid-external-service-id";
@@ -355,7 +355,7 @@ public class DatabaseFixtures {
         private boolean allowTelephonePaymentNotifications;
 
         private boolean recurringEnabled;
-        private final Map<String, String> defaultCredentials = Map.of(
+        private final Map<String, Object> defaultCredentials = Map.of(
                 CREDENTIALS_MERCHANT_ID, "merchant-id",
                 CREDENTIALS_USERNAME, "username",
                 CREDENTIALS_PASSWORD, "password"
@@ -445,7 +445,7 @@ public class DatabaseFixtures {
             return this;
         }
 
-        public TestAccount withCredentials(Map<String, String> credentials) {
+        public TestAccount withCredentials(Map<String, Object> credentials) {
             this.credentialsMap = credentials;
             return this;
         }

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -553,7 +553,7 @@ public class GatewayAccountDaoIT extends DaoITestBase {
     public void isATelephonePaymentNotificationAccount_shouldReturnTrueIfTelephonePaymentNotificationsAreEnabled() {
         long id = nextLong();
         String externalId = randomUuid();
-        Map<String, String> credentials = Map.of(CREDENTIALS_MERCHANT_ID, "merchant-id");
+        Map<String, Object> credentials = Map.of(CREDENTIALS_MERCHANT_ID, "merchant-id");
 
         databaseFixtures
                 .aTestAccount()
@@ -578,7 +578,7 @@ public class GatewayAccountDaoIT extends DaoITestBase {
     public void isATelephonePaymentNotificationAccount_shouldReturnFalseIfTelephonePaymentNotificationsAreNotEnabled() {
         long id = nextLong();
         String externalId = randomUuid();
-        Map<String, String> credentials = Map.of(CREDENTIALS_MERCHANT_ID, "merchant-id");
+        Map<String, Object> credentials = Map.of(CREDENTIALS_MERCHANT_ID, "merchant-id");
 
         databaseFixtures.aTestAccount()
                 .withAccountId(id)

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/BaseGatewayITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/BaseGatewayITest.java
@@ -35,7 +35,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 @RunWith(MockitoJUnitRunner.class)
 abstract public class BaseGatewayITest {
     private static final String TRANSACTION_ID = String.valueOf(nextLong());
-    private static final Map<String, String> CREDENTIALS =
+    private static final Map<String, Object> CREDENTIALS =
             ImmutableMap.of(
                     CREDENTIALS_MERCHANT_ID, "merchant-id",
                     CREDENTIALS_USERNAME, "test-user",

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresIT.java
@@ -50,7 +50,7 @@ import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGa
 public class GatewayAuthFailuresIT {
 
     private static final String TRANSACTION_ID = "7914440428682669";
-    private static final Map<String, String> CREDENTIALS =
+    private static final Map<String, Object> CREDENTIALS =
             ImmutableMap.of("username", "a-user", "password", "a-password", "merchant_id", "aMerchantCode");
     private static final String PAYMENT_PROVIDER = "smartpay";
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceEpdqIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceEpdqIT.java
@@ -152,20 +152,20 @@ public class ChargeExpiryResourceEpdqIT extends ChargingITestBase {
     private String getExpectedRequestBodyToPspForMaintenanceOrder(String gatewayTransactionId) {
         EpdqPayloadDefinitionForCancelOrder order = new EpdqPayloadDefinitionForCancelOrder();
         order.setPayId(gatewayTransactionId);
-        order.setPspId(credentials.get(CREDENTIALS_MERCHANT_ID));
-        order.setUserId(credentials.get(CREDENTIALS_USERNAME));
-        order.setPassword(credentials.get(CREDENTIALS_PASSWORD));
-        order.setShaInPassphrase(credentials.get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        order.setPspId(credentials.get(CREDENTIALS_MERCHANT_ID).toString());
+        order.setUserId(credentials.get(CREDENTIALS_USERNAME).toString());
+        order.setPassword(credentials.get(CREDENTIALS_PASSWORD).toString());
+        order.setShaInPassphrase(credentials.get(CREDENTIALS_SHA_IN_PASSPHRASE).toString());
         return order.createGatewayOrder().getPayload();
     }
 
     private String getExpectedRequestBodyToPspForQueryOrder(String chargeId) {
         EpdqPayloadDefinitionForQueryOrder order = new EpdqPayloadDefinitionForQueryOrder();
         order.setOrderId(chargeId);
-        order.setPspId(credentials.get(CREDENTIALS_MERCHANT_ID));
-        order.setUserId(credentials.get(CREDENTIALS_USERNAME));
-        order.setPassword(credentials.get(CREDENTIALS_PASSWORD));
-        order.setShaInPassphrase(credentials.get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        order.setPspId(credentials.get(CREDENTIALS_MERCHANT_ID).toString());
+        order.setUserId(credentials.get(CREDENTIALS_USERNAME).toString());
+        order.setPassword(credentials.get(CREDENTIALS_PASSWORD).toString());
+        order.setShaInPassphrase(credentials.get(CREDENTIALS_SHA_IN_PASSPHRASE).toString());
         return order.createGatewayOrder().getPayload();
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
@@ -182,8 +182,8 @@ public class GatewayAccountResourceTestBase {
             return this;
         }
 
-        public Map<String, String> getCredentials() {
-            HashMap<String, String> credentials = new HashMap<>();
+        public Map<String, Object> getCredentials() {
+            HashMap<String, Object> credentials = new HashMap<>();
 
             if (this.userName != null) {
                 credentials.put("username", userName);

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceIT.java
@@ -201,10 +201,10 @@ public class EpdqCardResourceIT extends ChargingITestBase {
         EpdqPayloadDefinitionForNewOrder epdqPayloadDefinition = new EpdqPayloadDefinitionForNewOrder();
         epdqPayloadDefinition.setAmount("6234");
         epdqPayloadDefinition.setOrderId(chargeId);
-        epdqPayloadDefinition.setPspId(credentials.get(CREDENTIALS_MERCHANT_ID));
-        epdqPayloadDefinition.setUserId(credentials.get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinition.setPassword(credentials.get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinition.setShaInPassphrase(credentials.get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinition.setPspId(credentials.get(CREDENTIALS_MERCHANT_ID).toString());
+        epdqPayloadDefinition.setUserId(credentials.get(CREDENTIALS_USERNAME).toString());
+        epdqPayloadDefinition.setPassword(credentials.get(CREDENTIALS_PASSWORD).toString());
+        epdqPayloadDefinition.setShaInPassphrase(credentials.get(CREDENTIALS_SHA_IN_PASSPHRASE).toString());
 
         Address address = new Address(ADDRESS_LINE_1, null, ADDRESS_POSTCODE, ADDRESS_CITY, ADDRESS_CITY, ADDRESS_COUNTRY_GB);
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
@@ -63,7 +63,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
         String transactionId = "transaction-id";
         String chargeId = createNewChargeWith(chargeStatus, transactionId);
 
-        String response = notifyConnector(transactionId, "1", "9", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
+        String response = notifyConnector(transactionId, "1", "9", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString().toString())
                 .statusCode(200)
                 .extract().body()
                 .asString();
@@ -78,7 +78,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
         String transactionId = "transaction-id";
         String chargeId = createNewChargeWith(AUTHORISATION_ERROR, transactionId);
 
-        String response = notifyConnector(transactionId, "1", "9", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
+        String response = notifyConnector(transactionId, "1", "9", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString().toString())
                 .statusCode(200)
                 .extract().body()
                 .asString();
@@ -103,7 +103,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
 
         ledgerStub.returnLedgerTransactionForProviderAndGatewayTransactionId(testCharge, getPaymentProvider());
         
-        String response = notifyConnector(gatewayTransactionId, payIdSub, "9", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
+        String response = notifyConnector(gatewayTransactionId, payIdSub, "9", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString())
                 .statusCode(200)
                 .extract().body()
                 .asString();
@@ -119,7 +119,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
         String transactionId = "transaction-id";
         String chargeId = createNewChargeWith(USER_CANCELLED, transactionId);
 
-        String response = notifyConnector(transactionId, "1", "6", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
+        String response = notifyConnector(transactionId, "1", "6", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString())
                 .statusCode(200)
                 .extract().body()
                 .asString();
@@ -138,7 +138,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
                 transactionId,
                 "1",
                 epdqAuthorisedNotificationCode,
-                getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE)
+                getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString()
         )
                 .statusCode(200)
                 .extract().body()
@@ -156,7 +156,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
                 transactionId,
                 "1",
                 epdqAuthorisedCancelledNotificationCode,
-                getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE)
+                getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString()
         )
                 .statusCode(200)
                 .extract().body()
@@ -177,7 +177,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
                 REFUND_SUBMITTED, transactionId + "/" + payIdSub, ZonedDateTime.now(),
                 externalChargeId.toString());
 
-        String response = notifyConnector(transactionId, payIdSub, "8", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
+        String response = notifyConnector(transactionId, payIdSub, "8", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString())
                 .statusCode(200)
                 .extract().body()
                 .asString();
@@ -209,7 +209,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
                 REFUND_SUBMITTED, refundReference, ZonedDateTime.now(),
                 chargeExternalId);
 
-        String response = notifyConnector(gatewayTransactionId, payIdSub, "8", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
+        String response = notifyConnector(gatewayTransactionId, payIdSub, "8", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString())
                 .statusCode(200)
                 .extract().body()
                 .asString();
@@ -231,7 +231,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
         String transactionId = "transaction-id";
         String chargeId = createNewChargeWith(CAPTURE_SUBMITTED, transactionId);
 
-        String response = notifyConnector(transactionId, "GARBAGE", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
+        String response = notifyConnector(transactionId, "GARBAGE", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString())
                 .statusCode(200)
                 .extract().body()
                 .asString();
@@ -246,7 +246,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
         String chargeId = createNewCharge(AUTHORISATION_SUCCESS);
         ledgerStub.returnNotFoundForFindByProviderAndGatewayTransactionId( "epdq", "unknown-transation-id");
 
-        notifyConnector("unknown-transation-id", "GARBAGE", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
+        notifyConnector("unknown-transation-id", "GARBAGE", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString())
                 .statusCode(200)
                 .extract().body()
                 .asString();
@@ -272,7 +272,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
     @Test
     public void shouldFailWhenUnexpectedContentType() {
         given().port(testContext.getPort())
-                .body(epdqNotificationPayload("any", "1", "WHATEVER", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE)))
+                .body(epdqNotificationPayload("any", "1", "WHATEVER", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString()))
                 .contentType(APPLICATION_JSON)
                 .post(NOTIFICATION_PATH)
                 .then()
@@ -284,7 +284,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
         String transactionId = "transaction-id";
         String chargeId = createNewChargeWith(CAPTURE_READY, transactionId);
 
-        notifyConnector(transactionId, "1", "9", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE), UNEXPECTED_IP_ADDRESS)
+        notifyConnector(transactionId, "1", "9", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString(), UNEXPECTED_IP_ADDRESS)
                 .statusCode(403);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundsResourceIT.java
@@ -115,10 +115,10 @@ public class EpdqRefundsResourceIT extends ChargingITestBase {
         EpdqPayloadDefinitionForRefundOrder order = new EpdqPayloadDefinitionForRefundOrder();
         order.setAmount(refundAmount.toString());
         order.setPayId(defaultTestCharge.getTransactionId());
-        order.setPspId(credentials.get(CREDENTIALS_MERCHANT_ID));
-        order.setUserId(credentials.get(CREDENTIALS_USERNAME));
-        order.setPassword(credentials.get(CREDENTIALS_PASSWORD));
-        order.setShaInPassphrase(credentials.get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        order.setPspId(credentials.get(CREDENTIALS_MERCHANT_ID).toString());
+        order.setUserId(credentials.get(CREDENTIALS_USERNAME).toString());
+        order.setPassword(credentials.get(CREDENTIALS_PASSWORD).toString());
+        order.setShaInPassphrase(credentials.get(CREDENTIALS_SHA_IN_PASSPHRASE).toString());
         
         wireMockServer.verify(
                 postRequestedFor(urlPathEqualTo(String.format("/epdq/%s", ROUTE_FOR_MAINTENANCE_ORDER)))

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -575,7 +575,7 @@ public class ContractTest {
 
     @State("a Worldpay gateway account with id 444 with gateway account credentials with id 555 and valid credentials")
     public void aWorldpayGatewayAccountWithFilledCredentialsWithIdExists() {
-        Map<String, String> credentials = Map.of(
+        Map<String, Object> credentials = Map.of(
                 "merchant_id", "a-merchant-id",
                 "username", "a-username",
                 "password", "blablabla");

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountCredentialsParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountCredentialsParams.java
@@ -16,7 +16,7 @@ public class AddGatewayAccountCredentialsParams {
     private Instant activeStartDate;
     private Instant activeEndDate;
     private String paymentProvider;
-    private Map<String, String> credentials;
+    private Map<String, Object> credentials;
     private GatewayAccountCredentialState state;
     private String externalId;
     private String lastUpdatedByUserExternalId;
@@ -42,7 +42,7 @@ public class AddGatewayAccountCredentialsParams {
         return paymentProvider;
     }
 
-    public Map<String, String> getCredentials() {
+    public Map<String, Object> getCredentials() {
         return credentials;
     }
 
@@ -68,7 +68,7 @@ public class AddGatewayAccountCredentialsParams {
         private Instant activeStartDate = null;
         private Instant activeEndDate = null;
         private String paymentProvider = WORLDPAY.getName();
-        private Map<String, String> credentials = Map.of();
+        private Map<String, Object> credentials = Map.of();
         private GatewayAccountCredentialState state = ACTIVE;
         private String externalId = randomUuid();
         private String lastUpdatedByUserExternalId;
@@ -106,7 +106,7 @@ public class AddGatewayAccountCredentialsParams {
             return this;
         }
 
-        public AddGatewayAccountCredentialsParamsBuilder withCredentials(Map<String, String> credentials) {
+        public AddGatewayAccountCredentialsParamsBuilder withCredentials(Map<String, Object> credentials) {
             this.credentials = credentials;
             return this;
         }

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -20,20 +20,11 @@ import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGa
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class AddGatewayAccountParams {
-    private static final Map<String, String> defaultCredentials = Map.of(
+    private static final Map<String, Object> defaultCredentials = Map.of(
             CREDENTIALS_MERCHANT_ID, "merchant-id",
             CREDENTIALS_USERNAME, "username",
             CREDENTIALS_PASSWORD, "password"
     );
-
-    private static final Map<String, String> epdqCredentials = Map.of(
-            CREDENTIALS_MERCHANT_ID, "merchant-id",
-            CREDENTIALS_USERNAME, "username",
-            CREDENTIALS_PASSWORD, "password",
-            CREDENTIALS_SHA_IN_PASSPHRASE, "sha-in",
-            CREDENTIALS_SHA_OUT_PASSPHRASE, "sha-out"
-    );
-
     private String accountId;
     private String externalId;
     private List<AddGatewayAccountCredentialsParams> credentials;
@@ -163,7 +154,7 @@ public class AddGatewayAccountParams {
     public static final class AddGatewayAccountParamsBuilder {
         private String accountId;
         private String paymentGateway = "sandbox";
-        private Map<String, String> credentialsMap = Map.of();
+        private Map<String, Object> credentialsMap = Map.of();
         private List<AddGatewayAccountCredentialsParams> gatewayAccountCredentialsParams;
         private String serviceName = "service name";
         private String serviceId = "a-valid-service-external-id";
@@ -206,7 +197,7 @@ public class AddGatewayAccountParams {
             return this;
         }
 
-        public AddGatewayAccountParamsBuilder withCredentials(Map<String, String> credentials) {
+        public AddGatewayAccountParamsBuilder withCredentials(Map<String, Object> credentials) {
             this.credentialsMap = credentials;
             return this;
         }


### PR DESCRIPTION
## WHAT YOU DID
We are changing credentials from a flat structure to a nested way for RCP. `recurring_merchant_initiated` is now a nested creds.
- refactor crdentials to be able to handle multilevel (Map<String, Object>)

with @alan-gds
