### PR TITLE
PP-10427: Set up Stripe recurring payment

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1041,6 +1041,15 @@
         "line_number": 20
       }
     ],
+    "src/test/resources/templates/stripe/create_payment_intent_success_response_with_customer.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/templates/stripe/create_payment_intent_success_response_with_customer.json",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
     "src/test/resources/templates/stripe/get_payment_intent_with_3ds_authorised_success_response.json": [
       {
         "type": "Base64 High Entropy String",

--- a/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
@@ -5,6 +5,7 @@ public enum OrderRequestType {
     AUTHORISE_3DS("authorise3DS"),
     AUTHORISE_APPLE_PAY("authoriseApplePay"),
     AUTHORISE_GOOGLE_PAY("authoriseGooglePay"),
+    AUTHORISE_SAVE_PAYMENT_DETAILS("authoriseSavePaymentDetails"),
     CAPTURE("capture"),
     CANCEL("cancel"),
     REFUND("refund"),

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -7,7 +7,6 @@ import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
-import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
@@ -27,9 +26,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     private final GatewayAccountEntity gatewayAccount;
     private final AuthorisationMode authorisationMode;
     private final boolean savePaymentInstrumentToAgreement;
-    private final String agreementId;
-    private final PaymentInstrumentEntity paymentInstrument;
-    
+    private final Optional<AgreementEntity> agreement;
     
     protected AuthorisationGatewayRequest(ChargeEntity charge) {
         // NOTE: we don't store the ChargeEntity as we want to discourage code that deals with this request from
@@ -46,8 +43,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.gatewayAccount = charge.getGatewayAccount();
         this.authorisationMode = charge.getAuthorisationMode();
         this.savePaymentInstrumentToAgreement = charge.isSavePaymentInstrumentToAgreement();
-        this.agreementId = charge.getAgreement().map(AgreementEntity::getExternalId).orElse(null);
-        this.paymentInstrument = charge.getPaymentInstrument().orElse(null);
+        this.agreement = charge.getAgreement();
     }
 
     public AuthorisationGatewayRequest(String gatewayTransactionId,
@@ -62,8 +58,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
                                        GatewayAccountEntity gatewayAccount,
                                        AuthorisationMode authorisationMode,
                                        boolean savePaymentInstrumentToAgreement,
-                                       String agreementId,
-                                       PaymentInstrumentEntity paymentInstrument) {
+                                       AgreementEntity agreement) {
         this.gatewayTransactionId = gatewayTransactionId;
         this.email = email;
         this.language = language;
@@ -76,8 +71,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.gatewayAccount = gatewayAccount;
         this.authorisationMode = authorisationMode;
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
-        this.agreementId = agreementId;
-        this.paymentInstrument = paymentInstrument;
+        this.agreement = Optional.ofNullable(agreement);
     }
 
     public String getEmail() {
@@ -136,10 +130,8 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         return savePaymentInstrumentToAgreement;
     }
 
-    public String getAgreementId() {
-        return agreementId;
+    public Optional<AgreementEntity> getAgreement() {
+        return agreement;
     }
-    
-    public Optional<PaymentInstrumentEntity> getPaymentInstrument() { return Optional.ofNullable(paymentInstrument); }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.gateway.model.request;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest {
     private AuthCardDetails authCardDetails;
@@ -29,8 +28,7 @@ public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest
                 other.getGatewayAccount(),
                 other.getAuthorisationMode(),
                 other.isSavePaymentInstrumentToAgreement(),
-                other.getAgreementId(),
-                other.getPaymentInstrument().orElse(null));
+                other.getAgreement().orElse(null));
         this.authCardDetails = authCardDetails;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
@@ -2,23 +2,37 @@ package uk.gov.pay.connector.gateway.stripe;
 
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
-import uk.gov.pay.connector.gateway.stripe.json.StripeCharge;
 import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
 import uk.gov.pay.connector.gateway.stripe.response.StripePaymentIntentResponse;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import static java.util.Map.entry;
+
 public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
+
+    public static final String STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY = "customerId";
+    public static final String STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY = "paymentMethodId";
 
     private final String transactionId;
     private final AuthoriseStatus authoriseStatus;
     private final String redirectUrl;
 
     private final String stringifiedResponse;
+    private final String customerId;
+    private final String paymentMethodId;
 
-    private StripeAuthorisationResponse(String transactionId, AuthoriseStatus authoriseStatus, String redirectUrl, String stringifiedResponse) {
-        if (Objects.isNull(authoriseStatus )) {
+    private StripeAuthorisationResponse(String transactionId,
+                                        AuthoriseStatus authoriseStatus,
+                                        String redirectUrl,
+                                        String stringifiedResponse,
+                                        String customerId,
+                                        String paymentMethodId) {
+        this.customerId = customerId;
+        this.paymentMethodId = paymentMethodId;
+        if (Objects.isNull(authoriseStatus)) {
             throw new IllegalArgumentException("Authorise status cannot be null");
         }
         this.transactionId = transactionId;
@@ -32,17 +46,10 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
                 stripePaymentIntent.getId(),
                 stripePaymentIntent.getAuthoriseStatus().orElse(null),
                 stripePaymentIntent.getRedirectUrl().orElse(null),
-                stripePaymentIntent.getStringifiedOutcome()
-        );
-    }
-
-    public static StripeAuthorisationResponse of(StripeCharge stripeCharge) {
-        return new StripeAuthorisationResponse(
-                stripeCharge.getId(),
-                stripeCharge.getAuthorisationStatus().orElse(null),
-                null,
-                null
-        );
+                stripePaymentIntent.getStringifiedOutcome(),
+                stripePaymentIntent.getCustomerId(),
+                stripePaymentIntent.getPaymentMethodId()
+                );
     }
 
     @Override
@@ -74,5 +81,13 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
     @Override
     public String toString() {
         return stringifiedResponse == null ? "" : stringifiedResponse;
+    }
+
+    @Override
+    public Optional<Map<String, String>> getGatewayRecurringAuthToken() {
+        return Optional.ofNullable(customerId).map(id -> Map.ofEntries(
+                entry(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY, customerId),
+                entry(STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY, paymentMethodId)
+        ));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequest.java
@@ -1,0 +1,72 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.Map;
+
+import static java.util.Map.entry;
+
+public class StripeCustomerRequest extends StripePostRequest {
+    
+    private final String name;
+    private final String description;
+
+    private StripeCustomerRequest(
+            GatewayAccountEntity gatewayAccount,
+            String idempotencyKey,
+            StripeGatewayConfig stripeGatewayConfig,
+            AuthCardDetails authCardDetails,
+            AgreementEntity agreement,
+            Map<String, Object> credentials) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
+        name = authCardDetails.getCardHolder();
+        description = agreement.getDescription();
+    }
+
+    public static StripeCustomerRequest of(CardAuthorisationGatewayRequest request, StripeGatewayConfig config, AgreementEntity agreement) {
+        return new StripeCustomerRequest(
+                request.getGatewayAccount(),
+                request.getGovUkPayPaymentId(),
+                config,
+                request.getAuthCardDetails(),
+                agreement,
+                request.getGatewayCredentials()
+        );
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    protected Map<String, String> params() {
+        return Map.ofEntries(
+                entry("name", name),
+                entry("description", description));
+    }
+
+    @Override
+    protected String urlPath() {
+        return "/v1/customers";
+    }
+
+    @Override
+    protected OrderRequestType orderRequestType() {
+        return OrderRequestType.AUTHORISE_SAVE_PAYMENT_DETAILS;
+    }
+
+    @Override
+    protected String idempotencyKeyType() {
+        return "customer";
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -21,11 +21,12 @@ public class StripePaymentIntentRequest extends StripePostRequest {
     private final String chargeExternalId;
     private final String description;
     private boolean moto;
+    private final String customerId;
 
     private StripePaymentIntentRequest(
             GatewayAccountEntity gatewayAccount, String idempotencyKey, StripeGatewayConfig stripeGatewayConfig,
             String amount, String paymentMethodId, String transferGroup, String frontendUrl, String chargeExternalId,
-            String description, boolean moto, Map<String, Object> credentials) {
+            String description, boolean moto, Map<String, Object> credentials, String customerId) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.amount = amount;
         this.paymentMethodId = paymentMethodId;
@@ -34,6 +35,7 @@ public class StripePaymentIntentRequest extends StripePostRequest {
         this.chargeExternalId = chargeExternalId;
         this.description = description;
         this.moto = moto;
+        this.customerId = customerId;
     }
 
     public static StripePaymentIntentRequest of(
@@ -52,8 +54,33 @@ public class StripePaymentIntentRequest extends StripePostRequest {
                 request.getGovUkPayPaymentId(),
                 request.getDescription(),
                 request.isMoto(),
-                request.getGatewayCredentials()
-        );
+                request.getGatewayCredentials(),
+                null);
+    }
+
+    public static StripePaymentIntentRequest of(
+            CardAuthorisationGatewayRequest request,
+            String paymentMethodId,
+            StripeGatewayConfig stripeGatewayConfig,
+            String frontendUrl,
+            String customerId) {
+        return new StripePaymentIntentRequest(
+                request.getGatewayAccount(),
+                request.getGovUkPayPaymentId(),
+                stripeGatewayConfig,
+                request.getAmount(),
+                paymentMethodId,
+                request.getGovUkPayPaymentId(),
+                frontendUrl,
+                request.getGovUkPayPaymentId(),
+                request.getDescription(),
+                request.isMoto(),
+                request.getGatewayCredentials(),
+                customerId);
+    }
+    
+    public String getCustomerId() {
+        return customerId;
     }
 
     @Override
@@ -83,6 +110,11 @@ public class StripePaymentIntentRequest extends StripePostRequest {
 
         if (moto) {
             params.put("payment_method_options[card[moto]]", "true");
+        }
+
+        if (customerId != null) {
+            params.put("customer", customerId);
+            params.put("setup_future_usage", "off_session");
         }
 
         return params;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeCustomerResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeCustomerResponse.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.gateway.stripe.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripeCustomerResponse {
+    @JsonProperty("id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentIntentResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentIntentResponse.java
@@ -29,6 +29,12 @@ public class StripePaymentIntentResponse {
     private StripePaymentIntent.ChargesCollection chargesCollection;
 
     private String status;
+    
+    @JsonProperty("customer")
+    private String customerId;
+    
+    @JsonProperty("payment_method")
+    private String paymentMethodId;
 
     public String getId() {
         return id;
@@ -36,6 +42,14 @@ public class StripePaymentIntentResponse {
 
     public String getStatus() {
         return status;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public String getPaymentMethodId() {
+        return paymentMethodId;
     }
 
     public Optional<String> getRedirectUrl() {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
@@ -47,7 +48,7 @@ public interface WorldpayOrderBuilder {
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getGovUkPayPaymentId()))
                 .with3dsRequired(is3dsRequired)
                 .withSavePaymentInstrumentToAgreement(request.isSavePaymentInstrumentToAgreement())
-                .withAgreementId(request.getAgreementId())
+                .withAgreementId(request.getAgreement().map(AgreementEntity::getExternalId).orElse(null))
                 .withTransactionId(request.getTransactionId().orElse(""))
                 .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode()))
                 .withAmount(request.getAmount())

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequestTest.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
+
+public class StripeCustomerRequestTest {
+    
+    private final static String CARD_HOLDER = "a-card-holder-name";
+    private final static String AGREEMENT_DESCRIPTION = "an-agreement-description";
+    
+    @Mock
+    private StripeGatewayConfig stripeGatewayConfig;
+    
+    @Test
+    public void shouldHaveCorrectParameters() {
+        StripeCustomerRequest stripeCustomerRequest = createStripeCustomerRequest();
+
+        String payload = stripeCustomerRequest.getGatewayOrder().getPayload();
+        assertThat(payload, containsString("name=" + CARD_HOLDER));
+        assertThat(payload, containsString("description=" + AGREEMENT_DESCRIPTION));
+    }
+
+    private StripeCustomerRequest createStripeCustomerRequest() {
+        var gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+                .withCredentials(Map.of("stripe_account_id", "stripeConnectAccountId"))
+                .withPaymentProvider(STRIPE.getName())
+                .withState(ACTIVE)
+                .build();
+        
+        var authCardDetails = new AuthCardDetails();
+        authCardDetails.setCardHolder(CARD_HOLDER);
+        
+        var charge = aValidChargeEntity()
+                .withGatewayAccountCredentialsEntity(gatewayAccountCredentialsEntity)
+                .build();
+        
+        var authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        var agreementEntity = anAgreementEntity().withDescription(AGREEMENT_DESCRIPTION).build();
+        
+        return StripeCustomerRequest.of(authorisationGatewayRequest, stripeGatewayConfig, agreementEntity);
+    }
+    
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
@@ -128,6 +128,28 @@ public class StripePaymentIntentRequestTest {
         String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
         assertThat(payload, not(containsString(URLEncoder.encode("payment_method_options[card[moto]]", UTF_8))));
     }
+
+    @Test
+    public void shouldIncludeCustomerIdAndSetupFutureUsageFlagWhenCustomerIdProvided() {
+        final var customerId = "a-customer-id";
+
+        var authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, new AuthCardDetails());
+        var stripePaymentIntentRequest = StripePaymentIntentRequest.of(authorisationGatewayRequest, paymentMethodId, stripeGatewayConfig, frontendUrl, customerId);
+        String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
+
+        assertThat(payload, containsString("customer=" + customerId));
+        assertThat(payload, containsString("setup_future_usage=off_session"));
+    }
+
+    @Test
+    public void shouldNotIncludeCustomerIdAndSetupFutureUsageFlagWhenCustomerIdNotProvided() {
+        var authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, new AuthCardDetails());
+        var stripePaymentIntentRequest = StripePaymentIntentRequest.of(authorisationGatewayRequest, paymentMethodId, stripeGatewayConfig, frontendUrl);
+        String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
+
+        assertThat(payload, not(containsString("customer=")));
+        assertThat(payload, not(containsString("setup_future_usage=")));
+    }
     
     private StripePaymentIntentRequest createStripePaymentIntentRequest() {
         var authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, new AuthCardDetails());

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -15,12 +15,14 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_FAILED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CUSTOMER_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CANCEL_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CUSTOMER;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_REFUND_FULL_CHARGE_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_SEARCH_PAYMENT_INTENTS_RESPONSE;
@@ -94,6 +96,11 @@ public class StripeMockClient {
         setupResponse(payload, "/v1/payment_intents", 200);
     }
 
+    public void mockCreatePaymentIntentWithCustomer() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CUSTOMER);
+        setupResponse(payload, "/v1/payment_intents", 200);
+    }
+
     public void mockCreatePaymentIntentRequiring3DS() {
         String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE);
         setupResponse(payload, "/v1/payment_intents", 200);
@@ -103,12 +110,17 @@ public class StripeMockClient {
         String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE);
         setupResponse(payload, "/v1/payment_methods", 200);
     }
+    
+    public void mockCreateCustomer() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_CUSTOMER_SUCCESS_RESPONSE);
+        setupResponse(payload, "/v1/customers", 200);
+    }
 
     public void mockTransferReversal(String transferid) {
         String payload = TestTemplateResourceLoader.load(STRIPE_TRANSFER_RESPONSE);
         setupResponse(payload, "/v1/transfers/" + transferid + "/reversals", 200);
     }
-    
+
     public void mockCreatePaymentIntentDelayedResponse() {
         String responseBody = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE);
         String path = "/v1/payment_intents";

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -169,12 +169,14 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/payment_intent_capture_success_response.json";
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response.json";
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CHARGE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response_with_charge.json";
+    public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CUSTOMER = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response_with_customer.json";
     public static final String STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_requires_3ds_response.json";
     public static final String STRIPE_PAYMENT_INTENT_CANCEL_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/payment_intent_cancel_response.json";
     public static final String STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/get_payment_intent_with_3ds_authorised_success_response.json";
     public static final String STRIPE_GET_PAYMENT_INTENT_WITH_MULTIPLE_CHARGES = TEMPLATE_BASE_NAME + "/stripe/get_payment_intent_with_multiple_charges.json";
     public static final String STRIPE_PAYMENT_INTENT_WITHOUT_BALANCE_TRANSACTION_EXPANDED = TEMPLATE_BASE_NAME + "/stripe/payment_intent_without_balance_transaction_expanded.json";
     public static final String STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_method_success_response.json";
+    public static final String STRIPE_CUSTOMER_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_customer_success_response.json";
     public static final String STRIPE_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/error_response.json";
     public static final String STRIPE_REFUND_FULL_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_full_charge.json";
     public static final String STRIPE_TRANSFER_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/transfer_success_response.json";

--- a/src/test/resources/templates/stripe/create_customer_success_response.json
+++ b/src/test/resources/templates/stripe/create_customer_success_response.json
@@ -1,0 +1,3 @@
+{
+  "id": "cus_4QFOF3xrvBT3nU"
+}

--- a/src/test/resources/templates/stripe/create_payment_intent_success_response_with_customer.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_success_response_with_customer.json
@@ -1,0 +1,52 @@
+{
+  "id": "pi_1FHESeEZsufgnuO08A2FUSPy",
+  "object": "payment_intent",
+  "amount": 1000,
+  "amount_capturable": 0,
+  "amount_received": 0,
+  "application": null,
+  "application_fee_amount": null,
+  "canceled_at": null,
+  "cancellation_reason": null,
+  "capture_method": "manual",
+  "charges": {
+    "object": "list",
+    "data": [
+    ],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/charges?payment_intent=pi_1FHESeEZsufgnuO08A2FUSPy"
+  },
+  "client_secret": "secret",
+  "confirmation_method": "automatic",
+  "created": 1568141588,
+  "currency": "gbp",
+  "customer": "cus_4QFOF3xrvBT3nU",
+  "description": null,
+  "invoice": null,
+  "last_payment_error": null,
+  "livemode": false,
+  "metadata": {
+  },
+  "next_action": null,
+  "on_behalf_of": "acct_1EVFduJTPZ7tq2xO",
+  "payment_method": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+  "payment_method_options": {
+    "card": {
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "receipt_email": null,
+  "review": null,
+  "setup_future_usage": null,
+  "shipping": null,
+  "source": null,
+  "statement_descriptor": null,
+  "statement_descriptor_suffix": null,
+  "status": "requires_capture",
+  "transfer_data": null,
+  "transfer_group": "bc3rl3m7po6do0mt7r11kbt588"
+}


### PR DESCRIPTION
When we are authorising a Stripe charge for setting up an agreement:
* Make a request to Stripe to create a customer
* Use the customerId returned from Stripe in the `PaymentIntentRequest`
* Save the customerId and paymentMethodId in the `recurring_auth_token` column on the payment instrument

with @stephencdaly 