### PR TITLE
PP-10427 Remove separate OrderRequestType

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
@@ -5,7 +5,6 @@ public enum OrderRequestType {
     AUTHORISE_3DS("authorise3DS"),
     AUTHORISE_APPLE_PAY("authoriseApplePay"),
     AUTHORISE_GOOGLE_PAY("authoriseGooglePay"),
-    AUTHORISE_SAVE_PAYMENT_DETAILS("authoriseSavePaymentDetails"),
     CAPTURE("capture"),
     CANCEL("cancel"),
     REFUND("refund"),

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequest.java
@@ -66,7 +66,7 @@ public class StripeCustomerRequest extends StripePostRequest {
 
     @Override
     protected OrderRequestType orderRequestType() {
-        return OrderRequestType.AUTHORISE_SAVE_PAYMENT_DETAILS;
+        return OrderRequestType.AUTHORISE;
     }
 
     @Override


### PR DESCRIPTION
We were going to use a separate OrderRequestType for gateway requests that authorise a payment and store payment details. This would have given us separate metrics.

This is going to be re-visited in a separate story just to look at the metrics, so for now just use OrderRequestType.AUTHORISE for operations that set up recurring payment agreements.