### PR TITLE
PP-10430 Add integration test for taking Worldpay recurring payment

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -68,17 +68,18 @@ public interface WorldpayOrderBuilder {
 
     static GatewayOrder buildAuthoriseRecurringOrder(RecurringPaymentAuthorisationGatewayRequest request) {
         var paymentInstrument = request.getPaymentInstrument().orElseThrow(() -> new IllegalArgumentException("Expected request to have payment instrument but it does not"));
+        var recurringAuthToken = paymentInstrument.getRecurringAuthToken().orElseThrow(() -> new IllegalArgumentException("Payment instrument does not have recurring auth token set"));
 
         WorldpayOrderRequestBuilder builder = (WorldpayOrderRequestBuilder) aWorldpayAuthoriseRecurringOrderRequestBuilder()
                 .withAgreementId(request.getAgreementId())
-                .withPaymentTokenId(Optional.ofNullable(paymentInstrument.getRecurringAuthToken().get(WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY)).orElse(""))
+                .withPaymentTokenId(Optional.ofNullable(recurringAuthToken.get(WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY)).orElse(""))
                 .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode()))
                 .withAmount(request.getAmount())
                 .withTransactionId(request.getGatewayTransactionId().orElse(""))
                 .withDescription(request.getDescription());
 
-        if (paymentInstrument.getRecurringAuthToken().get(WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY) != null) {
-            builder.withSchemeTransactionIdentifier(paymentInstrument.getRecurringAuthToken().get(WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY));
+        if (recurringAuthToken.get(WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY) != null) {
+            builder.withSchemeTransactionIdentifier(recurringAuthToken.get(WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY));
         }
 
         return builder.build();

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
@@ -25,6 +25,7 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
@@ -68,8 +69,8 @@ public class PaymentInstrumentEntity {
         this.paymentInstrumentStatus = paymentInstrumentStatus;
     }
 
-    public Map<String, String> getRecurringAuthToken() {
-        return recurringAuthToken;
+    public Optional<Map<String, String>> getRecurringAuthToken() {
+        return Optional.ofNullable(recurringAuthToken);
     }
 
     public void setRecurringAuthToken(Map<String, String> recurringAuthToken) {

--- a/src/test/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentServiceTest.java
@@ -21,6 +21,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Map;
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentInstrumentServiceTest {
@@ -50,7 +51,7 @@ class PaymentInstrumentServiceTest {
         verify(mockPaymentInstrumentDao).persist(paymentInstrumentEntityCaptor.capture());
         var actualPaymentInstrumentEntity = paymentInstrumentEntityCaptor.getValue();
         assertThat(actualPaymentInstrumentEntity.getCreatedDate(), is(NOW));
-        assertThat(actualPaymentInstrumentEntity.getRecurringAuthToken(), is(token));
+        assertThat(actualPaymentInstrumentEntity.getRecurringAuthToken(), is(Optional.of(token)));
         assertThat(actualPaymentInstrumentEntity.getCardDetails(), is(chargeEntity.getCardDetails()));
         assertThat(actualPaymentInstrumentEntity.getStartDate(), is(NOW));
         assertThat(actualPaymentInstrumentEntity.getPaymentInstrumentStatus(), is(PaymentInstrumentStatus.CREATED));

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceIT.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.connector.paymentprocessor.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.util.ChargeUtils;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class WorldpayCardAuthoriseServiceIT extends ChargingITestBase {
+
+    public WorldpayCardAuthoriseServiceIT() {
+        super(WORLDPAY.getName());
+    }
+    
+    @Test
+    public void shouldSuccessfullyAuthoriseUserNotPresentPayment() {
+        var recurringAuthToken = Map.of(
+                WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY, "a-token-id",
+                WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY, "transaction-identifier");
+        ChargeUtils.ExternalChargeId userNotPresentChargeId = addChargeWithAuthorisationModeAgreement(recurringAuthToken);
+
+        var successCharge = testContext.getInstanceFromGuiceContainer(ChargeService.class).findChargeByExternalId(userNotPresentChargeId.toString());
+
+        worldpayMockClient.mockAuthorisationSuccess();
+
+        var successResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseUserNotPresent(successCharge);
+        assertThat(successResponse.getGatewayError(), is(Optional.empty()));
+        assertThat(successResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/util/AddPaymentInstrumentParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddPaymentInstrumentParams.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -29,6 +30,8 @@ public class AddPaymentInstrumentParams {
     private final String stateOrProvince;
     private final String postcode;
     private final String countryCode;
+    
+    private Map<String, String> recurringAuthToken;
 
     public Long getPaymentInstrumentId() {
         return paymentInstrumentId;
@@ -98,6 +101,10 @@ public class AddPaymentInstrumentParams {
         return firstDigitsCardNumber;
     }
 
+    public Map<String, String> getRecurringAuthToken() {
+        return recurringAuthToken;
+    }
+
     private AddPaymentInstrumentParams(AddPaymentInstrumentParamsBuilder builder) {
         paymentInstrumentId = builder.paymentInstrumentId;
         externalPaymentInstrumentId = builder.externalPaymentInstrumentId;
@@ -116,6 +123,7 @@ public class AddPaymentInstrumentParams {
         postcode = builder.postcode;
         countryCode = builder.countryCode;
         firstDigitsCardNumber = builder.firstDigitsCardNumber;
+        recurringAuthToken = builder.recurringAuthToken;
     }
 
     public static final class AddPaymentInstrumentParamsBuilder {
@@ -136,6 +144,7 @@ public class AddPaymentInstrumentParams {
         private String stateOrProvince;
         private String postcode = "PAY ME";
         private String countryCode = "GB";
+        private Map<String, String> recurringAuthToken;
 
         private AddPaymentInstrumentParamsBuilder() {
         }
@@ -226,6 +235,11 @@ public class AddPaymentInstrumentParams {
 
         public AddPaymentInstrumentParamsBuilder withCountryCode(String countryCode) {
             this.countryCode = countryCode;
+            return this;
+        }
+        
+        public AddPaymentInstrumentParamsBuilder withRecurringAuthToken(Map<String, String> recurringAuthToken) {
+            this.recurringAuthToken = recurringAuthToken;
             return this;
         }
 


### PR DESCRIPTION
- Add integration test for taking a user not present payment from an agreement for Worldpay.
- Restructure some existing test code and helpers for better code re-use.
- Throw an exception in WorldpayOrderBuilder if no recurringAuthToken if present on the PaymentInstrument