### PR TITLE
PP-10712 Handle race condition for idempotency

### DIFF
--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceIT.java
@@ -1,0 +1,76 @@
+package uk.gov.pay.connector.charge.service;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.exception.IdempotencyKeyUsedException;
+import uk.gov.pay.connector.charge.model.ChargeCreateRequest;
+import uk.gov.pay.connector.charge.model.ChargeCreateRequestBuilder;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+
+import javax.ws.rs.core.UriInfo;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChargeServiceIT {
+
+    @ClassRule
+    public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
+
+    @Mock
+    private UriInfo mockUriInfo;
+
+    private ChargeService chargeService;
+
+    private DatabaseTestHelper databaseTestHelper;
+
+    private final long GATEWAY_ACCOUNT_ID = 123L;
+
+    @Before
+    public void setUp() throws Exception {
+        chargeService = app.getInstanceFromGuiceContainer(ChargeService.class);
+        databaseTestHelper = app.getDatabaseTestHelper();
+
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(GATEWAY_ACCOUNT_ID))
+                .withRecurringEnabled(true)
+                .build());
+    }
+
+    @Test
+    public void shouldThrowIdempotencyKeyUsedExceptionWhenConflictingDatabaseEntryExists() {
+        String idempotencyKey = "an-idempotency-key";
+        String agreementExternalId = "an-agreement-id";
+        databaseTestHelper.insertIdempotency(idempotencyKey, GATEWAY_ACCOUNT_ID, "a-charge-id", Map.of("amount", 1L));
+        DatabaseFixtures.TestPaymentInstrument paymentInstrument = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestPaymentInstrument()
+                .withStatus(PaymentInstrumentStatus.ACTIVE)
+                .insert();
+        DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
+                .aTestAgreement()
+                .withExternalId(agreementExternalId)
+                .withGatewayAccountId(GATEWAY_ACCOUNT_ID)
+                .withPaymentInstrumentId(paymentInstrument.getPaymentInstrumentId())
+                .insert();
+
+        ChargeCreateRequest chargeCreateRequest = ChargeCreateRequestBuilder.aChargeCreateRequest()
+                .withAmount(1000L)
+                .withReference("ref")
+                .withDescription("descr")
+                .withAgreementId(agreementExternalId)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .build();
+        assertThrows(IdempotencyKeyUsedException.class, () -> chargeService.create(chargeCreateRequest, GATEWAY_ACCOUNT_ID, mockUriInfo, idempotencyKey));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -603,6 +603,7 @@ public class DatabaseFixtures {
         Instant createdDate = Instant.now();
         boolean live = false;
         String serviceId = "service-id";
+        Long paymentInstumentId;
 
         public Long getAgreementId() {
             return agreementId;
@@ -681,6 +682,11 @@ public class DatabaseFixtures {
             return this;
         }
 
+        public DatabaseFixtures.TestAgreement withPaymentInstrumentId(long paymentInstrumentId) {
+            this.paymentInstumentId = paymentInstrumentId;
+            return this;
+        }
+
         public TestAgreement insert() {
             if (gatewayAccountId == null)
                 throw new IllegalStateException("Test Account must be provided.");
@@ -695,6 +701,7 @@ public class DatabaseFixtures {
                     .withReference(reference)
                     .withDescription(description)
                     .withUserIdentifier(userIdentifier)
+                    .withPaymentInstrumentId(paymentInstumentId)
                     .build());
 
             return this;
@@ -1227,22 +1234,26 @@ public class DatabaseFixtures {
 
         PaymentInstrumentStatus status = PaymentInstrumentStatus.CREATED;
 
-        TestPaymentInstrument withPaymentInstrumentId(Long paymentInstrumentId) {
+        public Long getPaymentInstrumentId() {
+            return paymentInstrumentId;
+        }
+
+        public TestPaymentInstrument withPaymentInstrumentId(Long paymentInstrumentId) {
             this.paymentInstrumentId = paymentInstrumentId;
             return this;
         }
 
-        TestPaymentInstrument withExternalId(String externalId) {
+        public TestPaymentInstrument withExternalId(String externalId) {
             this.externalId = externalId;
             return this;
         }
 
-        TestPaymentInstrument withAgreementExternalId(String agreementExternalId) {
+        public TestPaymentInstrument withAgreementExternalId(String agreementExternalId) {
             this.agreementExternalId = agreementExternalId;
             return this;
         }
 
-        TestPaymentInstrument withStatus(PaymentInstrumentStatus status) {
+        public TestPaymentInstrument withStatus(PaymentInstrumentStatus status) {
             this.status = status;
             return this;
         }


### PR DESCRIPTION
Handle the potential race condition when two requests to create a charge with the same Idempotency Key are made at about the same time, resulting in an entry in the idempotency table not existing when the check is made prior to creating a charge. In this case, one request will commit the database transaction first, resulting in a RollbackException being thrown when the other request attempts to commit its transaction to insert an entry in the `idempotency` table which violates the UNIQUE criteria.

Handle the RollbackException by responding to the request with a 409 and "error_identifier": "IDEMPOTENCY_KEY_USED".