### PR TITLE
PP-10711 Add validation for Idempotency-Key header

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -266,7 +266,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java",
         "hashed_secret": "423e3dd3782e3527b4f9af75dd9faf9ebbb7889c",
         "is_verified": false,
-        "line_number": 98
+        "line_number": 99
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java": [
@@ -1099,5 +1099,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-21T12:34:21Z"
+  "generated_at": "2023-03-22T17:52:13Z"
 }

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.hibernate.validator.constraints.Length;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.exception.InvalidAttributeValueException;
@@ -121,7 +122,7 @@ public class ChargesApiResource {
             @Parameter(example = "1", description = "Gateway account ID") @PathParam(ACCOUNT_ID) Long accountId,
             @NotNull @Valid ChargeCreateRequest chargeRequest,
             @Context UriInfo uriInfo,
-            @Nullable @HeaderParam("Idempotency-Key") String idempotencyKey) {
+            @Nullable @Length(min = 1, max = 255, message = "Header [Idempotency-Key] can have a size between 1 and 255") @HeaderParam("Idempotency-Key") String idempotencyKey) {
         logger.info("Creating new charge - {}", chargeRequest.toStringWithoutPersonalIdentifiableInformation());
 
         AuthorisationMode authorisationMode = chargeRequest.getAuthorisationMode();


### PR DESCRIPTION
Add validation that the value for the Idempotency-Key header is between 1 and 255 characters long.