### PR TITLE
PP-10711 implement handling idempotency key

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -148,98 +148,98 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "423e3dd3782e3527b4f9af75dd9faf9ebbb7889c",
         "is_verified": false,
-        "line_number": 370
+        "line_number": 374
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 783
+        "line_number": 787
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 3044
+        "line_number": 3048
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 3412
+        "line_number": 3416
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3750
+        "line_number": 3754
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3799
+        "line_number": 3803
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4410
+        "line_number": 4414
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4477
+        "line_number": 4481
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4499
+        "line_number": 4503
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4678
+        "line_number": 4682
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4681
+        "line_number": 4685
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4684
+        "line_number": 4688
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5276
+        "line_number": 5280
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5287
+        "line_number": 5291
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -266,7 +266,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java",
         "hashed_secret": "423e3dd3782e3527b4f9af75dd9faf9ebbb7889c",
         "is_verified": false,
-        "line_number": 94
+        "line_number": 96
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java": [
@@ -1099,5 +1099,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-16T12:37:10Z"
+  "generated_at": "2023-03-16T16:14:05Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -328,6 +328,10 @@ paths:
         schema:
           type: integer
           format: int64
+      - in: header
+        name: Idempotency-Key
+        schema:
+          type: string
       requestBody:
         content:
           '*/*':

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -25,10 +25,12 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -116,8 +118,8 @@ public class ChargesApiResource {
     public Response createNewCharge(
             @Parameter(example = "1", description = "Gateway account ID") @PathParam(ACCOUNT_ID) Long accountId,
             @NotNull @Valid ChargeCreateRequest chargeRequest,
-            @Context UriInfo uriInfo
-    ) {
+            @Context UriInfo uriInfo,
+            @Nullable @HeaderParam("Idempotency-Key") String idempotencyKey) {
         logger.info("Creating new charge - {}", chargeRequest.toStringWithoutPersonalIdentifiableInformation());
 
         AuthorisationMode authorisationMode = chargeRequest.getAuthorisationMode();
@@ -135,7 +137,7 @@ public class ChargesApiResource {
             throw new UnexpectedAttributeException(RETURN_URL);
         }
 
-        return chargeService.create(chargeRequest, accountId, uriInfo)
+        return chargeService.create(chargeRequest, accountId, uriInfo, idempotencyKey)
                 .map(response -> {
                     if (authorisationMode == AuthorisationMode.AGREEMENT) {
                         chargeService.markChargeAsEligibleForAuthoriseUserNotPresent(response.getChargeId());

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -1,5 +1,9 @@
 package uk.gov.pay.connector.charge.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.collect.Maps;
 import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +20,7 @@ import uk.gov.pay.connector.charge.exception.AgreementMissingPaymentInstrumentEx
 import uk.gov.pay.connector.charge.exception.AgreementNotFoundBadRequestException;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.exception.GatewayAccountDisabledException;
+import uk.gov.pay.connector.charge.exception.IdempotencyKeyUsedException;
 import uk.gov.pay.connector.charge.exception.IncorrectAuthorisationModeForSavePaymentToAgreementException;
 import uk.gov.pay.connector.charge.exception.MissingMandatoryAttributeException;
 import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountException;
@@ -44,6 +49,7 @@ import uk.gov.pay.connector.charge.model.telephone.Supplemental;
 import uk.gov.pay.connector.charge.model.telephone.TelephoneChargeCreateRequest;
 import uk.gov.pay.connector.charge.resource.ChargesApiResource;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
+import uk.gov.pay.connector.charge.util.ChargeCreateRequestIdempotencyComparatorUtil;
 import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
@@ -75,6 +81,8 @@ import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
+import uk.gov.pay.connector.idempotency.model.IdempotencyEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
@@ -130,6 +138,8 @@ public class ChargeService {
 
     private static final List<ChargeStatus> CURRENT_STATUSES_ALLOWING_UPDATE_TO_NEW_STATUS = newArrayList(CREATED, ENTERING_CARD_DETAILS);
 
+    private static final ObjectMapper mapper = new ObjectMapper().registerModule(new Jdk8Module());
+
     private final ChargeDao chargeDao;
     private final ChargeEventDao chargeEventDao;
     private final CardTypeDao cardTypeDao;
@@ -149,6 +159,7 @@ public class ChargeService {
     private final AuthCardDetailsToCardDetailsEntityConverter authCardDetailsToCardDetailsEntityConverter;
     private final PaymentInstrumentService paymentInstrumentService;
     private final TaskQueueService taskQueueService;
+    private final IdempotencyDao idempotencyDao;
 
     @Inject
     public ChargeService(TokenDao tokenDao,
@@ -166,8 +177,8 @@ public class ChargeService {
                          PaymentInstrumentService paymentInstrumentService,
                          GatewayAccountCredentialsService gatewayAccountCredentialsService,
                          AuthCardDetailsToCardDetailsEntityConverter authCardDetailsToCardDetailsEntityConverter,
-                         TaskQueueService taskQueueService
-    ) {
+                         TaskQueueService taskQueueService,
+                         IdempotencyDao idempotencyDao) {
         this.tokenDao = tokenDao;
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
@@ -186,6 +197,7 @@ public class ChargeService {
         this.gatewayAccountCredentialsService = gatewayAccountCredentialsService;
         this.authCardDetailsToCardDetailsEntityConverter = authCardDetailsToCardDetailsEntityConverter;
         this.taskQueueService = taskQueueService;
+        this.idempotencyDao = idempotencyDao;
     }
 
     @Transactional
@@ -246,15 +258,15 @@ public class ChargeService {
         }
     }
 
-    public Optional<ChargeResponse> create(ChargeCreateRequest chargeRequest, Long accountId, UriInfo uriInfo) {
-        return createCharge(chargeRequest, accountId, uriInfo)
+    public Optional<ChargeResponse> create(ChargeCreateRequest chargeRequest, Long accountId, UriInfo uriInfo, String idempotencyKey) {
+        return createCharge(chargeRequest, accountId, idempotencyKey)
                 .map(charge ->
                         populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, charge).build()
                 );
     }
 
     @Transactional
-    private Optional<ChargeEntity> createCharge(ChargeCreateRequest chargeRequest, Long accountId, UriInfo uriInfo) {
+    private Optional<ChargeEntity> createCharge(ChargeCreateRequest chargeRequest, Long accountId, String idempotencyKey) {
         return gatewayAccountDao.findById(accountId).map(gatewayAccount -> {
             checkIfGatewayAccountDisabled(gatewayAccount);
 
@@ -314,6 +326,19 @@ public class ChargeService {
                     .ifPresent(chargeEntity::setCardDetails);
 
             if (authorisationMode == AuthorisationMode.AGREEMENT) {
+                if (idempotencyKey != null) {
+                    Optional<IdempotencyEntity> optionalIdempotencyEntity = idempotencyDao.findByGatewayAccountIdAndKey(gatewayAccount.getId(), idempotencyKey);
+                    if (optionalIdempotencyEntity.isPresent()) {
+                        IdempotencyEntity idempotencyEntity = optionalIdempotencyEntity.get();
+                        if (ChargeCreateRequestIdempotencyComparatorUtil.compare(chargeRequest, idempotencyEntity.getRequestBody())) {
+                            LOGGER.info("Idempotency-Key was already used to create a request with matching values {}", idempotencyKey);
+                            // TODO implement PP-10833, query Ledger if Charge has been expunged
+                            return findChargeByExternalId(idempotencyEntity.getResourceExternalId());
+                        }
+                        LOGGER.info("Idempotency-Key already exist with different values {}", idempotencyKey);
+                        throw new IdempotencyKeyUsedException();
+                    }
+                }
                 agreementEntity.ifPresent(agreement -> {
                     checkAgreementHasActivePaymentInstrument(agreement);
                     agreement.getPaymentInstrument()
@@ -322,8 +347,20 @@ public class ChargeService {
             }
 
             chargeDao.persist(chargeEntity);
+
+            if (authorisationMode == AGREEMENT && idempotencyKey != null) {
+                IdempotencyEntity idempotencyEntity = new IdempotencyEntity(
+                        idempotencyKey,
+                        gatewayAccount,
+                        chargeEntity.getExternalId(),
+                        mapper.convertValue(chargeRequest, new TypeReference<>() {}),
+                        Instant.now());
+                idempotencyDao.persist(idempotencyEntity);
+            }
+
             transitionChargeState(chargeEntity, CREATED);
             chargeDao.merge(chargeEntity);
+
             return chargeEntity;
         });
     }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreatePrefilledCardholderDetailsTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreatePrefilledCardholderDetailsTest.java
@@ -32,6 +32,7 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
@@ -122,6 +123,9 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
     @Mock
     private TaskQueueService mockTaskQueueService;
 
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
+
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
 
@@ -159,7 +163,8 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         chargeService = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
     }
 
     @Test
@@ -175,7 +180,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         var address = new PrefilledAddress("Line1", "Line2", "AB1 CD2", "London", null, "GB");
         cardHolderDetails.setAddress(address);
         final ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -206,7 +211,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
 
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -237,7 +242,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         cardHolderDetails.setAddress(address);
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -266,7 +271,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         cardHolderDetails.setCardHolderName("Joe Bogs");
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -289,7 +294,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         cardHolderDetails.setAddress(address);
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -315,7 +320,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
 
         ChargeCreateRequest request = requestBuilder.build();
-        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTelephonePaymentTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTelephonePaymentTest.java
@@ -30,6 +30,7 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
@@ -114,6 +115,8 @@ class ChargeServiceCreateTelephonePaymentTest {
 
     @Mock
     private TaskQueueService mockTaskQueueService;
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
 
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
@@ -159,7 +162,8 @@ class ChargeServiceCreateTelephonePaymentTest {
         chargeService = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
@@ -37,6 +37,7 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
@@ -147,6 +148,8 @@ class ChargeServiceFindTest {
 
     @Mock
     private TaskQueueService mockTaskQueueService;
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
 
     @Captor ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor;
 
@@ -192,7 +195,7 @@ class ChargeServiceFindTest {
         chargeService = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao);
     }
     @Test
     void shouldNotFindCharge() {

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
@@ -24,6 +24,7 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
@@ -77,6 +78,8 @@ class ChargeServicePostAuthorisationTest {
     @Mock private CardDetailsEntity mockCardDetailsEntity;
     @Mock private ChargeEventEntity mockChargeEventEntity;
     @Mock private PaymentInstrumentEntity mockPaymentInstrumentEntity;
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
 
     private final Auth3dsRequiredEntity auth3dsRequiredEntity = new Auth3dsRequiredEntity();
     private final ChargeEntityFixture chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity();
@@ -110,7 +113,8 @@ class ChargeServicePostAuthorisationTest {
         chargeService = new ChargeService(mockTokenDao, mockChargeDao, mockChargeEventDao,
                 mockCardTypeDao, mockAgreementDao, mockGatewayAccountDao, mockConnectorConfig, mockProviders,
                 mockStateTransitionService, mockLedgerService, mockRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -48,6 +48,7 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
@@ -170,7 +171,10 @@ class ChargeServiceTest {
     
     @Mock
     private TaskQueueService mockTaskQueueService;
-    
+
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
+
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
 
@@ -211,7 +215,8 @@ class ChargeServiceTest {
         chargeService = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
     }
 
     @Test
@@ -334,7 +339,7 @@ class ChargeServiceTest {
         when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
 
-        chargeService.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        chargeService.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo, null);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationRespon
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsFlexRequiredParams;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsRequiredParams;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
@@ -85,6 +86,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
     @Mock
     private TaskQueueService mockTaskQueueService;
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
 
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
@@ -115,7 +118,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
                 null, null, mockConfiguration, null, mockStateTransitionService, ledgerService,
                 mockedRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
-                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao);
         AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment, mockConfiguration);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, authorisationService, mockConfiguration);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -63,6 +63,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
@@ -192,6 +193,9 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     @Mock
     private Appender<ILoggingEvent> mockAppender;
 
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
+
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
@@ -215,7 +219,8 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null,
                 stateTransitionService, ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
 
         LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService = mock(LinkPaymentInstrumentToAgreementService.class);
         CaptureQueue captureQueue = mock(CaptureQueue.class);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -39,6 +39,7 @@ import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.queue.capture.CaptureQueue;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
@@ -121,6 +122,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
     protected AuthCardDetailsToCardDetailsEntityConverter mockAuthCardDetailsToCardDetailsEntityConverter;
     @Mock
     private TaskQueueService mockTaskQueueService;
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
     private static final Clock GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK = Clock.fixed(Instant.parse("2020-01-01T10:10:10.100Z"), ZoneOffset.UTC);
 
     @Before
@@ -132,7 +135,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
-                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService);
+                mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
+                mockTaskQueueService, mockIdempotencyDao);
 
         cardCaptureService = new CardCaptureService(chargeService, mockedProviders, mockUserNotificationService, mockEnvironment,
                 GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK, mockCaptureQueue, mockEventService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthorisationRequestSummary
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
@@ -123,7 +124,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
                 null, mock(AgreementDao.class), null, mock(ConnectorConfiguration.class), null,
                 mock(StateTransitionService.class), mock(LedgerService.class), mock(RefundService.class),
                 mock(EventService.class), mock(PaymentInstrumentService.class), mock(GatewayAccountCredentialsService.class),
-                mock(AuthCardDetailsToCardDetailsEntityConverter.class), mockTaskQueueService);
+                mock(AuthCardDetailsToCardDetailsEntityConverter.class), mockTaskQueueService, mock(IdempotencyDao.class));
 
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
         when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -45,6 +45,7 @@ import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
 import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
@@ -149,6 +150,9 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     @Mock
     private AuthorisationConfig mockAuthorisationConfig;
 
+    @Mock
+    private IdempotencyDao mockIdempotencyDao;
+
     private WalletAuthoriseService walletAuthoriseService;
 
     private final AppleDecryptedPaymentData validApplePayDetails =
@@ -187,7 +191,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null, mockStateTransitionService,
                 ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
-                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService));
+                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,


### PR DESCRIPTION
## WHAT YOU DID
- add HeaderParam Idempotency-Key
- refactor ChargeService to pass on idempotency key
- refactor createCharge method to check for existing idempotency entry when AuthorisationMode is AGREEMENT and idempotency key is present

- if idempotency entry exists:
	- throw error (409) if request is different
	- return ChargeEntity if request matches
