### PR TITLE
PP-10498 add new method to AuthUtil

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -545,7 +545,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 643
+        "line_number": 715
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
@@ -1074,5 +1074,5 @@
       }
     ]
   },
-  "generated_at": "2023-02-08T17:30:03Z"
+  "generated_at": "2023-02-10T16:04:24Z"
 }

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -67,6 +67,7 @@ import uk.gov.pay.connector.gateway.smartpay.auth.SmartpayAccountSpecificAuthent
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountResource;
 import uk.gov.pay.connector.gatewayaccount.resource.StripeAccountResource;
 import uk.gov.pay.connector.gatewayaccount.resource.StripeAccountSetupResource;
+import uk.gov.pay.connector.gatewayaccountcredentials.exception.MissingCredentialsForRecurringPaymentExceptionMapper;
 import uk.gov.pay.connector.gatewayaccountcredentials.exception.NoCredentialsExistForProviderExceptionMapper;
 import uk.gov.pay.connector.gatewayaccountcredentials.exception.NoCredentialsInUsableStateExceptionMapper;
 import uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsResource;
@@ -170,6 +171,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new AuthorisationTimedOutExceptionMapper());
         environment.jersey().register(new GatewayAccountDisabledExceptionMapper());
         environment.jersey().register(new RecurringCardPaymentsNotAllowedExceptionMapper());
+        environment.jersey().register(new MissingCredentialsForRecurringPaymentExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -60,7 +60,7 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
                     WorldpayOrderBuilder.buildAuthoriseOrderWithExemptionEngine(request, withExemptionEngine, acceptLanguageHeaderParser),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode()));
 
             if (response.getEntity().contains("request3DSecure")) {
                 LOGGER.info(format("Worldpay authorisation response when 3ds required: %s", sanitiseMessage(response.getEntity())));

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -41,7 +41,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
                     buildCaptureOrder(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode()));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, WorldpayCaptureResponse.class), PENDING);
         } catch (GatewayException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -143,7 +143,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                 WORLDPAY,
                 chargeQueryGatewayRequest.getGatewayAccount().getType(),
                 buildQuery(chargeQueryGatewayRequest),
-                getGatewayAccountCredentialsAsAuthHeader(chargeQueryGatewayRequest.getGatewayCredentials())
+                getGatewayAccountCredentialsAsAuthHeader(chargeQueryGatewayRequest.getGatewayCredentials(), chargeQueryGatewayRequest.getAuthorisationMode())
         );
         GatewayResponse<WorldpayQueryResponse> worldpayGatewayResponse = getWorldpayGatewayResponse(response, WorldpayQueryResponse.class);
 
@@ -289,7 +289,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                     request.getGatewayAccount().getType(),
                     build3dsResponseAuthOrder(request),
                     cookies,
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode()));
             GatewayResponse<WorldpayOrderStatusResponse> gatewayResponse = getWorldpayGatewayResponse(response);
 
             calculateAndStoreExemption(request.getCharge(), gatewayResponse);
