### PR TITLE
PP-10427 Add additional logging

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummary.java
@@ -10,10 +10,13 @@ public class StripeAuthorisationRequestSummary implements AuthorisationRequestSu
 
     private final Presence billingAddress;
     private final String ipAddress;
+    
+    private Presence isSetupAgreement;
 
-    public StripeAuthorisationRequestSummary(AuthCardDetails authCardDetails) {
+    public StripeAuthorisationRequestSummary(AuthCardDetails authCardDetails, boolean isSetupAgreement) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
         ipAddress = authCardDetails.getIpAddress().orElse(null);
+        this.isSetupAgreement = isSetupAgreement ? PRESENT: NOT_PRESENT;
     }
 
     @Override
@@ -26,4 +29,8 @@ public class StripeAuthorisationRequestSummary implements AuthorisationRequestSu
         return ipAddress; 
     }
 
+    @Override
+    public Presence setUpAgreement() {
+        return isSetupAgreement;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -176,7 +176,7 @@ public class StripePaymentProvider implements PaymentProvider {
 
     @Override
     public StripeAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
-        return new StripeAuthorisationRequestSummary(authCardDetails);
+        return new StripeAuthorisationRequestSummary(authCardDetails, isSetUpAgreement);
     }
     
     public List<Fee> calculateAndTransferFeesForFailedPayments(ChargeEntity charge) throws GatewayException {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummaryTest.java
@@ -25,33 +25,44 @@ class StripeAuthorisationRequestSummaryTest {
     @Test
     void billingAddressPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
         assertThat(stripeAuthorisationRequestSummary.billingAddress(), is(PRESENT));
     }
 
     @Test
     void billingAddressNotPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
         assertThat(stripeAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
     }
 
     @Test
     void dataFor3dsAlwaysNotApplicable() {
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
         assertThat(stripeAuthorisationRequestSummary.dataFor3ds(), is(NOT_APPLICABLE));
     }
 
     @Test
     void dataFor3ds2AlwaysNotApplicable() {
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
         assertThat(stripeAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
     }
 
     @Test
     void deviceDataCollectionResultAlwaysNotApplicable() {
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
         assertThat(stripeAuthorisationRequestSummary.deviceDataCollectionResult(), is(NOT_APPLICABLE));
     }
 
+    @Test
+    void isSetUpAgreementPresent() {
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, true);
+        assertThat(stripeAuthorisationRequestSummary.setUpAgreement(), is(PRESENT));
+    }
+
+    @Test
+    void isSetUpAgreementNotPresent() {
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
+        assertThat(stripeAuthorisationRequestSummary.setUpAgreement(), is(NOT_PRESENT));
+    }
 }


### PR DESCRIPTION
Add additional logging for requests to Stripe to set up recurring payment agreement.

We already have general logging when the authorise status response is resolved in CardAuthoriseService which indicates whether the request was to set up an agreement. This commit adds some additional logging specific to the Stripe requests.