### PR TITLE
PP-10715 Add deletion of expired idempotency keys to charge expiry sweep

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -162,84 +162,84 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 3047
+        "line_number": 3048
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 3415
+        "line_number": 3416
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3753
+        "line_number": 3754
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3802
+        "line_number": 3803
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4407
+        "line_number": 4408
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4468
+        "line_number": 4469
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4490
+        "line_number": 4491
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4669
+        "line_number": 4670
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4672
+        "line_number": 4673
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4675
+        "line_number": 4676
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5265
+        "line_number": 5266
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5276
+        "line_number": 5277
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1099,5 +1099,5 @@
       }
     ]
   },
-  "generated_at": "2023-04-03T12:07:38Z"
+  "generated_at": "2023-04-13T11:05:19Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -2097,14 +2097,15 @@ paths:
       - Tasks
   /v1/tasks/expired-charges-sweep:
     post:
-      description: This starts a task to expire the charges with a default window
-        of 90 minutes. The default value can be overridden by setting an environment
-        variable CHARGE_EXPIRY_WINDOW_SECONDS in seconds. Response of the call will
-        tell you how many charges were successfully expired and how many of them failed
-        for some reason. This endpoint also expires charges in AWAITING_CAPTURE_REQUEST
-        status. The default window is 120 hours. It can be overriden by setting an
-        environment variable AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW in seconds. Also
-        expires tokens older than the configured TOKEN_EXPIRY_WINDOW_SECONDS.
+      description: "This starts a task to expire the charges with a default window\
+        \ of 90 minutes. The default value can be overridden by setting an environment\
+        \ variable CHARGE_EXPIRY_WINDOW_SECONDS in seconds. Response of the call will\
+        \ tell you how many charges were successfully expired and how many of them\
+        \ failed for some reason. This endpoint also expires charges in AWAITING_CAPTURE_REQUEST\
+        \ status. The default window is 120 hours. It can be overriden by setting\
+        \ an environment variable AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW in seconds.\
+        \ Also expires tokens older than the configured TOKEN_EXPIRY_WINDOW_SECONDS,\
+        \ and expires idempotency keys older than the configured IDEMPOTENCY_KEY_EXPIRY_WINDOW_SECONDS."
       operationId: expireCharges
       responses:
         "200":
@@ -2116,7 +2117,7 @@ paths:
                   expiry-success: 2
                   expiry-failed: 0
           description: OK
-      summary: 'Expire charges and tokens '
+      summary: "Expire charges, tokens and idempotency keys"
       tags:
       - Tasks
   /v1/tasks/expunge:

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -203,13 +203,14 @@ public class ChargesApiResource {
     @Path("/v1/tasks/expired-charges-sweep")
     @Produces(APPLICATION_JSON)
     @Operation(
-            summary = "Expire charges and tokens ",
+            summary = "Expire charges, tokens and idempotency keys",
             description = "This starts a task to expire the charges with a default window of 90 minutes. " +
                     "The default value can be overridden by setting an environment variable CHARGE_EXPIRY_WINDOW_SECONDS in seconds. " +
                     "Response of the call will tell you how many charges were successfully expired and how many of them failed for some reason. " +
                     "This endpoint also expires charges in AWAITING_CAPTURE_REQUEST status. The default window is 120 hours. " +
                     "It can be overriden by setting an environment variable AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW in seconds. " +
-                    "Also expires tokens older than the configured TOKEN_EXPIRY_WINDOW_SECONDS.",
+                    "Also expires tokens older than the configured TOKEN_EXPIRY_WINDOW_SECONDS, " +
+                    "and expires idempotency keys older than the configured IDEMPOTENCY_KEY_EXPIRY_WINDOW_SECONDS.",
             tags = {"Tasks"},
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",
@@ -220,7 +221,7 @@ public class ChargesApiResource {
             }
     )
     public Response expireCharges(@Context UriInfo uriInfo) {
-        Map<String, Integer> resultMap = chargeExpiryService.sweepAndExpireChargesAndTokens();
+        Map<String, Integer> resultMap = chargeExpiryService.sweepAndExpireChargesAndTokensAndIdempotencyKeys();
         return successResponseWithEntity(resultMap);
     }
 

--- a/src/main/java/uk/gov/pay/connector/idempotency/dao/IdempotencyDao.java
+++ b/src/main/java/uk/gov/pay/connector/idempotency/dao/IdempotencyDao.java
@@ -27,11 +27,11 @@ public class IdempotencyDao extends JpaDao<IdempotencyEntity> {
                 .getResultList().stream().findFirst();
     }
 
-    public int deleteIdempotencyKeysOlderThanSpecifiedDateTime(Instant idempotencyKeyExpiryDate) {
-        String query = "DELETE FROM IdempotencyEntity ie WHERE ie.createdDate < :idempotencyKeyExpiryDate";
+    public int deleteIdempotencyKeysOlderThanSpecifiedDateTime(Instant expiryDate) {
+        String query = "DELETE FROM IdempotencyEntity ie WHERE ie.createdDate < :expiryDate";
         return entityManager.get()
                 .createQuery(query, IdempotencyEntity.class)
-                .setParameter("idempotencyKeyExpiryDate", idempotencyKeyExpiryDate)
+                .setParameter("expiryDate", expiryDate)
                 .executeUpdate();
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -259,7 +259,7 @@ chargesSweepConfig:
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
   skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
-  idempotencyKeyExpiryThresholdInSeconds: ${IDEMPOTENCY_KEY_EXPIRY_THRESHOLD_IN_SECONDS:-86400}
+  idempotencyKeyExpiryThresholdInSeconds: ${IDEMPOTENCY_KEY_EXPIRY_WINDOW_SECONDS:-86400}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}


### PR DESCRIPTION
- Context: idempotency keys should be deleted after agreed lifespan (currently 24 hours)
- call deletion of idempotency keys older than the threshold set in config
- update unit test
- rename methods for clarity