### PR TITLE
PP-10430 add a new gateway request type

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RecurringPaymentAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RecurringPaymentAuthorisationGatewayRequest.java
@@ -1,0 +1,89 @@
+package uk.gov.pay.connector.gateway.model.request;
+
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
+import uk.gov.pay.connector.gateway.GatewayOperation;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class RecurringPaymentAuthorisationGatewayRequest implements GatewayRequest{
+    private PaymentInstrumentEntity paymentInstrument;
+    private String agreementId;
+    private String amount;
+    private String gatewayTransactionId;
+    private String description;
+    private Map<String, Object> credentials;
+    private GatewayAccountEntity gatewayAccountEntity;
+
+    private RecurringPaymentAuthorisationGatewayRequest(GatewayAccountEntity gatewayAccountEntity,
+                                                        Map<String, Object> credentials,
+                                                        String agreementId,
+                                                        String amount,
+                                                        String gatewayTransactionId,
+                                                        String description,
+                                                        PaymentInstrumentEntity paymentInstrument) {
+        this.gatewayAccountEntity = gatewayAccountEntity;
+        this.credentials = credentials;
+        this.agreementId = agreementId;
+        this.amount = amount;
+        this.gatewayTransactionId = gatewayTransactionId;
+        this.description = description;
+        this.paymentInstrument = paymentInstrument;
+    }
+
+    public static RecurringPaymentAuthorisationGatewayRequest valueOf(ChargeEntity charge) {
+        return new RecurringPaymentAuthorisationGatewayRequest(charge.getGatewayAccount(),
+                Optional.ofNullable(charge.getGatewayAccountCredentialsEntity()).map(GatewayAccountCredentialsEntity::getCredentials).orElse(null),
+                charge.getAgreement().map(AgreementEntity::getExternalId).orElse(null),
+                String.valueOf(CorporateCardSurchargeCalculator.getTotalAmountFor(charge)),
+                charge.getGatewayTransactionId(),
+                charge.getDescription(),
+                charge.getPaymentInstrument().orElse(null));
+    }
+
+    public Optional<PaymentInstrumentEntity> getPaymentInstrument() {
+        return Optional.ofNullable(paymentInstrument);
+    }
+
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    public String getAmount() {
+        return amount;
+    }
+
+    public Optional<String> getGatewayTransactionId() {
+        return Optional.ofNullable(gatewayTransactionId);
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public GatewayAccountEntity getGatewayAccount() {
+        return gatewayAccountEntity;
+    }
+
+    @Override
+    public GatewayOperation getRequestType() {
+        return GatewayOperation.AUTHORISE;
+    }
+
+    @Override
+    public Map<String, Object> getGatewayCredentials() {
+        return credentials;
+    }
+
+    @Override
+    public AuthorisationMode getAuthorisationMode() {
+        return AuthorisationMode.AGREEMENT;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.worldpay;
 
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.util.AuthUtil;
 import uk.gov.pay.connector.util.AcceptLanguageHeaderParser;
 
@@ -64,7 +65,7 @@ public interface WorldpayOrderBuilder {
         }
     }
 
-    static GatewayOrder buildAuthoriseRecurringOrder(CardAuthorisationGatewayRequest request) {
+    static GatewayOrder buildAuthoriseRecurringOrder(RecurringPaymentAuthorisationGatewayRequest request) {
         var paymentInstrument = request.getPaymentInstrument().orElseThrow(() -> new RuntimeException("Payment instrument not provided when trying to authorise a recurring payment"));
 
         WorldpayOrderRequestBuilder builder = (WorldpayOrderRequestBuilder) aWorldpayAuthoriseRecurringOrderRequestBuilder()
@@ -72,11 +73,11 @@ public interface WorldpayOrderBuilder {
                 .withPaymentTokenId(Optional.ofNullable(paymentInstrument.getRecurringAuthToken().get(WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY)).orElse(""))
                 .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode()))
                 .withAmount(request.getAmount())
-                .withTransactionId(request.getTransactionId().orElse(""))
+                .withTransactionId(request.getGatewayTransactionId().orElse(""))
                 .withDescription(request.getDescription());
 
         if (paymentInstrument.getRecurringAuthToken().get(WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY) != null) {
-            builder.withSchemeTransactionIdentifier(request.getPaymentInstrument().get().getRecurringAuthToken().get(WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY));
+            builder.withSchemeTransactionIdentifier(paymentInstrument.getRecurringAuthToken().get(WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY));
         }
 
         return builder.build();


### PR DESCRIPTION
## WHAT YOU DID
Recurring payments only needs a trimmed down version of CardAuthorisationGatewayRequest.

- add a new implementation of `GatewayRequest` that is to be used by Worldpay's recurring payment order.

with @james-peacock-gds
