### PR TITLE
PP-10711 add idempotency key used exception

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -176,70 +176,70 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3749
+        "line_number": 3750
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3798
+        "line_number": 3799
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4409
+        "line_number": 4410
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4476
+        "line_number": 4477
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4498
+        "line_number": 4499
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4677
+        "line_number": 4678
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4680
+        "line_number": 4681
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4683
+        "line_number": 4684
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5273
+        "line_number": 5274
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5284
+        "line_number": 5285
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1099,5 +1099,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-13T17:50:47Z"
+  "generated_at": "2023-03-14T14:21:53Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3449,6 +3449,7 @@ components:
           - UNEXPECTED_ATTRIBUTE
           - ACCOUNT_DISABLED
           - RECURRING_CARD_PAYMENTS_NOT_ALLOWED
+          - IDEMPOTENCY_KEY_USED
           example: GENERIC
         message:
           type: array

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.11</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.14.2</jackson.version>
-        <pay-java-commons.version>1.0.20230306161941</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20230314135251</pay-java-commons.version>
         <surefire.version>3.0.0-M9</surefire.version>
         <jooq.version>3.17.8</jooq.version>
         <postgresql.version>42.5.4</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -32,6 +32,7 @@ import uk.gov.pay.connector.charge.exception.AgreementNotFoundBadRequestExceptio
 import uk.gov.pay.connector.charge.exception.AuthorisationModeAgreementRequiresAgreementIdExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapper;
 import uk.gov.pay.connector.charge.exception.GatewayAccountDisabledExceptionMapper;
+import uk.gov.pay.connector.charge.exception.IdempotencyKeyUsedExceptionMapper;
 import uk.gov.pay.connector.charge.exception.IncorrectAuthorisationModeForSavePaymentToAgreementExceptionMapper;
 import uk.gov.pay.connector.charge.exception.InvalidAttributeValueExceptionMapper;
 import uk.gov.pay.connector.charge.exception.MissingMandatoryAttributeExceptionMapper;
@@ -172,6 +173,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new GatewayAccountDisabledExceptionMapper());
         environment.jersey().register(new RecurringCardPaymentsNotAllowedExceptionMapper());
         environment.jersey().register(new MissingCredentialsForRecurringPaymentExceptionMapper());
+        environment.jersey().register(new IdempotencyKeyUsedExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/exception/IdempotencyKeyUsedException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/IdempotencyKeyUsedException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.charge.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+public class IdempotencyKeyUsedException extends WebApplicationException {
+    public IdempotencyKeyUsedException() {
+        super("The Idempotency-Key has already been used to create a payment");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/IdempotencyKeyUsedExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/IdempotencyKeyUsedExceptionMapper.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.charge.exception;
+
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class IdempotencyKeyUsedExceptionMapper implements ExceptionMapper<IdempotencyKeyUsedException> {
+    @Override
+    public Response toResponse(IdempotencyKeyUsedException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.IDEMPOTENCY_KEY_USED, exception.getMessage());
+
+        return Response.status(Response.Status.CONFLICT)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- add a new exception for when an idempotency key has already been used.
- add exception mapper with `IDEMPOTENCY_KEY_USED` identifier
- update pom to use pay-java-commons' latest
