### PR TITLE
PP-10830 Stop using agreement_id column in charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -200,16 +200,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @Column(name = "service_id")
     @Schema(example = "46eb1b601348499196c99de90482ee68")
     private String serviceId;
-
-    @JsonIgnore
-    @ManyToOne
-    @JoinColumn(name = "agreement_id", referencedColumnName="external_id", updatable = false, nullable = true)
-    private AgreementEntity agreementEntity;
-
+    
     @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "agreement_external_id", referencedColumnName="external_id", updatable = false, nullable = true)
-    private AgreementEntity agreementExternalEntity;
+    private AgreementEntity agreementEntity;
     
     @Column(name = "save_payment_instrument_to_agreement")
     private boolean savePaymentInstrumentToAgreement;
@@ -276,7 +271,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.moto = moto;
         this.serviceId = serviceId;
         this.agreementEntity = agreementEntity;
-        this.agreementExternalEntity = agreementEntity;
+        this.agreementEntity = agreementEntity;
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
         this.authorisationMode = authorisationMode;
     }
@@ -581,12 +576,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     @JsonIgnore
     public Optional<AgreementEntity> getAgreement() {
-        return Optional.ofNullable(agreementExternalEntity);
-    }
-
-    @JsonIgnore
-    public Optional<AgreementEntity> getExternalAgreement() {
-        return Optional.ofNullable(agreementExternalEntity);
+        return Optional.ofNullable(agreementEntity);
     }
     
     public boolean isSavePaymentInstrumentToAgreement() {
@@ -825,7 +815,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
             return this;
         }
 
