### PR TITLE
Pp 10512 delete token when agreement cancelled worldpay

### DIFF
--- a/src/main/java/uk/gov/pay/connector/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/dao/AgreementDao.java
@@ -31,4 +31,15 @@ public class AgreementDao extends JpaDao<AgreementEntity> {
                 .setParameter("gatewayAccountId", gatewayAccountId)
                 .getResultList().stream().findFirst();
     }
+
+    public Optional<AgreementEntity> findByExternalId(String externalId) {
+
+        String query = "SELECT ae FROM AgreementEntity ae " +
+                "WHERE ae.externalId = :externalId";
+
+        return entityManager.get()
+                .createQuery(query, AgreementEntity.class)
+                .setParameter("externalId", externalId)
+                .getResultList().stream().findFirst();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/agreement/model/AgreementEntity.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/model/AgreementEntity.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.agreement.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import net.logstash.logback.argument.StructuredArgument;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.util.RandomIdGenerator;
@@ -19,7 +21,14 @@ import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_TYPE;
 
 @Entity
 @Table(name = "agreements")
@@ -161,6 +170,15 @@ public class AgreementEntity {
         this.paymentInstrument = paymentInstrumentEntity;
     }
 
+    @JsonIgnore
+    public Object[] getStructuredLoggingArgs() {
+        ArrayList<StructuredArgument> structuredArguments = new ArrayList<>(List.of(
+                kv(AGREEMENT_EXTERNAL_ID, getExternalId()),
+                kv(GATEWAY_ACCOUNT_ID, getGatewayAccount().getId()),
+                kv(GATEWAY_ACCOUNT_TYPE, getGatewayAccount().getType())
+        ));
+        return structuredArguments.toArray();
+    }
     public static class AgreementEntityBuilder {
         private GatewayAccountEntity gatewayAccount;
         private Instant createdDate;

--- a/src/main/java/uk/gov/pay/connector/charge/exception/AgreementNotFoundRuntimeException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/AgreementNotFoundRuntimeException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.charge.exception;
+
+import static java.lang.String.format;
+
+public class AgreementNotFoundRuntimeException extends RuntimeException {
+    public AgreementNotFoundRuntimeException(String externalId) {
+        super(format("Agreement with id [%s] not found.", externalId));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/PaymentInstrumentNotFoundRuntimeException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/PaymentInstrumentNotFoundRuntimeException.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.charge.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
+
+public class PaymentInstrumentNotFoundRuntimeException extends RuntimeException {
+    public PaymentInstrumentNotFoundRuntimeException(String externalId) {
+        super(format("Payment Instrument with id [%s] not found.", externalId));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/dao/PaymentInstrumentDao.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/dao/PaymentInstrumentDao.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+import java.util.Optional;
 
 @Transactional
 public class PaymentInstrumentDao extends JpaDao<PaymentInstrumentEntity> {
@@ -14,5 +15,16 @@ public class PaymentInstrumentDao extends JpaDao<PaymentInstrumentEntity> {
     @Inject
     public PaymentInstrumentDao(final Provider<EntityManager> entityManager) {
         super(entityManager);
+    }
+
+    public Optional<PaymentInstrumentEntity> findByExternalId(String externalId) {
+
+        String query = "SELECT p FROM PaymentInstrumentEntity p " +
+                "WHERE p.externalId = :externalId";
+
+        return entityManager.get()
+                .createQuery(query, PaymentInstrumentEntity.class)
+                .setParameter("externalId", externalId)
+                .getResultList().stream().findFirst();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentService.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.paymentinstrument.service;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
-import uk.gov.pay.connector.charge.model.CardDetailsEntity;
+import uk.gov.pay.connector.charge.exception.PaymentInstrumentNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.events.model.charge.PaymentInstrumentCreated;
@@ -26,6 +26,10 @@ public class PaymentInstrumentService {
         this.clock = clock;
     }
 
+    public PaymentInstrumentEntity findByExternalId(String externalId) {
+        return paymentInstrumentDao.findByExternalId(externalId).orElseThrow(() -> new PaymentInstrumentNotFoundRuntimeException(externalId));
+    }
+    
     @Transactional
     public PaymentInstrumentEntity createPaymentInstrument(ChargeEntity charge, Map<String, String> recurringAuthToken) {
         var now = clock.instant();

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
@@ -8,7 +8,9 @@ import org.slf4j.MDC;
 import uk.gov.pay.connector.gateway.stripe.response.StripeNotification;
 import uk.gov.pay.connector.queue.tasks.handlers.AuthoriseWithUserNotPresentHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.CollectFeesForFailedPaymentsTaskHandler;
+import uk.gov.pay.connector.queue.tasks.handlers.DeleteStoredPaymentDetailsHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.StripeWebhookTaskHandler;
+import uk.gov.pay.connector.queue.tasks.model.DeleteStoredPaymentDetailsTaskData;
 import uk.gov.pay.connector.queue.tasks.model.PaymentTaskData;
 import uk.gov.service.payments.commons.queue.exception.QueueException;
 
@@ -16,7 +18,9 @@ import javax.inject.Inject;
 import java.util.List;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_INSTRUMENT_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.STRIPE_EVENT_ID;
 
 public class TaskQueueMessageHandler {
@@ -26,6 +30,7 @@ public class TaskQueueMessageHandler {
     private final CollectFeesForFailedPaymentsTaskHandler collectFeesForFailedPaymentsTaskHandler;
     private final StripeWebhookTaskHandler stripeWebhookTaskHandler;
     private final AuthoriseWithUserNotPresentHandler authoriseWithUserNotPresentHandler;
+    private final DeleteStoredPaymentDetailsHandler deleteStoredPaymentDetailsHandler;
     private final ObjectMapper objectMapper;
 
     @Inject
@@ -33,11 +38,13 @@ public class TaskQueueMessageHandler {
                                    CollectFeesForFailedPaymentsTaskHandler collectFeesForFailedPaymentsTaskHandler,
                                    StripeWebhookTaskHandler stripeWebhookTaskHandler,
                                    AuthoriseWithUserNotPresentHandler authoriseWithUserNotPresentHandler,
+                                   DeleteStoredPaymentDetailsHandler deleteStoredPaymentDetailsHandler,
                                    ObjectMapper objectMapper) {
         this.taskQueue = taskQueue;
         this.collectFeesForFailedPaymentsTaskHandler = collectFeesForFailedPaymentsTaskHandler;
         this.stripeWebhookTaskHandler = stripeWebhookTaskHandler;
         this.authoriseWithUserNotPresentHandler = authoriseWithUserNotPresentHandler;
+        this.deleteStoredPaymentDetailsHandler = deleteStoredPaymentDetailsHandler;
         this.objectMapper = objectMapper;
     }
 
@@ -76,6 +83,13 @@ public class TaskQueueMessageHandler {
                         LOGGER.info("Processing [{}] task.", taskType.getName());
                         authoriseWithUserNotPresentHandler.process(taskData.getPaymentExternalId());
                         break;
+                    case DELETE_STORED_PAYMENT_DETAILS:
+                        var deleteStoredPaymentDetailsTaskData = objectMapper.readValue(taskMessage.getTask().getData(), DeleteStoredPaymentDetailsTaskData.class);
+                        MDC.put(AGREEMENT_EXTERNAL_ID, deleteStoredPaymentDetailsTaskData.getAgreementExternalId());
+                        MDC.put(PAYMENT_INSTRUMENT_EXTERNAL_ID, deleteStoredPaymentDetailsTaskData.getPaymentInstrumentExternalId());
+                        LOGGER.info("Processing [{}] task.", taskType.getName());
+                        deleteStoredPaymentDetailsHandler.process(deleteStoredPaymentDetailsTaskData.getAgreementExternalId(), deleteStoredPaymentDetailsTaskData.getPaymentInstrumentExternalId());
+                        break;
                     default:
                         LOGGER.error("Task [{}] is not supported.", taskType.getName());
                 }
@@ -89,6 +103,8 @@ public class TaskQueueMessageHandler {
             } finally {
                 MDC.remove(PAYMENT_EXTERNAL_ID);
                 MDC.remove(STRIPE_EVENT_ID);
+                MDC.remove(AGREEMENT_EXTERNAL_ID);
+                MDC.remove(PAYMENT_INSTRUMENT_EXTERNAL_ID);
             }
         });
     }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
@@ -5,8 +5,9 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum TaskType {
     COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT("collect_fee_for_stripe_failed_payment"),
     HANDLE_STRIPE_WEBHOOK_NOTIFICATION("handle_stripe_webhook_notification"),
-    AUTHORISE_WITH_USER_NOT_PRESENT("authorise_with_user_not_present");
-
+    AUTHORISE_WITH_USER_NOT_PRESENT("authorise_with_user_not_present"),
+    DELETE_STORED_PAYMENT_DETAILS("delete_stored_payment_details");
+    
     TaskType(String name) {
         this.name = name;
     }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/DeleteStoredPaymentDetailsHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/DeleteStoredPaymentDetailsHandler.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.queue.tasks.handlers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.agreement.service.AgreementService;
+import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
+
+import javax.inject.Inject;
+
+public class DeleteStoredPaymentDetailsHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteStoredPaymentDetailsHandler.class);
+    private AgreementService agreementService;
+    private PaymentInstrumentService paymentInstrumentService;
+    
+    @Inject
+    public DeleteStoredPaymentDetailsHandler(AgreementService agreementService, PaymentInstrumentService paymentInstrumentService) {
+        this.agreementService = agreementService;
+        this.paymentInstrumentService = paymentInstrumentService;
+    }
+
+    public void process(String agreementId, String paymentInstrumentId) {
+        var agreement = agreementService.findByExternalId(agreementId);
+        var paymentInstrument = paymentInstrumentService.findByExternalId(paymentInstrumentId);
+        //TODO: replace logging statement with request to Payment Processor to delete stored payment details
+        LOGGER.info("Processed deleteStoredPaymentDetails task for agreement [{}] and payment instrument [{}].", 
+                agreement.getExternalId(),
+                paymentInstrument.getExternalId());
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/model/DeleteStoredPaymentDetailsTaskData.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/model/DeleteStoredPaymentDetailsTaskData.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.connector.queue.tasks.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DeleteStoredPaymentDetailsTaskData {
+    @JsonProperty("agreement_external_id")
+    private String agreementExternalId;
+
+    @JsonProperty("paymentInstrument_external_id")
+    private String paymentInstrumentExternalId;
+    
+    public DeleteStoredPaymentDetailsTaskData() {
+        // empty
+    }
+
+    public DeleteStoredPaymentDetailsTaskData(String agreementExternalId, String paymentInstrumentExternalId) {
+        this.agreementExternalId = agreementExternalId;
+        this.paymentInstrumentExternalId = paymentInstrumentExternalId;
+    }
+
+    public String getAgreementExternalId() {
+        return agreementExternalId;
+    }
+
+    public String getPaymentInstrumentExternalId() {
+        return paymentInstrumentExternalId;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DeleteStoredPaymentDetailsTaskData that = (DeleteStoredPaymentDetailsTaskData) o;
+        return Objects.equals(agreementExternalId, that.agreementExternalId) && Objects.equals(paymentInstrumentExternalId, that.paymentInstrumentExternalId);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/dao/AgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/AgreementDaoIT.java
@@ -64,6 +64,19 @@ public class AgreementDaoIT extends DaoITestBase {
         assertThat(agreement.isPresent(), is(false));
     }
 
+    @Test
+    public void findByExternalIdOnly_shouldFindAnAgreementEntity() {
+        insertTestAgreement(AGREEMENT_EXTERNAL_ID_ONE, gatewayAccount1.getId());
+        Optional<AgreementEntity> agreement = agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID_ONE);
+        assertThat(agreement.isPresent(), is(true));
+        assertThat(agreement.get().getExternalId(), is(AGREEMENT_EXTERNAL_ID_ONE));
+    }
+
+    @Test
+    public void findByExternalIdOnly_shouldNotFindAnAgreementEntity() {
+        Optional<AgreementEntity> agreement = agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID_TWO);
+        assertThat(agreement.isPresent(), is(false));
+    }
 
     @After
     public void clear() {

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -40,6 +40,7 @@ import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBui
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
+import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
 
@@ -65,6 +66,9 @@ public class DatabaseFixtures {
 
     public TestAgreement aTestAgreement() {
         return new TestAgreement();
+    }
+    public TestPaymentInstrument aTestPaymentInstrument() {
+        return new TestPaymentInstrument();
     }
 
     public TestChargeEvent aTestChargeEvent() {
@@ -1205,6 +1209,34 @@ public class DatabaseFixtures {
 
         public boolean getRequires3DS() {
             return requires3DS;
+        }
+    }
+    
+    public class TestPaymentInstrument {
+        Long paymentInstrumentId = RandomUtils.nextLong();;
+        Map<String, String> recurringAuthToken;
+        Instant createdDate = Instant.now();
+        Instant startDate = Instant.now();
+        String externalId = "externalIDabc";
+        
+        TestPaymentInstrument withPaymentInstrumentId(Long paymentInstrumentId) {
+            this.paymentInstrumentId = paymentInstrumentId;
+            return this;
+        }
+        
+        TestPaymentInstrument withExternalId(String externalId) {
+            this.externalId = externalId;
+            return this;
+        }
+
+        public TestPaymentInstrument insert() {
+            databaseTestHelper.addPaymentInstrument(anAddPaymentInstrumentParams()
+                    .withPaymentInstrumentId(paymentInstrumentId)
+                    .withExternalPaymentInstrumentId(externalId)
+                    .withCreatedDate(createdDate)
+                    .withStartDate(startDate)
+                    .build());
+            return this;
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/PaymentInstrumentDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/PaymentInstrumentDaoIT.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.connector.it.dao;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.paymentinstrument.dao.PaymentInstrumentDao;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+
+import java.util.Optional;
+
+import static org.apache.commons.lang.math.RandomUtils.nextLong;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+
+public class PaymentInstrumentDaoIT extends DaoITestBase {
+
+    private PaymentInstrumentDao paymentInstrumentDao;
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+    private DatabaseFixtures.TestCardDetails defaultTestCardDetails;
+    
+    private static final String PAYMENT_INSTRUMENT_EXTERNAL_ID_ONE = "12345678901234567890123456";
+    private static final String PAYMENT_INSTRUMENT_EXTERNAL_ID_TWO= "99912345678901234567890123";
+   
+    @Before
+    public void setUp() {
+        paymentInstrumentDao = env.getInstance(PaymentInstrumentDao.class);
+
+    }
+
+    @Test
+    public void findByExternalId_shouldFindAPaymentInstrumentEntity() {
+        insertTestPaymentInstrument(PAYMENT_INSTRUMENT_EXTERNAL_ID_ONE);
+        Optional<PaymentInstrumentEntity> paymentInstrument = paymentInstrumentDao.findByExternalId(PAYMENT_INSTRUMENT_EXTERNAL_ID_ONE);
+        assertThat(paymentInstrument.isPresent(), is(true));
+        assertThat(paymentInstrument.get().getExternalId(), is(PAYMENT_INSTRUMENT_EXTERNAL_ID_ONE));
+    }
+
+    @Test
+    public void findByExternalId_shouldNotFindAPaymentInstrumentEntity() {
+        Optional<PaymentInstrumentEntity> paymentInstrument = paymentInstrumentDao.findByExternalId(PAYMENT_INSTRUMENT_EXTERNAL_ID_ONE);
+        assertThat(paymentInstrument.isPresent(), is(false));
+    }
+
+    @After
+    public void clear() {
+        databaseTestHelper.truncateAllData();
+    }
+    
+    private void insertTestPaymentInstrument(String paymentInstrumentExternalId) {
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestPaymentInstrument()
+                .withPaymentInstrumentId(nextLong())
+                .withExternalId(paymentInstrumentExternalId)
+                .insert();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
@@ -6,7 +6,6 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.stripe.response.StripeNotification;
 import uk.gov.pay.connector.queue.tasks.handlers.AuthoriseWithUserNotPresentHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.CollectFeesForFailedPaymentsTaskHandler;
+import uk.gov.pay.connector.queue.tasks.handlers.DeleteStoredPaymentDetailsHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.StripeWebhookTaskHandler;
 import uk.gov.pay.connector.queue.tasks.model.PaymentTaskData;
 import uk.gov.pay.connector.queue.tasks.model.Task;
@@ -51,6 +51,8 @@ class TaskQueueMessageHandlerTest {
     private AuthoriseWithUserNotPresentHandler authoriseWithUserNotPresentHandler;
 
     @Mock
+    private DeleteStoredPaymentDetailsHandler deleteStoredPaymentDetailsHandler;
+    @Mock
     private Appender<ILoggingEvent> mockAppender;
 
     @Captor
@@ -69,6 +71,7 @@ class TaskQueueMessageHandlerTest {
                 collectFeesForFailedPaymentsTaskHandler,
                 stripeWebhookTaskHandler,
                 authoriseWithUserNotPresentHandler,
+                deleteStoredPaymentDetailsHandler,
                 objectMapper);
 
         Logger logger = (Logger) LoggerFactory.getLogger(TaskQueueMessageHandler.class);
@@ -128,6 +131,14 @@ class TaskQueueMessageHandlerTest {
         verify(taskQueue).markMessageAsProcessed(taskMessage.getQueueMessage());
     }
 
+    @Test
+    public void shouldProcessDeleteStoredPaymentDetailsTask() throws QueueException {
+        TaskMessage taskMessage = setupQueueMessage("{ \"agreement_external_id\": \"external-agreement-id\", \"paymentInstrument_external_id\": \"external-paymentInstrument-id\"}", TaskType.DELETE_STORED_PAYMENT_DETAILS);
+        taskQueueMessageHandler.processMessages();
+        verify(deleteStoredPaymentDetailsHandler).process("external-agreement-id", "external-paymentInstrument-id");
+        verify(taskQueue).markMessageAsProcessed(taskMessage.getQueueMessage());
+    }
+    
     private TaskMessage setupQueueMessage(String data, TaskType taskType) throws QueueException {
         Task paymentTask = new Task(data, taskType);
         QueueMessage mockQueueMessage = mock(QueueMessage.class);


### PR DESCRIPTION
**PP-10512 Delete-payment-details-task**
    
- Context: When an agreement is cancelled, we need to send a request to the Payment Provider to delete the associated stored payment details
- When agreement cancelled, queue a deleteStoredPaymentDetails task
- Pick up the task from the queue and handle it
- Add methods for finding agreement and payment instrument by id
- Add custom exceptions if agreement or payment instrument can't be found
- Add/update associated unit tests
- Request to Payment Provider will be covered in a separate PR
