### PR TITLE
PP-10715 DAO method to delete old idempotency keys

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ChargeSweepConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/ChargeSweepConfig.java
@@ -10,7 +10,8 @@ public class ChargeSweepConfig extends Configuration {
     private int awaitingCaptureExpiryThreshold;
     private int tokenExpiryThresholdInSeconds;
     private int skipExpiringChargesLastUpdatedInSeconds;
-
+    private int idempotencyKeyExpiryThresholdInSeconds;
+    
     public Duration getDefaultChargeExpiryThreshold() {
         return Duration.ofSeconds(defaultChargeExpiryThreshold);
     }
@@ -25,5 +26,9 @@ public class ChargeSweepConfig extends Configuration {
 
     public Duration getSkipExpiringChargesLastUpdatedInSeconds() {
         return Duration.ofSeconds(skipExpiringChargesLastUpdatedInSeconds);
+    }
+    
+    public Duration getIdempotencyKeyExpiryThresholdInSeconds() {
+        return Duration.ofSeconds(idempotencyKeyExpiryThresholdInSeconds);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/idempotency/dao/IdempotencyDao.java
+++ b/src/main/java/uk/gov/pay/connector/idempotency/dao/IdempotencyDao.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.common.dao.JpaDao;
 import uk.gov.pay.connector.idempotency.model.IdempotencyEntity;
 
 import javax.persistence.EntityManager;
+import java.time.Instant;
 import java.util.Optional;
 
 public class IdempotencyDao extends JpaDao<IdempotencyEntity> {
@@ -24,5 +25,13 @@ public class IdempotencyDao extends JpaDao<IdempotencyEntity> {
                 .setParameter("gatewayAccountId", gatewayAccountId)
                 .setParameter("key", key)
                 .getResultList().stream().findFirst();
+    }
+
+    public int deleteIdempotencyKeysOlderThanSpecifiedDateTime(Instant idempotencyKeyExpiryDate) {
+        String query = "DELETE FROM IdempotencyEntity ie WHERE ie.createdDate < :idempotencyKeyExpiryDate";
+        return entityManager.get()
+                .createQuery(query, IdempotencyEntity.class)
+                .setParameter("idempotencyKeyExpiryDate", idempotencyKeyExpiryDate)
+                .executeUpdate();
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -259,6 +259,7 @@ chargesSweepConfig:
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
   skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
+  idempotencyKeyExpiryThresholdInSeconds: ${IDEMPOTENCY_KEY_EXPIRY_THRESHOLD_IN_SECONDS:-86400}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -1152,6 +1152,21 @@ public class DatabaseTestHelper {
                         .execute());
     }
 
+    public void insertIdempotency(String key, Instant createdDate, Long gatewayAccountId, String resourceExternalId, Map<String,Object> requestBody) {
+        PGobject requestBodyJson = mapToJsonPGobject(requestBody);
+
+        jdbi.withHandle(handle ->
+                handle.createUpdate("INSERT INTO idempotency(key, created_date, gateway_account_id, " +
+                                "resource_external_id, request_body) " +
+                                " VALUES (:key, :createdDate, :gatewayAccountId, :resourceExternalId, :requestBody)")
+                        .bind("key", key)
+                        .bind("createdDate", createdDate)
+                        .bind("gatewayAccountId", gatewayAccountId)
+                        .bind("resourceExternalId", resourceExternalId)
+                        .bindBySqlType("requestBody", requestBodyJson, OTHER)
+                        .execute());
+    }
+    
     public void insertGatewayAccountCredentials(AddGatewayAccountCredentialsParams params) {
         PGobject credentialsJson = buildCredentialsJson(params);
 


### PR DESCRIPTION
- Idempotency keys should be deleted when they are over 24 hours old
- Add DAO method to delete expiring keys
- Add integration test
- Add environment variable for idempotency key expiry threshold
- Changes to Resource and Service to call the deletion method will be added in a separate PR