### PR TITLE
PP-10429 Update Worldpay XML Request for Setup Agreement

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -24,7 +24,9 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     private final Map<String, Object> credentials;
     private final GatewayAccountEntity gatewayAccount;
     private final AuthorisationMode authorisationMode;
-
+    private final boolean savePaymentInstrumentToAgreement;
+    private final String agreementId;
+    
     protected AuthorisationGatewayRequest(ChargeEntity charge) {
         // NOTE: we don't store the ChargeEntity as we want to discourage code that deals with this request from
         // updating the charge in the database.
@@ -39,6 +41,8 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.credentials = Optional.ofNullable(charge.getGatewayAccountCredentialsEntity()).map(GatewayAccountCredentialsEntity::getCredentials).orElse(null);
         this.gatewayAccount = charge.getGatewayAccount();
         this.authorisationMode = charge.getAuthorisationMode();
+        this.savePaymentInstrumentToAgreement = charge.isSavePaymentInstrumentToAgreement();
+        this.agreementId = charge.getAgreementId().orElse(null);
     }
 
     public AuthorisationGatewayRequest(String gatewayTransactionId,
@@ -51,7 +55,9 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
                                        String govUkPayPaymentId,
                                        Map<String, Object> credentials,
                                        GatewayAccountEntity gatewayAccount,
-                                       AuthorisationMode authorisationMode) {
+                                       AuthorisationMode authorisationMode,
+                                       boolean savePaymentInstrumentToAgreement,
+                                       String agreementId) {
         this.gatewayTransactionId = gatewayTransactionId;
         this.email = email;
         this.language = language;
@@ -63,6 +69,8 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.credentials = credentials;
         this.gatewayAccount = gatewayAccount;
         this.authorisationMode = authorisationMode;
+        this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
+        this.agreementId = agreementId;
     }
 
     public String getEmail() {
@@ -116,4 +124,13 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     public AuthorisationMode getAuthorisationMode() {
         return authorisationMode;
     }
+
+    public boolean isSavePaymentInstrumentToAgreement() {
+        return savePaymentInstrumentToAgreement;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
@@ -27,7 +27,9 @@ public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest
                 other.getGovUkPayPaymentId(),
                 other.getGatewayCredentials(),
                 other.getGatewayAccount(),
-                other.getAuthorisationMode());
+                other.getAuthorisationMode(),
+                other.isSavePaymentInstrumentToAgreement(),
+                other.getAgreementId());
         this.authCardDetails = authCardDetails;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -42,11 +42,14 @@ public interface WorldpayOrderBuilder {
         return (WorldpayOrderRequestBuilder) builder
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getGovUkPayPaymentId()))
                 .with3dsRequired(is3dsRequired)
+                .withSavePaymentInstrumentToAgreement(request.isSavePaymentInstrumentToAgreement())
+                .withAgreementId(request.getAgreementId())
                 .withTransactionId(request.getTransactionId().orElse(""))
                 .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString())
                 .withAmount(request.getAmount())
                 .withAuthorisationDetails(request.getAuthCardDetails())
                 .withIntegrationVersion3ds(request.getGatewayAccount().getIntegrationVersion3ds())
+                .withPaymentPlatformReference(request.getGovUkPayPaymentId())
                 .withBrowserLanguage(acceptLanguageHeaderParser.getPreferredLanguageFromAcceptLanguageHeader(request.getAuthCardDetails().getAcceptLanguageHeader()));
     }
     

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -34,6 +34,9 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         private String state;
         private boolean exemptionEngineEnabled;
         private int integrationVersion3ds;
