### PR TITLE
PP-10429 Handle Worldpay Response With Recurring Auth Token

### DIFF
--- a/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
@@ -15,6 +15,7 @@ import static javax.ws.rs.core.HttpHeaders.COOKIE;
 import static javax.ws.rs.core.HttpHeaders.SET_COOKIE;
 import static javax.ws.rs.core.MediaType.TEXT_XML;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_3DS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_CREATE_TOKEN_SUCCESS_RESPONSE_WITH_TRANSACTION_IDENTIFIER;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_FAILED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_PARES_PARSE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE;
@@ -59,6 +60,11 @@ public class WorldpayMockClient {
         paymentServiceResponseStubWithMatchingCookieHeader(authorise3dsResponse, cookie);
     }
 
+    public void mockAuthorisationSuccessWithRecurringPaymentToken() {
+        String authoriseResponse = load(WORLDPAY_AUTHORISATION_CREATE_TOKEN_SUCCESS_RESPONSE_WITH_TRANSACTION_IDENTIFIER);
+        paymentServiceResponse(authoriseResponse);
+    }
+    
     public void mockAuthorisationFailure() {
         String authoriseResponse = load(WORLDPAY_AUTHORISATION_FAILED_RESPONSE);
         paymentServiceResponse(authoriseResponse);

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -166,7 +166,7 @@ public class DatabaseTestHelper {
                         .bind("payment_instrument_id", addAgreementParams.getPaymentInstrumentId())
                         .execute());
     }
-
+    
     public void addPaymentInstrument(AddPaymentInstrumentParams addPaymentInstrumentParams) {
         jdbi.withHandle(h ->
                 h.createUpdate("INSERT INTO payment_instruments(" +
@@ -376,7 +376,25 @@ public class DatabaseTestHelper {
                         .execute()
         );
     }
+    
+    public Map<String, Object> getAgreementByExternalId(String agreementExternalId) {
+        return jdbi.withHandle(h -> 
+                h.createQuery("SELECT * FROM agreements WHERE external_id = :agreement_external_id")
+                        .bind("agreement_external_id", agreementExternalId)
+                        .mapToMap()
+                        .first());
+    }
 
+    public Map<String, Object> getPaymentInstrumentByChargeExternalId(String chargeExternalId) {
+        return jdbi.withHandle(h ->
+                h.createQuery("SELECT payment_instruments.* FROM charges " +
+                                "INNER JOIN payment_instruments ON charges.payment_instrument_id = payment_instruments.id " +
+                                "WHERE charges.external_id = :charge_external_id")
+                        .bind("charge_external_id", chargeExternalId)
+                        .mapToMap()
+                        .first());
+    }
+    
     public String getChargeTokenId(Long chargeId) {
 
         return jdbi.withHandle(h ->

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -15,6 +15,10 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_EXEMPTION_REQUEST_SOFT_DECLINE_RESULT_OUT_OF_SCOPE_RESPONSE = WORLDPAY_BASE_NAME + "/exemption-request-soft-decline-result-out-of-scope-response.xml";
     public static final String WORLDPAY_EXEMPTION_REQUEST_DECLINE_RESPONSE = WORLDPAY_BASE_NAME + "/exemption-request-decline-response.xml";
     public static final String WORLDPAY_EXEMPTION_REQUEST_REJECTED_AUTHORISED_RESPONSE = WORLDPAY_BASE_NAME + "/exemption-request-rejected-authorised-response.xml";
+    
+    public static final String WORLDPAY_AUTHORISATION_CREATE_TOKEN_SUCCESS_RESPONSE_WITH_TRANSACTION_IDENTIFIER = WORLDPAY_BASE_NAME + "/authorisation-create-token-success-response-with-transaction-identifier.xml";
+
+    public static final String WORLDPAY_AUTHORISATION_CREATE_TOKEN_SUCCESS_RESPONSE_WITHOUT_TRANSACTION_IDENTIFIER = WORLDPAY_BASE_NAME + "/authorisation-create-token-success-response-without-transaction-identifier.xml";
     static final String WORLDPAY_AUTHORISATION_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-error-response.xml";
     public static final String WORLDPAY_AUTHORISATION_FAILED_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-failed-response.xml";
     static final String WORLDPAY_AUTHORISATION_CANCELLED_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-cancelled-response.xml";

--- a/src/test/resources/templates/worldpay/authorisation-create-token-success-response-with-transaction-identifier.xml
+++ b/src/test/resources/templates/worldpay/authorisation-create-token-success-response-with-transaction-identifier.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <reply>
+        <orderStatus orderCode="transaction-id">
+            <payment>
+                <paymentMethod>VISA-SSL</paymentMethod>
+                <paymentMethodDetail>
+                    <card number="4444********1111" type="creditcard">
+                        <expiryDate>
+                            <date month="11" year="2099"/>
+                        </expiryDate>
+                    </card>
+                </paymentMethodDetail>
+                <amount value="500" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+                <lastEvent>AUTHORISED</lastEvent>
+                <AuthorisationId id="666"/>
+                <CVCResultCode description="NOT SENT TO ACQUIRER"/>
+                <AVSResultCode description="NOT SENT TO ACQUIRER"/>
+                <cardHolderName>
+                    <![CDATA[Coucou]]>
+                </cardHolderName>
+                <issuerCountryCode>N/A</issuerCountryCode>
+                <balance accountType="IN_PROCESS_AUTHORISED">
+                    <amount value="500" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+                </balance>
+                <riskScore value="51"/>
+                <schemeResponse>
+                    <transactionIdentifier>1234567890</transactionIdentifier>
+                </schemeResponse>
+            </payment>
+            <token>
+                <tokenDetails tokenEvent="NEW">
+                    <paymentTokenID>9961191959944156907</paymentTokenID>
+                </tokenDetails>
+            </token>
+        </orderStatus>
+    </reply>
+</paymentService>

--- a/src/test/resources/templates/worldpay/authorisation-create-token-success-response-without-transaction-identifier.xml
+++ b/src/test/resources/templates/worldpay/authorisation-create-token-success-response-without-transaction-identifier.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <reply>
+        <orderStatus orderCode="transaction-id">
+            <payment>
+                <paymentMethod>VISA-SSL</paymentMethod>
+                <paymentMethodDetail>
+                    <card number="4444********1111" type="creditcard">
+                        <expiryDate>
+                            <date month="11" year="2099"/>
+                        </expiryDate>
+                    </card>
+                </paymentMethodDetail>
+                <amount value="500" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+                <lastEvent>AUTHORISED</lastEvent>
+                <AuthorisationId id="666"/>
+                <CVCResultCode description="NOT SENT TO ACQUIRER"/>
+                <AVSResultCode description="NOT SENT TO ACQUIRER"/>
+                <cardHolderName>
+                    <![CDATA[Coucou]]>
+                </cardHolderName>
+                <issuerCountryCode>N/A</issuerCountryCode>
+                <balance accountType="IN_PROCESS_AUTHORISED">
+                    <amount value="500" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+                </balance>
+                <riskScore value="51"/>
+            </payment>
+            <token>
+                <tokenDetails tokenEvent="NEW">
+                    <paymentTokenID>9961191959944156907</paymentTokenID>
+                </tokenDetails>
+            </token>
+        </orderStatus>
+    </reply>
+</paymentService>


### PR DESCRIPTION
Context: when setting up an agreement, Worldpay response includes a paymentTokenID and optionally a transactionIdentifier.
- Save above fields to the recurring_auth_token column in payment_instruments
- Add integration test