### PR TITLE
PP-10428 Implement authorise for user not present for Stripe

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
@@ -116,7 +117,12 @@ public class StripePaymentProvider implements PaymentProvider {
     public GatewayResponse authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) {
         return stripeAuthoriseHandler.authorise(request);
     }
-    
+
+    @Override
+    public GatewayResponse authoriseUserNotPresent(RecurringPaymentAuthorisationGatewayRequest request) {
+        return stripeAuthoriseHandler.authoriseUserNotPresent(request);
+    }
+
     /**
      * IMPORTANT: this method should not attempt to update the Charge in the database. This is because it is executed
      * on a worker thread and the initiating thread can attempt to update the Charge status while it is still being

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -122,6 +122,10 @@ public class StripePaymentIntentRequest extends StripePostRequest {
         return customerId;
     }
 
+    public String getPaymentMethodId() {
+        return paymentMethodId;
+    }
+
     @Override
     protected String urlPath() {
         return "/v1/payment_intents";

--- a/src/test/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntityFixture.java
@@ -5,6 +5,9 @@ import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import java.time.Instant;
 import java.util.Map;
 
+import static uk.gov.pay.connector.gateway.stripe.StripeAuthorisationResponse.STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY;
+import static uk.gov.pay.connector.gateway.stripe.StripeAuthorisationResponse.STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY;
+
 public final class PaymentInstrumentEntityFixture {
     private Map<String, String> recurringAuthToken;
     private Instant createdDate = Instant.now();
@@ -22,6 +25,13 @@ public final class PaymentInstrumentEntityFixture {
 
     public PaymentInstrumentEntityFixture withRecurringAuthToken(Map<String, String> recurringAuthToken) {
         this.recurringAuthToken = recurringAuthToken;
+        return this;
+    }
+
+    public PaymentInstrumentEntityFixture withStripeRecurringAuthToken(String customerId, String paymentMethodId) {
+        this.recurringAuthToken = Map.of(
+                STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY, customerId,
+                STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY, paymentMethodId);
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/StripeCardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/StripeCardAuthoriseServiceIT.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.connector.paymentprocessor.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.util.ChargeUtils;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+import static uk.gov.pay.connector.gateway.stripe.StripeAuthorisationResponse.STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY;
+import static uk.gov.pay.connector.gateway.stripe.StripeAuthorisationResponse.STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class StripeCardAuthoriseServiceIT extends ChargingITestBase {
+
+    public StripeCardAuthoriseServiceIT() {
+        super(STRIPE.getName());
+    }
+
+    @Test
+    public void shouldSuccessfullyAuthoriseUserNotPresentPayment() {
+        var recurringAuthToken = Map.of(
+                STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY, "cus_abc123",
+                STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY, "pm_abc123");
+        ChargeUtils.ExternalChargeId userNotPresentChargeId = addChargeWithAuthorisationModeAgreement(recurringAuthToken);
+
+        var successCharge = testContext.getInstanceFromGuiceContainer(ChargeService.class).findChargeByExternalId(userNotPresentChargeId.toString());
+
+        stripeMockClient.mockCreatePaymentIntent();
+
+        var successResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseUserNotPresent(successCharge);
+        assertThat(successResponse.getGatewayError(), is(Optional.empty()));
+        assertThat(successResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED)));
+    }
+
+}


### PR DESCRIPTION
- Implement the PaymentProvider#authoriseUserNotPresent method for Stripe.
- This creates a payment intent, providing the customer ID and payment method ID saved in the `recurring_auth_token` jsonb on a payment instrument.
- Error handling is identical to user present payments for now.