### PR TITLE
PP-10798 Add agreement_external_id column to payment_instruments

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1963,4 +1963,19 @@
                 UNIQUE (gateway_account_id, key);</sql>
     </changeSet>
 
+    <changeSet id="add agreement_external_id column to payment_instruments table" author="">
+        <addColumn tableName="payment_instruments">
+            <column name="agreement_external_id" type="varchar(32)">
+                <constraints
+                        foreignKeyName="fk__payment_instruments_agreements"
+                        referencedTableName="agreements"
+                        referencedColumnNames="external_id"
+                        nullable="true"/>
+            </column>
+        </addColumn>
+        <createIndex tableName="payment_instruments" indexName="idx_payment_instruments_agreement_external_id">
+            <column name="agreement_external_id"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
- We are adding `agreement_external_id` rather than `agreement_id` as we have the idea that in future, agreements should live outside of connector if we add more payment method with different "connector" microservices.
- Add foreign key constraint and index.