### PR TITLE
PP-10513 Handle delete payment details task for Stripe

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -530,17 +530,17 @@
         "line_number": 120
       }
     ],
-    "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeSDKClientTest.java": [
+    "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClientTest.java": [
       {
         "type": "Secret Keyword",
-        "filename": "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeSDKClientTest.java",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClientTest.java",
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
         "line_number": 45
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeSDKClientTest.java",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClientTest.java",
         "hashed_secret": "4fb086e72ed8bb3e57d737d3e108cfbe5731cfcb",
         "is_verified": false,
         "line_number": 46

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe;
 
+import com.stripe.exception.StripeException;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +24,7 @@ import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.DeleteStoredPaymentDetailsGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
@@ -33,18 +35,19 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeAuthoriseHandler;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCancelHandler;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCaptureHandler;
+import uk.gov.pay.connector.gateway.stripe.handler.StripeDisputeHandler;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeFailedPaymentFeeCollectionHandler;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeQueryPaymentStatusHandler;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeRefundHandler;
 import uk.gov.pay.connector.gateway.stripe.json.StripeTransfer;
 import uk.gov.pay.connector.gateway.stripe.request.StripeTransferInRequest;
 import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
+import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gateway.stripe.response.StripeDisputeData;
-import uk.gov.pay.connector.gateway.stripe.handler.StripeDisputeHandler;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -57,6 +60,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+import static uk.gov.pay.connector.gateway.stripe.StripeAuthorisationResponse.STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY;
 
 @Singleton
 public class StripePaymentProvider implements PaymentProvider {
@@ -74,13 +78,16 @@ public class StripePaymentProvider implements PaymentProvider {
     private final StripeFailedPaymentFeeCollectionHandler stripeFailedPaymentFeeCollectionHandler;
     private final StripeQueryPaymentStatusHandler stripeQueryPaymentStatusHandler;
     private final StripeDisputeHandler stripeDisputeHandler;
+    private final StripeSdkClient stripeSDKClient;
 
     @Inject
     public StripePaymentProvider(GatewayClientFactory gatewayClientFactory,
                                  ConnectorConfiguration configuration,
                                  JsonObjectMapper jsonObjectMapper,
-                                 Environment environment) {
+                                 Environment environment,
+                                 StripeSdkClient stripeSDKClient) {
         this.stripeGatewayConfig = configuration.getStripeConfig();
+        this.stripeSDKClient = stripeSDKClient;
         this.client = gatewayClientFactory.createGatewayClient(STRIPE, environment.metrics());
         this.jsonObjectMapper = jsonObjectMapper;
         this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
@@ -184,7 +191,22 @@ public class StripePaymentProvider implements PaymentProvider {
     public StripeAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
         return new StripeAuthorisationRequestSummary(authCardDetails, isSetUpAgreement);
     }
-    
+
+    @Override
+    public void deleteStoredPaymentDetails(DeleteStoredPaymentDetailsGatewayRequest request) throws GatewayException {
+        PaymentInstrumentEntity paymentInstrument = request.getPaymentInstrument();
+        var recurringAuthToken = paymentInstrument.getRecurringAuthToken()
+                .orElseThrow(() -> new RuntimeException("Expected payment instrument to have recurring auth token set when attempting to delete Stripe customer"));
+        var customerId = recurringAuthToken.get(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY);
+        try {
+            stripeSDKClient.deleteCustomer(customerId, request.getGatewayAccount().isLive());
+        } catch (StripeException e) {
+            var message = String.format("Error when attempting to delete Stripe customer %s. Status code: %s, Error code: %s, Message: %s",
+                    customerId, e.getStatusCode(), e.getCode(), e.getMessage());
+            throw new GatewayException.GenericGatewayException(message);
+        }
+    }
+
     public List<Fee> calculateAndTransferFeesForFailedPayments(ChargeEntity charge) throws GatewayException {
         return stripeFailedPaymentFeeCollectionHandler.calculateAndTransferFees(charge);
     }
@@ -192,17 +214,17 @@ public class StripePaymentProvider implements PaymentProvider {
     public StripeDisputeData submitTestDisputeEvidence(String disputeId, String evidenceText, String transactionId) throws GatewayException {
         return stripeDisputeHandler.submitTestDisputeEvidence(disputeId, evidenceText, transactionId);
     }
-    
+
     public void transferDisputeAmount(StripeDisputeData stripeDisputeData, Charge charge, GatewayAccountEntity gatewayAccount,
                                       GatewayAccountCredentialsEntity gatewayAccountCredentials) throws GatewayException {
-        
+
         if (stripeDisputeData.getBalanceTransactionList().size() > 1) {
             throw new RuntimeException("Expected lost dispute to have a single balance_transaction, but has " + stripeDisputeData.getBalanceTransactionList().size());
         }
         BalanceTransaction balanceTransaction = stripeDisputeData.getBalanceTransactionList().get(0);
         long transferAmount = Math.abs(balanceTransaction.getNetAmount());
         String disputeExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeData.getId());
-        
+
         StripeTransferInRequest transferInRequest = StripeTransferInRequest.createDisputeTransferRequest(
                 String.valueOf(transferAmount),
                 gatewayAccount,

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClient.java
@@ -9,14 +9,14 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 
-public class StripeSDKClient {
+public class StripeSdkClient {
 
     private final StripeGatewayConfig stripeGatewayConfig;
     
-    private final StripeSDKWrapper stripeSDKWrapper;
+    private final StripeSdkWrapper stripeSDKWrapper;
     
     @Inject
-    public StripeSDKClient(StripeGatewayConfig stripeGatewayConfig, StripeSDKWrapper stripeSDKWrapper) {
+    public StripeSdkClient(StripeGatewayConfig stripeGatewayConfig, StripeSdkWrapper stripeSDKWrapper) {
         this.stripeGatewayConfig = stripeGatewayConfig;
         this.stripeSDKWrapper = stripeSDKWrapper;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeSdkWrapper.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeSdkWrapper.java
@@ -11,7 +11,7 @@ import java.util.Map;
  * This class is just a thin wrapper around the Stripe SDK to allow us to mock out the static stripe methods in our 
  * tests. It should not contain any logic that requires unit tests.
  */
-class StripeSDKWrapper {
+class StripeSdkWrapper {
 
     Iterable<BalanceTransaction> listBalanceTransactions(Map<String, Object> params, RequestOptions requestOptions) 
             throws StripeException {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
@@ -16,10 +16,6 @@ public interface WorldpayGatewayResponseGenerator {
     default GatewayResponse getWorldpayGatewayResponse(GatewayClient.Response response) throws GatewayErrorException {
         return getWorldpayGatewayResponse(response, WorldpayOrderStatusResponse.class);
     }
-
-    default GatewayResponse<WorldpayDeleteTokenResponse> getWorldpayDeleteTokenGatewayResponse(GatewayClient.Response response) throws GatewayErrorException {
-        return getWorldpayGatewayResponse(response, WorldpayDeleteTokenResponse.class);
-    }
     
     default <T extends BaseResponse> GatewayResponse<T> getWorldpayGatewayResponse(GatewayClient.Response response, Class<T> target) throws GatewayErrorException {
         GatewayResponse.GatewayResponseBuilder<T> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -353,7 +353,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
 
     @Override
     public void deleteStoredPaymentDetails(DeleteStoredPaymentDetailsGatewayRequest request) throws GatewayException {
-        GatewayClient.Response response = deleteTokenClient.postRequestFor(
+         deleteTokenClient.postRequestFor(
                 gatewayUrlMap.get(request.getGatewayAccount().getType()),
                 WORLDPAY,
                 request.getGatewayAccount().getType(),

--- a/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
@@ -15,7 +15,7 @@ import uk.gov.pay.connector.events.model.dispute.DisputeIncludedInPayout;
 import uk.gov.pay.connector.events.model.payout.PayoutCreated;
 import uk.gov.pay.connector.events.model.payout.PayoutEvent;
 import uk.gov.pay.connector.events.model.refund.RefundIncludedInPayout;
-import uk.gov.pay.connector.gateway.stripe.StripeSDKClient;
+import uk.gov.pay.connector.gateway.stripe.StripeSdkClient;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayoutStatus;
 import uk.gov.pay.connector.gateway.stripe.request.StripeTransferMetadata;
@@ -45,7 +45,7 @@ public class PayoutReconcileProcess {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PayoutReconcileProcess.class);
     private final PayoutReconcileQueue payoutReconcileQueue;
-    private final StripeSDKClient stripeClient;
+    private final StripeSdkClient stripeClient;
     private final ConnectorConfiguration connectorConfiguration;
     private final GatewayAccountCredentialsService gatewayAccountCredentialsService;
     private final EventService eventService;
@@ -53,7 +53,7 @@ public class PayoutReconcileProcess {
 
     @Inject
     public PayoutReconcileProcess(PayoutReconcileQueue payoutReconcileQueue,
-                                  StripeSDKClient stripeClient,
+                                  StripeSdkClient stripeClient,
                                   ConnectorConfiguration connectorConfiguration,
                                   GatewayAccountCredentialsService gatewayAccountCredentialsService,
                                   EventService eventService,

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
@@ -94,6 +94,7 @@ public class TaskQueueMessageHandler {
                         LOGGER.error("Task [{}] is not supported.", taskType.getName());
                 }
                 taskQueue.markMessageAsProcessed(taskMessage.getQueueMessage());
+                LOGGER.info("Successfully processed [{}] task.", taskType.getName());
             } catch (Exception e) {
                 LOGGER.error("Error processing message from queue",
                         kv("queueMessageId", taskMessage.getQueueMessageId()),

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/DeleteStoredPaymentDetailsTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/DeleteStoredPaymentDetailsTaskHandler.java
@@ -18,7 +18,7 @@ public class DeleteStoredPaymentDetailsTaskHandler {
     private AgreementService agreementService;
     private PaymentInstrumentService paymentInstrumentService;
     private PaymentProviders providers;
-    
+
     @Inject
     public DeleteStoredPaymentDetailsTaskHandler(AgreementService agreementService, PaymentInstrumentService paymentInstrumentService, PaymentProviders providers) {
         this.agreementService = agreementService;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClientTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClientTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class StripeSDKClientTest {
+class StripeSdkClientTest {
 
     @Mock
     private StripeGatewayConfig stripeGatewayConfig;
@@ -31,10 +31,10 @@ class StripeSDKClientTest {
     private StripeAuthTokens stripeAuthTokens;
 
     @Mock
-    private StripeSDKWrapper stripeSDKWrapper;
+    private StripeSdkWrapper stripeSDKWrapper;
 
     @InjectMocks
-    private StripeSDKClient stripeSDKClient;
+    private StripeSdkClient stripeSDKClient;
 
     @Captor
     private ArgumentCaptor<RequestOptions> requestOptionsArgumentCaptor;

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -27,7 +27,7 @@ import uk.gov.pay.connector.events.model.payout.PayoutEvent;
 import uk.gov.pay.connector.events.model.payout.PayoutFailed;
 import uk.gov.pay.connector.events.model.payout.PayoutPaid;
 import uk.gov.pay.connector.events.model.refund.RefundIncludedInPayout;
-import uk.gov.pay.connector.gateway.stripe.StripeSDKClient;
+import uk.gov.pay.connector.gateway.stripe.StripeSdkClient;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
@@ -70,7 +70,7 @@ public class PayoutReconcileProcessTest {
     private PayoutReconcileQueue payoutReconcileQueue;
 
     @Mock
-    private StripeSDKClient stripeSDKClient;
+    private StripeSdkClient stripeSDKClient;
 
     @Mock
     private ConnectorConfiguration connectorConfiguration;

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/DeleteStoredPaymentDetailsTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/DeleteStoredPaymentDetailsTaskHandlerIT.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
@@ -45,7 +46,7 @@ public class DeleteStoredPaymentDetailsTaskHandlerIT {
     public void setUp() {
         databaseTestHelper = testContext.getDatabaseTestHelper();
         accountCredentialsParams = anAddGatewayAccountCredentialsParams()
-                .withPaymentProvider(STRIPE.getName())
+                .withPaymentProvider(SANDBOX.getName())
                 .withGatewayAccountId(Long.parseLong(accountId))
                 .withState(ACTIVE)
                 .withCredentials(Map.of("stripe_account_id", stripeAccountId))
@@ -53,7 +54,7 @@ public class DeleteStoredPaymentDetailsTaskHandlerIT {
 
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(accountId)
-                .withPaymentGateway(STRIPE.getName())
+                .withPaymentGateway(SANDBOX.getName())
                 .withGatewayAccountCredentials(List.of(accountCredentialsParams))
                 .withIntegrationVersion3ds(1)
                 .build());

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
@@ -89,10 +89,10 @@ class TaskQueueMessageHandlerTest {
         verify(collectFeesForFailedPaymentsTaskHandler).collectAndPersistFees(paymentTaskData);
         verify(taskQueue).markMessageAsProcessed(taskMessage.getQueueMessage());
 
-        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
-        LoggingEvent loggingEvent = loggingEventArgumentCaptor.getValue();
-        assertThat(loggingEvent.getLevel(), is(Level.INFO));
-        assertThat(loggingEvent.getFormattedMessage(), is("Processing [collect_fee_for_stripe_failed_payment] task."));
+        verify(mockAppender, times(3)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.get(1).getFormattedMessage(), is("Processing [collect_fee_for_stripe_failed_payment] task."));
+        assertThat(loggingEvents.get(2).getFormattedMessage(), is("Successfully processed [collect_fee_for_stripe_failed_payment] task."));
     }
 
     @Test
@@ -110,10 +110,10 @@ class TaskQueueMessageHandlerTest {
         verify(collectFeesForFailedPaymentsTaskHandler).collectAndPersistFees(paymentTaskData);
         verify(taskQueue).markMessageAsProcessed(taskMessage.getQueueMessage());
 
-        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
-        LoggingEvent loggingEvent = loggingEventArgumentCaptor.getValue();
-        assertThat(loggingEvent.getLevel(), is(Level.INFO));
-        assertThat(loggingEvent.getFormattedMessage(), is("Processing [collect_fee_for_stripe_failed_payment] task."));
+        verify(mockAppender, times(3)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.get(1).getFormattedMessage(), is("Processing [collect_fee_for_stripe_failed_payment] task."));
+        assertThat(loggingEvents.get(2).getFormattedMessage(), is("Successfully processed [collect_fee_for_stripe_failed_payment] task."));
     }
 
     @Test
@@ -133,7 +133,7 @@ class TaskQueueMessageHandlerTest {
     }
 
     @Test
-    public void shouldProcessDeleteStoredPaymentDetailsTask() throws QueueException, GatewayException {
+    public void shouldProcessDeleteStoredPaymentDetailsTask() throws Exception {
         TaskMessage taskMessage = setupQueueMessage("{ \"agreement_external_id\": \"external-agreement-id\", \"paymentInstrument_external_id\": \"external-paymentInstrument-id\"}", TaskType.DELETE_STORED_PAYMENT_DETAILS);
         taskQueueMessageHandler.processMessages();
         verify(deleteStoredPaymentDetailsHandler).process("external-agreement-id", "external-paymentInstrument-id");


### PR DESCRIPTION
Implement the deleteStoredPaymentDetails method for the StripePaymentProvider, so that the task to delete payment details works for Stripe agreements.

Renamed:
StripeSDKClient -> StripeSdkClient
StripeSDKWrapper -> StripeSdkWrapper

Added Stripe "contract" test which can be run locally to verify that deleting a customer on Stripe actually works.