### PR TITLE
PP-10430 Add new template for WP recurring payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
@@ -27,6 +28,8 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     private final AuthorisationMode authorisationMode;
     private final boolean savePaymentInstrumentToAgreement;
     private final String agreementId;
+    private final PaymentInstrumentEntity paymentInstrument;
+    
     
     protected AuthorisationGatewayRequest(ChargeEntity charge) {
         // NOTE: we don't store the ChargeEntity as we want to discourage code that deals with this request from
@@ -44,6 +47,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.authorisationMode = charge.getAuthorisationMode();
         this.savePaymentInstrumentToAgreement = charge.isSavePaymentInstrumentToAgreement();
         this.agreementId = charge.getAgreement().map(AgreementEntity::getExternalId).orElse(null);
+        this.paymentInstrument = charge.getPaymentInstrument().orElse(null);
     }
 
     public AuthorisationGatewayRequest(String gatewayTransactionId,
@@ -58,7 +62,8 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
                                        GatewayAccountEntity gatewayAccount,
                                        AuthorisationMode authorisationMode,
                                        boolean savePaymentInstrumentToAgreement,
-                                       String agreementId) {
+                                       String agreementId,
+                                       PaymentInstrumentEntity paymentInstrument) {
         this.gatewayTransactionId = gatewayTransactionId;
         this.email = email;
         this.language = language;
@@ -72,6 +77,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.authorisationMode = authorisationMode;
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
         this.agreementId = agreementId;
+        this.paymentInstrument = paymentInstrument;
     }
 
     public String getEmail() {
@@ -133,5 +139,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     public String getAgreementId() {
         return agreementId;
     }
+    
+    public Optional<PaymentInstrumentEntity> getPaymentInstrument() { return Optional.ofNullable(paymentInstrument); }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
@@ -29,7 +29,8 @@ public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest
                 other.getGatewayAccount(),
                 other.getAuthorisationMode(),
                 other.isSavePaymentInstrumentToAgreement(),
-                other.getAgreementId());
+                other.getAgreementId(),
+                other.getPaymentInstrument().orElse(null));
         this.authCardDetails = authCardDetails;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -35,9 +35,9 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         private boolean exemptionEngineEnabled;
         private int integrationVersion3ds;
         private boolean savePaymentInstrumentToAgreement;
-
         private String agreementId;
-
+        private String schemeTransactionIdentifier;
+        private String paymentTokenId;
         public int getIntegrationVersion3ds() {
             return integrationVersion3ds;
         }
@@ -160,9 +160,26 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         public void setAgreementId(String agreementId) {
             this.agreementId = agreementId;
         }
+
+        public String getSchemeTransactionIdentifier() {
+            return schemeTransactionIdentifier;
+        }
+
+        public void setSchemeTransactionIdentifier(String schemeTransactionIdentifier) {
+            this.schemeTransactionIdentifier = schemeTransactionIdentifier;
+        }
+
+        public String getPaymentTokenId() {
+            return paymentTokenId;
+        }
+
+        public void setPaymentTokenId(String paymentTokenId) {
+            this.paymentTokenId = paymentTokenId;
+        }
     }
 
     public static final TemplateBuilder AUTHORISE_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayAuthoriseOrderTemplate.xml");
+    public static final TemplateBuilder AUTHORISE_RECURRING_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayAuthoriseRecurringOrderTemplate.xml");
     public static final TemplateBuilder AUTHORISE_APPLE_PAY_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayAuthoriseApplePayOrderTemplate.xml");
     public static final TemplateBuilder AUTHORISE_GOOGLE_PAY_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml");
     public static final TemplateBuilder AUTH_3DS_RESPONSE_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/Worldpay3dsResponseAuthOrderTemplate.xml");
@@ -176,6 +193,10 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
 
     public static WorldpayOrderRequestBuilder aWorldpayAuthoriseOrderRequestBuilder() {
         return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), AUTHORISE_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE);
