### PR TITLE
PP-10427: Put `AgreementEntity` on `ChargeEntity` directly

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -162,84 +162,84 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 3030
+        "line_number": 3028
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 3398
+        "line_number": 3396
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3735
+        "line_number": 3733
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3784
+        "line_number": 3782
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4395
+        "line_number": 4393
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4462
+        "line_number": 4460
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4484
+        "line_number": 4482
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4663
+        "line_number": 4661
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4666
+        "line_number": 4664
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4669
+        "line_number": 4667
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5259
+        "line_number": 5257
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5270
+        "line_number": 5268
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -257,7 +257,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 200
+        "line_number": 201
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java": [
@@ -1074,5 +1074,5 @@
       }
     ]
   },
-  "generated_at": "2023-02-10T16:04:24Z"
+  "generated_at": "2023-02-14T17:25:08Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -2873,8 +2873,6 @@ components:
       type: object
       description: The charge associated with the token
       properties:
-        agreementId:
-          type: string
         amount:
           type: integer
           format: int64

--- a/src/main/java/uk/gov/pay/connector/agreement/model/AgreementEntity.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/model/AgreementEntity.java
@@ -68,7 +68,7 @@ public class AgreementEntity {
         // For JPA
     }
     
-    private AgreementEntity(GatewayAccountEntity gatewayAccount, String serviceId, String reference,
+    public AgreementEntity(GatewayAccountEntity gatewayAccount, String serviceId, String reference,
                             String description, String userIdentifier, boolean live, Instant createdDate, PaymentInstrumentEntity paymentInstrument) {
         this.externalId = RandomIdGenerator.newId();
         this.gatewayAccount = gatewayAccount;

--- a/src/main/java/uk/gov/pay/connector/agreement/model/AgreementResponse.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/model/AgreementResponse.java
@@ -43,14 +43,31 @@ public class AgreementResponse {
     @JsonProperty
     private boolean live;
 
+    private AgreementResponse(String agreementId,
+            Instant createdDate,
+            String reference,
+            String description,
+            String userIdentifier,
+            String serviceId,
+            boolean live) {
+        this.agreementId = agreementId;
+        this.createdDate = createdDate;
+        this.reference = reference;
+        this.description = description;
+        this.userIdentifier = userIdentifier;
+        this.serviceId = serviceId;
+        this.live = live;
+    }
+
     public AgreementResponse(AgreementResponseBuilder agreementResponseBuilder) {
-        this.agreementId = agreementResponseBuilder.getAgreementId();
-        this.createdDate = agreementResponseBuilder.getCreatedDate();
-        this.reference = agreementResponseBuilder.getReference();
-        this.description = agreementResponseBuilder.getDescription();
-        this.userIdentifier = agreementResponseBuilder.getUserIdentifier();
-        this.serviceId = agreementResponseBuilder.getServiceId();
-        this.live = agreementResponseBuilder.isLive();
+        this(agreementResponseBuilder.getAgreementId(),
+            agreementResponseBuilder.getCreatedDate(),
+            agreementResponseBuilder.getReference(),
+            agreementResponseBuilder.getDescription(),
+            agreementResponseBuilder.getUserIdentifier(),
+            agreementResponseBuilder.getServiceId(),
+            agreementResponseBuilder.isLive()
+        );
     }
     
     public String getAgreementId() {
@@ -79,6 +96,18 @@ public class AgreementResponse {
 
     public String getUserIdentifier() {
         return userIdentifier;
+    }
+
+    public static AgreementResponse from(AgreementEntity agreementEntity) {
+        return new AgreementResponse(
+                agreementEntity.getExternalId(),
+                agreementEntity.getCreatedDate(),
+                agreementEntity.getReference(),
+                agreementEntity.getDescription(),
+                agreementEntity.getUserIdentifier(),
+                agreementEntity.getServiceId(),
+                agreementEntity.isLive()
+        );
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
@@ -41,15 +41,7 @@ public class AgreementService {
 
     public Optional<AgreementResponse> findByExternalId(String externalId, long gatewayAccountId) {
         return agreementDao.findByExternalId(externalId, gatewayAccountId)
-                .map(agreementEntity -> new AgreementResponseBuilder()
-                        .withAgreementId(agreementEntity.getExternalId())
-                        .withServiceId(agreementEntity.getServiceId())
-                        .withReference(agreementEntity.getReference())
-                        .withLive(agreementEntity.isLive())
-                        .withCreatedDate(agreementEntity.getCreatedDate())
-                        .withDescription(agreementEntity.getDescription())
-                        .withUserIdentifier(agreementEntity.getUserIdentifier())
-                        .build());
+                .map(AgreementResponse::from);
     }
 
     @Transactional

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import net.logstash.logback.argument.StructuredArgument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.util.ExternalMetadataConverter;
@@ -200,8 +201,10 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @Schema(example = "46eb1b601348499196c99de90482ee68")
     private String serviceId;
 
-    @Column(name = "agreement_id")
-    private String agreementId;
+    @JsonIgnore
+    @ManyToOne
+    @JoinColumn(name = "agreement_id", referencedColumnName="external_id", updatable = false, nullable = true)
+    private AgreementEntity agreementEntity;
     
     @Column(name = "save_payment_instrument_to_agreement")
     private boolean savePaymentInstrumentToAgreement;
@@ -244,7 +247,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
             CardDetailsEntity cardDetails,
             boolean moto,
             String serviceId,
-            String agreementId,
+            AgreementEntity agreementEntity,
             boolean savePaymentInstrumentToAgreement,
             AuthorisationMode authorisationMode
     ) {
@@ -267,7 +270,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.cardDetails = cardDetails;
         this.moto = moto;
         this.serviceId = serviceId;
-        this.agreementId = agreementId;
+        this.agreementEntity = agreementEntity;
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
         this.authorisationMode = authorisationMode;
     }
@@ -416,7 +419,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
                 kv(GATEWAY_ACCOUNT_TYPE, getGatewayAccount().getType()),
                 kv(AUTHORISATION_MODE, authorisationMode)
         ));
-        getAgreementId().ifPresent(agreementExternalId -> structuredArguments.add(kv(AGREEMENT_EXTERNAL_ID, agreementExternalId)));
+        getAgreement().ifPresent(agreementEntity -> structuredArguments.add(kv(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId())));
         return structuredArguments.toArray();
     }
 
@@ -448,8 +451,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.walletType = walletType;
     }
     
-    public void setAgreementId(String agreementId) {
-        this.agreementId = agreementId;
+    public void setAgreementEntity(AgreementEntity agreementEntity) {
+        this.agreementEntity = agreementEntity;
     }
 
     public void setSavePaymentInstrumentToAgreement(boolean savePaymentInstrumentToAgreement) {
@@ -570,8 +573,9 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.serviceId = serviceId;
     }
 
-    public Optional<String> getAgreementId() {
-        return Optional.ofNullable(agreementId);
+    @JsonIgnore
+    public Optional<AgreementEntity> getAgreement() {
+        return Optional.ofNullable(agreementEntity);
     }
 
     public boolean isSavePaymentInstrumentToAgreement() {
@@ -609,7 +613,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         private Source source;
         private boolean moto;
         private String serviceId;
-        private String agreementId;
+        private AgreementEntity agreementEntity;
         private boolean savePaymentInstrumentToAgreement;
         private AuthorisationMode authorisationMode;
 
@@ -691,8 +695,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
             return this;
         }
 
-        public WebChargeEntityBuilder withAgreementId(String agreementId) {
-            this.agreementId = agreementId;
+        public WebChargeEntityBuilder withAgreementEntity(AgreementEntity agreementEntity) {
+            this.agreementEntity = agreementEntity;
             return this;
         }
 
@@ -726,7 +730,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
                     null,
                     moto,
                     serviceId,
-                    agreementId,
+                    agreementEntity,
                     savePaymentInstrumentToAgreement,
                     authorisationMode);
         }
@@ -744,7 +748,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         private ServicePaymentReference reference;
         private ExternalMetadata externalMetadata;
         private String serviceId;
-        private String agreementId;
+        private AgreementEntity agreementEntity;
         private boolean savePaymentInstrumentToAgreement;
 
         private TelephoneChargeEntityBuilder() {
@@ -810,8 +814,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
             return this;
         }
 
-        public TelephoneChargeEntityBuilder withAgreementId(String agreementId) {
-            this.agreementId = agreementId;
+        public TelephoneChargeEntityBuilder withAgreementId(AgreementEntity agreementEntity) {
+            this.agreementEntity = agreementEntity;
             return this;
         }
 
@@ -840,7 +844,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
                     cardDetails,
                     false,
                     serviceId,
-                    agreementId,
+                    agreementEntity,
                     savePaymentInstrumentToAgreement,
                     AuthorisationMode.EXTERNAL);
         }

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -255,8 +255,8 @@ public class ChargesFrontendResource {
             responseBuilder.withCardDetails(persistedCard);
         }
 
-        charge.getAgreementId().ifPresent(responseBuilder::withAgreementId);
-        charge.getAgreementId().flatMap(agreementId -> findAgreement(agreementId, charge.getGatewayAccount().getId())).ifPresent(responseBuilder::withAgreement);
+        charge.getAgreement().ifPresent(agreementEntity -> responseBuilder.withAgreementId(agreementEntity.getExternalId()));
+        charge.getAgreement().map(AgreementResponse::from).ifPresent(responseBuilder::withAgreement);
 
         if (charge.get3dsRequiredDetails() != null) {
             var auth3dsData = new ChargeResponse.Auth3dsData();

--- a/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
@@ -35,17 +35,15 @@ public class LinkPaymentInstrumentToAgreementService {
     @Transactional
     public void linkPaymentInstrumentFromChargeToAgreementFromCharge(ChargeEntity chargeEntity) {
         chargeEntity.getPaymentInstrument().ifPresentOrElse(paymentInstrumentEntity -> {
-            chargeEntity.getAgreementId().ifPresentOrElse(agreementId -> {
-                agreementDao.findByExternalId(agreementId, chargeEntity.getGatewayAccount().getId()).ifPresentOrElse(agreementEntity -> {
-                    agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
-                    paymentInstrumentEntity.setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
-                    ledgerService.postEvent(List.of(
-                            AgreementSetUp.from(agreementEntity, clock.instant()),
-                            PaymentInstrumentConfirmed.from(agreementEntity, clock.instant())
-                    ));
-                    LOGGER.info("Agreement successfully set up with payment instrument",
-                            kv(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrumentEntity.getExternalId()));
-                }, () -> LOGGER.error("Charge {} references agreement {} but that agreement does not exist", chargeEntity.getExternalId(), agreementId));
+            chargeEntity.getAgreement().ifPresentOrElse(agreementEntity -> {
+                agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
+                paymentInstrumentEntity.setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
+                ledgerService.postEvent(List.of(
+                        AgreementSetUp.from(agreementEntity, clock.instant()),
+                        PaymentInstrumentConfirmed.from(agreementEntity, clock.instant())
+                ));
+                LOGGER.info("Agreement successfully set up with payment instrument",
+                        kv(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrumentEntity.getExternalId()));
             }, () -> LOGGER.error("Expected charge {} to have an agreement but it does not have one", chargeEntity.getExternalId()));
         }, () -> LOGGER.error("Expected charge {} to have a payment instrument but it does not have one", chargeEntity.getExternalId()));
     }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
@@ -94,7 +94,7 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 .withSavePaymentInstrumentToAgreement(charge.isSavePaymentInstrumentToAgreement())
                 .withAuthorisationMode(charge.getAuthorisationMode());
 
-        charge.getAgreementId().ifPresent(builder::withAgreementId);
+        charge.getAgreement().ifPresent(agreementEntity -> builder.withAgreementId(agreementEntity.getExternalId()));
         charge.getPaymentInstrument().map(PaymentInstrumentEntity::getExternalId).ifPresent(builder::withPaymentInstrumentId);
 
         if (isAMotoAPIPayment(charge.getAuthorisationMode()) ||

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.model.request;
 
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
@@ -42,7 +43,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.gatewayAccount = charge.getGatewayAccount();
         this.authorisationMode = charge.getAuthorisationMode();
         this.savePaymentInstrumentToAgreement = charge.isSavePaymentInstrumentToAgreement();
-        this.agreementId = charge.getAgreementId().orElse(null);
+        this.agreementId = charge.getAgreement().map(AgreementEntity::getExternalId).orElse(null);
     }
 
     public AuthorisationGatewayRequest(String gatewayTransactionId,

--- a/src/main/java/uk/gov/pay/connector/util/MDCUtils.java
+++ b/src/main/java/uk/gov/pay/connector/util/MDCUtils.java
@@ -16,7 +16,7 @@ public class MDCUtils {
         MDC.put(PAYMENT_EXTERNAL_ID, charge.getExternalId());
         MDC.put(PROVIDER, charge.getPaymentProvider());
         MDC.put(AUTHORISATION_MODE, charge.getAuthorisationMode().getName());
-        charge.getAgreementId().ifPresent(agreementId -> MDC.put(AGREEMENT_EXTERNAL_ID, agreementId));
+        charge.getAgreement().ifPresent(agreementEntity -> MDC.put(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId()));
         
         addGatewayAccountDetailsToMDC(charge.getGatewayAccount());
     }

--- a/src/test/java/uk/gov/pay/connector/agreement/model/AgreementEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/model/AgreementEntityFixture.java
@@ -1,0 +1,75 @@
+package uk.gov.pay.connector.agreement.model;
+
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+
+import java.time.Instant;
+
+public class AgreementEntityFixture {
+
+    private String externalId = "an-agreement-external-id";
+    private GatewayAccountEntity gatewayAccount;
+    private Instant createdDate = Instant.now();
+    private String reference = "an-agreement-reference";
+    private String description = "an-agreement-description";
+    private String userIdentifier;
+    private String serviceId = "a-service-id";
+    private boolean live;
+    private PaymentInstrumentEntity paymentInstrument;
+
+    public static AgreementEntityFixture anAgreementEntity() {
+        return new AgreementEntityFixture();
+    }
+    
+    public AgreementEntityFixture withExternalId(String externalId) {
+        this.externalId = externalId;
+        return this;
+    }
+
+    public AgreementEntityFixture withGatewayAccount(GatewayAccountEntity gatewayAccountEntity) {
+        this.gatewayAccount = gatewayAccountEntity;
+        return this;
+    }
+
+    public AgreementEntityFixture withCreatedDate(Instant createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
+
+    public AgreementEntityFixture withReference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    public AgreementEntityFixture withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public AgreementEntityFixture withUserIdentifier(String userIdentifier) {
+        this.userIdentifier = userIdentifier;
+        return this;
+    }
+
+    public AgreementEntityFixture withServiceId(String serviceId) {
+        this.serviceId = serviceId;
+        return this;
+    }
+
+    public AgreementEntityFixture withLive(boolean live) {
+        this.live = live;
+        return this;
+    }
+
+    public AgreementEntityFixture withPaymentInstrument(PaymentInstrumentEntity paymentInstrument) {
+        this.paymentInstrument = paymentInstrument;
+        return this;
+    }
+
+    public AgreementEntity build() {
+        var agreementEntity = new AgreementEntity(gatewayAccount, serviceId, reference, description, userIdentifier, live, createdDate, paymentInstrument);
+        agreementEntity.setExternalId(externalId);
+        return agreementEntity;
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 import com.google.common.collect.ImmutableMap;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.charge.model.AddressEntity;
@@ -66,7 +67,7 @@ public class ChargeEntityFixture {
     private Exemption3ds exemption3ds;
     private String paymentProvider = "sandbox";
     private String serviceId = randomUuid();
-    private String agreementId;
+    private AgreementEntity agreementEntity;
     private boolean savePaymentInstrumentToAgreement = false;
     private PaymentInstrumentEntity paymentInstrument = null;
     private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
@@ -154,7 +155,7 @@ public class ChargeEntityFixture {
                 cardDetails,
                 moto,
                 serviceId,
-                agreementId,
+                agreementEntity,
                 savePaymentInstrumentToAgreement,
                 authorisationMode);
         chargeEntity.setId(id);
@@ -165,7 +166,7 @@ public class ChargeEntityFixture {
         chargeEntity.set3dsRequiredDetails(auth3DsRequiredEntity);
         chargeEntity.setWalletType(walletType);
         chargeEntity.setExemption3ds(exemption3ds);
-        chargeEntity.setAgreementId(agreementId);
+        chargeEntity.setAgreementEntity(agreementEntity);
         chargeEntity.setPaymentInstrument(paymentInstrument);
         chargeEntity.setUpdatedDate(updatedDate);
 
@@ -342,8 +343,8 @@ public class ChargeEntityFixture {
         return this;
     }
 
-    public ChargeEntityFixture withAgreementId(String agreementId) {
-        this.agreementId = agreementId;
+    public ChargeEntityFixture withAgreementEntity(AgreementEntity agreementEntity) {
+        this.agreementEntity = agreementEntity;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
@@ -204,8 +204,8 @@ class ChargeServiceCreateAgreementTest {
         verify(mockChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
-        assertThat(createdChargeEntity.getAgreementId().isPresent(), is(true));
-        assertThat(createdChargeEntity.getAgreementId().get(), is(AGREEMENT_ID));
+        assertThat(createdChargeEntity.getAgreement().isPresent(), is(true));
+        assertThat(createdChargeEntity.getAgreement().get(), is(mockAgreementEntity));
         assertThat(createdChargeEntity.isSavePaymentInstrumentToAgreement(), is(true));
     }
 
@@ -230,8 +230,8 @@ class ChargeServiceCreateAgreementTest {
         verify(mockChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
-        assertThat(createdChargeEntity.getAgreementId().isPresent(), is(true));
-        assertThat(createdChargeEntity.getAgreementId().get(), is(AGREEMENT_ID));
+        assertThat(createdChargeEntity.getAgreement().isPresent(), is(true));
+        assertThat(createdChargeEntity.getAgreement().get(), is(mockAgreementEntity));
         assertThat(createdChargeEntity.getAuthorisationMode(), is(AuthorisationMode.AGREEMENT));
         assertThat(createdChargeEntity.isSavePaymentInstrumentToAgreement(), is(false));
         assertThat(createdChargeEntity.getPaymentInstrument(), is(Optional.of(mockPaymentInstrumentEntity)));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
@@ -24,6 +24,7 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -52,11 +53,11 @@ class PaymentCreatedTest {
             .withSource(Source.CARD_API)
             .withExternalMetadata(new ExternalMetadata(ImmutableMap.of("key1", "value1", "key2", "value2")))
             .withAuthorisationMode(AuthorisationMode.WEB)
-            .withAgreementId(AGREEMENT_EXTERNAL_ID);
+            .withAgreementEntity(anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build());
     private ChargeEntity chargeEntity;
 
     private String preparePaymentCreatedEvent() throws JsonProcessingException {
-        chargeEntity = chargeEntityFixture.build();
+        chargeEntity = chargeEntityFixture.withAgreementEntity(anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build()).build();
         var paymentCreatedEvent = PaymentCreated.from(chargeEntity);
         return paymentCreatedEvent.toJsonString();
     }
@@ -130,7 +131,7 @@ class PaymentCreatedTest {
     void serializesPayloadWithAgreementIdAndSavePaymentInstrumentToAgreement() throws JsonProcessingException {
         chargeEntityFixture
                 .withSavePaymentInstrumentToAgreement(true)
-                .withAgreementId(AGREEMENT_EXTERNAL_ID);
+                .withAgreementEntity(anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build());
 
         var paymentCreatedEvent = preparePaymentCreatedEvent();
 
@@ -145,7 +146,7 @@ class PaymentCreatedTest {
         PaymentInstrumentEntity paymentInstrumentEntity = aPaymentInstrumentEntity(Instant.parse("2022-07-26T11:22:25Z")).build();
 
         chargeEntityFixture
-                .withAgreementId(AGREEMENT_EXTERNAL_ID)
+                .withAgreementEntity(anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build())
                 .withPaymentInstrument(paymentInstrumentEntity);
 
         var paymentCreatedEvent = preparePaymentCreatedEvent();
@@ -257,7 +258,7 @@ class PaymentCreatedTest {
 
     private void assertRecurringPaymentCreatedDetails(String actual) {
         assertBasePaymentCreatedDetails(actual);
-        assertThat(actual, hasJsonPath("$.event_details.agreement_id", equalTo(chargeEntity.getAgreementId().orElseThrow(IllegalStateException::new))));
+        assertThat(actual, hasJsonPath("$.event_details.agreement_id", equalTo(AGREEMENT_EXTERNAL_ID)));
         assertThat(actual, hasJsonPath("$.event_details.save_payment_instrument_to_agreement", equalTo(chargeEntity.isSavePaymentInstrumentToAgreement())));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -62,6 +62,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
@@ -482,7 +483,7 @@ class WorldpayAuthoriseHandlerTest {
                 .withTransactionId("transaction-id")
                 .withEmail(null)
                 .withSavePaymentInstrumentToAgreement(true)
-                .withAgreementId("test-agreement-123456")
+                .withAgreementEntity(anAgreementEntity().withExternalId("test-agreement-123456").build())
                 .build();
 
         gatewayAccountEntity.setRequires3ds(false);

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -71,6 +71,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
@@ -331,7 +332,7 @@ class WorldpayPaymentProviderTest {
         AuthCardDetails authCardDetails = anAuthCardDetails().withCardNo(cardNumber).build();
         ChargeEntity charge = createChargeEntity();
         charge.setSavePaymentInstrumentToAgreement(true);
-        charge.setAgreementId("test-agreement-123456");
+        charge.setAgreementEntity(anAgreementEntity().build());
         CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
@@ -202,7 +203,7 @@ public class ChargeEntityTest {
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .withPaymentProvider(paymentProvider)
                 .withAuthorisationMode(authorisationMode)
-                .withAgreementId(agreementId)
+                .withAgreementEntity(anAgreementEntity().withExternalId(agreementId).build())
                 .build();
         Object[] structuredLoggingArgs = chargeEntity.getStructuredLoggingArgs();
         assertThat(structuredLoggingArgs, arrayContainingInAnyOrder(

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -64,6 +64,7 @@ import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static java.time.ZonedDateTime.parse;
+import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.events.model.payout.PayoutCreated.from;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
@@ -88,7 +89,7 @@ public class QueueMessageContractTest {
                 .withCorporateSurcharge(55L)
                 .withSource(CARD_API)
                 .withCardDetails(anAuthCardDetails().getCardDetailsEntity())
-                .withAgreementId("an-agreement-id")
+                .withAgreementEntity(anAgreementEntity().build())
                 .build();
 
         PaymentCreated paymentCreatedEvent = new PaymentCreated(
@@ -168,7 +169,7 @@ public class QueueMessageContractTest {
     public String verifyUserEmailCollectedEvent() throws JsonProcessingException {
         ChargeEntity charge = aValidChargeEntity()
                 .withEmail("test@example.org")
-                .withAgreementId("an-agreement-id")
+                .withAgreementEntity(anAgreementEntity().build())
                 .build();
 
         UserEmailCollected userEmailCollected = new UserEmailCollected(


### PR DESCRIPTION
Instead of `ChargeEntity` exposting an `agreementExternalId`, have it contain and expose the `AgreementEntity` directly, so that the `AgreementEntity` doesn't have to keep being looked up by id everywhere else.