### PR TITLE
PP-10428 Add create method for off-session payment intent

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RecurringPaymentAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RecurringPaymentAuthorisationGatewayRequest.java
@@ -20,6 +20,7 @@ public class RecurringPaymentAuthorisationGatewayRequest implements GatewayReque
     private String description;
     private Map<String, Object> credentials;
     private GatewayAccountEntity gatewayAccountEntity;
+    private String govUkPayPaymentId;
 
     private RecurringPaymentAuthorisationGatewayRequest(GatewayAccountEntity gatewayAccountEntity,
                                                         Map<String, Object> credentials,
@@ -27,7 +28,8 @@ public class RecurringPaymentAuthorisationGatewayRequest implements GatewayReque
                                                         String amount,
                                                         String gatewayTransactionId,
                                                         String description,
-                                                        PaymentInstrumentEntity paymentInstrument) {
+                                                        PaymentInstrumentEntity paymentInstrument, 
+                                                        String govUkPayPaymentId) {
         this.gatewayAccountEntity = gatewayAccountEntity;
         this.credentials = credentials;
         this.agreementId = agreementId;
@@ -35,6 +37,7 @@ public class RecurringPaymentAuthorisationGatewayRequest implements GatewayReque
         this.gatewayTransactionId = gatewayTransactionId;
         this.description = description;
         this.paymentInstrument = paymentInstrument;
+        this.govUkPayPaymentId = govUkPayPaymentId;
     }
 
     public static RecurringPaymentAuthorisationGatewayRequest valueOf(ChargeEntity charge) {
@@ -44,7 +47,8 @@ public class RecurringPaymentAuthorisationGatewayRequest implements GatewayReque
                 String.valueOf(CorporateCardSurchargeCalculator.getTotalAmountFor(charge)),
                 charge.getGatewayTransactionId(),
                 charge.getDescription(),
-                charge.getPaymentInstrument().orElse(null));
+                charge.getPaymentInstrument().orElse(null),
+                charge.getExternalId());
     }
 
     public Optional<PaymentInstrumentEntity> getPaymentInstrument() {
@@ -65,6 +69,10 @@ public class RecurringPaymentAuthorisationGatewayRequest implements GatewayReque
 
     public String getDescription() {
         return description;
+    }
+
+    public String getGovUkPayPaymentId() {
+        return govUkPayPaymentId;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeAuthoriseHandler.java
@@ -120,13 +120,17 @@ public class StripeAuthoriseHandler implements AuthoriseHandler {
 
     private StripePaymentIntentResponse createPaymentIntent(CardAuthorisationGatewayRequest request, String paymentMethodId)
             throws GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException, GatewayException.GatewayErrorException {
-        String jsonResponse = client.postRequestFor(StripePaymentIntentRequest.of(request, paymentMethodId, stripeGatewayConfig, frontendUrl)).getEntity();
+        StripePaymentIntentRequest paymentIntentRequest = StripePaymentIntentRequest.createOneOffPaymentIntentRequest(
+                request, paymentMethodId, stripeGatewayConfig, frontendUrl);
+        String jsonResponse = client.postRequestFor(paymentIntentRequest).getEntity();
         return jsonObjectMapper.getObject(jsonResponse, StripePaymentIntentResponse.class);
     }
 
     private StripePaymentIntentResponse createPaymentIntentForSetUpAgreement(CardAuthorisationGatewayRequest request, String paymentMethodId, String customerId)
             throws GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException, GatewayException.GatewayErrorException {
-        String jsonResponse = client.postRequestFor(StripePaymentIntentRequest.of(request, paymentMethodId, stripeGatewayConfig, frontendUrl, customerId)).getEntity();
+        var paymentIntentRequest = StripePaymentIntentRequest.createPaymentIntentRequestWithSetupFutureUsage(
+                request, paymentMethodId, customerId, stripeGatewayConfig, frontendUrl);
+        String jsonResponse = client.postRequestFor(paymentIntentRequest).getEntity();
         return jsonObjectMapper.getObject(jsonResponse, StripePaymentIntentResponse.class);
     }
 }


### PR DESCRIPTION
Add a new static method to StripePaymentIntentRequest to construct the request for taking an off-session payment using a payment method stored for a customer.

Also
- Rename existing `of` methods to be more descriptive
- Re-order some parameters