### PR TITLE
PP-10715 Add idempotency key expiry to test config

### DIFF
--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -416,6 +416,7 @@ public class ChargeExpiryServiceTest {
                 ));
         verify(mockChargeService).transitionChargeState(chargeEntityAwaitingCapture.getExternalId(), EXPIRED);
         verify(mockChargeService).transitionChargeState(chargeEntityAuthorisationSuccess.getExternalId(), EXPIRED);
+        verify(mockIdempotencyDao).deleteIdempotencyKeysOlderThanSpecifiedDateTime(Instant.parse("2022-06-08T00:00:00Z"));
     }
 
     @Test

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -194,6 +194,7 @@ chargesSweepConfig:
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
   skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
+  idempotencyKeyExpiryThresholdInSeconds: ${IDEMPOTENCY_KEY_EXPIRY_WINDOW_SECONDS:-86400}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -196,6 +196,7 @@ chargesSweepConfig:
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
   skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
+  idempotencyKeyExpiryThresholdInSeconds: ${IDEMPOTENCY_KEY_EXPIRY_WINDOW_SECONDS:-86400}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -186,6 +186,7 @@ chargesSweepConfig:
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
   skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
+  idempotencyKeyExpiryThresholdInSeconds: ${IDEMPOTENCY_KEY_EXPIRY_WINDOW_SECONDS:-86400}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -195,6 +195,7 @@ chargesSweepConfig:
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
   skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
+  idempotencyKeyExpiryThresholdInSeconds: ${IDEMPOTENCY_KEY_EXPIRY_WINDOW_SECONDS:-86400}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -195,6 +195,7 @@ chargesSweepConfig:
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-432000}
   tokenExpiryThresholdInSeconds: ${TOKEN_EXPIRY_WINDOW_SECONDS:-604800}
   skipExpiringChargesLastUpdatedInSeconds: ${SKIP_EXPIRING_CHARGES_LAST_UPDATED_IN_SECONDS:-300}
+  idempotencyKeyExpiryThresholdInSeconds: ${IDEMPOTENCY_KEY_EXPIRY_WINDOW_SECONDS:-86400}
 
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}


### PR DESCRIPTION
- Idempotency keys expire after a set time (currently 24 hours)
- Add the corresponding environment variable to test configs
- Update unit test to add additional verification