### PR TITLE
PP-10427 Add test for setting up Stripe recurring payments

### DIFF
--- a/src/test/java/uk/gov/pay/connector/rules/DropwizardAppWithPostgresRule.java
+++ b/src/test/java/uk/gov/pay/connector/rules/DropwizardAppWithPostgresRule.java
@@ -10,6 +10,10 @@ public class DropwizardAppWithPostgresRule extends AppWithPostgresRule {
         super(configOverrides);
     }
 
+    public DropwizardAppWithPostgresRule(boolean stubPaymentGateways, ConfigOverride... configOverrides) {
+        super(stubPaymentGateways, configOverrides);
+    }
+
     @Override
     protected AppRule<ConnectorConfiguration> newApplication(final String configPath,
                                                              final ConfigOverride... configOverrides) {


### PR DESCRIPTION
- Add ignored payment provider test that talks to the real Stripe gateway to set up a recurring payment agreement
- Updates to other tests so they pass
- Update instructions for running the tests to set environment variables rather than editing the config yaml file, in order to reduce the chances of accidentally committing secrets