### PR TITLE
PP-10430 refactor authorise user not present

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
@@ -31,7 +32,7 @@ public interface PaymentProvider {
 
     GatewayResponse authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) throws GatewayException;
 
-    default GatewayResponse authoriseUserNotPresent(CardAuthorisationGatewayRequest request, ChargeEntity charge) {
+    default GatewayResponse authoriseUserNotPresent(RecurringPaymentAuthorisationGatewayRequest request) {
         throw new NotImplementedException("User-not-present authorisation is not implemented for this payment provider");
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
@@ -68,8 +69,8 @@ public class SandboxPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse authoriseUserNotPresent(CardAuthorisationGatewayRequest request, ChargeEntity charge) {
-        var paymentInstrumentEntity = charge.getPaymentInstrument()
+    public GatewayResponse authoriseUserNotPresent(RecurringPaymentAuthorisationGatewayRequest request) {
+        var paymentInstrumentEntity = request.getPaymentInstrument()
                 .orElseThrow(() -> new IllegalArgumentException("Expected charge to have payment instrument but it does not"));
         var firstDigitsCardNumber = paymentInstrumentEntity.getCardDetails().getFirstDigitsCardNumber().toString();
         var lastDigitsCardNumber = paymentInstrumentEntity.getCardDetails().getLastDigitsCardNumber().toString();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -66,7 +66,7 @@ public interface WorldpayOrderBuilder {
     }
 
     static GatewayOrder buildAuthoriseRecurringOrder(RecurringPaymentAuthorisationGatewayRequest request) {
-        var paymentInstrument = request.getPaymentInstrument().orElseThrow(() -> new RuntimeException("Payment instrument not provided when trying to authorise a recurring payment"));
+        var paymentInstrument = request.getPaymentInstrument().orElseThrow(() -> new IllegalArgumentException("Expected request to have payment instrument but it does not"));
 
         WorldpayOrderRequestBuilder builder = (WorldpayOrderRequestBuilder) aWorldpayAuthoriseRecurringOrderRequestBuilder()
                 .withAgreementId(request.getAgreementId())

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -25,6 +25,7 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
@@ -96,14 +97,15 @@ public class CardAuthoriseService {
 
         try {
             PaymentProvider paymentProvider = getPaymentProviderFor(charge);
-            CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
 
             switch (charge.getAuthorisationMode()) {
                 case WEB:
+                    CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
                     operationResponse = (GatewayResponse<BaseAuthoriseResponse>) paymentProvider.authorise(request, charge);
                     break;
                 case AGREEMENT:
-                    operationResponse = (GatewayResponse<BaseAuthoriseResponse>) paymentProvider.authoriseUserNotPresent(request, charge);
+                    RecurringPaymentAuthorisationGatewayRequest recurringRequest = RecurringPaymentAuthorisationGatewayRequest.valueOf(charge);
+                    operationResponse = (GatewayResponse<BaseAuthoriseResponse>) paymentProvider.authoriseUserNotPresent(recurringRequest);
                     break;
                 default:
                     throw new IllegalArgumentException("Authorise operation does not support authorisation mode");

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
@@ -24,7 +25,6 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
-import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
@@ -115,9 +115,8 @@ public class SandboxPaymentProviderTest {
         var paymentInstrument = aPaymentInstrumentEntity(Instant.now())
                 .withCardDetails(cardDetails)
                 .build();
-        AuthCardDetails authCardDetails = new AuthCardDetails();
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().withPaymentInstrument(paymentInstrument).build();
-        GatewayResponse gatewayResponse = provider.authoriseUserNotPresent(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
+        GatewayResponse gatewayResponse = provider.authoriseUserNotPresent(RecurringPaymentAuthorisationGatewayRequest.valueOf(charge));
 
         assertThat(gatewayResponse.isSuccessful(), is(true));
         assertThat(gatewayResponse.isFailed(), is(false));

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -1048,7 +1048,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     }
 
     private void providerWillRespondToAuthoriseUserNotPresentWith(GatewayResponse authResponse) throws GatewayException {
-        when(mockedPaymentProvider.authoriseUserNotPresent(any(), eq(charge))).thenReturn(authResponse);
+        when(mockedPaymentProvider.authoriseUserNotPresent(any())).thenReturn(authResponse);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.generateTransactionId()).thenReturn(Optional.empty());


### PR DESCRIPTION
## WHAT YOU DID
For recurring payments we're going to use `RecurringPaymentAuthorisationGatewayRequest`. This is because we only need a small subset of `instead of `CardAuthorisationGatewayRequest`

- refactor `PaymentProvider.authoriseUserNotPresent()` to use `RecurringPaymentAuthorisationGatewayRequest` instead of `CardAuthorisationGatewayRequest`.
- refactor `SandboxPaymentProvider`
- refactor relevant, existing tests

with @james-peacock-gds 