### PR TITLE
PP-10430 Fix NullPointerException

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/PayersCardType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/PayersCardType.java
@@ -14,13 +14,16 @@ public enum PayersCardType {
     CREDIT_OR_DEBIT;
 
     public static PayersCardType from(CardType cardType) {
+        if (cardType == null) {
+            return PayersCardType.CREDIT_OR_DEBIT;
+        }
         switch (cardType) {
             case DEBIT:
                 return PayersCardType.DEBIT;
             case CREDIT:
                 return PayersCardType.CREDIT;
             default:
-                return null;
+                return CREDIT_OR_DEBIT;
         }
     }
 


### PR DESCRIPTION
It is possible for the CardType saved on a PaymentInstrumentEntity to be null.

Handle this when we convert the PaymentInstrumentEntity into an AuthCardDetails by treating null as PayersCardType.CREDIT_OR_DEBIT, as this is what we do when we convert from a CardidCardType to a PayersCardType for taking user present payments.