### PR TITLE
PP-10429 Add logging for worldpay token creation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -53,6 +53,6 @@ public interface PaymentProvider {
 
     ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundEntityList);
     
-    AuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails);
+    AuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement);
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -253,7 +253,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public EpdqAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
+    public EpdqAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
         return new EpdqAuthorisationRequestSummary(gatewayAccount, authCardDetails);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
@@ -31,5 +31,7 @@ public interface AuthorisationRequestSummary {
     default String ipAddress() { 
         return null; 
     };
+    
+    default Presence setUpAgreement() { return NOT_APPLICABLE; }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -137,7 +137,7 @@ public class SandboxPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public SandboxAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
+    public SandboxAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
         return new SandboxAuthorisationRequestSummary();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -176,7 +176,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public SmartpayAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
+    public SmartpayAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
         return new SmartpayAuthorisationRequestSummary(gatewayAccount, authCardDetails);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -175,7 +175,7 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public StripeAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
+    public StripeAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
         return new StripeAuthorisationRequestSummary(authCardDetails);
     }
     

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
@@ -5,11 +5,17 @@ import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 import java.util.Optional;
 import java.util.StringJoiner;
 
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
 public class AuthorisationRequestSummaryStringifier {
 
     public String stringify(AuthorisationRequestSummary authorisationRequestSummary) {
         var stringJoiner = new StringJoiner(" and ", " ", "");
 
+        if (authorisationRequestSummary.setUpAgreement() == PRESENT) {
+            stringJoiner.add("with set up agreement");
+        }
+        
         switch (authorisationRequestSummary.billingAddress()) {
             case PRESENT:
                 stringJoiner.add("with billing address");

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
@@ -13,12 +13,14 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
     private final Presence dataFor3ds;
     private final Presence deviceDataCollectionResult;
     private String ipAddress;
+    private Presence isSetupAgreement;
 
-    public WorldpayAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
+    public WorldpayAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetupAgreement) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
         deviceDataCollectionResult = authCardDetails.getWorldpay3dsFlexDdcResult().map(address -> PRESENT).orElse(NOT_PRESENT);
         dataFor3ds = (deviceDataCollectionResult == PRESENT || gatewayAccount.isRequires3ds()) ? PRESENT : NOT_PRESENT;
         ipAddress = authCardDetails.getIpAddress().orElse(null);
+        this.isSetupAgreement = isSetupAgreement ? PRESENT: NOT_PRESENT;
     }
 
     @Override
@@ -41,5 +43,8 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
         return ipAddress; 
     }
 
