### PR TITLE
PP-10711 implement checking existing idempotency

### DIFF
--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -328,6 +328,10 @@ paths:
         schema:
           type: integer
           format: int64
+      - in: header
+        name: Idempotency-Key
+        schema:
+          type: string
       requestBody:
         content:
           '*/*':

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -25,10 +25,12 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -116,8 +118,8 @@ public class ChargesApiResource {
     public Response createNewCharge(
             @Parameter(example = "1", description = "Gateway account ID") @PathParam(ACCOUNT_ID) Long accountId,
             @NotNull @Valid ChargeCreateRequest chargeRequest,
-            @Context UriInfo uriInfo
-    ) {
+            @Context UriInfo uriInfo,
+            @Nullable @HeaderParam("Idempotency-Key") String idempotencyKey) {
         logger.info("Creating new charge - {}", chargeRequest.toStringWithoutPersonalIdentifiableInformation());
 
         AuthorisationMode authorisationMode = chargeRequest.getAuthorisationMode();
@@ -135,7 +137,7 @@ public class ChargesApiResource {
             throw new UnexpectedAttributeException(RETURN_URL);
         }
 
-        return chargeService.create(chargeRequest, accountId, uriInfo)
+        return chargeService.create(chargeRequest, accountId, uriInfo, idempotencyKey)
                 .map(response -> {
                     if (authorisationMode == AuthorisationMode.AGREEMENT) {
                         chargeService.markChargeAsEligibleForAuthoriseUserNotPresent(response.getChargeId());

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreatePrefilledCardholderDetailsTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreatePrefilledCardholderDetailsTest.java
@@ -32,6 +32,7 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
@@ -122,6 +123,9 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
     @Mock
     private TaskQueueService mockTaskQueueService;
 
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
+
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
 
@@ -159,7 +163,8 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         chargeService = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
     }
 
     @Test
@@ -175,7 +180,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         var address = new PrefilledAddress("Line1", "Line2", "AB1 CD2", "London", null, "GB");
         cardHolderDetails.setAddress(address);
         final ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -206,7 +211,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
 
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -237,7 +242,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         cardHolderDetails.setAddress(address);
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -266,7 +271,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         cardHolderDetails.setCardHolderName("Joe Bogs");
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -289,7 +294,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         cardHolderDetails.setAddress(address);
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -315,7 +320,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
 
         ChargeCreateRequest request = requestBuilder.build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTelephonePaymentTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTelephonePaymentTest.java
@@ -30,6 +30,7 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
@@ -114,6 +115,8 @@ class ChargeServiceCreateTelephonePaymentTest {
 
     @Mock
     private TaskQueueService mockTaskQueueService;
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
 
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
@@ -159,7 +162,8 @@ class ChargeServiceCreateTelephonePaymentTest {
         chargeService = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.charge.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,7 +10,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.app.CaptureProcessConfig;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.LinksConfig;
@@ -16,6 +20,7 @@ import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.exception.GatewayAccountDisabledException;
+import uk.gov.pay.connector.charge.exception.IdempotencyKeyUsedException;
 import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountException;
 import uk.gov.pay.connector.charge.exception.ZeroAmountNotAllowedForGatewayAccountException;
 import uk.gov.pay.connector.charge.exception.motoapi.AuthorisationApiNotAllowedForGatewayAccountException;
@@ -46,6 +51,10 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
+import uk.gov.pay.connector.idempotency.model.IdempotencyEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
@@ -59,6 +68,8 @@ import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -88,11 +99,13 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.agreement.model.AgreementEntity.AgreementEntityBuilder.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.ChargeResponse.aChargeResponseBuilder;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity.PaymentInstrumentEntityBuilder.aPaymentInstrumentEntity;
 import static uk.gov.service.payments.commons.model.Source.CARD_API;
 
 @ExtendWith(MockitoExtension.class)
@@ -102,7 +115,9 @@ class ChargeServiceCreateTest {
     private static final long GATEWAY_ACCOUNT_ID = 10L;
     private static final long CHARGE_ENTITY_ID = 12345L;
     private static final String[] EXTERNAL_CHARGE_ID = new String[1];
+    private static final String AGREEMENT_ID = "agreement-id";
     private static final List<Map<String, Object>> EMPTY_LINKS = new ArrayList<>();
+    private static final com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper().registerModule(new Jdk8Module());
 
     private ChargeCreateRequestBuilder requestBuilder;
     private TelephoneChargeCreateRequest.Builder telephoneRequestBuilder;
@@ -166,11 +181,16 @@ class ChargeServiceCreateTest {
 
     @Mock
     private TaskQueueService mockTaskQueueService;
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
 
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
 
     @Captor ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor;
+
+    @Captor
+    private ArgumentCaptor<IdempotencyEntity> idempotencyEntityArgumentCaptor;
 
     private ChargeService chargeService;
     private GatewayAccountEntity gatewayAccount;
@@ -225,7 +245,8 @@ class ChargeServiceCreateTest {
         chargeService = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
     }
 
     @Test
@@ -318,7 +339,7 @@ class ChargeServiceCreateTest {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
         populateChargeEntity();
 
-        chargeService.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -354,7 +375,7 @@ class ChargeServiceCreateTest {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
 
         final ChargeCreateRequest request = requestBuilder.withEmail("").build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -372,7 +393,7 @@ class ChargeServiceCreateTest {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
 
         final ChargeCreateRequest request = requestBuilder.withDelayedCapture(true).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
     }
@@ -387,7 +408,7 @@ class ChargeServiceCreateTest {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
 
         final ChargeCreateRequest request = requestBuilder.withDelayedCapture(false).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
     }
@@ -408,7 +429,7 @@ class ChargeServiceCreateTest {
                 "key4", 1.23);
         final ChargeCreateRequest request = requestBuilder.withExternalMetadata(new ExternalMetadata(metadata)).build();
 
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         assertThat(chargeEntityArgumentCaptor.getValue().getExternalMetadata().get().getMetadata(), equalTo(metadata));
@@ -425,7 +446,7 @@ class ChargeServiceCreateTest {
 
         final ChargeCreateRequest request = requestBuilder.withLanguage(SupportedLanguage.WELSH).build();
 
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -446,7 +467,7 @@ class ChargeServiceCreateTest {
 
         final ChargeCreateRequest request = requestBuilder.withAmount(0).build();
 
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -459,7 +480,7 @@ class ChargeServiceCreateTest {
         final ChargeCreateRequest request = requestBuilder.withAmount(0).build();
         when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
 
-        assertThrows(ZeroAmountNotAllowedForGatewayAccountException.class, () -> chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo));
+        assertThrows(ZeroAmountNotAllowedForGatewayAccountException.class, () -> chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null));
 
         verify(mockedChargeDao, never()).persist(any(ChargeEntity.class));
     }
@@ -475,7 +496,7 @@ class ChargeServiceCreateTest {
 
         gatewayAccount.setAllowMoto(true);
         ChargeCreateRequest request = requestBuilder.withMoto(true).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -489,7 +510,7 @@ class ChargeServiceCreateTest {
 
         when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
 
-        assertThrows(MotoPaymentNotAllowedForGatewayAccountException.class, () -> chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo));
+        assertThrows(MotoPaymentNotAllowedForGatewayAccountException.class, () -> chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null));
 
         verify(mockedChargeDao, never()).persist(any(ChargeEntity.class));
     }
@@ -505,7 +526,7 @@ class ChargeServiceCreateTest {
 
         final ChargeCreateRequest request = requestBuilder.
                 withSource(CARD_API).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         assertThat(chargeEntityArgumentCaptor.getValue().getSource(), equalTo(CARD_API));
@@ -522,7 +543,7 @@ class ChargeServiceCreateTest {
 
         final ChargeCreateRequest request = requestBuilder.
                 withSource(CARD_API).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -540,7 +561,7 @@ class ChargeServiceCreateTest {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
         populateChargeEntity();
 
-        ChargeResponse response = chargeService.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo).get();
+        ChargeResponse response = chargeService.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo, null).get();
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
@@ -580,7 +601,7 @@ class ChargeServiceCreateTest {
                 .withAuthorisationMode(AuthorisationMode.MOTO_API)
                 .build();
 
-        ChargeResponse response = chargeService.create(chargeCreateRequest, GATEWAY_ACCOUNT_ID, mockedUriInfo).get();
+        ChargeResponse response = chargeService.create(chargeCreateRequest, GATEWAY_ACCOUNT_ID, mockedUriInfo, null).get();
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
@@ -606,7 +627,7 @@ class ChargeServiceCreateTest {
 
         when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
 
-        assertThrows(AuthorisationApiNotAllowedForGatewayAccountException.class, () -> chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo));
+        assertThrows(AuthorisationApiNotAllowedForGatewayAccountException.class, () -> chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null));
 
         verify(mockedChargeDao, never()).persist(any(ChargeEntity.class));
     }
@@ -621,7 +642,7 @@ class ChargeServiceCreateTest {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
         populateChargeEntity();
 
-        chargeService.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
 
@@ -638,7 +659,136 @@ class ChargeServiceCreateTest {
 
         when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
 
-        assertThrows(GatewayAccountDisabledException.class, () -> chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo));
+        assertThrows(GatewayAccountDisabledException.class, () -> chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null));
+
+        verify(mockedChargeDao, never()).persist(any(ChargeEntity.class));
+    }
+
+    @Test
+    void shouldCreateNewChargeAndPersistIdempotency() throws URISyntaxException {
+        String idempotencyKey = "idempotency-key";
+        ChargeCreateRequest chargeCreateRequest = requestBuilder
+                .withAgreementId(AGREEMENT_ID)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withReturnUrl(null)
+                .build();
+
+        gatewayAccount.setRecurringEnabled(true);
+
+        PaymentInstrumentEntity paymentInstrument = aPaymentInstrumentEntity(Instant.now())
+                .withStatus(PaymentInstrumentStatus.ACTIVE)
+                .build();
+        AgreementEntity agreementEntity = anAgreementEntity(Instant.now())
+                .withReference("This is the reference")
+                .withDescription("This is a description")
+                .withUserIdentifier("This is the user identifier")
+                .withPaymentInstrument(paymentInstrument)
+                .build();
+        Map<String, Object> requestBody = mapper.convertValue(chargeCreateRequest, new TypeReference<>() {});
+
+        doAnswer(invocation -> fromUri(SERVICE_HOST)).when(this.mockedUriInfo).getBaseUriBuilder();
+        when(mockedProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockedPaymentProvider);
+        when(mockedPaymentProvider.getExternalChargeRefundAvailability(any(Charge.class), anyList())).thenReturn(EXTERNAL_AVAILABLE);
+        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
+        when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
+        when(mockedAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreementEntity));
+        when(mockIdempotencyDao.findByGatewayAccountIdAndKey(GATEWAY_ACCOUNT_ID, idempotencyKey)).thenReturn(Optional.empty());
+        populateChargeEntity();
+
+        ChargeResponse response = chargeService.create(chargeCreateRequest, GATEWAY_ACCOUNT_ID, mockedUriInfo, idempotencyKey).get();
+
+        verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
+        verify(mockIdempotencyDao).persist(idempotencyEntityArgumentCaptor.capture());
+
+        IdempotencyEntity idempotency = idempotencyEntityArgumentCaptor.getValue();
+        assertThat(idempotency.getRequestBody(), is(requestBody));
+
+        ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
+        ChargeResponse.ChargeResponseBuilder expectedChargeResponse = chargeResponseBuilderOf(createdChargeEntity);
+
+        expectedChargeResponse.withLink("self", GET, new URI(SERVICE_HOST + "/v1/api/accounts/10/charges/" + EXTERNAL_CHARGE_ID[0]));
+        expectedChargeResponse.withLink("refunds", GET, new URI(SERVICE_HOST + "/v1/api/accounts/10/charges/" + EXTERNAL_CHARGE_ID[0] + "/refunds"));
+
+        assertThat(response, is(expectedChargeResponse.build()));
+    }
+
+    @Test
+    void shouldReturnExisingChargeAndNotPersistNewOne_whenIdempotencyExistsAndMatches() throws URISyntaxException {
+        String existingChargeExternalId = "existing-id";
+        String idempotencyKey = "idempotency-key";
+        ChargeCreateRequest chargeCreateRequest = requestBuilder
+                .withAgreementId(AGREEMENT_ID)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withReturnUrl(null)
+                .build();
+
+        gatewayAccount.setRecurringEnabled(true);
+
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withExternalId(existingChargeExternalId)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .build();
+        PaymentInstrumentEntity paymentInstrument = aPaymentInstrumentEntity(Instant.now())
+                .withStatus(PaymentInstrumentStatus.ACTIVE)
+                .build();
+        AgreementEntity agreementEntity = anAgreementEntity(Instant.now())
+                .withReference("This is the reference")
+                .withDescription("This is a description")
+                .withUserIdentifier("This is the user identifier")
+                .withPaymentInstrument(paymentInstrument)
+                .build();
+        Map<String, Object> requestBody = mapper.convertValue(chargeCreateRequest, new TypeReference<>() {});
+        IdempotencyEntity idempotencyEntity = new IdempotencyEntity(idempotencyKey, gatewayAccount, existingChargeExternalId,
+                requestBody, Instant.now());
+
+        doAnswer(invocation -> fromUri(SERVICE_HOST)).when(this.mockedUriInfo).getBaseUriBuilder();
+        when(mockedProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockedPaymentProvider);
+        when(mockedPaymentProvider.getExternalChargeRefundAvailability(any(Charge.class), anyList())).thenReturn(EXTERNAL_AVAILABLE);
+        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
+        when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
+        when(mockedAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreementEntity));
+        when(mockIdempotencyDao.findByGatewayAccountIdAndKey(GATEWAY_ACCOUNT_ID, idempotencyKey)).thenReturn(Optional.of(idempotencyEntity));
+        when(mockedChargeDao.findByExternalId(existingChargeExternalId)).thenReturn(Optional.of(chargeEntity));
+
+        ChargeResponse response = chargeService.create(chargeCreateRequest, GATEWAY_ACCOUNT_ID, mockedUriInfo, idempotencyKey).get();
+
+        verify(mockedChargeDao, never()).persist(any(ChargeEntity.class));
+        assertThat(response.getChargeId(), is(existingChargeExternalId));
+    }
+
+    @Test
+    void shouldThrowException_whenIdempotencyExistsAndRequestBodyNotMatch() {
+        String existingChargeExternalId = "existing-id";
+        String idempotencyKey = "idempotency-key";
+        ChargeCreateRequest chargeCreateRequest = requestBuilder
+                .withAgreementId(AGREEMENT_ID)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withReturnUrl(null)
+                .build();
+
+        gatewayAccount.setRecurringEnabled(true);
+
+        PaymentInstrumentEntity paymentInstrument = aPaymentInstrumentEntity(Instant.now())
+                .withStatus(PaymentInstrumentStatus.ACTIVE)
+                .build();
+        AgreementEntity agreementEntity = anAgreementEntity(Instant.now())
+                .withReference("This is the reference")
+                .withDescription("This is a description")
+                .withUserIdentifier("This is the user identifier")
+                .withPaymentInstrument(paymentInstrument)
+                .build();
+        Map<String, Object> requestBody = mapper.convertValue(chargeCreateRequest, new TypeReference<>() {});
+        requestBody.put("metadata", Map.of("invoice", "invoice"));
+
+        IdempotencyEntity idempotencyEntity = new IdempotencyEntity(idempotencyKey, gatewayAccount, existingChargeExternalId,
+                requestBody, Instant.now());
+
+        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
+        when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
+        when(mockedAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreementEntity));
+        when(mockIdempotencyDao.findByGatewayAccountIdAndKey(GATEWAY_ACCOUNT_ID, idempotencyKey)).thenReturn(Optional.of(idempotencyEntity));
+
+        assertThrows(IdempotencyKeyUsedException.class, () -> chargeService.create(chargeCreateRequest, GATEWAY_ACCOUNT_ID, mockedUriInfo, idempotencyKey).get());
 
         verify(mockedChargeDao, never()).persist(any(ChargeEntity.class));
     }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
@@ -37,6 +37,7 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
@@ -147,6 +148,8 @@ class ChargeServiceFindTest {
 
     @Mock
     private TaskQueueService mockTaskQueueService;
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
 
     @Captor ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor;
 
@@ -192,7 +195,7 @@ class ChargeServiceFindTest {
         chargeService = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao);
     }
     @Test
     void shouldNotFindCharge() {

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
@@ -24,6 +24,7 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
@@ -77,6 +78,8 @@ class ChargeServicePostAuthorisationTest {
     @Mock private CardDetailsEntity mockCardDetailsEntity;
     @Mock private ChargeEventEntity mockChargeEventEntity;
     @Mock private PaymentInstrumentEntity mockPaymentInstrumentEntity;
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
 
     private final Auth3dsRequiredEntity auth3dsRequiredEntity = new Auth3dsRequiredEntity();
     private final ChargeEntityFixture chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity();
@@ -110,7 +113,8 @@ class ChargeServicePostAuthorisationTest {
         chargeService = new ChargeService(mockTokenDao, mockChargeDao, mockChargeEventDao,
                 mockCardTypeDao, mockAgreementDao, mockGatewayAccountDao, mockConnectorConfig, mockProviders,
                 mockStateTransitionService, mockLedgerService, mockRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -48,6 +48,7 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
@@ -170,6 +171,9 @@ class ChargeServiceTest {
     
     @Mock
     private TaskQueueService mockTaskQueueService;
+
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
     
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
@@ -211,7 +215,8 @@ class ChargeServiceTest {
         chargeService = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
     }
 
     @Test
@@ -334,7 +339,7 @@ class ChargeServiceTest {
         when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
 
-        chargeService.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationRespon
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsFlexRequiredParams;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsRequiredParams;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
@@ -85,6 +86,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
     @Mock
     private TaskQueueService mockTaskQueueService;
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
 
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
@@ -115,7 +118,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
                 null, null, mockConfiguration, null, mockStateTransitionService, ledgerService,
                 mockedRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
-                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao);
         AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment, mockConfiguration);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, authorisationService, mockConfiguration);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -63,6 +63,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
@@ -192,6 +193,9 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     @Mock
     private Appender<ILoggingEvent> mockAppender;
 
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
+
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
@@ -215,7 +219,8 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null,
                 stateTransitionService, ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
 
         LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService = mock(LinkPaymentInstrumentToAgreementService.class);
         CaptureQueue captureQueue = mock(CaptureQueue.class);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -39,6 +39,7 @@ import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.queue.capture.CaptureQueue;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
@@ -121,6 +122,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
     protected AuthCardDetailsToCardDetailsEntityConverter mockAuthCardDetailsToCardDetailsEntityConverter;
     @Mock
     private TaskQueueService mockTaskQueueService;
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
     private static final Clock GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK = Clock.fixed(Instant.parse("2020-01-01T10:10:10.100Z"), ZoneOffset.UTC);
 
     @Before
@@ -132,7 +135,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
 
         cardCaptureService = new CardCaptureService(chargeService, mockedProviders, mockUserNotificationService, mockEnvironment,
                 GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK, mockCaptureQueue, mockEventService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthorisationRequestSummary
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
@@ -123,7 +124,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
                 null, mock(AgreementDao.class), null, mock(ConnectorConfiguration.class), null,
                 mock(StateTransitionService.class), mock(LedgerService.class), mock(RefundService.class),
                 mock(EventService.class), mock(PaymentInstrumentService.class), mock(GatewayAccountCredentialsService.class),
-                mock(AuthCardDetailsToCardDetailsEntityConverter.class), mockTaskQueueService);
+                mock(AuthCardDetailsToCardDetailsEntityConverter.class), mockTaskQueueService, mock(IdempotencyDao.class));
 
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
         when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -45,6 +45,7 @@ import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
@@ -149,6 +150,9 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     @Mock
     private AuthorisationConfig mockAuthorisationConfig;
 
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
+
     private WalletAuthoriseService walletAuthoriseService;
 
     private final AppleDecryptedPaymentData validApplePayDetails =
@@ -187,7 +191,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null, mockStateTransitionService,
                 ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
-                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService));
+                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,


### PR DESCRIPTION
## WHAT YOU DID

- add HeaderParam `Idempotency-Key`
- refactor ChargeService to pass on idempotency key
- refactor createCharge method to check for existing idempotency entry when AuthorisationMode is AGREEMENT and idempotency key is present
- if idempotency entry exists:
	- throw error (409) if request is different
	- return ChargeEntity if request matches