@@ -331,7 +331,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                 WORLDPAY,
                 request.getGatewayAccount().getType(),
                 buildCancelOrder(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode()));
         return getWorldpayGatewayResponse(response);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -39,7 +39,7 @@ public class WorldpayRefundHandler implements RefundHandler {
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
                     buildRefundOrder(request), 
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode()));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, WorldpayRefundResponse.class), PENDING);
         } catch (GatewayException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
@@ -41,7 +41,7 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
                 WORLDPAY,
                 request.getGatewayAccount().getType(),
                 buildWalletAuthoriseOrder(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode()));
         
         return getWorldpayGatewayResponse(response);
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/MissingCredentialsForRecurringPaymentException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/MissingCredentialsForRecurringPaymentException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.exception;
+
+public class MissingCredentialsForRecurringPaymentException extends RuntimeException {
+    public MissingCredentialsForRecurringPaymentException() {
+        super("Credentials are missing for merchant initiated recurring payment");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/MissingCredentialsForRecurringPaymentExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/MissingCredentialsForRecurringPaymentExceptionMapper.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class MissingCredentialsForRecurringPaymentExceptionMapper implements ExceptionMapper<MissingCredentialsForRecurringPaymentException> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MissingCredentialsForRecurringPaymentExceptionMapper.class);
+    @Override
+    public Response toResponse(MissingCredentialsForRecurringPaymentException exception) {
+        LOGGER.info(exception.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.ACCOUNT_NOT_LINKED_WITH_PSP, exception.getMessage());
+        return Response.status(400)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
@@ -1,0 +1,75 @@
+package uk.gov.pay.connector.gateway.util;
+
+import org.junit.Rule;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.rules.ExpectedException;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gatewayaccountcredentials.exception.MissingCredentialsForRecurringPaymentException;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+
+import java.util.Base64;
+import java.util.Map;
+
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
+
+@ExtendWith(MockitoExtension.class)
+class AuthUtilTest {
+    private String merchantCode = "MERCHANTCODE";
+    private String username = "worldpay-username";
+    private String password = "password"; //pragma: allowlist secret
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    void shouldThrowException_whenAuthModeAgreement_andNoCredentials() {
+        MissingCredentialsForRecurringPaymentException thrown = Assertions.assertThrows(MissingCredentialsForRecurringPaymentException.class, () -> {
+            Map<String, Object> credentials = Map.of(
+                    CREDENTIALS_MERCHANT_ID, merchantCode,
+                    CREDENTIALS_USERNAME, username,
+                    CREDENTIALS_PASSWORD, password);
+            AuthUtil.getGatewayAccountCredentialsAsAuthHeader(credentials, AuthorisationMode.AGREEMENT);
+        });
+        assertThat(thrown.getMessage(), is("Credentials are missing for merchant initiated recurring payment"));
+    }
+
+    @Test
+    void shouldRetrieveTheRightCredentialsForRecurringPayments() {
+        Map<String, Object> credentials = Map.of(
+                CREDENTIALS_MERCHANT_ID, merchantCode,
+                CREDENTIALS_USERNAME, username,
+                CREDENTIALS_PASSWORD, password,
+                RECURRING_MERCHANT_INITIATED, Map.of(
+                        CREDENTIALS_MERCHANT_ID, "RC-" + merchantCode,
+                        CREDENTIALS_USERNAME, "RC-" + username,
+                        CREDENTIALS_PASSWORD, "RC-" + password
+                ));
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String("RC-" + username + ":" + "RC-" + password).getBytes());
+        Map<String, String> encodedHeader = AuthUtil.getGatewayAccountCredentialsAsAuthHeader(credentials, AuthorisationMode.AGREEMENT);
+        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
+    }
+
+    @Test
+    void shouldRetrieveTheRightCredentialsForNonRecurringPayments() {
+        Map<String, Object> credentials = Map.of(
+                CREDENTIALS_MERCHANT_ID, merchantCode,
+                CREDENTIALS_USERNAME, username,
+                CREDENTIALS_PASSWORD, password,
+                RECURRING_MERCHANT_INITIATED, Map.of(
+                        CREDENTIALS_MERCHANT_ID, "RC-" + merchantCode,
+                        CREDENTIALS_USERNAME, "RC-" + username,
+                        CREDENTIALS_PASSWORD, "RC-" + password
+                ));
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
+        Map<String, String> encodedHeader = AuthUtil.getGatewayAccountCredentialsAsAuthHeader(credentials, AuthorisationMode.WEB);
+        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandlerTest.java
@@ -33,6 +33,7 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
@@ -69,6 +70,60 @@ class WorldpayRefundHandlerTest {
                         CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
                         CREDENTIALS_USERNAME, "worldpay-password",
                         CREDENTIALS_PASSWORD, "password"
+                ))
+                .withGatewayAccountEntity(gatewayAccountEntity)
+                .withPaymentProvider(WORLDPAY.getName())
+                .withState(ACTIVE)
+                .build();
+        ChargeEntity chargeEntity = chargeEntityFixture
+                .withTransactionId("transaction-id")
+                .withGatewayAccountCredentialsEntity(credentialsEntity)
+                .withPaymentProvider(WORLDPAY.getName())
+                .build();
+        gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntity));
+
+        when(refundGatewayClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
+                .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
+
+        worldpayRefundHandler.refund(RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity, credentialsEntity));
+
+        String expectedRefundRequest =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<!DOCTYPE paymentService PUBLIC \"-//WorldPay//DTD WorldPay PaymentService v1//EN\"\n" +
+                        "        \"http://dtd.worldpay.com/paymentService_v1.dtd\">\n" +
+                        "<paymentService version=\"1.4\" merchantCode=\"MERCHANTCODE\">\n" +
+                        "    <modify>\n" +
+                        "        <orderModification orderCode=\"transaction-id\">\n" +
+                        "            <refund reference=\"" + refundEntity.getExternalId() + "\">\n" +
+                        "                <amount currencyCode=\"GBP\" exponent=\"2\" value=\"500\"/>\n" +
+                        "            </refund>\n" +
+                        "        </orderModification>\n" +
+                        "    </modify>\n" +
+                        "</paymentService>\n" +
+                        "";
+
+        verify(refundGatewayClient).postRequestFor(
+                eq(WORLDPAY_URL),
+                eq(WORLDPAY),
+                eq("test"),
+                argThat(argument -> argument.getPayload().equals(expectedRefundRequest) &&
+                        argument.getOrderRequestType().equals(OrderRequestType.REFUND)),
+                anyMap());
+    }
+
+    @Test
+    void test_refund_request_contains_reference_for_a_recurring_payment() throws Exception {
+        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity().build();
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withCredentials(Map.of(
+                        CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
+                        CREDENTIALS_USERNAME, "worldpay-password",
+                        CREDENTIALS_PASSWORD, "password",
+                        RECURRING_MERCHANT_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_ID, "ECURRING-MERCHANTCODE",
+                                CREDENTIALS_USERNAME, "recurring-worldpay-password",
+                                CREDENTIALS_PASSWORD, "recurring-password"
+                        )
                 ))
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .withPaymentProvider(WORLDPAY.getName())


### PR DESCRIPTION
## WHAT YOU DID
A new method needed that accepts AuthorisationMode with gateway credentials map. If AuthorisationMode is `AGREEMENT`, it should return the nested `recurring_merchant_initiated` creds or throw an excpetion if they are absent.

- implement method
- refactor Worldpay classes to use new method
- add relevant tests

with @alan-gds