-
+    @Override
+    public Presence setUpAgreement() {
+        return isSetupAgreement;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
@@ -276,6 +276,15 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
         if (isNotBlank(exemptionResponseReason)) {
             joiner.add("exemptionResponse reason: " + exemptionResponseReason);
         }
+        if (isNotBlank(paymentTokenId)) {
+            joiner.add("paymentTokenId: present");
+        }
+        if (isNotBlank(schemeTransactionIdentifier)) {
+            joiner.add("schemeTransactionIdentifier: present");
+        }
+        if (isNotBlank(tokenEvent)) {
+            joiner.add("tokenEvent: " + tokenEvent);
+        }
         if (isNotBlank(getErrorCode())) {
             joiner.add("error code: " + getErrorCode());
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -205,7 +205,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
 
         if (response.getBaseResponse().map(WorldpayOrderStatusResponse::isSoftDecline).orElse(false)) {
 
-            var authorisationRequestSummary = generateAuthorisationRequestSummary(request.getGatewayAccount(), request.getAuthCardDetails());
+            var authorisationRequestSummary = generateAuthorisationRequestSummary(request.getGatewayAccount(), request.getAuthCardDetails(), request.isSavePaymentInstrumentToAgreement());
 
             authorisationLogger.logChargeAuthorisation(
                     LOGGER,
@@ -342,8 +342,8 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     }
 
     @Override
-    public WorldpayAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails) {
-        return new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails);
+    public WorldpayAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
+        return new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails, isSetUpAgreement);
     }
 
     private GatewayOrder build3dsResponseAuthOrder(Auth3dsResponseGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -266,7 +266,7 @@ public class CardAuthoriseService {
     }
 
     private AuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
-        return getPaymentProviderFor(chargeEntity).generateAuthorisationRequestSummary(chargeEntity.getGatewayAccount(), authCardDetails);
+        return getPaymentProviderFor(chargeEntity).generateAuthorisationRequestSummary(chargeEntity.getGatewayAccount(), authCardDetails, chargeEntity.isSavePaymentInstrumentToAgreement());
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
@@ -32,6 +33,21 @@ class AuthorisationRequestSummaryStringifierTest {
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 
         assertThat(result, is(" with billing address and with 3DS data and without device data collection result and with exemption and with remote IP 1.1.1.1"));
+    }
+
+    @Test
+    void stringifySummarises_forSetUpAgreement() {
+        given(mockAuthorisationRequestSummary.billingAddress()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
+        given(mockAuthorisationRequestSummary.exemptionRequest()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.ipAddress()).willReturn("1.1.1.1");
+        given(mockAuthorisationRequestSummary.setUpAgreement()).willReturn(PRESENT);
+
+        String result = stringifier.stringify(mockAuthorisationRequestSummary);
+
+        assertThat(result, is(" with set up agreement and with billing address and with 3DS data and without device data collection result and with exemption and with remote IP 1.1.1.1"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
@@ -27,43 +27,54 @@ class WorldpayAuthorisationRequestSummaryTest {
     @Test
     void billingAddressPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.billingAddress(), is(PRESENT));
     }
 
     @Test
     void billingAddressNotPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
     }
 
     @Test
     void requires3dsFalseMeansDataFor3dsNotPresent() {
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(NOT_PRESENT));
     }
 
     @Test
     void deviceDataCollectionResultPresentMeansDataFor3dsPresent() {
         given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
     }
 
     @Test
     void deviceDataCollectionResultPresent() {
         given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.deviceDataCollectionResult(), is(PRESENT));
     }
 
     @Test
     void dataFor3ds2AlwaysNotApplicable() {
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
     }
 
+    @Test
+    void isSetUpAgreementTrue() {
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, true);
+        assertThat(worldpayAuthorisationRequestSummary.setUpAgreement(), is(PRESENT));
+    }
+
+    @Test
+    void isSetUpAgreementFalse() {
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
+        assertThat(worldpayAuthorisationRequestSummary.setUpAgreement(), is(NOT_PRESENT));
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -96,6 +96,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -207,7 +208,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     @BeforeEach
     void setUpCardAuthorisationService() {
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
-        when(mockedPaymentProvider.generateAuthorisationRequestSummary(any(GatewayAccountEntity.class), any(AuthCardDetails.class)))
+        when(mockedPaymentProvider.generateAuthorisationRequestSummary(any(GatewayAccountEntity.class), any(AuthCardDetails.class), anyBoolean()))
                 .thenReturn(new SandboxAuthorisationRequestSummary());
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -140,8 +140,8 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(WORLDPAY)).thenReturn(mockedWorldpayPaymentProvider);
         when(mockedWorldpayPaymentProvider.generateTransactionId()).thenReturn(Optional.of(TRANSACTION_ID));
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails));
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails, false))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails, false));
 
         Logger root = (Logger) LoggerFactory.getLogger(CardAuthoriseService.class);
         root.setLevel(Level.INFO);
@@ -154,8 +154,8 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
         var worldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build();
         gatewayAccount.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails));
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails, false))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails, false));
 
         AuthorisationResponse response = cardAuthorisationService.doAuthoriseWeb(charge.getExternalId(), authCardDetails);
 
@@ -176,8 +176,8 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
         var worldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build();
         gatewayAccount.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails));
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails, false))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails, false));
 
         AuthorisationResponse response = cardAuthorisationService.doAuthoriseWeb(charge.getExternalId(), authCardDetails);
 


### PR DESCRIPTION
- Update logging for worldpay requests to indicate when setting up an agreement
- Update logging for worldpay response to include existence of paymentTokenId and transactionIdentifier and to include detail of token event