-        public TelephoneChargeEntityBuilder withAgreementId(AgreementEntity agreementEntity) {
+        public TelephoneChargeEntityBuilder withAgreementEntity(AgreementEntity agreementEntity) {
             this.agreementEntity = agreementEntity;
             return this;
         }

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -484,7 +484,7 @@ public class ChargingITestBase {
                 .withStatus(status)
                 .withEmail("email@fake.test")
                 .withSavePaymentInstrumentToAgreement(true)
-                .withAgreementId(agreementExternalId)
+                .withAgreementExternalId(agreementExternalId)
                 .withGatewayCredentialId((long) gatewayAccountCredentialsId)
                 .withPaymentInstrumentId(paymentInstrumentId)
                 .build());
@@ -542,7 +542,7 @@ public class ChargingITestBase {
                 .withPaymentProvider(getPaymentProvider())
                 .withGatewayAccountId(accountId)
                 .withGatewayCredentialId((long) gatewayAccountCredentialsId)
-                .withAgreementId(agreementExternalId)
+                .withAgreementExternalId(agreementExternalId)
                 .withAmount(10000)
                 .withStatus(ChargeStatus.CREATED)
                 .withAuthorisationMode(AuthorisationMode.AGREEMENT)

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -8,7 +8,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
-import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -86,7 +85,7 @@ public class ChargeDaoIT extends DaoITestBase {
     public void setUp() {
         chargeDao = env.getInstance(ChargeDao.class);
         agreementDao = env.getInstance(AgreementDao.class);
-        
+
         defaultTestCardDetails = new DatabaseFixtures(databaseTestHelper).validTestCardDetails();
         insertTestAccount();
 
@@ -340,29 +339,6 @@ public class ChargeDaoIT extends DaoITestBase {
 
         assertThat(charge.get().getParityCheckStatus(), equalTo(ParityCheckStatus.EXISTS_IN_LEDGER));
         assertThat(charge.get().getParityCheckDate(), is(notNullValue()));
-    }
-
-    @Test
-    public void shouldCreateNewChargeWithAgreementExternalIdRecordedAsAgreementIdAndAsAgreementExternalId() {
-        
-        String testAgreementId = "test-agreement-id";
-        insertTestAgreement(testAgreementId, gatewayAccount.getId());
-        Optional<AgreementEntity> testAgreement = agreementDao.findByExternalId("test-agreement-id");
-        
-        ChargeEntity chargeEntity = aValidChargeEntity()
-                .withGatewayAccountEntity(gatewayAccount)
-                .withGatewayAccountCredentialsEntity(gatewayAccountCredentialsEntity)
-                .withAgreementEntity(testAgreement.get())
-                .build();
-        
-        chargeDao.persist(chargeEntity);
-        chargeDao.forceRefresh(chargeEntity);
-        Optional<ChargeEntity> charge = chargeDao.findById(chargeEntity.getId());
-        
-        assertThat(charge.get().getAgreement().isPresent(), is(true));
-        assertThat(charge.get().getAgreement().get().getExternalId(), is(testAgreementId));
-        assertThat(charge.get().getExternalAgreement().isPresent(), is(true));
-        assertThat(charge.get().getExternalAgreement().get().getExternalId(), is(testAgreementId));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
@@ -351,7 +351,7 @@ public class StripeResourceAuthorizeIT {
         return externalChargeId;
     }
 
-    private String addChargeWithAgreement(ChargeStatus chargeStatus, String agreementId) {
+    private String addChargeWithAgreement(ChargeStatus chargeStatus, String agreementExternalId) {
         long chargeId = RandomUtils.nextInt();
         String externalChargeId = "charge-" + chargeId;
         databaseTestHelper.addCharge(anAddChargeParams()
@@ -362,7 +362,7 @@ public class StripeResourceAuthorizeIT {
                 .withAmount(Long.valueOf(AMOUNT))
                 .withStatus(chargeStatus)
                 .withGatewayCredentialId(accountCredentialsParams.getId())
-                .withAgreementId(agreementId)
+                .withAgreementExternalId(agreementExternalId)
                 .withSavePaymentInstrumentToAgreement(true)
                 .build());
         return externalChargeId;

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.model.domain;
 
 import org.junit.Test;
-import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.FeeType;
@@ -11,7 +10,6 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
-import java.time.Instant;
 import java.util.Optional;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
@@ -162,7 +160,7 @@ public class ChargeEntityTest {
     }
 
     @Test
-    public void shouldReturnLoggingFieldsWithoutAgreementId() {
+    public void shouldReturnLoggingFieldsWithoutAgreementExternalId() {
         Long gatewayAccountId = 12L;
         String externalId = "anExternalId";
         String paymentProvider = "sandbox";
@@ -189,11 +187,11 @@ public class ChargeEntityTest {
     }
 
     @Test
-    public void shouldReturnLoggingFieldsWithAgreementId() {
+    public void shouldReturnLoggingFieldsWithAgreementExternalId() {
         Long gatewayAccountId = 12L;
         String externalId = "anExternalId";
         String paymentProvider = "sandbox";
-        String agreementId = "anAgreementId";
+        String agreementExternalId = "anAgreementExternalId";
         GatewayAccountType gatewayAccountType = GatewayAccountType.LIVE;
         GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
                 .withId(gatewayAccountId)
@@ -205,7 +203,7 @@ public class ChargeEntityTest {
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .withPaymentProvider(paymentProvider)
                 .withAuthorisationMode(authorisationMode)
-                .withAgreementEntity(anAgreementEntity().withExternalId(agreementId).build())
+                .withAgreementEntity(anAgreementEntity().withExternalId(agreementExternalId).build())
                 .build();
         Object[] structuredLoggingArgs = chargeEntity.getStructuredLoggingArgs();
         assertThat(structuredLoggingArgs, arrayContainingInAnyOrder(
@@ -214,20 +212,8 @@ public class ChargeEntityTest {
                 kv(PROVIDER, paymentProvider),
                 kv(GATEWAY_ACCOUNT_TYPE, gatewayAccountType.toString()),
                 kv(AUTHORISATION_MODE, authorisationMode),
-                kv(AGREEMENT_EXTERNAL_ID, agreementId)
+                kv(AGREEMENT_EXTERNAL_ID, agreementExternalId)
         ));
     }
-    
-    @Test
-    public void shouldAssignAgreementIdToBothAgreementIdAndAgreementExternalIdForWebCharges() {
-        String testAgreementId = "test-agreement-id-123";
-        AgreementEntity testAgreement = AgreementEntity.AgreementEntityBuilder.anAgreementEntity(Instant.now()).build();
-        testAgreement.setExternalId(testAgreementId);
-
-        ChargeEntity chargeCreated = ChargeEntity.WebChargeEntityBuilder.aWebChargeEntity().withAgreementEntity(testAgreement).build();
-        
-        assertThat(chargeCreated.getExternalAgreement().isPresent(), is(true));
-        assertThat(chargeCreated.getExternalAgreement(), is(chargeCreated.getAgreement()));
-        assertThat(chargeCreated.getExternalAgreement().get().getExternalId(), is(testAgreementId));
-    }
+     
 }

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -663,7 +663,7 @@ public class ContractTest {
                 .withChargeId(chargeId)
                 .withExternalChargeId(chargeExternalId)
                 .withGatewayAccountId(gatewayAccountId)
-                .withAgreementId(agreementExternalId)
+                .withAgreementExternalId(agreementExternalId)
                 .withAmount(amount)
                 .withReference(ServicePaymentReference.of(reference))
                 .withDescription(description)

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -39,7 +39,7 @@ public class AddChargeParams {
     private final Long gatewayCredentialId;
     private final String serviceId;
     private final String issuerUrl;
-    private final String agreementId;
+    private final String agreementExternalId;
     private final boolean savePaymentInstrumentToAgreement;
     private final AuthorisationMode authorisationMode;
     private final Instant updatedDate;
@@ -70,7 +70,7 @@ public class AddChargeParams {
         gatewayCredentialId = builder.gatewayCredentialId;
         serviceId = builder.serviceId;
         issuerUrl = builder.issuerUrl;
-        agreementId = builder.agreementId;
+        agreementExternalId = builder.agreementExternalId;
         savePaymentInstrumentToAgreement = builder.savePaymentInstrumentToAgreement;
         authorisationMode = builder.authorisationMode;
         this.updatedDate = builder.updatedDate;
@@ -177,8 +177,8 @@ public class AddChargeParams {
         return savePaymentInstrumentToAgreement;
     }
 
-    public String getAgreementId() {
-        return agreementId;
+    public String getAgreementExternalId() {
+        return agreementExternalId;
     }
 
     public AuthorisationMode getAuthorisationMode() {
@@ -218,7 +218,7 @@ public class AddChargeParams {
         private Long gatewayCredentialId;
         private String serviceId;
         private String issuerUrl;
-        private String agreementId;
+        private String agreementExternalId;
         private boolean savePaymentInstrumentToAgreement;
         private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
         private Instant updatedDate;
@@ -352,8 +352,8 @@ public class AddChargeParams {
             return this;
         }
 
-        public AddChargeParamsBuilder withAgreementId(String agreementId) {
-            this.agreementId = agreementId;
+        public AddChargeParamsBuilder withAgreementExternalId(String agreementExternalId) {
+            this.agreementExternalId = agreementExternalId;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -102,13 +102,13 @@ public class DatabaseTestHelper {
                                 "description, created_date, reference, version, email, language, " +
                                 "delayed_capture, corporate_surcharge, parity_check_status, parity_check_date, " +
                                 "external_metadata, card_type, payment_provider, gateway_account_credential_id, service_id, " +
-                                "issuer_url_3ds, agreement_id, save_payment_instrument_to_agreement, authorisation_mode, updated_date, payment_instrument_id, agreement_external_id) " +
+                                "issuer_url_3ds, save_payment_instrument_to_agreement, authorisation_mode, updated_date, payment_instrument_id, agreement_external_id) " +
                                 "VALUES(:id, :external_id, :amount, " +
                                 ":status, :gateway_account_id, :return_url, :gateway_transaction_id, " +
                                 ":description, :created_date, :reference, :version, :email, :language, " +
                                 ":delayed_capture, :corporate_surcharge, :parity_check_status, :parity_check_date, " +
                                 ":external_metadata, :card_type, :payment_provider, :gateway_account_credential_id, :service_id, " +
-                                ":issuer_url_3ds, :agreementId, :savePaymentInstrumentToAgreement, :authorisationMode, :updatedDate, :paymentInstrumentId, :agreementId)")
+                                ":issuer_url_3ds, :savePaymentInstrumentToAgreement, :authorisationMode, :updatedDate, :paymentInstrumentId, :agreementExternalId)")
                         .bind("id", addChargeParams.getChargeId())
                         .bind("external_id", addChargeParams.getExternalChargeId())
                         .bind("amount", addChargeParams.getAmount())
@@ -132,7 +132,7 @@ public class DatabaseTestHelper {
                         .bind("gateway_account_credential_id", addChargeParams.getGatewayCredentialId())
                         .bind("service_id", addChargeParams.getServiceId())
                         .bind("issuer_url_3ds", addChargeParams.getIssuerUrl())
-                        .bind("agreementId", addChargeParams.getAgreementId())
+                        .bind("agreementExternalId", addChargeParams.getAgreementExternalId())
                         .bind("savePaymentInstrumentToAgreement", addChargeParams.getSavePaymentInstrumentToAgreement())
                         .bind("authorisationMode", addChargeParams.getAuthorisationMode())
                         .bind("updatedDate", addChargeParams.getUpdatedDate() != null ? LocalDateTime.ofInstant(addChargeParams.getUpdatedDate(), UTC) : null)


### PR DESCRIPTION
Context: We are renaming charges.agreement_id to charges.agreement_external_id.
We have already created the agreement_external_id column and copied values across.
We have already changed code so that the external id is saved to both columns.
We have already changed code so that it reads the external id from the new column

- Stop saving agreement external id to the old agreement_id column
- In ChargeEntity and associated tests, refer to the agreement external id as agreementExternalId
- In ChargeEntity and associated tests, refer to the agreement entity as agreementEntity
- Remove redundant tests that existed solely for the short-term situation where agreement external id was being saved to both columns

Subsequent PR will deal with deletion of the old agreement_id column.