### PR TITLE
PP-9033 Remove`requires_additional_kyc_data` flag

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -190,56 +190,56 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4414
+        "line_number": 4408
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4481
+        "line_number": 4469
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4503
+        "line_number": 4491
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4682
+        "line_number": 4670
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4685
+        "line_number": 4673
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4688
+        "line_number": 4676
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5280
+        "line_number": 5268
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5291
+        "line_number": 5279
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1099,5 +1099,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-29T09:11:22Z"
+  "generated_at": "2023-04-03T10:23:31Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -4031,8 +4031,6 @@ components:
           type: boolean
         requires3ds:
           type: boolean
-        requires_additional_kyc_data:
-          type: boolean
         send_payer_email_to_gateway:
           type: boolean
         send_payer_ip_address_to_gateway:
@@ -4134,8 +4132,6 @@ components:
           type: boolean
         requires3ds:
           type: boolean
-        requires_additional_kyc_data:
-          type: boolean
         send_payer_email_to_gateway:
           type: boolean
         send_payer_ip_address_to_gateway:
@@ -4234,8 +4230,6 @@ components:
         recurring_enabled:
           type: boolean
         requires3ds:
-          type: boolean
-        requires_additional_kyc_data:
           type: boolean
         send_payer_email_to_gateway:
           type: boolean
@@ -4450,12 +4444,6 @@ components:
         requires3ds:
           type: boolean
           description: Flag to indicate whether 3DS is enabled
-          example: true
-        requires_additional_kyc_data:
-          type: boolean
-          default: false
-          description: Flag to indicate whether the account requires additional KYC
-            data. Used to enable additional KYC data collection for stripe accounts
           example: true
         send_payer_email_to_gateway:
           type: boolean

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -169,10 +169,6 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     @Column(name = "provider_switch_enabled")
     private boolean providerSwitchEnabled;
-
-    @Column(name = "requires_additional_kyc_data")
-    private boolean requiresAdditionalKycData;
-
     @Column(name = "recurring_enabled")
     private boolean recurringEnabled;
 
@@ -447,12 +443,6 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return sendReferenceToGateway;
     }
 
