### PR TITLE
PP-10830 Read from agreement_external_id column

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -581,7 +581,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     @JsonIgnore
     public Optional<AgreementEntity> getAgreement() {
-        return Optional.ofNullable(agreementEntity);
+        return Optional.ofNullable(agreementExternalEntity);
     }
 
     @JsonIgnore

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -166,7 +166,6 @@ public class ChargeEntityFixture {
         chargeEntity.set3dsRequiredDetails(auth3DsRequiredEntity);
         chargeEntity.setWalletType(walletType);
         chargeEntity.setExemption3ds(exemption3ds);
-        chargeEntity.setAgreementEntity(agreementEntity);
         chargeEntity.setPaymentInstrument(paymentInstrument);
         chargeEntity.setUpdatedDate(updatedDate);
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -102,13 +102,13 @@ public class DatabaseTestHelper {
                                 "description, created_date, reference, version, email, language, " +
                                 "delayed_capture, corporate_surcharge, parity_check_status, parity_check_date, " +
                                 "external_metadata, card_type, payment_provider, gateway_account_credential_id, service_id, " +
-                                "issuer_url_3ds, agreement_id, save_payment_instrument_to_agreement, authorisation_mode, updated_date, payment_instrument_id) " +
+                                "issuer_url_3ds, agreement_id, save_payment_instrument_to_agreement, authorisation_mode, updated_date, payment_instrument_id, agreement_external_id) " +
                                 "VALUES(:id, :external_id, :amount, " +
                                 ":status, :gateway_account_id, :return_url, :gateway_transaction_id, " +
                                 ":description, :created_date, :reference, :version, :email, :language, " +
                                 ":delayed_capture, :corporate_surcharge, :parity_check_status, :parity_check_date, " +
                                 ":external_metadata, :card_type, :payment_provider, :gateway_account_credential_id, :service_id, " +
-                                ":issuer_url_3ds, :agreementId, :savePaymentInstrumentToAgreement, :authorisationMode, :updatedDate, :paymentInstrumentId)")
+                                ":issuer_url_3ds, :agreementId, :savePaymentInstrumentToAgreement, :authorisationMode, :updatedDate, :paymentInstrumentId, :agreementId)")
                         .bind("id", addChargeParams.getChargeId())
                         .bind("external_id", addChargeParams.getExternalChargeId())
                         .bind("amount", addChargeParams.getAmount())


### PR DESCRIPTION
Context: We are renaming charges.agreement_id to charges.agreement_external_id.
We have already created the new column and changed the code to save agreement id into both columns.
We have also copied pre-existing agreement id values into the agreement_external_id column.

- Read from agreement_external_id column instead of the agreement_id column
- Update databaseTestHelper so that both columns are populated with agreement ids as in the real database
- Remove duplicated setting of agreement entity in ChargeEntityFixture

Subsequent PRs will remove redundant fields, ensure standardisation of naming of agreement_external_id, and delete the old agreement_id column from the charges table.