### PR TITLE
PP-10794 Update WorldpayAuthorisationRejectedCodeMapper

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/WorldpayAuthorisationRejectedCodeMapper.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/WorldpayAuthorisationRejectedCodeMapper.java
@@ -38,6 +38,7 @@ public class WorldpayAuthorisationRejectedCodeMapper {
                 entry("13", INVALID_AMOUNT),
                 entry("14", INVALID_CARD_NUMBER),
                 entry("15", NO_SUCH_ISSUER),
+                entry("34", SUSPECTED_FRAUD),
                 entry("41", LOST_CARD),
                 entry("43", STOLEN_CARD),
                 entry("46", CLOSED_ACCOUNT),


### PR DESCRIPTION
- add Worldpay code 34 ("Fraud suspicion") to the mapper
- this ensures that payments declined with code 34 are logged with a rejection reason of SUSPECTED_FRAUD.