### PR TITLE
PP-10427 Send agreement ID as metadata

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequest.java
@@ -12,9 +12,12 @@ import java.util.Map;
 import static java.util.Map.entry;
 
 public class StripeCustomerRequest extends StripePostRequest {
+
+    private static final String GOVUK_PAY_AGREEMENT_EXTERNAL_ID = "govuk_pay_agreement_external_id";
     
     private final String name;
     private final String description;
+    private final String agreementExternalId;
 
     private StripeCustomerRequest(
             GatewayAccountEntity gatewayAccount,
@@ -26,6 +29,7 @@ public class StripeCustomerRequest extends StripePostRequest {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         name = authCardDetails.getCardHolder();
         description = agreement.getDescription();
+        agreementExternalId = agreement.getExternalId();
     }
 
     public static StripeCustomerRequest of(CardAuthorisationGatewayRequest request, StripeGatewayConfig config, AgreementEntity agreement) {
@@ -51,7 +55,8 @@ public class StripeCustomerRequest extends StripePostRequest {
     protected Map<String, String> params() {
         return Map.ofEntries(
                 entry("name", name),
-                entry("description", description));
+                entry("description", description),
+                entry(String.format("metadata[%s]", GOVUK_PAY_AGREEMENT_EXTERNAL_ID), agreementExternalId));
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequestTest.java
@@ -6,8 +6,11 @@ import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 
+import java.net.URLEncoder;
 import java.util.Map;
 
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
@@ -21,6 +24,8 @@ public class StripeCustomerRequestTest {
     private final static String CARD_HOLDER = "a-card-holder-name";
     private final static String AGREEMENT_DESCRIPTION = "an-agreement-description";
     
+    private final static String AGREEMENT_EXTERNAL_ID = "an-agreement-id";
+    
     @Mock
     private StripeGatewayConfig stripeGatewayConfig;
     
@@ -31,6 +36,7 @@ public class StripeCustomerRequestTest {
         String payload = stripeCustomerRequest.getGatewayOrder().getPayload();
         assertThat(payload, containsString("name=" + CARD_HOLDER));
         assertThat(payload, containsString("description=" + AGREEMENT_DESCRIPTION));
+        assertThat(payload, containsString("metadata%5Bgovuk_pay_agreement_external_id%5D=" + AGREEMENT_EXTERNAL_ID));
     }
 
     private StripeCustomerRequest createStripeCustomerRequest() {
@@ -48,7 +54,10 @@ public class StripeCustomerRequestTest {
                 .build();
         
         var authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
-        var agreementEntity = anAgreementEntity().withDescription(AGREEMENT_DESCRIPTION).build();
+        var agreementEntity = anAgreementEntity()
+                .withExternalId(AGREEMENT_EXTERNAL_ID)
+                .withDescription(AGREEMENT_DESCRIPTION)
+                .build();
         
         return StripeCustomerRequest.of(authorisationGatewayRequest, stripeGatewayConfig, agreementEntity);
     }


### PR DESCRIPTION
When creating a customer object in Stripe, send the agreement external ID as metadata to store against the customer.