### PR TITLE
PP-10513 Refactor DeleteStoredPaymentDetailsGatewayRequest

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/DeleteStoredPaymentDetailsGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/DeleteStoredPaymentDetailsGatewayRequest.java
@@ -1,47 +1,58 @@
 package uk.gov.pay.connector.gateway.model.request;
 
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
-import uk.gov.pay.connector.gateway.GatewayOperation;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
-import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.util.Map;
 
-public class DeleteStoredPaymentDetailsGatewayRequest implements GatewayRequest{
-    private PaymentInstrumentEntity paymentInstrument;
-    private AgreementEntity agreement;
+public class DeleteStoredPaymentDetailsGatewayRequest {
+    private String agreementExternalId;
+    private Map<String, String> recurringAuthToken;
+    private String gatewayAccountType;
+    private boolean live;
+    private Map<String, Object> gatewayCredentials;
 
-    public DeleteStoredPaymentDetailsGatewayRequest(AgreementEntity agreement, PaymentInstrumentEntity paymentInstrument) {
-        this.agreement = agreement;
-        this.paymentInstrument = paymentInstrument;
+    private DeleteStoredPaymentDetailsGatewayRequest(String agreementExternalId,
+                                                     Map<String, String> recurringAuthToken,
+                                                     String gatewayAccountType,
+                                                     boolean live,
+                                                     Map<String, Object> gatewayCredentials) {
+        this.agreementExternalId = agreementExternalId;
+        this.recurringAuthToken = recurringAuthToken;
+        this.gatewayAccountType = gatewayAccountType;
+        this.live = live;
+        this.gatewayCredentials = gatewayCredentials;
     }
 
-    public AgreementEntity getAgreement() {
-        return agreement;
+    public static DeleteStoredPaymentDetailsGatewayRequest from(AgreementEntity agreement, PaymentInstrumentEntity paymentInstrument) {
+        var recurringAuthToken = paymentInstrument.getRecurringAuthToken()
+                .orElseThrow(() -> new IllegalArgumentException("Expected payment instrument to have recurring auth token set"));
+        return new DeleteStoredPaymentDetailsGatewayRequest(
+                agreement.getExternalId(),
+                recurringAuthToken,
+                agreement.getGatewayAccount().getType(),
+                agreement.isLive(),
+                agreement.getGatewayAccount().getCredentials(agreement.getGatewayAccount().getGatewayName())
+        );
     }
 
-    public PaymentInstrumentEntity getPaymentInstrument() {
-        return paymentInstrument;
+    public String getAgreementExternalId() {
+        return agreementExternalId;
     }
 
-    @Override
-    public GatewayAccountEntity getGatewayAccount() {
-        return agreement.getGatewayAccount();
+    public Map<String, String> getRecurringAuthToken() {
+        return recurringAuthToken;
     }
 
-    @Override
-    public GatewayOperation getRequestType() {
-        return GatewayOperation.DELETE_STORED_PAYMENT_DETAILS;
+    public String getGatewayAccountType() {
+        return gatewayAccountType;
     }
 
-    @Override
+    public boolean isLive() {
+        return live;
+    }
+
     public Map<String, Object> getGatewayCredentials() {
-        return agreement.getGatewayAccount().getCredentials(agreement.getGatewayAccount().getGatewayName());
-    }
-
-    @Override
-    public AuthorisationMode getAuthorisationMode() {
-        return AuthorisationMode.AGREEMENT;
+        return gatewayCredentials;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -194,12 +194,9 @@ public class StripePaymentProvider implements PaymentProvider {
 
     @Override
     public void deleteStoredPaymentDetails(DeleteStoredPaymentDetailsGatewayRequest request) throws GatewayException {
-        PaymentInstrumentEntity paymentInstrument = request.getPaymentInstrument();
-        var recurringAuthToken = paymentInstrument.getRecurringAuthToken()
-                .orElseThrow(() -> new RuntimeException("Expected payment instrument to have recurring auth token set when attempting to delete Stripe customer"));
-        var customerId = recurringAuthToken.get(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY);
+        var customerId = request.getRecurringAuthToken().get(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY);
         try {
-            stripeSDKClient.deleteCustomer(customerId, request.getGatewayAccount().isLive());
+            stripeSDKClient.deleteCustomer(customerId, request.isLive());
         } catch (StripeException e) {
             var message = String.format("Error when attempting to delete Stripe customer %s. Status code: %s, Error code: %s, Message: %s",
                     customerId, e.getStatusCode(), e.getCode(), e.getMessage());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -354,9 +354,9 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     @Override
     public void deleteStoredPaymentDetails(DeleteStoredPaymentDetailsGatewayRequest request) throws GatewayException {
          deleteTokenClient.postRequestFor(
-                gatewayUrlMap.get(request.getGatewayAccount().getType()),
+                gatewayUrlMap.get(request.getGatewayAccountType()),
                 WORLDPAY,
-                request.getGatewayAccount().getType(),
+                request.getGatewayAccountType(),
                 buildDeleteTokenOrder(request),
                 getGatewayAccountCredentialsForManagingTokensAsAuthHeader(request.getGatewayCredentials()));
     }
@@ -390,10 +390,9 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     }
 
     private GatewayOrder buildDeleteTokenOrder(DeleteStoredPaymentDetailsGatewayRequest request) {
-        var token = request.getPaymentInstrument().getRecurringAuthToken().orElseThrow(NoSuchElementException::new);
         return aWorldpayDeleteTokenOrderRequestBuilder()
-                .withAgreementId(request.getAgreement().getExternalId())
-                .withPaymentTokenId(token.get(WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY))
+                .withAgreementId(request.getAgreementExternalId())
+                .withPaymentTokenId(request.getRecurringAuthToken().get(WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY))
                 .withMerchantCode(AuthUtil.getWorldpayMerchantCodeForManagingTokens(request.getGatewayCredentials()))
                 .build();
     }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/DeleteStoredPaymentDetailsTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/DeleteStoredPaymentDetailsTaskHandler.java
@@ -30,7 +30,7 @@ public class DeleteStoredPaymentDetailsTaskHandler {
         var agreement = agreementService.findByExternalId(agreementExternalId);
         var paymentInstrument = paymentInstrumentService.findByExternalId(paymentInstrumentExternalId);
         PaymentProvider paymentProvider = providers.byName(PaymentGatewayName.valueFrom(agreement.getGatewayAccount().getGatewayName()));
-        DeleteStoredPaymentDetailsGatewayRequest request = new DeleteStoredPaymentDetailsGatewayRequest(agreement, paymentInstrument);
+        var request = DeleteStoredPaymentDetailsGatewayRequest.from(agreement, paymentInstrument);
         paymentProvider.deleteStoredPaymentDetails(request);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -569,7 +569,7 @@ class StripePaymentProviderTest {
             String customerId = "cus_123";
             AgreementEntity agreementEntity = createAgreementWithPaymentInstrument(customerId);
 
-            var request = new DeleteStoredPaymentDetailsGatewayRequest(agreementEntity, agreementEntity.getPaymentInstrument().get());
+            var request = DeleteStoredPaymentDetailsGatewayRequest.from(agreementEntity, agreementEntity.getPaymentInstrument().get());
             provider.deleteStoredPaymentDetails(request);
 
             verify(stripeSDKClient).deleteCustomer(customerId, true);
@@ -586,7 +586,7 @@ class StripePaymentProviderTest {
             when(mockStripeException.getMessage()).thenReturn("I'm a teapot");
             doThrow(mockStripeException).when(stripeSDKClient).deleteCustomer(customerId, true);
             
-            var request = new DeleteStoredPaymentDetailsGatewayRequest(agreementEntity, agreementEntity.getPaymentInstrument().get());
+            var request = DeleteStoredPaymentDetailsGatewayRequest.from(agreementEntity, agreementEntity.getPaymentInstrument().get());
             GatewayException gatewayException = assertThrows(GatewayException.class, () -> provider.deleteStoredPaymentDetails(request));
             assertThat(gatewayException.getMessage(), is("Error when attempting to delete Stripe customer cus_123. Status code: 418, Error code: im_a_teapot, Message: I'm a teapot"));
         }
@@ -595,10 +595,14 @@ class StripePaymentProviderTest {
             PaymentInstrumentEntity paymentInstrumentEntity = aPaymentInstrumentEntity()
                     .withStripeRecurringAuthToken(customerId, "pm_123")
                     .build();
-            GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(LIVE).build();
+            GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                    .withType(LIVE)
+                    .withActiveStripeGatewayAccountCredentials()
+                    .build();
             return anAgreementEntity()
                     .withPaymentInstrument(paymentInstrumentEntity)
                     .withGatewayAccount(gatewayAccountEntity)
+                    .withLive(true)
                     .build();
         }
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -524,7 +524,7 @@ public class WorldpayPaymentProviderTest {
     void should_include_paymentTokenID_and_agreementId_in_delete_token_order() throws Exception {
         PaymentInstrumentEntity paymentInstrument = setUpPaymentInstrument();
         AgreementEntity agreement = setUpAgreement(paymentInstrument);
-        DeleteStoredPaymentDetailsGatewayRequest request = new DeleteStoredPaymentDetailsGatewayRequest(agreement, paymentInstrument);
+        DeleteStoredPaymentDetailsGatewayRequest request = DeleteStoredPaymentDetailsGatewayRequest.from(agreement, paymentInstrument);
 
         worldpayPaymentProvider.deleteStoredPaymentDetails(request);
         
@@ -657,7 +657,7 @@ public class WorldpayPaymentProviderTest {
     void assert_authorization_header_is_passed_to_gateway_client_when_deleting_token() throws Exception {
         PaymentInstrumentEntity paymentInstrument = setUpPaymentInstrument();
         AgreementEntity agreement = setUpAgreement(paymentInstrument);
-        DeleteStoredPaymentDetailsGatewayRequest request = new DeleteStoredPaymentDetailsGatewayRequest(agreement, paymentInstrument);
+        DeleteStoredPaymentDetailsGatewayRequest request = DeleteStoredPaymentDetailsGatewayRequest.from(agreement, paymentInstrument);
 
         worldpayPaymentProvider.deleteStoredPaymentDetails(request);
         

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
@@ -13,6 +14,7 @@ import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 
@@ -171,6 +173,16 @@ public final class GatewayAccountEntityFixture {
 
     public GatewayAccountEntityFixture withGatewayAccountCredentials(List<GatewayAccountCredentialsEntity> credentials) {
         this.gatewayAccountCredentialsEntities = credentials;
+        return this;
+    }
+    
+    public GatewayAccountEntityFixture withActiveStripeGatewayAccountCredentials() {
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .withPaymentProvider(WORLDPAY.getName())
+                .withStripeCredentials()
+                .build();
+        this.gatewayAccountCredentialsEntities = List.of(credentialsEntity);
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityFixture.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.Map;
 
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_STRIPE_ACCOUNT_ID;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
@@ -42,6 +43,11 @@ public final class GatewayAccountCredentialsEntityFixture {
 
     public GatewayAccountCredentialsEntityFixture withCredentials(Map<String, Object> credentials) {
         this.credentials = credentials;
+        return this;
+    }
+    
+    public GatewayAccountCredentialsEntityFixture withStripeCredentials() {
+        this.credentials = Map.of(CREDENTIALS_STRIPE_ACCOUNT_ID, "acct_abc123");
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -287,7 +287,7 @@ public class StripePaymentProviderTest {
     public void shouldDeleteStoredPaymentDetails() throws Exception {
         ChargeEntity setUpAgreementCharge = setUpAgreement();
 
-        var request = new DeleteStoredPaymentDetailsGatewayRequest(setUpAgreementCharge.getAgreement().get(), setUpAgreementCharge.getPaymentInstrument().get());
+        var request = DeleteStoredPaymentDetailsGatewayRequest.from(setUpAgreementCharge.getAgreement().get(), setUpAgreementCharge.getPaymentInstrument().get());
         stripePaymentProvider.deleteStoredPaymentDetails(request);
 
         // attempt to take recurring payment to ensure customer is deleted

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -379,7 +379,7 @@ class WorldpayPaymentProviderTest {
         AgreementEntity agreement = anAgreementEntity().withGatewayAccount(validGatewayAccount).build();
         PaymentInstrumentEntity paymentInstrument = setUpAgreement(paymentProvider, agreement);
 
-        var gatewayDeleteTokenRequest = new DeleteStoredPaymentDetailsGatewayRequest(agreement, paymentInstrument);
+        var gatewayDeleteTokenRequest = DeleteStoredPaymentDetailsGatewayRequest.from(agreement, paymentInstrument);
         paymentProvider.deleteStoredPaymentDetails(gatewayDeleteTokenRequest);
         assertDoesNotThrow(() -> paymentProvider.deleteStoredPaymentDetails(gatewayDeleteTokenRequest));
         

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/DeleteStoredPaymentDetailsTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/DeleteStoredPaymentDetailsTaskHandlerIT.java
@@ -80,6 +80,7 @@ public class DeleteStoredPaymentDetailsTaskHandlerIT {
         AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)
                 .withExternalPaymentInstrumentId(paymentInstrumentExternalId)
+                .withRecurringAuthToken(Map.of("token", "something"))
                 .build();
         databaseTestHelper.addPaymentInstrument(paymentInstrumentParams);
         


### PR DESCRIPTION
Don't implement the GatewayRequest interface. This interface isn't directly referenced anywhere so there is no need to implement it, it seems it was just created for code organisation purposes. There is no AuthorisationMode associated with this request, so it doesn't make sense implementing the getAuthorisationMode interface method.

Have getters for the individual properties of the Agreement, Payment Instrument and Gateway Account. The intention of the GatewayRequest classes is to pass information to the PaymentProvider code level. It looks like we try to only allow access to the individual bits of information that the PaymentProvider code needs rather than the entire database entities. This is likely to make sure that the PaymentProvider code does not modify the database entities, as this is outside of its concern.