+    }
+
+    public static WorldpayOrderRequestBuilder aWorldpayAuthoriseRecurringOrderRequestBuilder() {
+        return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), AUTHORISE_RECURRING_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE);
     }
 
     public static WorldpayOrderRequestBuilder aWorldpayAuthoriseWalletOrderRequestBuilder(WalletType walletType) {
@@ -291,6 +312,16 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
 
     public WorldpayOrderRequestBuilder withAgreementId(String agreementId) {
         worldpayTemplateData.setAgreementId(agreementId);
+        return this;
+    }
+
+    public WorldpayOrderRequestBuilder withPaymentTokenId(String paymentTokenId) {
+        worldpayTemplateData.setPaymentTokenId(paymentTokenId);
+        return this;
+    }
+    
+    public WorldpayOrderRequestBuilder withSchemeTransactionIdentifier(String schemeTransactionIdentifier) {
+        worldpayTemplateData.setSchemeTransactionIdentifier(schemeTransactionIdentifier);
         return this;
     }
     @Override

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseRecurringOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseRecurringOrderTemplate.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="${merchantCode}">
+    <submit>
+        <order orderCode="${transactionId?xml}">
+            <description>${description?xml}</description>
+            <amount currencyCode="GBP" exponent="2" value="${amount}"/>
+            <paymentDetails>
+                <TOKEN-SSL tokenScope="shopper">
+                    <paymentTokenID>${paymentTokenId}</paymentTokenID>
+                </TOKEN-SSL>
+                <storedCredentials usage="USED" merchantInitiatedReason="UNSCHEDULED">
+                    <#if schemeTransactionIdentifier??>
+                        <schemeTransactionIdentifier>${schemeTransactionIdentifier}</schemeTransactionIdentifier>
+                    </#if>
+                </storedCredentials>
+            </paymentDetails>
+            <shopper>
+                <authenticatedShopperID>${agreementId?xml}</authenticatedShopperID>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -20,6 +20,7 @@ import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.junit.Assert.assertEquals;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpay3dsResponseAuthOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseRecurringOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseWalletOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCancelOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCaptureOrderRequestBuilder;
@@ -30,6 +31,8 @@ import static uk.gov.pay.connector.model.domain.googlepay.GooglePayAuthRequestFi
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_SPECIAL_CHAR_VALID_CAPTURE_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST;
@@ -79,6 +82,37 @@ public class WorldpayOrderRequestBuilderTest {
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 
+    @Test
+    public void shouldGenerateValidAuthoriseRecurringOrderRequestWithSchemeIdentifier() throws Exception {
+        GatewayOrder actualRequest = aWorldpayAuthoriseRecurringOrderRequestBuilder()
+                .withPaymentTokenId("test-payment-token-123456")
+                .withSchemeTransactionIdentifier("test-transaction-id-999999")
+                .withAgreementId("test-agreement-123456")
+                .withTransactionId("test-transaction-id-123")
+                .withMerchantCode("MERCHANTCODE")
+                .withDescription("This is the description")
+                .withAmount("500")
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthoriseRecurringOrderRequestWithOutSchemeIdentifier() throws Exception {
+        GatewayOrder actualRequest = aWorldpayAuthoriseRecurringOrderRequestBuilder()
+                .withPaymentTokenId("test-payment-token-123456")
+                .withAgreementId("test-agreement-123456")
+                .withTransactionId("test-transaction-id-123")
+                .withMerchantCode("MERCHANTCODE")
+                .withDescription("This is the description")
+                .withAmount("500")
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+    
     @Test
     public void shouldGenerateValidAuthoriseOrderRequestForAddressWithMinimumFieldsWhen3dsEnabled() throws Exception {
 

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -35,6 +35,9 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-3ds-with-email.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-state.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-min-address.xml";
+    
+    public static final String WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-recurring-request-with-scheme-identifier.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-recurring-request-without-scheme-identifier.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-without-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_SETUP_AGREEMENT = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-setup-agreement.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-min-data.xml";

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-with-scheme-identifier.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-with-scheme-identifier.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="test-transaction-id-123">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <TOKEN-SSL tokenScope="shopper">
+                    <paymentTokenID>test-payment-token-123456</paymentTokenID>
+                </TOKEN-SSL>
+                <storedCredentials usage="USED" merchantInitiatedReason="UNSCHEDULED">
+                        <schemeTransactionIdentifier>test-transaction-id-999999</schemeTransactionIdentifier>
+                </storedCredentials>
+            </paymentDetails>
+            <shopper>
+                <authenticatedShopperID>test-agreement-123456</authenticatedShopperID>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-without-scheme-identifier.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-without-scheme-identifier.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="test-transaction-id-123">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <TOKEN-SSL tokenScope="shopper">
+                    <paymentTokenID>test-payment-token-123456</paymentTokenID>
+                </TOKEN-SSL>
+                <storedCredentials usage="USED" merchantInitiatedReason="UNSCHEDULED">
+                </storedCredentials>
+            </paymentDetails>
+            <shopper>
+                <authenticatedShopperID>test-agreement-123456</authenticatedShopperID>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
- add a new Worldpay order request template for taking recurring payments
- update the associated order builder
- use this new template when authorisation mode is agreement
- add test for template generation

with @SandorArpa 