### PR TITLE
PP-10512-Implement-deleteStoredPaymentDetails-for-Worldpay

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -561,7 +561,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 715
+        "line_number": 774
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
@@ -1099,5 +1099,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-08T16:54:12Z"
+  "generated_at": "2023-03-13T17:50:47Z"
 }

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
 import static uk.gov.pay.connector.gateway.GatewayOperation.CANCEL;
 import static uk.gov.pay.connector.gateway.GatewayOperation.CAPTURE;
+import static uk.gov.pay.connector.gateway.GatewayOperation.DELETE_STORED_PAYMENT_DETAILS;
 import static uk.gov.pay.connector.gateway.GatewayOperation.QUERY;
 import static uk.gov.pay.connector.gateway.GatewayOperation.REFUND;
 import static uk.gov.pay.connector.gateway.GatewayOperation.VALIDATE_CREDENTIALS;
@@ -171,6 +172,13 @@ public class ConnectorModule extends AbstractModule {
     @Named("WorldpayInquiryGatewayClient")
     public GatewayClient worldpayInquiryGatewayClient(GatewayClientFactory gatewayClientFactory) {
         return gatewayClientFactory.createGatewayClient(WORLDPAY, QUERY, environment.metrics());
+    }
+
+    @Provides
+    @Singleton
+    @Named("WorldpayDeleteTokenGatewayClient")
+    public GatewayClient worldpayDeleteTokenGatewayClient(GatewayClientFactory gatewayClientFactory) {
+        return gatewayClientFactory.createGatewayClient(WORLDPAY, DELETE_STORED_PAYMENT_DETAILS, environment.metrics());
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -57,7 +57,7 @@ public interface PaymentProvider {
     
     AuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement);
 
-    default GatewayResponse deleteStoredPaymentDetails(DeleteStoredPaymentDetailsGatewayRequest request) {
+    default void deleteStoredPaymentDetails(DeleteStoredPaymentDetailsGatewayRequest request) throws GatewayException {
         throw new NotImplementedException("Delete Stored Payment Details is not implemented for this payment provider");
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
@@ -59,6 +59,10 @@ public class AuthUtil {
         return gatewayCredentials.get(CREDENTIALS_MERCHANT_ID).toString();
     }
 
+    public static String getWorldpayMerchantCodeForManagingTokens(Map<String, Object> gatewayCredentials) {
+        return gatewayCredentials.get(CREDENTIALS_MERCHANT_ID).toString();
+    }
+
     public static Map<String, String> getGatewayAccountCredentialsAsAuthHeader(Map<String, Object> gatewayCredentials) {
         String value = encode(gatewayCredentials.get(CREDENTIALS_USERNAME).toString(), gatewayCredentials.get(CREDENTIALS_PASSWORD).toString());
         return ImmutableMap.of(AUTHORIZATION, value);
@@ -77,6 +81,11 @@ public class AuthUtil {
         return ImmutableMap.of(AUTHORIZATION, value);
     }
 
+    public static Map<String, String> getGatewayAccountCredentialsForManagingTokensAsAuthHeader(Map<String, Object> gatewayCredentials) {
+        String value = encode(gatewayCredentials.get(CREDENTIALS_USERNAME).toString(), gatewayCredentials.get(CREDENTIALS_PASSWORD).toString());
+        return ImmutableMap.of(AUTHORIZATION, value);
+    }
+    
     public static Map<String, String> getWorldpayCredentialsCheckAuthHeader(WorldpayCredentials worldpayCredentials) {
         String value = encode(worldpayCredentials.getUsername(), worldpayCredentials.getPassword());
         return ImmutableMap.of(AUTHORIZATION, value);

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayDeleteTokenResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayDeleteTokenResponse.java
@@ -8,8 +8,7 @@ import java.util.StringJoiner;
 
 @XmlRootElement(name = "paymentService")
 public class WorldpayDeleteTokenResponse extends WorldpayBaseResponse {
-
-
+    
     @XmlPath("reply/ok/deleteTokenReceived/@paymentTokenID")
     private String paymentTokenID;
     
@@ -21,7 +20,6 @@ public class WorldpayDeleteTokenResponse extends WorldpayBaseResponse {
         if (!StringUtils.isNotBlank(getErrorCode()) && !StringUtils.isNotBlank(getErrorMessage())) {
             return "Worldpay delete token response";
         }
-
         StringJoiner joiner = new StringJoiner(", ", "Worldpay delete token response (", ")");
         if (StringUtils.isNotBlank(getErrorCode())) {
             joiner.add("error code: " + getErrorCode());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
@@ -17,6 +17,10 @@ public interface WorldpayGatewayResponseGenerator {
         return getWorldpayGatewayResponse(response, WorldpayOrderStatusResponse.class);
     }
 
+    default GatewayResponse<WorldpayDeleteTokenResponse> getWorldpayDeleteTokenGatewayResponse(GatewayClient.Response response) throws GatewayErrorException {
+        return getWorldpayGatewayResponse(response, WorldpayDeleteTokenResponse.class);
+    }
+    
     default <T extends BaseResponse> GatewayResponse<T> getWorldpayGatewayResponse(GatewayClient.Response response, Class<T> target) throws GatewayErrorException {
         GatewayResponse.GatewayResponseBuilder<T> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
         responseBuilder.withResponse(unmarshallResponse(response, target));

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/DeleteStoredPaymentDetailsTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/DeleteStoredPaymentDetailsTaskHandler.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.queue.tasks.handlers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.agreement.service.AgreementService;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
@@ -25,13 +26,11 @@ public class DeleteStoredPaymentDetailsTaskHandler {
         this.providers = providers;
     }
 
-    public void process(String agreementExternalId, String paymentInstrumentExternalId) {
+    public void process(String agreementExternalId, String paymentInstrumentExternalId) throws GatewayException {
         var agreement = agreementService.findByExternalId(agreementExternalId);
         var paymentInstrument = paymentInstrumentService.findByExternalId(paymentInstrumentExternalId);
         PaymentProvider paymentProvider = providers.byName(PaymentGatewayName.valueFrom(agreement.getGatewayAccount().getGatewayName()));
-
         DeleteStoredPaymentDetailsGatewayRequest request = new DeleteStoredPaymentDetailsGatewayRequest(agreement, paymentInstrument);
-        var response = paymentProvider.deleteStoredPaymentDetails(request);
-        LOGGER.info("Processed deleteStoredPaymentDetails task with response: {}", response.toString());
+        paymentProvider.deleteStoredPaymentDetails(request);
     }
 }

--- a/src/main/resources/templates/worldpay/WorldpayDeleteTokenOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayDeleteTokenOrderTemplate.xml
@@ -3,7 +3,9 @@
         "http://dtd.worldpay.com/paymentService_v1.dtd">
 <paymentService version="1.4" merchantCode="${merchantCode}">
     <modify>
-        <paymentTokenDelete tokenScope="shopper" paymentTokenID="${paymentTokenId}" authenticatedShopperID="${agreementId}">
+        <paymentTokenDelete tokenScope="shopper">
+            <paymentTokenID>${paymentTokenId}</paymentTokenID>
+            <authenticatedShopperID>${agreementId}</authenticatedShopperID>
         </paymentTokenDelete>
     </modify>
 </paymentService>

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
@@ -74,6 +74,21 @@ class AuthUtilTest {
     }
 
     @Test
+    void shouldRetrieveTheRightCredentialsForManagingTokens() {
+        Map<String, Object> credentials = Map.of(
+                CREDENTIALS_MERCHANT_ID, merchantCode,
+                CREDENTIALS_USERNAME, username,
+                CREDENTIALS_PASSWORD, password,
+                RECURRING_MERCHANT_INITIATED, Map.of(
+                        CREDENTIALS_MERCHANT_ID, "RC-" + merchantCode,
+                        CREDENTIALS_USERNAME, "RC-" + username,
+                        CREDENTIALS_PASSWORD, "RC-" + password
+                ));
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
+        Map<String, String> encodedHeader = AuthUtil.getGatewayAccountCredentialsForManagingTokensAsAuthHeader(credentials);
+        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
+    }
+    @Test
     void shouldThrowException_whenAuthModeAgreement_andNoCredentialsForMerchantId() {
         MissingCredentialsForRecurringPaymentException thrown = Assertions.assertThrows(MissingCredentialsForRecurringPaymentException.class, () -> {
             Map<String, Object> credentials = Map.of(
@@ -114,4 +129,20 @@ class AuthUtilTest {
         String merchantId = AuthUtil.getWorldpayMerchantCode(credentials, AuthorisationMode.WEB);
         assertThat(merchantId, is(merchantCode));
     }
+
+    @Test
+    void shouldRetrieveTheRightMerchantIdForManagingTokens() {
+        Map<String, Object> credentials = Map.of(
+                CREDENTIALS_MERCHANT_ID, merchantCode,
+                CREDENTIALS_USERNAME, username,
+                CREDENTIALS_PASSWORD, password,
+                RECURRING_MERCHANT_INITIATED, Map.of(
+                        CREDENTIALS_MERCHANT_ID, "RC-" + merchantCode,
+                        CREDENTIALS_USERNAME, "RC-" + username,
+                        CREDENTIALS_PASSWORD, "RC-" + password
+                ));
+        String merchantId = AuthUtil.getWorldpayMerchantCodeForManagingTokens(credentials);
+        assertThat(merchantId, is(merchantCode));
+    }
+
 }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
@@ -15,6 +15,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.stripe.response.StripeNotification;
 import uk.gov.pay.connector.queue.tasks.handlers.AuthoriseWithUserNotPresentHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.CollectFeesForFailedPaymentsTaskHandler;
@@ -132,7 +133,7 @@ class TaskQueueMessageHandlerTest {
     }
 
     @Test
-    public void shouldProcessDeleteStoredPaymentDetailsTask() throws QueueException {
+    public void shouldProcessDeleteStoredPaymentDetailsTask() throws QueueException, GatewayException {
         TaskMessage taskMessage = setupQueueMessage("{ \"agreement_external_id\": \"external-agreement-id\", \"paymentInstrument_external_id\": \"external-paymentInstrument-id\"}", TaskType.DELETE_STORED_PAYMENT_DETAILS);
         taskQueueMessageHandler.processMessages();
         verify(deleteStoredPaymentDetailsHandler).process("external-agreement-id", "external-paymentInstrument-id");

--- a/src/test/resources/templates/worldpay/valid-delete-token-worldpay-request.xml
+++ b/src/test/resources/templates/worldpay/valid-delete-token-worldpay-request.xml
@@ -3,7 +3,9 @@
         "http://dtd.worldpay.com/paymentService_v1.dtd">
 <paymentService version="1.4" merchantCode="{{merchantCode}}">
     <modify>
-        <paymentTokenDelete tokenScope="shopper" paymentTokenID="{{paymentTokenId}}" authenticatedShopperID="{{agreementId}}">
+        <paymentTokenDelete tokenScope="shopper" >
+            <paymentTokenID>{{paymentTokenId}}</paymentTokenID>
+            <authenticatedShopperID>{{agreementId}}</authenticatedShopperID>
         </paymentTokenDelete>
     </modify>
 </paymentService>


### PR DESCRIPTION
Context: When an agreement is cancelled, a delete token request should be sent to Worldpay
- Add Worldpay implementation for deleteStoredPaymentDetails interface method
- Build delete token order, applying agreement and paymentTokenID to template
- Add unit tests and contract test
- Correct template and valid request file
