### PR TITLE
PP-10798 Set agreement_external_id on payment instrument

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -232,14 +232,14 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5274
+        "line_number": 5276
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5285
+        "line_number": 5287
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1099,5 +1099,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-14T14:21:53Z"
+  "generated_at": "2023-03-16T12:37:10Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -4721,6 +4721,8 @@ components:
     PaymentInstrumentEntity_FrontendView:
       type: object
       properties:
+        agreementExternalId:
+          type: string
         cardDetails:
           $ref: '#/components/schemas/CardDetailsEntity_FrontendView'
         createdDate:

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeEligibleForCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeEligibleForCaptureService.java
@@ -70,7 +70,7 @@ public class ChargeEligibleForCaptureService {
             }
 
             if (charge.isSavePaymentInstrumentToAgreement()) {
-                linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreementFromCharge(charge);
+                linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreement(charge);
             }
 
             return charge;

--- a/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
@@ -33,10 +33,11 @@ public class LinkPaymentInstrumentToAgreementService {
     }
 
     @Transactional
-    public void linkPaymentInstrumentFromChargeToAgreementFromCharge(ChargeEntity chargeEntity) {
+    public void linkPaymentInstrumentFromChargeToAgreement(ChargeEntity chargeEntity) {
         chargeEntity.getPaymentInstrument().ifPresentOrElse(paymentInstrumentEntity -> {
             chargeEntity.getAgreement().ifPresentOrElse(agreementEntity -> {
                 agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
+                paymentInstrumentEntity.setAgreementExternalId(agreementEntity.getExternalId());
                 paymentInstrumentEntity.setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
                 ledgerService.postEvent(List.of(
                         AgreementSetUp.from(agreementEntity, clock.instant()),

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
@@ -59,6 +59,9 @@ public class PaymentInstrumentEntity {
 
     @Column(name = "external_id")
     private String externalId;
+    
+    @Column(name = "agreement_external_id")
+    private String agreementExternalId;
 
     private PaymentInstrumentEntity(Instant createdDate, Map<String, String> recurringAuthToken, Instant startDate, CardDetailsEntity cardDetails, PaymentInstrumentStatus paymentInstrumentStatus) {
         this.createdDate = createdDate;
@@ -119,6 +122,14 @@ public class PaymentInstrumentEntity {
 
     public void setCardDetails(CardDetailsEntity cardDetails) {
         this.cardDetails = cardDetails;
+    }
+
+    public String getAgreementExternalId() {
+        return agreementExternalId;
+    }
+
+    public void setAgreementExternalId(String agreementExternalId) {
+        this.agreementExternalId = agreementExternalId;
     }
 
     @Column(name = "status")

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeEligibleForCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeEligibleForCaptureServiceTest.java
@@ -89,7 +89,7 @@ class ChargeEligibleForCaptureServiceTest {
 
         var inOrder = inOrder(mockChargeService, mockLinkPaymentInstrumentToAgreementService, mockCaptureQueue, mockUserNotificationService);
         inOrder.verify(mockChargeService).transitionChargeState(chargeEntity, CAPTURE_APPROVED);
-        inOrder.verify(mockLinkPaymentInstrumentToAgreementService).linkPaymentInstrumentFromChargeToAgreementFromCharge(chargeEntity);
+        inOrder.verify(mockLinkPaymentInstrumentToAgreementService).linkPaymentInstrumentFromChargeToAgreement(chargeEntity);
         inOrder.verify(mockCaptureQueue).sendForCapture(result);
         inOrder.verify(mockUserNotificationService).sendPaymentConfirmedEmail(chargeEntity, chargeEntity.getGatewayAccount());
     }
@@ -158,7 +158,7 @@ class ChargeEligibleForCaptureServiceTest {
 
         var inOrder = inOrder(mockChargeService, mockLinkPaymentInstrumentToAgreementService);
         inOrder.verify(mockChargeService).transitionChargeState(chargeEntity, AWAITING_CAPTURE_REQUEST);
-        inOrder.verify(mockLinkPaymentInstrumentToAgreementService).linkPaymentInstrumentFromChargeToAgreementFromCharge(chargeEntity);
+        inOrder.verify(mockLinkPaymentInstrumentToAgreementService).linkPaymentInstrumentFromChargeToAgreement(chargeEntity);
 
         verifyNoInteractions(mockCaptureQueue);
         verifyNoInteractions(mockUserNotificationService);

--- a/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
@@ -80,14 +80,17 @@ class LinkPaymentInstrumentToAgreementServiceTest {
 
     @Test
     void linksPaymentInstrumentFromChargeToAgreementFromChargeAndSetsPaymentInstrumentToActive() {
+        String agreementExternalId = "an-agreement-external-id";
         when(mockAgreementEntity.getGatewayAccount()).thenReturn(mockGatewayAccountEntity);
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
+        when(mockAgreementEntity.getExternalId()).thenReturn(agreementExternalId);
         when(mockPaymentInstrumentEntity.getExternalId()).thenReturn("payment instrument external ID");
         var chargeEntity = aValidChargeEntity().withPaymentInstrument(mockPaymentInstrumentEntity).withAgreementEntity(mockAgreementEntity).build();
 
-        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreementFromCharge(chargeEntity);
+        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreement(chargeEntity);
 
         verify(mockAgreementEntity).setPaymentInstrument(mockPaymentInstrumentEntity);
+        verify(mockPaymentInstrumentEntity).setAgreementExternalId(agreementExternalId);
         verify(mockPaymentInstrumentEntity).setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
         verify(ledgerService).postEvent(List.of(
                 AgreementSetUp.from(mockAgreementEntity, clock.instant()),
@@ -99,7 +102,7 @@ class LinkPaymentInstrumentToAgreementServiceTest {
     void logsErrorIfChargeDoesNotHavePaymentInstrument() {
         var chargeEntity = aValidChargeEntity().withPaymentInstrument(null).withAgreementEntity(mockAgreementEntity).build();
 
-        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreementFromCharge(chargeEntity);
+        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreement(chargeEntity);
 
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
         var loggingEvent = loggingEventArgumentCaptor.getValue();
@@ -116,7 +119,7 @@ class LinkPaymentInstrumentToAgreementServiceTest {
     void logsErrorIfChargeHasPaymentInstrumentButDoesNotHaveAgreementId() {
         var chargeEntity = aValidChargeEntity().withPaymentInstrument(mockPaymentInstrumentEntity).withAgreementEntity(null).build();
 
-        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreementFromCharge(chargeEntity);
+        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreement(chargeEntity);
 
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
         var loggingEvent = loggingEventArgumentCaptor.getValue();


### PR DESCRIPTION
When an agreement is set up, set the `agreement_external_id` on the payment instrument. This is done at the same time we record the `payment_instrument_id` on the agreement.

By adding the `agreementExternalId` field to the PaymentInstrumentEntity this means it will be included in API responses that include the PaymentInstrumentEntity_FrontendView schema. There probably isn't an reason this shouldn't be returned, so not adding the @JsonIgnore field.