### PR TITLE
PP-10512 Delete Token Worldpay Success Response

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -775,7 +775,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 123
+        "line_number": 125
       }
     ],
     "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayDecrypterTest.java": [
@@ -1099,5 +1099,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-07T15:46:32Z"
+  "generated_at": "2023-03-08T16:07:42Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayDeleteTokenResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayDeleteTokenResponse.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.persistence.oxm.annotations.XmlPath;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
+
+@XmlRootElement(name = "paymentService")
+public class WorldpayDeleteTokenResponse extends WorldpayBaseResponse {
+
+
+    @XmlPath("reply/ok/deleteTokenReceived/@paymentTokenID")
+    private String paymentTokenID;
+    
+    public String getPaymentTokenID() {
+        return paymentTokenID;
+    }
+    
+    public String stringify() {
+        if (!StringUtils.isNotBlank(getErrorCode()) && !StringUtils.isNotBlank(getErrorMessage())) {
+            return "Worldpay delete token response";
+        }
+
+        StringJoiner joiner = new StringJoiner(", ", "Worldpay delete token response (", ")");
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("error code: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("error: " + getErrorMessage());
+        }
+        return joiner.toString();
+    }
+
+    @Override
+    public String toString() {
+        return stringify();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -71,6 +71,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-refund-worldpay-request.xml";
     
     public static final String WORLDPAY_VALID_DELETE_TOKEN_REQUEST = WORLDPAY_BASE_NAME + "/valid-delete-token-worldpay-request.xml";
+    public static final String WORLDPAY_DELETE_TOKEN_SUCCESS_RESPONSE = WORLDPAY_BASE_NAME + "/delete-token-success-response.xml";
     
     public static final String WORLDPAY_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/error-response.xml";
     public static final String WORLDPAY_NOTIFICATION = WORLDPAY_BASE_NAME + "/notification.xml";

--- a/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayCancelResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayCaptureResponse;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayDeleteTokenResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayNotification;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayRefundResponse;
@@ -29,6 +30,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CANC
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CANCEL_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CAPTURE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CAPTURE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_DELETE_TOKEN_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_NOTIFICATION;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_REFUND_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_REFUND_SUCCESS_RESPONSE;
@@ -211,5 +213,15 @@ public class WorldpayXMLUnmarshallerTest {
         assertThat(response.getReference().isPresent(), is(false));
         assertThat(response.getErrorCode(), is("2"));
         assertThat(response.getErrorMessage(), is("Something went wrong."));
+    }
+
+    @Test
+    public void shouldUnmarshallADeleteTokenSuccessResponse() throws Exception {
+        String successPayload = TestTemplateResourceLoader.load(WORLDPAY_DELETE_TOKEN_SUCCESS_RESPONSE);
+        WorldpayDeleteTokenResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayDeleteTokenResponse.class);
+
+        assertThat(response.getPaymentTokenID(), is("payment-token-123"));
+        assertThat(response.getErrorCode(), is(nullValue()));
+        assertThat(response.getErrorMessage(), is(nullValue()));
     }
 }

--- a/src/test/resources/templates/worldpay/delete-token-success-response.xml
+++ b/src/test/resources/templates/worldpay/delete-token-success-response.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MYMERCHANT">
+    <reply>
+        <ok>
+            <deleteTokenReceived paymentTokenID="payment-token-123"/>
+        </ok>
+    </reply>
+</paymentService>


### PR DESCRIPTION
- add WorldpayDeleteTokenResponse class
- add sample success response
- add test for success response

to be covered in separate PR:
- sample error response and associated test
- converting deleteStoredPaymentDetailsTask into WP delete token request
