### PR TITLE
PP-10732 Remove authorisation_mode from MDC

### DIFF
--- a/src/main/java/uk/gov/pay/connector/filters/LoggingMDCResponseFilter.java
+++ b/src/main/java/uk/gov/pay/connector/filters/LoggingMDCResponseFilter.java
@@ -8,6 +8,7 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import java.util.List;
 
 import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.AUTHORISATION_MODE;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_TYPE;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
@@ -20,6 +21,6 @@ public class LoggingMDCResponseFilter implements ContainerResponseFilter {
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
         List.of(PAYMENT_EXTERNAL_ID, GATEWAY_ACCOUNT_ID, PROVIDER, GATEWAY_ACCOUNT_TYPE, REFUND_EXTERNAL_ID, 
-                SECURE_TOKEN, PROVIDER_PAYMENT_ID, AGREEMENT_EXTERNAL_ID).forEach(MDC::remove);
+                SECURE_TOKEN, PROVIDER_PAYMENT_ID, AGREEMENT_EXTERNAL_ID, AUTHORISATION_MODE).forEach(MDC::remove);
     }
 }


### PR DESCRIPTION
We add the authorisation_mode to the MDC during handling of some API requests. We need to clean up the MDC when the request responds to ensure no state is leftover that is used by subsequent requests that use the same thread.