### PR TITLE
PP-10979 Add `can_retry` column to charges table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1985,4 +1985,10 @@
         <dropColumn tableName="charges" columnName="agreement_id"/>
     </changeSet>
 
+    <changeSet id="add can_retry column to charges table" author="">
+        <addColumn tableName="charges">
+            <column name="can_retry" type="boolean"></column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
- Added `can_retry` column to charges table to store retry status(true/false) for recurring payments declined.

