### PR TITLE
PP-10675: replaced usage of set-output in run-pact-provider-tests.yml

### DIFF
--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Get Provider SHA
         id: get-provider-sha
         run: |
-          echo ::set-output name=provider-sha::$(git rev-parse HEAD)
+          echo "provider-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Set up JDK 11
         uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b
         with:


### PR DESCRIPTION
Located and replaced all usages of set-output commands in our workflows.
