### PR TITLE
PP-10798 Add DAO method to get payment instruments for agreement

### DIFF
--- a/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
@@ -92,9 +92,9 @@ public class AgreementService {
                 .findByExternalId(agreementExternalId, gatewayAccountId)
                 .orElseThrow(() -> new AgreementNotFoundException("Agreement with ID [" + agreementExternalId + "] not found."));
         agreement.getPaymentInstrument()
-                .filter(paymentInstrument -> paymentInstrument.getPaymentInstrumentStatus() == PaymentInstrumentStatus.ACTIVE)
+                .filter(paymentInstrument -> paymentInstrument.getStatus() == PaymentInstrumentStatus.ACTIVE)
                 .ifPresentOrElse(paymentInstrument -> {
-                    paymentInstrument.setPaymentInstrumentStatus(PaymentInstrumentStatus.CANCELLED);
+                    paymentInstrument.setStatus(PaymentInstrumentStatus.CANCELLED);
                     taskQueueService.addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
                     if (agreementCancelRequest != null && agreementCancelRequest.getUserEmail() != null && agreementCancelRequest.getUserExternalId() != null) {
                         ledgerService.postEvent(AgreementCancelledByUser.from(agreement, agreementCancelRequest, Instant.now()));

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -1029,9 +1029,9 @@ public class ChargeService {
                 .orElseThrow(() -> new AgreementMissingPaymentInstrumentException("Agreement with ID [" + agreementEntity.getExternalId() +
                         "] does not have a payment instrument"));
 
-        if (paymentInstrumentEntity.getPaymentInstrumentStatus() != PaymentInstrumentStatus.ACTIVE) {
+        if (paymentInstrumentEntity.getStatus() != PaymentInstrumentStatus.ACTIVE) {
             throw new PaymentInstrumentNotActiveException("Agreement with ID [" + agreementEntity.getExternalId() + "] has payment instrument with ID [" +
-                    paymentInstrumentEntity.getExternalId() + "] but its state is [" + paymentInstrumentEntity.getPaymentInstrumentStatus() + "]");
+                    paymentInstrumentEntity.getExternalId() + "] but its state is [" + paymentInstrumentEntity.getStatus() + "]");
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
@@ -38,7 +38,7 @@ public class LinkPaymentInstrumentToAgreementService {
             chargeEntity.getAgreement().ifPresentOrElse(agreementEntity -> {
                 agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
                 paymentInstrumentEntity.setAgreementExternalId(agreementEntity.getExternalId());
-                paymentInstrumentEntity.setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
+                paymentInstrumentEntity.setStatus(PaymentInstrumentStatus.ACTIVE);
                 ledgerService.postEvent(List.of(
                         AgreementSetUp.from(agreementEntity, clock.instant()),
                         PaymentInstrumentConfirmed.from(agreementEntity, clock.instant())

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/dao/PaymentInstrumentDao.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/dao/PaymentInstrumentDao.java
@@ -4,9 +4,11 @@ import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
 import uk.gov.pay.connector.common.dao.JpaDao;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+import java.util.List;
 import java.util.Optional;
 
 @Transactional
@@ -26,5 +28,17 @@ public class PaymentInstrumentDao extends JpaDao<PaymentInstrumentEntity> {
                 .createQuery(query, PaymentInstrumentEntity.class)
                 .setParameter("externalId", externalId)
                 .getResultList().stream().findFirst();
+    }
+    
+    public List<PaymentInstrumentEntity> findPaymentInstrumentsByAgreementAndStatus(String agreementExternalId, PaymentInstrumentStatus status) {
+        String query = "SELECT p from PaymentInstrumentEntity p " +
+                "WHERE p.agreementExternalId = :agreementExternalId " +
+                "AND p.status = :status";
+        
+        return entityManager.get()
+                .createQuery(query, PaymentInstrumentEntity.class)
+                .setParameter("agreementExternalId", agreementExternalId)
+                .setParameter("status", status)
+                .getResultList();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
@@ -63,13 +63,21 @@ public class PaymentInstrumentEntity {
     @Column(name = "agreement_external_id")
     private String agreementExternalId;
 
-    private PaymentInstrumentEntity(Instant createdDate, Map<String, String> recurringAuthToken, Instant startDate, CardDetailsEntity cardDetails, PaymentInstrumentStatus paymentInstrumentStatus) {
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    @JsonSerialize(using = ToLowerCaseStringSerializer.class)
+    private PaymentInstrumentStatus status;
+
+    @Embedded
+    private CardDetailsEntity cardDetails;
+
+    private PaymentInstrumentEntity(Instant createdDate, Map<String, String> recurringAuthToken, Instant startDate, CardDetailsEntity cardDetails, PaymentInstrumentStatus status) {
         this.createdDate = createdDate;
         this.externalId = RandomIdGenerator.newId();
         this.recurringAuthToken = recurringAuthToken;
         this.startDate = startDate;
         this.cardDetails = cardDetails;
-        this.paymentInstrumentStatus = paymentInstrumentStatus;
+        this.status = status;
     }
 
     public Optional<Map<String, String>> getRecurringAuthToken() {
@@ -104,16 +112,16 @@ public class PaymentInstrumentEntity {
         this.externalId = externalId;
     }
 
-    public PaymentInstrumentStatus getPaymentInstrumentStatus() {
-        return paymentInstrumentStatus;
+    public PaymentInstrumentStatus getStatus() {
+        return status;
     }
 
-    public void setPaymentInstrumentStatus(PaymentInstrumentStatus newStatus) {
-        logger.info(format("Changing payment instrument status for externalId [%s] [%s]->[%s]", this.externalId, this.paymentInstrumentStatus, newStatus),
+    public void setStatus(PaymentInstrumentStatus newStatus) {
+        logger.info(format("Changing payment instrument status for externalId [%s] [%s]->[%s]", this.externalId, this.status, newStatus),
                 kv(PAYMENT_INSTRUMENT_EXTERNAL_ID, this.externalId),
-                kv("from_state", this.paymentInstrumentStatus),
+                kv("from_state", this.status),
                 kv("to_state", newStatus));
-        this.paymentInstrumentStatus = newStatus;
+        this.status = newStatus;
     }
 
     public CardDetailsEntity getCardDetails() {
@@ -131,15 +139,6 @@ public class PaymentInstrumentEntity {
     public void setAgreementExternalId(String agreementExternalId) {
         this.agreementExternalId = agreementExternalId;
     }
-
-    @Column(name = "status")
-    @Enumerated(EnumType.STRING)
-    @JsonProperty("status")
-    @JsonSerialize(using = ToLowerCaseStringSerializer.class)
-    private PaymentInstrumentStatus paymentInstrumentStatus;
-
-    @Embedded
-    private CardDetailsEntity cardDetails;
 
     public PaymentInstrumentEntity() {
         // For JPA

--- a/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
@@ -143,7 +143,7 @@ public class AgreementServiceTest {
         agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, cancelRequest);
         verify(mockedTaskQueueService).addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
         verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByUser.class));
-        assertThat(paymentInstrument.getPaymentInstrumentStatus(), is(PaymentInstrumentStatus.CANCELLED));
+        assertThat(paymentInstrument.getStatus(), is(PaymentInstrumentStatus.CANCELLED));
     }
 
     @Test
@@ -161,6 +161,6 @@ public class AgreementServiceTest {
         agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest());
         verify(mockedTaskQueueService).addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
         verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByService.class));
-        assertThat(paymentInstrument.getPaymentInstrumentStatus(), is(PaymentInstrumentStatus.CANCELLED));
+        assertThat(paymentInstrument.getStatus(), is(PaymentInstrumentStatus.CANCELLED));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
@@ -213,7 +213,7 @@ class ChargeServiceCreateAgreementTest {
     void shouldCreateChargeWithAuthorisationModeAgreement() {
         when(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
-        when(mockPaymentInstrumentEntity.getPaymentInstrumentStatus()).thenReturn(PaymentInstrumentStatus.ACTIVE);
+        when(mockPaymentInstrumentEntity.getStatus()).thenReturn(PaymentInstrumentStatus.ACTIVE);
         when(mockedUriInfo.getBaseUriBuilder()).thenReturn(fromUri(SERVICE_HOST));
         when(mockProviders.byName(PaymentGatewayName.SANDBOX)).thenReturn(mockPaymentProvider);
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
@@ -459,7 +459,7 @@ class ChargeServiceCreateAgreementTest {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
         when(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
-        when(mockPaymentInstrumentEntity.getPaymentInstrumentStatus()).thenReturn(paymentInstrumentStatus);
+        when(mockPaymentInstrumentEntity.getStatus()).thenReturn(paymentInstrumentStatus);
 
         final ChargeCreateRequest request = requestBuilder.withAmount(1000)
                 .withAgreementId(AGREEMENT_ID)

--- a/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
@@ -30,11 +30,9 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 
 @ExtendWith(MockitoExtension.class)
@@ -91,7 +89,7 @@ class LinkPaymentInstrumentToAgreementServiceTest {
 
         verify(mockAgreementEntity).setPaymentInstrument(mockPaymentInstrumentEntity);
         verify(mockPaymentInstrumentEntity).setAgreementExternalId(agreementExternalId);
-        verify(mockPaymentInstrumentEntity).setPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE);
+        verify(mockPaymentInstrumentEntity).setStatus(PaymentInstrumentStatus.ACTIVE);
         verify(ledgerService).postEvent(List.of(
                 AgreementSetUp.from(mockAgreementEntity, clock.instant()),
                 PaymentInstrumentConfirmed.from(mockAgreementEntity, clock.instant())

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.charge.model.domain.FeeType;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
@@ -67,6 +68,7 @@ public class DatabaseFixtures {
     public TestAgreement aTestAgreement() {
         return new TestAgreement();
     }
+
     public TestPaymentInstrument aTestPaymentInstrument() {
         return new TestPaymentInstrument();
     }
@@ -428,7 +430,7 @@ public class DatabaseFixtures {
         public void setRecurringEnabled(boolean recurringEnabled) {
             this.recurringEnabled = recurringEnabled;
         }
-        
+
         public TestAccount withAccountId(long accountId) {
             this.accountId = accountId;
             return this;
@@ -538,11 +540,12 @@ public class DatabaseFixtures {
             this.allowTelephonePaymentNotifications = allowTelephonePaymentNotifications;
             return this;
         }
-        
+
         public TestAccount withRecurringEnabled(boolean recurringEnabled) {
             this.recurringEnabled = recurringEnabled;
             return this;
         }
+
         public TestAccount withDefaultCredentials() {
             this.credentialsMap = defaultCredentials;
             return this;
@@ -1211,21 +1214,36 @@ public class DatabaseFixtures {
             return requires3DS;
         }
     }
-    
+
     public class TestPaymentInstrument {
-        Long paymentInstrumentId = RandomUtils.nextLong();;
+        Long paymentInstrumentId = RandomUtils.nextLong();
+        ;
         Map<String, String> recurringAuthToken;
         Instant createdDate = Instant.now();
         Instant startDate = Instant.now();
         String externalId = "externalIDabc";
-        
+
+        String agreementExternalId;
+
+        PaymentInstrumentStatus status = PaymentInstrumentStatus.CREATED;
+
         TestPaymentInstrument withPaymentInstrumentId(Long paymentInstrumentId) {
             this.paymentInstrumentId = paymentInstrumentId;
             return this;
         }
-        
+
         TestPaymentInstrument withExternalId(String externalId) {
             this.externalId = externalId;
+            return this;
+        }
+
+        TestPaymentInstrument withAgreementExternalId(String agreementExternalId) {
+            this.agreementExternalId = agreementExternalId;
+            return this;
+        }
+
+        TestPaymentInstrument withStatus(PaymentInstrumentStatus status) {
+            this.status = status;
             return this;
         }
 
@@ -1235,6 +1253,8 @@ public class DatabaseFixtures {
                     .withExternalPaymentInstrumentId(externalId)
                     .withCreatedDate(createdDate)
                     .withStartDate(startDate)
+                    .withPaymentInstrumentStatus(status)
+                    .withAgreementExternalId(agreementExternalId)
                     .build());
             return this;
         }

--- a/src/test/java/uk/gov/pay/connector/it/dao/PaymentInstrumentDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/PaymentInstrumentDaoIT.java
@@ -5,13 +5,17 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.connector.paymentinstrument.dao.PaymentInstrumentDao;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 
 public class PaymentInstrumentDaoIT extends DaoITestBase {
 
@@ -42,6 +46,30 @@ public class PaymentInstrumentDaoIT extends DaoITestBase {
         assertThat(paymentInstrument.isPresent(), is(false));
     }
 
+    @Test
+    public void shouldFindByAgreementIdAndStatus() {
+        String agreementExternalId = "an-agreement-id";
+        String otherAgreementExternalId = "other-agreement-id";
+        insertAgreement(agreementExternalId);
+        insertAgreement(otherAgreementExternalId);
+
+        insertTestPaymentInstrument("payment-instrument-1", agreementExternalId, 
+                PaymentInstrumentStatus.ACTIVE);
+        insertTestPaymentInstrument("payment-instrument-2", agreementExternalId, 
+                PaymentInstrumentStatus.ACTIVE);
+        insertTestPaymentInstrument("payment-instrument-3", agreementExternalId, 
+                PaymentInstrumentStatus.CREATED);
+        insertTestPaymentInstrument("payment-instrument-4", otherAgreementExternalId, 
+                PaymentInstrumentStatus.ACTIVE);
+        List<PaymentInstrumentEntity> paymentInstruments = paymentInstrumentDao.findPaymentInstrumentsByAgreementAndStatus(
+                agreementExternalId, PaymentInstrumentStatus.ACTIVE);
+        
+        assertThat(paymentInstruments, hasSize(2));
+        List<String> returnedPaymentInstrumentExternalIds = paymentInstruments.stream()
+                .map(PaymentInstrumentEntity::getExternalId).collect(Collectors.toList());
+        assertThat(returnedPaymentInstrumentExternalIds, containsInAnyOrder("payment-instrument-1", "payment-instrument-2"));
+    }
+
     @After
     public void clear() {
         databaseTestHelper.truncateAllData();
@@ -53,6 +81,26 @@ public class PaymentInstrumentDaoIT extends DaoITestBase {
                 .aTestPaymentInstrument()
                 .withPaymentInstrumentId(nextLong())
                 .withExternalId(paymentInstrumentExternalId)
+                .insert();
+    }
+    
+    private void insertTestPaymentInstrument(String externalId, String agreementExternalId, PaymentInstrumentStatus status) {
+        DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
+                .aTestPaymentInstrument()
+                .withExternalId(externalId)
+                .withAgreementExternalId(agreementExternalId)
+                .withStatus(status)
+                .insert();
+    }
+
+    private static void insertAgreement(String agreementExternalId) {
+        DatabaseFixtures.TestAccount testAccount = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+        DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
+                .aTestAgreement()
+                .withExternalId(agreementExternalId)
+                .withGatewayAccountId(testAccount.getAccountId())
                 .insert();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntityFixture.java
@@ -66,7 +66,7 @@ public final class PaymentInstrumentEntityFixture {
         paymentInstrumentEntity.setCreatedDate(createdDate);
         paymentInstrumentEntity.setStartDate(startDate);
         paymentInstrumentEntity.setExternalId(externalId);
-        paymentInstrumentEntity.setPaymentInstrumentStatus(paymentInstrumentStatus);
+        paymentInstrumentEntity.setStatus(paymentInstrumentStatus);
         paymentInstrumentEntity.setCardDetails(cardDetails);
         return paymentInstrumentEntity;
     }

--- a/src/test/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentServiceTest.java
@@ -54,7 +54,7 @@ class PaymentInstrumentServiceTest {
         assertThat(actualPaymentInstrumentEntity.getRecurringAuthToken(), is(Optional.of(token)));
         assertThat(actualPaymentInstrumentEntity.getCardDetails(), is(chargeEntity.getCardDetails()));
         assertThat(actualPaymentInstrumentEntity.getStartDate(), is(NOW));
-        assertThat(actualPaymentInstrumentEntity.getPaymentInstrumentStatus(), is(PaymentInstrumentStatus.CREATED));
+        assertThat(actualPaymentInstrumentEntity.getStatus(), is(PaymentInstrumentStatus.CREATED));
         assertThat(actualPaymentInstrumentEntity, is(paymentInstrument));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/AddPaymentInstrumentParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddPaymentInstrumentParams.java
@@ -18,6 +18,7 @@ public class AddPaymentInstrumentParams {
     private final Instant createdDate;
     private final Instant startDate;
     private final PaymentInstrumentStatus paymentInstrumentStatus;
+    private final String agreementExternalId;
     private final CardType cardType;
     private final String cardBrand;
     private final CardExpiryDate expiryDate;
@@ -51,6 +52,10 @@ public class AddPaymentInstrumentParams {
 
     public PaymentInstrumentStatus getPaymentInstrumentStatus() {
         return paymentInstrumentStatus;
+    }
+
+    public String getAgreementExternalId() {
+        return agreementExternalId;
     }
 
     public CardType getCardType() {
@@ -111,6 +116,7 @@ public class AddPaymentInstrumentParams {
         createdDate = builder.createdDate;
         startDate = builder.startDate;
         paymentInstrumentStatus = builder.paymentInstrumentStatus;
+        agreementExternalId = builder.agreementExternalId;
         cardType = builder.cardType;
         cardBrand = builder.cardBrand;
         expiryDate = builder.expiryDate;
@@ -132,6 +138,7 @@ public class AddPaymentInstrumentParams {
         private Instant createdDate = Instant.now();
         private Instant startDate = Instant.now();
         private PaymentInstrumentStatus paymentInstrumentStatus = PaymentInstrumentStatus.ACTIVE;
+        private String agreementExternalId;
         private CardType cardType = CardType.DEBIT;
         private String cardBrand = "visa";
         private CardExpiryDate expiryDate = CardExpiryDate.valueOf("12/27");
@@ -175,6 +182,11 @@ public class AddPaymentInstrumentParams {
 
         public AddPaymentInstrumentParamsBuilder withPaymentInstrumentStatus(PaymentInstrumentStatus paymentInstrumentStatus) {
             this.paymentInstrumentStatus = paymentInstrumentStatus;
+            return this;
+        }
+        
+        public AddPaymentInstrumentParamsBuilder withAgreementExternalId(String agreementExternalId) {
+            this.agreementExternalId = agreementExternalId;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -172,6 +172,7 @@ public class DatabaseTestHelper {
                                 "created_date, " +
                                 "start_date, " +
                                 "status, " +
+                                "agreement_external_id, " +
                                 "card_type, " +
                                 "card_brand, " +
                                 "expiry_date, " +
@@ -191,6 +192,7 @@ public class DatabaseTestHelper {
                                 ":created_date, " +
                                 ":start_date, " +
                                 ":status, " +
+                                ":agreement_external_id, " +
                                 ":card_type, " +
                                 ":card_brand, " +
                                 ":expiry_date, " +
@@ -210,6 +212,7 @@ public class DatabaseTestHelper {
                         .bind("created_date", LocalDateTime.ofInstant(addPaymentInstrumentParams.getCreatedDate(), UTC))
                         .bind("start_date", LocalDateTime.ofInstant(addPaymentInstrumentParams.getStartDate(), UTC))
                         .bind("status", addPaymentInstrumentParams.getPaymentInstrumentStatus())
+                        .bind("agreement_external_id", addPaymentInstrumentParams.getAgreementExternalId())
                         .bind("card_type", addPaymentInstrumentParams.getCardType())
                         .bind("card_brand", addPaymentInstrumentParams.getCardBrand())
                         .bind("expiry_date", addPaymentInstrumentParams.getExpiryDate().toString())


### PR DESCRIPTION
Add DAO method to find payment instruments by agreement external ID and status. This will be used to find active payment instruments for an agreement to cancel when a payment instrument is replaced on an agreement.