### PR TITLE
PP-10512 Build Worldpay Delete Token XML request

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
@@ -9,6 +9,7 @@ public enum OrderRequestType {
     CANCEL("cancel"),
     REFUND("refund"),
     QUERY("query"), 
+    DELETE_STORED_PAYMENT_DETAILS("delete_stored_payment_details"),
     STRIPE_TOKEN("authorise.create_token"), 
     STRIPE_CREATE_SOURCE("authorise.create_source"), 
     STRIPE_CREATE_CHARGE("authorise.create_charge"), 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -187,7 +187,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     public static final TemplateBuilder CANCEL_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayCancelOrderTemplate.xml");
     public static final TemplateBuilder REFUND_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayRefundOrderTemplate.xml");
     public static final TemplateBuilder INQUIRY_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayInquiryOrderTemplate.xml");
-
+    public static final TemplateBuilder DELETE_TOKEN_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("worldpay/WorldpayDeleteTokenOrderTemplate.xml");
     private final WorldpayTemplateData worldpayTemplateData;
     private final NorthAmericanRegionMapper northAmericanRegionMapper;
 
@@ -222,6 +222,11 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     public static WorldpayOrderRequestBuilder aWorldpayInquiryRequestBuilder() {
         return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), INQUIRY_TEMPLATE_BUILDER, OrderRequestType.QUERY);
     }
+
+    public static WorldpayOrderRequestBuilder aWorldpayDeleteTokenOrderRequestBuilder() {
+        return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), DELETE_TOKEN_ORDER_TEMPLATE_BUILDER, OrderRequestType.DELETE_STORED_PAYMENT_DETAILS);
+    }
+    
 
     private WorldpayOrderRequestBuilder(WorldpayTemplateData worldpayTemplateData, PayloadBuilder payloadBuilder, OrderRequestType orderRequestType) {
         super(worldpayTemplateData, payloadBuilder, orderRequestType);

--- a/src/main/resources/templates/worldpay/WorldpayDeleteTokenOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayDeleteTokenOrderTemplate.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="${merchantCode}">
+    <modify>
+        <paymentTokenDelete tokenScope="shopper" paymentTokenID="${paymentTokenId}" authenticatedShopperID="${agreementId}">
+        </paymentTokenDelete>
+    </modify>
+</paymentService>

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -24,6 +24,7 @@ import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseWalletOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCancelOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCaptureOrderRequestBuilder;
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayDeleteTokenOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayRefundOrderRequestBuilder;
 import static uk.gov.pay.connector.model.domain.applepay.ApplePayDecryptedPaymentDataFixture.anApplePayDecryptedPaymentData;
 import static uk.gov.pay.connector.model.domain.applepay.ApplePayPaymentInfoFixture.anApplePayPaymentInfo;
@@ -47,6 +48,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CANCEL_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CAPTURE_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_DELETE_TOKEN_REQUEST;
 
 public class WorldpayOrderRequestBuilderTest {
 
@@ -471,6 +473,23 @@ public class WorldpayOrderRequestBuilderTest {
 
         assertXMLEqual(expectedRequestBody, actualRequest.getPayload());
         assertEquals(OrderRequestType.REFUND, actualRequest.getOrderRequestType());
+    }
+
+    @Test 
+    public void shouldGenerateValidDeleteTokenRequest() throws Exception {
+        GatewayOrder actualRequest = aWorldpayDeleteTokenOrderRequestBuilder()
+                .withAgreementId("test-agreement-123")
+                .withPaymentTokenId("test-paymentToken-789")
+                .withMerchantCode("MYMERCHANT")
+                .build();
+        
+        String expectedRequestBody = TestTemplateResourceLoader.load(WORLDPAY_VALID_DELETE_TOKEN_REQUEST)
+                .replace("{{merchantCode}}", "MYMERCHANT")
+                .replace("{{agreementId}}", "test-agreement-123")
+                .replace("{{paymentTokenId}}", "test-paymentToken-789");
+        
+        assertXMLEqual(expectedRequestBody, actualRequest.getPayload());
+        assertEquals(OrderRequestType.DELETE_STORED_PAYMENT_DETAILS, actualRequest.getOrderRequestType());
     }
 
     private AuthCardDetails getValidTestCard(Address address) {

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -69,7 +69,9 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_REFUND_SUCCESS_RESPONSE = WORLDPAY_BASE_NAME + "/refund-success-response.xml";
     public static final String WORLDPAY_REFUND_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/refund-error-response.xml";
     public static final String WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-refund-worldpay-request.xml";
-
+    
+    public static final String WORLDPAY_VALID_DELETE_TOKEN_REQUEST = WORLDPAY_BASE_NAME + "/valid-delete-token-worldpay-request.xml";
+    
     public static final String WORLDPAY_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/error-response.xml";
     public static final String WORLDPAY_NOTIFICATION = WORLDPAY_BASE_NAME + "/notification.xml";
     

--- a/src/test/resources/templates/worldpay/valid-delete-token-worldpay-request.xml
+++ b/src/test/resources/templates/worldpay/valid-delete-token-worldpay-request.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="{{merchantCode}}">
+    <modify>
+        <paymentTokenDelete tokenScope="shopper" paymentTokenID="{{paymentTokenId}}" authenticatedShopperID="{{agreementId}}">
+        </paymentTokenDelete>
+    </modify>
+</paymentService>


### PR DESCRIPTION
Context: when an agreement is cancelled, a delete token request should be sent to Worldpay
- add new delete token XML template
- add builder for the template
- add test for the above
- submission of the request detail from the delete token task, and handling the Worldpay response, will be dealt with in a separate PR