### PR TITLE
PP-10830 Add agreement_external_id column to charges

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1974,4 +1974,11 @@
         <dropColumn tableName="gateway_accounts" columnName="requires_additional_kyc_data"/>
     </changeSet>
 
+    <changeSet id="add agreement_external_id column to charges table" author="">
+        <addColumn tableName="charges">
+            <column name="agreement_external_id" type="varchar(26)">
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
The agreement_id column on the charges table stores the agreement external_id rather than the internal ID. We need to rename agreement_id → agreement_external_id to make this clearer:
- Add agreement_external_id column to charges table.
- Subsequent PRs will address the code changes and migrations necessary to safely transfer values to the new column.