+        private boolean savePaymentInstrumentToAgreement;
+
+        private String agreementId;
 
         public int getIntegrationVersion3ds() {
             return integrationVersion3ds;
@@ -140,6 +143,22 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
 
         public void setExemptionEngineEnabled(boolean exemptionEngineEnabled) {
             this.exemptionEngineEnabled = exemptionEngineEnabled;
+        }
+
+        public boolean isSavePaymentInstrumentToAgreement() {
+            return savePaymentInstrumentToAgreement;
+        }
+
+        public void setSavePaymentInstrumentToAgreement(boolean savePaymentInstrumentToAgreement) {
+            this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
+        }
+
+        public String getAgreementId() {
+            return agreementId;
+        }
+
+        public void setAgreementId(String agreementId) {
+            this.agreementId = agreementId;
         }
     }
 
@@ -265,6 +284,15 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         return this;
     }
 
+    public WorldpayOrderRequestBuilder withSavePaymentInstrumentToAgreement(boolean savePaymentInstrumentToAgreement) {
+        worldpayTemplateData.setSavePaymentInstrumentToAgreement(savePaymentInstrumentToAgreement);
+        return this;
+    }
+
+    public WorldpayOrderRequestBuilder withAgreementId(String agreementId) {
+        worldpayTemplateData.setAgreementId(agreementId);
+        return this;
+    }
     @Override
     public MediaType getMediaType() {
         return MediaType.APPLICATION_XML_TYPE;

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -31,6 +31,9 @@
                     </cardAddress>
                     </#if>
                 </CARD-SSL>
+                <#if savePaymentInstrumentToAgreement>
+                <storedCredentials usage="FIRST"/>
+                </#if>
                 <#if requires3ds>
                 <#if payerIpAddress??>
                 <session id="${sessionId?xml}" shopperIPAddress="${payerIpAddress?xml}"/>
@@ -39,8 +42,11 @@
                 </#if>
                 </#if>
             </paymentDetails>
-            <#if requires3ds || payerEmail??>
+            <#if requires3ds || payerEmail?? || savePaymentInstrumentToAgreement>
             <shopper>
+                <#if savePaymentInstrumentToAgreement>
+                <authenticatedShopperID>${agreementId?xml}</authenticatedShopperID>
+                </#if>
                 <#if payerEmail??>
                 <shopperEmailAddress>${payerEmail?xml}</shopperEmailAddress>
                 </#if>
@@ -54,6 +60,11 @@
                 </browser>
                 </#if>
             </shopper>
+            </#if>
+            <#if savePaymentInstrumentToAgreement>
+            <createToken tokenScope="shopper">
+                <tokenEventReference>${paymentPlatformReference?xml}</tokenEventReference>
+            </createToken>
             </#if>
             <#if requires3ds>
             <#if authCardDetails.worldpay3dsFlexDdcResult.isPresent()>

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -32,6 +32,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-state.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-min-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-without-address.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_SETUP_AGREEMENT = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-setup-agreement.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-min-data.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-with-email.xml";

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-setup-agreement.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-setup-agreement.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="transaction-id">
+            <description>This is a description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <CARD-SSL>
+                    <cardNumber>4111111111111111</cardNumber>
+                    <expiryDate>
+                        <date month="12" year="2015"/>
+                    </expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cvc>123</cvc>
+                    <cardAddress>
+                        <address>
+                            <address1>123 My Street</address1>
+                            <address2>This road</address2>
+                            <postalCode>SW8URR</postalCode>
+                            <city>London</city>
+                            <countryCode>GB</countryCode>
+                        </address>
+                    </cardAddress>
+                </CARD-SSL>
+                <storedCredentials usage="FIRST"/>
+            </paymentDetails>
+            <shopper>
+                <authenticatedShopperID>test-agreement-123456</authenticatedShopperID>
+            </shopper>
+            <createToken tokenScope="shopper">
+                <tokenEventReference>test-chargeId-789</tokenEventReference>
+            </createToken>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
- For RCP setup agreement requests to Worldpay, we need to include additional elements in the XML request
- Add storedCredentials element to XML request
- Add authenticatedShopperId to XML request
- Add createToken element to XML request
- Add unit test to ensure XML request is built correctly when savePaymentToInstrument is true