### PR TITLE
PP-10830 Save agreement_external_id in charges.agreement_external_id

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -205,6 +205,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @ManyToOne
     @JoinColumn(name = "agreement_id", referencedColumnName="external_id", updatable = false, nullable = true)
     private AgreementEntity agreementEntity;
+
+    @JsonIgnore
+    @ManyToOne
+    @JoinColumn(name = "agreement_external_id", referencedColumnName="external_id", updatable = false, nullable = true)
+    private AgreementEntity agreementExternalEntity;
     
     @Column(name = "save_payment_instrument_to_agreement")
     private boolean savePaymentInstrumentToAgreement;
@@ -271,6 +276,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.moto = moto;
         this.serviceId = serviceId;
         this.agreementEntity = agreementEntity;
+        this.agreementExternalEntity = agreementEntity;
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
         this.authorisationMode = authorisationMode;
     }
@@ -578,6 +584,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
         return Optional.ofNullable(agreementEntity);
     }
 
+    @JsonIgnore
+    public Optional<AgreementEntity> getExternalAgreement() {
+        return Optional.ofNullable(agreementExternalEntity);
+    }
+    
     public boolean isSavePaymentInstrumentToAgreement() {
         return savePaymentInstrumentToAgreement;
     }
@@ -818,7 +829,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
             this.agreementEntity = agreementEntity;
             return this;
         }
-
+        
         public TelephoneChargeEntityBuilder withSavePaymentInstrumentToAgreement(boolean savePaymentInstrumentToAgreement) {
             this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
             return this;

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.model.domain;
 
 import org.junit.Test;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.FeeType;
@@ -10,6 +11,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
+import java.time.Instant;
 import java.util.Optional;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
@@ -214,5 +216,18 @@ public class ChargeEntityTest {
                 kv(AUTHORISATION_MODE, authorisationMode),
                 kv(AGREEMENT_EXTERNAL_ID, agreementId)
         ));
+    }
+    
+    @Test
+    public void shouldAssignAgreementIdToBothAgreementIdAndAgreementExternalIdForWebCharges() {
+        String testAgreementId = "test-agreement-id-123";
+        AgreementEntity testAgreement = AgreementEntity.AgreementEntityBuilder.anAgreementEntity(Instant.now()).build();
+        testAgreement.setExternalId(testAgreementId);
+
+        ChargeEntity chargeCreated = ChargeEntity.WebChargeEntityBuilder.aWebChargeEntity().withAgreementEntity(testAgreement).build();
+        
+        assertThat(chargeCreated.getExternalAgreement().isPresent(), is(true));
+        assertThat(chargeCreated.getExternalAgreement(), is(chargeCreated.getAgreement()));
+        assertThat(chargeCreated.getExternalAgreement().get().getExternalId(), is(testAgreementId));
     }
 }


### PR DESCRIPTION
The agreement_id column on the charges table stores the agreement external_id rather than the internal ID.
We need to rename agreement_id → agreement_external_id to make this clearer.
In the previous PR we added an agreement_external_id column to the charges table.

When a charge is created for an agreement, we need to save the agreement external id to the new agreement_external_id column, in addition to the agreement_id column:
- Add agreementExternalEntity to ChargeEntity.
- Unit test and integration test to cover.

Subsequent PRs will deal with copying pre-existing agreement ids to the new agreement_external_id column, code changes to read from the new column, and dropping the old column.