### PR TITLE
PP-10830 Drop agreement_id column from charges

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1981,4 +1981,8 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="drop agreement_id column from charges table" author="">
+        <dropColumn tableName="charges" columnName="agreement_id"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Context: We are renaming charges.agreement_id to charges.agreement_external_id.
We have already created the new column and copied agreement external id values to it.
We have already changed code so that it reads from and writes to the new column.
We have already removed references in code to the old column.

- Drop agreement_id column
