### PR TITLE
PP-10429 Create payment instrument after authorise 3ds

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION;
@@ -15,44 +16,50 @@ public class Gateway3DSAuthorisationResponse {
     private final String stringifiedResponse;
     private final Gateway3dsRequiredParams gateway3dsRequiredParams;
     private final ProviderSessionIdentifier providerSessionIdentifier;
+    private Map<String, String> gatewayRecurringAuthToken;
 
-    private Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId, String stringifiedResponse,
-                                            Gateway3dsRequiredParams gateway3dsRequiredParams, ProviderSessionIdentifier providerSessionIdentifier) {
+    private Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus,
+                                            String transactionId,
+                                            String stringifiedResponse,
+                                            Gateway3dsRequiredParams gateway3dsRequiredParams,
+                                            ProviderSessionIdentifier providerSessionIdentifier,
+                                            Map<String, String> gatewayRecurringAuthToken) {
         this.transactionId = transactionId;
         this.authorisationStatus = authorisationStatus;
         this.stringifiedResponse = stringifiedResponse;
         this.gateway3dsRequiredParams = gateway3dsRequiredParams;
         this.providerSessionIdentifier = providerSessionIdentifier;
+        this.gatewayRecurringAuthToken = gatewayRecurringAuthToken;
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, null, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, null, null, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId,
-                                                     Gateway3dsRequiredParams gateway3dsRequiredParams, ProviderSessionIdentifier providerSessionIdentifier) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, gateway3dsRequiredParams, providerSessionIdentifier);
+                                                     Gateway3dsRequiredParams gateway3dsRequiredParams, ProviderSessionIdentifier providerSessionIdentifier, Map<String, String> gatewayRecurringAuthToken) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, gateway3dsRequiredParams, providerSessionIdentifier, gatewayRecurringAuthToken);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", null, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", null, null, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId,
                                                      Gateway3dsRequiredParams gateway3dsRequiredParams, ProviderSessionIdentifier providerSessionIdentifier) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", gateway3dsRequiredParams, providerSessionIdentifier);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", gateway3dsRequiredParams, providerSessionIdentifier, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringifiedResponse, null, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringifiedResponse, null, null, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "", null, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "", null, null, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, Gateway3dsRequiredParams gateway3dsRequiredParams) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringifiedResponse, gateway3dsRequiredParams, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringifiedResponse, gateway3dsRequiredParams, null, null);
     }
 
     public boolean isSuccessful() {
@@ -78,6 +85,10 @@ public class Gateway3DSAuthorisationResponse {
 
     public Optional<ProviderSessionIdentifier> getProviderSessionIdentifier() {
         return Optional.ofNullable(providerSessionIdentifier);
+    }
+
+    public Optional<Map<String, String>> getGatewayRecurringAuthToken() {
+        return Optional.ofNullable(gatewayRecurringAuthToken);
     }
 
     public String toString() {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -303,7 +303,8 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
             BaseAuthoriseResponse authoriseResponse = gatewayResponse.getBaseResponse().get();
 
             return Gateway3DSAuthorisationResponse.of(gatewayResponse.toString(), authoriseResponse.authoriseStatus(), authoriseResponse.getTransactionId(),
-                    authoriseResponse.getGatewayParamsFor3ds().orElse(null), gatewayResponse.getSessionIdentifier().orElse(null));
+                    authoriseResponse.getGatewayParamsFor3ds().orElse(null), gatewayResponse.getSessionIdentifier().orElse(null),
+                    authoriseResponse.getGatewayRecurringAuthToken().orElse(null));
         } catch (GatewayException e) {
             return Gateway3DSAuthorisationResponse.of(e.getMessage(), BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION);
         }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -15,10 +15,12 @@ import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 
 import javax.inject.Inject;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
@@ -126,7 +128,8 @@ public class Card3dsResponseAuthService {
                 AUTHORISATION_3DS,
                 transactionId.orElse(null),
                 operationResponse.getGateway3dsRequiredParams().map(Gateway3dsRequiredParams::toAuth3dsRequiredEntity).orElse(null),
-                operationResponse.getProviderSessionIdentifier().orElse(null)
+                operationResponse.getProviderSessionIdentifier().orElse(null),
+                operationResponse.getGatewayRecurringAuthToken().orElse(null)
         );
 
         var worldPay3dsOrFlexLogMessage = integration3dsType(auth3dsResult, updatedCharge);

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
@@ -4,7 +4,6 @@ import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.apache.commons.lang.math.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.hamcrest.core.Is;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
@@ -13,7 +12,6 @@ import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.it.util.ChargeUtils;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
-import uk.gov.pay.connector.util.AddAgreementParams;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
@@ -29,7 +27,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -47,7 +44,6 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
@@ -59,11 +55,8 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDe
 import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
 import static uk.gov.pay.connector.it.util.ChargeUtils.createNewChargeWithAccountId;
 import static uk.gov.pay.connector.rules.WorldpayMockClient.WORLDPAY_URL;
-import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
-import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
-import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.TransactionId.randomId;
 
 @RunWith(DropwizardJUnitRunner.class)
@@ -301,26 +294,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
 
     @Test
     public void shouldAuthoriseChargeWithSavePaymentInstrumentToAgreement() {
-        AddAgreementParams agreementParams = anAddAgreementParams()
-                .withGatewayAccountId(accountId)
-                .withExternalAgreementId("12345678901234567890123456")
-                .build();
-        databaseTestHelper.addAgreement(agreementParams);
-
-        long chargeId = RandomUtils.nextInt();
-        ChargeUtils.ExternalChargeId externalChargeId = ChargeUtils.ExternalChargeId.fromChargeId(chargeId);
-        databaseTestHelper.addCharge(anAddChargeParams()
-                .withChargeId(chargeId)
-                .withExternalChargeId(externalChargeId.toString())
-                .withGatewayAccountId(accountId)
-                .withPaymentProvider(getPaymentProvider())
-                .withAmount(6234L)
-                .withStatus(ENTERING_CARD_DETAILS)
-                .withEmail("email@fake.test")
-                .withSavePaymentInstrumentToAgreement(true)
-                .withAgreementId("12345678901234567890123456")
-                .withGatewayCredentialId((long) gatewayAccountCredentialsId)
-                .build());
+        ChargeUtils.ExternalChargeId externalChargeId = addChargeForSetUpAgreement(ENTERING_CARD_DETAILS);
 
         givenSetup()
                 .body(buildCorporateJsonAuthorisationDetailsFor(PayersCardType.CREDIT_OR_DEBIT))


### PR DESCRIPTION
Currently, if a recurring auth token is returned from the request to authorise a payment without 3DS, a payment instrument is created and set on the charge.

However, the token may instead be returned on the response to the request to do the 3DS authorisation. If it is returned in this response, create the payment instrument, setting the recurring auth token on it.

Currently this is only done for Worldpay payments.

Co-authored-by: James Peacock <james.peacock@digital.cabinet-office.gov.uk>