-    @JsonProperty("requires_additional_kyc_data")
-    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
-    public boolean isRequiresAdditionalKycData() {
-        return requiresAdditionalKycData;
-    }
-
     @JsonProperty("allow_authorisation_api")
     @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public boolean isAllowAuthorisationApi() {
@@ -626,10 +616,6 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public void setSendReferenceToGateway(boolean sendReferenceToGateway) {
         this.sendReferenceToGateway = sendReferenceToGateway;
-    }
-
-    public void setRequiresAdditionalKycData(boolean requiresAdditionalKycData) {
-        this.requiresAdditionalKycData = requiresAdditionalKycData;
     }
 
     public void setRecurringEnabled(boolean recurringEnabled) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -149,11 +149,6 @@ public class GatewayAccountResourceDTO {
             "Otherwise payment description is sent to the gateway. Only applicable for Worldpay accounts. Default value is 'false'", defaultValue = "false")
     private boolean sendReferenceToGateway;
 
-    @JsonProperty("requires_additional_kyc_data")
-    @Schema(example = "true", description = "Flag to indicate whether the account requires additional KYC data. Used to enable additional KYC data collection for stripe accounts",
-            defaultValue = "false")
-    private boolean requiresAdditionalKycData;
-
     @JsonProperty("allow_authorisation_api")
     @Schema(example = "true", description = "Flag to indicate whether the account is allowed to initiate MOTO payments that are authorised via " +
             "an API request rather than the web interface", defaultValue = "false")
@@ -203,7 +198,6 @@ public class GatewayAccountResourceDTO {
         this.sendReferenceToGateway = gatewayAccountEntity.isSendReferenceToGateway();
         this.sendPayerIpAddressToGateway = gatewayAccountEntity.isSendPayerIpAddressToGateway();
         this.serviceId = gatewayAccountEntity.getServiceId();
-        this.requiresAdditionalKycData = gatewayAccountEntity.isRequiresAdditionalKycData();
         this.allowAuthorisationApi = gatewayAccountEntity.isAllowAuthorisationApi();
         this.recurringEnabled = gatewayAccountEntity.isRecurringEnabled();
         this.disabled = gatewayAccountEntity.isDisabled();
@@ -328,10 +322,6 @@ public class GatewayAccountResourceDTO {
 
     public Optional<Worldpay3dsFlexCredentials> getWorldpay3dsFlexCredentials() {
         return Optional.ofNullable(worldpay3dsFlexCredentials);
-    }
-
-    public boolean isRequiresAdditionalKycData() {
-        return requiresAdditionalKycData;
     }
 
     public boolean isAllowAuthorisationApi() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -45,7 +45,6 @@ public class GatewayAccountRequestValidator {
     public static final String FIELD_SEND_PAYER_EMAIL_TO_GATEWAY = "send_payer_email_to_gateway";
     public static final String FIELD_PROVIDER_SWITCH_ENABLED = "provider_switch_enabled";
     public static final String FIELD_SEND_REFERENCE_TO_GATEWAY = "send_reference_to_gateway";
-    public static final String FIELD_REQUIRES_ADDITIONAL_KYC_DATA = "requires_additional_kyc_data";
     public static final String FIELD_ALLOW_AUTHORISATION_API = "allow_authorisation_api";
     public static final String FIELD_RECURRING_ENABLED = "recurring_enabled";
     public static final String FIELD_DISABLED = "disabled";
@@ -72,7 +71,6 @@ public class GatewayAccountRequestValidator {
             FIELD_SEND_PAYER_EMAIL_TO_GATEWAY,
             FIELD_PROVIDER_SWITCH_ENABLED,
             FIELD_SEND_REFERENCE_TO_GATEWAY,
-            FIELD_REQUIRES_ADDITIONAL_KYC_DATA,
             FIELD_ALLOW_AUTHORISATION_API,
             FIELD_RECURRING_ENABLED,
             FIELD_DISABLED,
@@ -114,7 +112,6 @@ public class GatewayAccountRequestValidator {
             case FIELD_SEND_PAYER_EMAIL_TO_GATEWAY:
             case FIELD_PROVIDER_SWITCH_ENABLED:
             case FIELD_SEND_REFERENCE_TO_GATEWAY:
-            case FIELD_REQUIRES_ADDITIONAL_KYC_DATA:
             case FIELD_ALLOW_AUTHORISATION_API:
             case FIELD_RECURRING_ENABLED:
             case FIELD_DISABLED:

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -49,7 +49,6 @@ import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequest
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_NOTIFY_SETTINGS;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_PROVIDER_SWITCH_ENABLED;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_RECURRING_ENABLED;
-import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_REQUIRES_ADDITIONAL_KYC_DATA;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_PAYER_EMAIL_TO_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_REFERENCE_TO_GATEWAY;
@@ -219,8 +218,6 @@ public class GatewayAccountService {
                         }
                     }
             ),
-            entry(FIELD_REQUIRES_ADDITIONAL_KYC_DATA, (gatewayAccountRequest, gatewayAccountEntity) ->
-                    gatewayAccountEntity.setRequiresAdditionalKycData(gatewayAccountRequest.valueAsBoolean())),
             entry(FIELD_ALLOW_AUTHORISATION_API, (gatewayAccountRequest, gatewayAccountEntity) ->
                     gatewayAccountEntity.setAllowAuthorisationApi(gatewayAccountRequest.valueAsBoolean())),
             entry(FIELD_RECURRING_ENABLED, (gatewayAccountRequest, gatewayAccountEntity) ->

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1978,4 +1978,8 @@
         </createIndex>
     </changeSet>
 
+    <changeSet id="remove requires_additional_kyc_data field from gateway accounts table" author="">
+        <dropColumn tableName="gateway_accounts" columnName="requires_additional_kyc_data"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
@@ -45,7 +45,6 @@ public final class GatewayAccountEntityFixture {
     private boolean sendPayerIpAddressToGateway;
     private List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntities = new ArrayList<>();
     private boolean providerSwitchEnabled = false;
-    private boolean requiresAdditionalKycData = false;
     private boolean blockPrepaidCards;
     private boolean disabled = false;
 
@@ -191,11 +190,6 @@ public final class GatewayAccountEntityFixture {
         return this;
     }
 
-    public GatewayAccountEntityFixture withRequiresAdditionalKycData(boolean requiresAdditionalKycData) {
-        this.requiresAdditionalKycData = requiresAdditionalKycData;
-        return this;
-    }
-    
     public GatewayAccountEntityFixture withBlockPrepaidCards(boolean blockPrepaidCards) {
         this.blockPrepaidCards = blockPrepaidCards;
         return this;
@@ -229,7 +223,6 @@ public final class GatewayAccountEntityFixture {
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
         gatewayAccountEntity.setSendPayerIpAddressToGateway(sendPayerIpAddressToGateway);
         gatewayAccountEntity.setProviderSwitchEnabled(providerSwitchEnabled);
-        gatewayAccountEntity.setRequiresAdditionalKycData(requiresAdditionalKycData);
         gatewayAccountEntity.setBlockPrepaidCards(blockPrepaidCards);
         gatewayAccountEntity.setDisabled(disabled);
         gatewayAccountEntity.setAllowMoto(allowMoto);

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -59,7 +59,6 @@ class GatewayAccountResourceDTOTest {
         Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
         emailNotifications.put(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(new GatewayAccountEntity(), "testTemplate", true));
         entity.setEmailNotifications(emailNotifications);
-        entity.setRequiresAdditionalKycData(true);
         
         GatewayAccountResourceDTO dto = new GatewayAccountResourceDTO(entity);
         assertThat(dto.getAccountId(), is(entity.getId()));
@@ -90,7 +89,6 @@ class GatewayAccountResourceDTOTest {
         assertThat(dto.isSendPayerIpAddressToGateway(), is(true));
         assertThat(dto.isSendPayerEmailToGateway(), is(true));
         assertThat(dto.isSendReferenceToGateway(), is(true));
-        assertThat(dto.isRequiresAdditionalKycData(), is(true));
         assertThat(dto.isAllowAuthorisationApi(), is(entity.isAllowAuthorisationApi()));
         assertThat(dto.isRecurringEnabled(), is(entity.isRecurringEnabled()));
         assertThat(dto.isDisabled(), is(entity.isDisabled()));

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
@@ -269,7 +269,6 @@ class GatewayAccountRequestValidatorTest {
                 arguments("replace", "provider_switch_enabled", "unfalse", "Value [unfalse] must be of type boolean for path [provider_switch_enabled]"),
                 arguments("replace", "send_reference_to_gateway", null, "Field [value] is required"),
                 arguments("replace", "send_reference_to_gateway", "unfalse", "Value [unfalse] must be of type boolean for path [send_reference_to_gateway]"),
-                arguments("replace", "requires_additional_kyc_data", "unfalse", "Value [unfalse] must be of type boolean for path [requires_additional_kyc_data]"),
                 arguments("replace", "allow_authorisation_api", "unfalse", "Value [unfalse] must be of type boolean for path [allow_authorisation_api]"),
                 arguments("replace", "recurring_enabled", "unfalse", "Value [unfalse] must be of type boolean for path [recurring_enabled]"),
                 arguments("replace", "disabled", "unfalse", "Value [unfalse] must be of type boolean for path [disabled]"),

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -6,11 +6,11 @@ import io.restassured.http.ContentType;
 import org.hamcrest.core.Is;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.util.Map;
 
@@ -832,27 +832,6 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .patch("/v1/api/accounts/" + gatewayAccountId)
                 .then()
                 .statusCode(NOT_FOUND.getStatusCode());
-    }
-
-    @Test
-    public void patchGatewayAccount_forRequiresAdditionalKycData() throws JsonProcessingException {
-        String gatewayAccountId = createAGatewayAccountFor("sandbox", "a-description", "analytics-id");
-        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
-                "path", "requires_additional_kyc_data",
-                "value", true));
-        givenSetup()
-                .get("/v1/api/accounts/" + gatewayAccountId)
-                .then()
-                .body("requires_additional_kyc_data", is(false));
-        givenSetup()
-                .body(payload)
-                .patch("/v1/api/accounts/" + gatewayAccountId)
-                .then()
-                .statusCode(OK.getStatusCode());
-        givenSetup()
-                .get("/v1/api/accounts/" + gatewayAccountId)
-                .then()
-                .body("requires_additional_kyc_data", is(true));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- Remove `requires_additional_kyc_data` flag from gateway accounts as the flag is no longer required
- Blocked on https://github.com/alphagov/pay-selfservice/pull/3890

