### PR TITLE
PP-10979 Persist `can_retry` field post-authorisation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -157,84 +157,84 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 3048
+        "line_number": 3050
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 3416
+        "line_number": 3418
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3754
+        "line_number": 3756
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3803
+        "line_number": 3805
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4408
+        "line_number": 4410
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4469
+        "line_number": 4471
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4491
+        "line_number": 4493
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4670
+        "line_number": 4672
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4673
+        "line_number": 4675
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4676
+        "line_number": 4678
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5266
+        "line_number": 5268
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5277
+        "line_number": 5279
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1078,5 +1078,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-03T11:09:57Z"
+  "generated_at": "2023-05-10T11:54:40Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -2904,6 +2904,8 @@ components:
           - moto_api
           - agreement
           - external
+        canRetry:
+          type: boolean
         captureSubmitTime:
           type: string
           format: date-time

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -217,6 +217,9 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @Enumerated(EnumType.STRING)
     private AuthorisationMode authorisationMode;
 
+    @Column(name = "can_retry")
+    private Boolean canRetry;
+
     @Column(name = "updated_date")
     @JsonIgnore
     @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
@@ -270,7 +273,6 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.cardDetails = cardDetails;
         this.moto = moto;
         this.serviceId = serviceId;
-        this.agreementEntity = agreementEntity;
         this.agreementEntity = agreementEntity;
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
         this.authorisationMode = authorisationMode;
@@ -589,6 +591,14 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     public void setAuthorisationMode(AuthorisationMode authorisationMode) {
         this.authorisationMode = authorisationMode;
+    }
+
+    public Boolean getCanRetry() {
+        return canRetry;
+    }
+
+    public void setCanRetry(Boolean canRetry) {
+        this.canRetry = canRetry;
     }
 
     public void setUpdatedDate(Instant updatedDate) {

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
@@ -127,7 +127,7 @@ class ChargeServicePostAuthorisationTest {
         when(mockChargeEventDao.persistChargeEventOf(chargeEntity, null)).thenReturn(mockChargeEventEntity);
         
         chargeService.updateChargePostCardAuthorisation(EXTERNAL_ID, AUTHORISATION_SUCCESS, TRANSACTION_ID, auth3dsRequiredEntity,
-                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN);
+                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, null);
 
         assertThat(chargeEntity.getStatus(), is(AUTHORISATION_SUCCESS.toString()));
         assertThat(chargeEntity.getEmail(), is(EMAIL));
@@ -135,6 +135,7 @@ class ChargeServicePostAuthorisationTest {
         assertThat(chargeEntity.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(chargeEntity.getWalletType(), is(nullValue()));
         assertThat(chargeEntity.getCardDetails(), is(mockCardDetailsEntity));
+        assertThat(chargeEntity.getCanRetry(), is(nullValue()));
 
         verify(mockStateTransitionService).offerPaymentStateTransition(EXTERNAL_ID, AUTHORISATION_READY, AUTHORISATION_SUCCESS, mockChargeEventEntity);
         verify(mockEventService).emitAndRecordEvent(PaymentDetailsEntered.from(chargeEntity));
@@ -152,7 +153,7 @@ class ChargeServicePostAuthorisationTest {
         when(mockChargeEventDao.persistChargeEventOf(chargeEntity, null)).thenReturn(mockChargeEventEntity);
 
         chargeService.updateChargePostCardAuthorisation(EXTERNAL_ID, AUTHORISATION_SUCCESS, TRANSACTION_ID, auth3dsRequiredEntity,
-                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN);
+                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, true);
 
         assertThat(chargeEntity.getStatus(), is(AUTHORISATION_SUCCESS.toString()));
         assertThat(chargeEntity.getEmail(), is(EMAIL));
@@ -160,6 +161,7 @@ class ChargeServicePostAuthorisationTest {
         assertThat(chargeEntity.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(chargeEntity.getWalletType(), is(nullValue()));
         assertThat(chargeEntity.getCardDetails(), is(cardDetails));
+        assertThat(chargeEntity.getCanRetry(), is(true));
 
         verify(mockStateTransitionService).offerPaymentStateTransition(EXTERNAL_ID, AUTHORISATION_READY, AUTHORISATION_SUCCESS, mockChargeEventEntity);
         verify(mockEventService).emitAndRecordEvent(PaymentDetailsTakenFromPaymentInstrument.from(chargeEntity));
@@ -173,7 +175,7 @@ class ChargeServicePostAuthorisationTest {
         when(mockPaymentInstrumentService.createPaymentInstrument(chargeEntity, TOKEN)).thenReturn(mockPaymentInstrumentEntity);
 
         chargeService.updateChargePostCardAuthorisation(EXTERNAL_ID, AUTHORISATION_SUCCESS, TRANSACTION_ID, auth3dsRequiredEntity,
-                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN);
+                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, null);
 
         assertThat(chargeEntity.getPaymentInstrument().isPresent(), is(true));
         assertThat(chargeEntity.getPaymentInstrument().get(), is(mockPaymentInstrumentEntity));

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -731,6 +731,7 @@ public class DatabaseFixtures {
         Long gatewayCredentialId;
         private AuthorisationMode authorisationMode = WEB;
         private Instant updatedDate;
+        private Boolean canRetry;
 
         public TestCardDetails getCardDetails() {
             return cardDetails;
@@ -831,6 +832,11 @@ public class DatabaseFixtures {
             return this;
         }
 
+        public TestCharge withCanRetry(Boolean canRetry) {
+            this.canRetry = canRetry;
+            return this;
+        }
+
         public TestCharge insert() {
             if (testAccount == null)
                 throw new IllegalStateException("Test Account must be provided.");
@@ -856,6 +862,7 @@ public class DatabaseFixtures {
                     .withParityCheckDate(parityCheckDate)
                     .withGatewayCredentialId(gatewayCredentialId)
                     .withAuthorisationMode(authorisationMode)
+                    .withCanRetry(canRetry)
                     .withUpdatedDate(updatedDate)
                     .build());
 
@@ -937,6 +944,10 @@ public class DatabaseFixtures {
 
         public AuthorisationMode getAuthorisationMode() {
             return authorisationMode;
+        }
+
+        public Boolean getCanRetry() {
+            return canRetry;
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/StripeCardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/StripeCardAuthoriseServiceIT.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.stripe.StripeAuthorisationResponse.STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY;
 import static uk.gov.pay.connector.gateway.stripe.StripeAuthorisationResponse.STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY;
@@ -43,4 +44,63 @@ public class StripeCardAuthoriseServiceIT extends ChargingITestBase {
         assertThat(successResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED)));
     }
 
+    @Test
+    public void shouldProcessFailedAuthorisationForUserNotPresentPaymentAndSetCanRetryFieldToTrue() {
+        var recurringAuthToken = Map.of(
+                STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY, "cus_abc123",
+                STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY, "pm_abc123");
+        ChargeUtils.ExternalChargeId userNotPresentChargeId = addChargeWithAuthorisationModeAgreement(recurringAuthToken);
+
+        var chargeEntity = testContext.getInstanceFromGuiceContainer(ChargeService.class).findChargeByExternalId(userNotPresentChargeId.toString());
+
+        stripeMockClient.mockAuthorisationFailedPaymentIntentAndRetriableForUserNotPresentPayment();
+
+        var authorisationResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseUserNotPresent(chargeEntity);
+        assertThat(authorisationResponse.getGatewayError(), is(Optional.empty()));
+        assertThat(authorisationResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED)));
+
+        Map<String, Object> chargeUpdated = databaseTestHelper.getChargeByExternalId(userNotPresentChargeId.toString());
+
+        assertThat(chargeUpdated.get("can_retry"), is(true));
+    }
+
+    @Test
+    public void shouldProcessFailedAuthorisationForUserNotPresentPaymentAndSetCanRetryFieldToFalse() {
+        var recurringAuthToken = Map.of(
+                STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY, "cus_abc123",
+                STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY, "pm_abc123");
+        ChargeUtils.ExternalChargeId userNotPresentChargeId = addChargeWithAuthorisationModeAgreement(recurringAuthToken);
+
+        var chargeEntity = testContext.getInstanceFromGuiceContainer(ChargeService.class).findChargeByExternalId(userNotPresentChargeId.toString());
+
+        stripeMockClient.mockAuthorisationFailedPaymentIntentAndNonRetriableForUserNotPresentPayment();
+
+        var authorisationResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseUserNotPresent(chargeEntity);
+        assertThat(authorisationResponse.getGatewayError(), is(Optional.empty()));
+        assertThat(authorisationResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED)));
+
+        Map<String, Object> chargeUpdated = databaseTestHelper.getChargeByExternalId(userNotPresentChargeId.toString());
+
+        assertThat(chargeUpdated.get("can_retry"), is(false));
+    }
+
+    @Test
+    public void shouldProcessFailedAuthorisationForUserNotPresentPaymentAndSetCanRetryFieldToNullForUnknownError() {
+        var recurringAuthToken = Map.of(
+                STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY, "cus_abc123",
+                STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY, "pm_abc123");
+        ChargeUtils.ExternalChargeId userNotPresentChargeId = addChargeWithAuthorisationModeAgreement(recurringAuthToken);
+
+        var chargeEntity = testContext.getInstanceFromGuiceContainer(ChargeService.class).findChargeByExternalId(userNotPresentChargeId.toString());
+
+        stripeMockClient.mockAuthorisationErrorForUserNotPresentPayment();
+
+        var authorisationResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseUserNotPresent(chargeEntity);
+        assertThat(authorisationResponse.getGatewayError().get().getMessage(), is("There was an internal server error authorising charge"));
+        assertThat(authorisationResponse.getAuthoriseStatus(), is(Optional.empty()));
+
+        Map<String, Object> chargeUpdated = databaseTestHelper.getChargeByExternalId(userNotPresentChargeId.toString());
+
+        assertThat(chargeUpdated.get("can_retry"), is(nullValue()));
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceIT.java
@@ -3,20 +3,19 @@ package uk.gov.pay.connector.paymentprocessor.service;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.it.util.ChargeUtils;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
-import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY;
@@ -28,7 +27,7 @@ public class WorldpayCardAuthoriseServiceIT extends ChargingITestBase {
     public WorldpayCardAuthoriseServiceIT() {
         super(WORLDPAY.getName());
     }
-    
+
     @Test
     public void shouldSuccessfullyAuthoriseUserNotPresentPayment() {
         var recurringAuthToken = Map.of(
@@ -45,4 +44,69 @@ public class WorldpayCardAuthoriseServiceIT extends ChargingITestBase {
         assertThat(successResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED)));
     }
 
+    @Test
+    public void shouldProcessFailedAuthorisationForUserNotPresentPaymentAndSetCanRetryFieldToTrue() {
+        var recurringAuthToken = Map.of(
+                WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY, "a-token-id",
+                WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY, "transaction-identifier");
+        ChargeUtils.ExternalChargeId userNotPresentChargeId = addChargeWithAuthorisationModeAgreement(recurringAuthToken);
+
+        var chargeEntity = testContext.getInstanceFromGuiceContainer(ChargeService.class)
+                .findChargeByExternalId(userNotPresentChargeId.toString());
+
+        worldpayMockClient.mockAuthorisationFailure();
+
+        var authorisationResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class)
+                .doAuthoriseUserNotPresent(chargeEntity);
+        assertThat(authorisationResponse.getGatewayError(), is(Optional.empty()));
+        assertThat(authorisationResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED)));
+
+        Map<String, Object> chargeUpdated = databaseTestHelper.getChargeByExternalId(userNotPresentChargeId.toString());
+
+        assertThat(chargeUpdated.get("can_retry"), is(true));
+    }
+
+    @Test
+    public void shouldProcessFailedAuthorisationForUserNotPresentPaymentAndSetCanRetryFieldToFalse() {
+        var recurringAuthToken = Map.of(
+                WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY, "a-token-id",
+                WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY, "transaction-identifier");
+        ChargeUtils.ExternalChargeId userNotPresentChargeId = addChargeWithAuthorisationModeAgreement(recurringAuthToken);
+
+        var chargeEntity = testContext.getInstanceFromGuiceContainer(ChargeService.class)
+                .findChargeByExternalId(userNotPresentChargeId.toString());
+
+        worldpayMockClient.mockAuthorisationFailureUserNotPresentNonRetriablePayment();
+
+        var successResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class)
+                .doAuthoriseUserNotPresent(chargeEntity);
+        assertThat(successResponse.getGatewayError(), is(Optional.empty()));
+        assertThat(successResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED)));
+
+        Map<String, Object> chargeUpdated = databaseTestHelper.getChargeByExternalId(userNotPresentChargeId.toString());
+
+        assertThat(chargeUpdated.get("can_retry"), is(false));
+    }
+
+    @Test
+    public void shouldProcessFailedAuthorisationForUserNotPresentPaymentAndSetCanRetryFieldToNullForUnknownError() {
+        var recurringAuthToken = Map.of(
+                WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY, "a-token-id",
+                WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY, "transaction-identifier");
+        ChargeUtils.ExternalChargeId userNotPresentChargeId = addChargeWithAuthorisationModeAgreement(recurringAuthToken);
+
+        var chargeEntity = testContext.getInstanceFromGuiceContainer(ChargeService.class)
+                .findChargeByExternalId(userNotPresentChargeId.toString());
+
+        worldpayMockClient.mockAuthorisationGatewayError();
+
+        var successResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class)
+                .doAuthoriseUserNotPresent(chargeEntity);
+        assertThat(successResponse.getGatewayError().get().getMessage(), is("Non-success HTTP status code 404 from gateway"));
+        assertThat(successResponse.getAuthoriseStatus(), is(Optional.empty()));
+
+        Map<String, Object> chargeUpdated = databaseTestHelper.getChargeByExternalId(userNotPresentChargeId.toString());
+
+        assertThat(chargeUpdated.get("can_retry"), is(nullValue()));
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -14,6 +14,8 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_FAILED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_FAILED_RESPONSE_USER_NOT_PRESENT_PAYMENT_NOT_RETRIABLE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_FAILED_RESPONSE_USER_NOT_PRESENT_PAYMENT_RETRIABLE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CUSTOMER_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE;
@@ -53,6 +55,20 @@ public class StripeMockClient {
     public void mockAuthorisationFailedWithPaymentIntents() {
         String payload = TestTemplateResourceLoader.load(STRIPE_AUTHORISATION_FAILED_RESPONSE);
         setupResponse(payload, "/v1/payment_methods", 400);
+    }
+
+    public void mockAuthorisationFailedPaymentIntentAndRetriableForUserNotPresentPayment() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_AUTHORISATION_FAILED_RESPONSE_USER_NOT_PRESENT_PAYMENT_RETRIABLE);
+        setupResponse(payload, "/v1/payment_intents", 400);
+    }
+
+    public void mockAuthorisationFailedPaymentIntentAndNonRetriableForUserNotPresentPayment() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_AUTHORISATION_FAILED_RESPONSE_USER_NOT_PRESENT_PAYMENT_NOT_RETRIABLE);
+        setupResponse(payload, "/v1/payment_intents", 400);
+    }
+
+    public void mockAuthorisationErrorForUserNotPresentPayment() {
+        setupResponse(null, "/v1/payment_intents", 500);
     }
 
     public void mockCancelPaymentIntent(String paymentIntentId) {
@@ -113,11 +129,6 @@ public class StripeMockClient {
     public void mockCreateCustomer() {
         String payload = TestTemplateResourceLoader.load(STRIPE_CUSTOMER_SUCCESS_RESPONSE);
         setupResponse(payload, "/v1/customers", 200);
-    }
-
-    public void mockTransferReversal(String transferid) {
-        String payload = TestTemplateResourceLoader.load(STRIPE_TRANSFER_RESPONSE);
-        setupResponse(payload, "/v1/transfers/" + transferid + "/reversals", 200);
     }
 
     public void mockCreatePaymentIntentDelayedResponse() {

--- a/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
@@ -17,6 +17,7 @@ import static javax.ws.rs.core.MediaType.TEXT_XML;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_3DS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_CREATE_TOKEN_SUCCESS_RESPONSE_WITH_TRANSACTION_IDENTIFIER;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_FAILED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_FAILED_USER_NON_PRESENT_NON_RETRIABLE_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_PARES_PARSE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CANCEL_ERROR_RESPONSE;
@@ -67,6 +68,11 @@ public class WorldpayMockClient {
     
     public void mockAuthorisationFailure() {
         String authoriseResponse = load(WORLDPAY_AUTHORISATION_FAILED_RESPONSE);
+        paymentServiceResponse(authoriseResponse);
+    }
+
+    public void mockAuthorisationFailureUserNotPresentNonRetriablePayment() {
+        String authoriseResponse = load(WORLDPAY_AUTHORISATION_FAILED_USER_NON_PRESENT_NON_RETRIABLE_RESPONSE);
         paymentServiceResponse(authoriseResponse);
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -44,6 +44,7 @@ public class AddChargeParams {
     private final AuthorisationMode authorisationMode;
     private final Instant updatedDate;
     private final Long paymentInstrumentId;
+    private final Boolean canRetry;
 
     private AddChargeParams(AddChargeParamsBuilder builder) {
         chargeId = builder.chargeId;
@@ -75,6 +76,7 @@ public class AddChargeParams {
         authorisationMode = builder.authorisationMode;
         this.updatedDate = builder.updatedDate;
         paymentInstrumentId = builder.paymentInstrumentId;
+        canRetry = builder.canRetry;
     }
 
     public Long getChargeId() {
@@ -193,6 +195,10 @@ public class AddChargeParams {
         return paymentInstrumentId;
     }
 
+    public Boolean getCanRetry() {
+        return canRetry;
+    }
+
     public static final class AddChargeParamsBuilder {
         private Long chargeId = new Random().nextLong();
         private String externalChargeId = "anExternalChargeId";
@@ -223,6 +229,7 @@ public class AddChargeParams {
         private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
         private Instant updatedDate;
         private Long paymentInstrumentId;
+        private Boolean canRetry;
 
         private AddChargeParamsBuilder() {
         }
@@ -374,6 +381,11 @@ public class AddChargeParams {
 
         public AddChargeParamsBuilder withPaymentInstrumentId(Long paymentInstrumentId) {
             this.paymentInstrumentId = paymentInstrumentId;
+            return this;
+        }
+
+        public AddChargeParamsBuilder withCanRetry(Boolean canRetry) {
+            this.canRetry = canRetry;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -102,13 +102,13 @@ public class DatabaseTestHelper {
                                 "description, created_date, reference, version, email, language, " +
                                 "delayed_capture, corporate_surcharge, parity_check_status, parity_check_date, " +
                                 "external_metadata, card_type, payment_provider, gateway_account_credential_id, service_id, " +
-                                "issuer_url_3ds, save_payment_instrument_to_agreement, authorisation_mode, updated_date, payment_instrument_id, agreement_external_id) " +
+                                "issuer_url_3ds, save_payment_instrument_to_agreement, authorisation_mode, updated_date, payment_instrument_id, agreement_external_id, can_retry) " +
                                 "VALUES(:id, :external_id, :amount, " +
                                 ":status, :gateway_account_id, :return_url, :gateway_transaction_id, " +
                                 ":description, :created_date, :reference, :version, :email, :language, " +
                                 ":delayed_capture, :corporate_surcharge, :parity_check_status, :parity_check_date, " +
                                 ":external_metadata, :card_type, :payment_provider, :gateway_account_credential_id, :service_id, " +
-                                ":issuer_url_3ds, :savePaymentInstrumentToAgreement, :authorisationMode, :updatedDate, :paymentInstrumentId, :agreementExternalId)")
+                                ":issuer_url_3ds, :savePaymentInstrumentToAgreement, :authorisationMode, :updatedDate, :paymentInstrumentId, :agreementExternalId, :canRetry)")
                         .bind("id", addChargeParams.getChargeId())
                         .bind("external_id", addChargeParams.getExternalChargeId())
                         .bind("amount", addChargeParams.getAmount())
@@ -137,6 +137,7 @@ public class DatabaseTestHelper {
                         .bind("authorisationMode", addChargeParams.getAuthorisationMode())
                         .bind("updatedDate", addChargeParams.getUpdatedDate() != null ? LocalDateTime.ofInstant(addChargeParams.getUpdatedDate(), UTC) : null)
                         .bind("paymentInstrumentId", addChargeParams.getPaymentInstrumentId())
+                        .bind("canRetry", addChargeParams.getCanRetry())
                         .execute());
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -21,6 +21,8 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_AUTHORISATION_CREATE_TOKEN_SUCCESS_RESPONSE_WITHOUT_TRANSACTION_IDENTIFIER = WORLDPAY_BASE_NAME + "/authorisation-create-token-success-response-without-transaction-identifier.xml";
     static final String WORLDPAY_AUTHORISATION_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-error-response.xml";
     public static final String WORLDPAY_AUTHORISATION_FAILED_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-failed-response.xml";
+    public static final String WORLDPAY_AUTHORISATION_FAILED_USER_NON_PRESENT_NON_RETRIABLE_RESPONSE =
+            WORLDPAY_BASE_NAME + "/authorisation-failed-response-user-not-present-payment-non-retriable.xml";
     static final String WORLDPAY_AUTHORISATION_CANCELLED_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-cancelled-response.xml";
     public static final String WORLDPAY_AUTHORISATION_PARES_PARSE_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-pares-parse-error-response.xml";
     public static final String WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS = WORLDPAY_BASE_NAME + "/special-char-valid-authorise-worldpay-request-address.xml";
@@ -126,6 +128,10 @@ public class TestTemplateResourceLoader {
     public static final String EPDQ_NOTIFICATION_TEMPLATE = EPDQ_BASE_NAME + "/notification-template.txt";
 
     public static final String STRIPE_AUTHORISATION_FAILED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/authorisation_failed_response.json";
+    public static final String STRIPE_AUTHORISATION_FAILED_RESPONSE_USER_NOT_PRESENT_PAYMENT_NOT_RETRIABLE =
+            TEMPLATE_BASE_NAME + "/stripe/create_payment_method_failed_and_non_retriable_for_recurring_payment.json";
+    public static final String STRIPE_AUTHORISATION_FAILED_RESPONSE_USER_NOT_PRESENT_PAYMENT_RETRIABLE =
+            TEMPLATE_BASE_NAME + "/stripe/create_payment_method_failed_and_retriable_for_recurring_payment.json";
     public static final String STRIPE_NOTIFICATION_BALANCE_AVAILABLE = TEMPLATE_BASE_NAME + "/stripe/balance_available.json";
     public static final String STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/payment_intent_capture_success_response.json";
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response.json";

--- a/src/test/resources/templates/stripe/create_payment_method_failed_and_non_retriable_for_recurring_payment.json
+++ b/src/test/resources/templates/stripe/create_payment_method_failed_and_non_retriable_for_recurring_payment.json
@@ -1,0 +1,26 @@
+{
+  "error": {
+    "charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+    "code": "card_declined",
+    "decline_code": "revocation_of_all_authorizations",
+    "doc_url": "https://stripe.com/docs/declines/codes",
+    "message": "The card was declined for an unknown reason.",
+    "payment_intent": {
+      "id": "pi_3N6AIYHj08j2jFuB1IozJAVc",
+      "object": "payment_intent",
+      "amount": 10000,
+      "customer": "cus_123",
+      "last_payment_error": {
+        "charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+        "code": "card_declined",
+        "decline_code": "revocation_of_all_authorizations",
+        "doc_url": "https://stripe.com/docs/declines/codes",
+        "message": "The card was declined for an unknown reason.",
+        "type": "card_error"
+      },
+      "latest_charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+      "livemode": false
+    },
+    "type": "card_error"
+  }
+}

--- a/src/test/resources/templates/stripe/create_payment_method_failed_and_retriable_for_recurring_payment.json
+++ b/src/test/resources/templates/stripe/create_payment_method_failed_and_retriable_for_recurring_payment.json
@@ -1,0 +1,26 @@
+{
+  "error": {
+    "charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+    "code": "card_declined",
+    "decline_code": "invalid_amount",
+    "doc_url": "https://stripe.com/docs/declines/codes",
+    "message": "The payment amount is invalid, or exceeds the amount that’s allowed.",
+    "payment_intent": {
+      "id": "pi_3N6AIYHj08j2jFuB1IozJAVc",
+      "object": "payment_intent",
+      "amount": 10000,
+      "customer": "cus_123",
+      "last_payment_error": {
+        "charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+        "code": "card_declined",
+        "decline_code": "invalid_amount",
+        "doc_url": "https://stripe.com/docs/declines/codes",
+        "message": "The payment amount is invalid, or exceeds the amount that’s allowed.",
+        "type": "card_error"
+      },
+      "latest_charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+      "livemode": false
+    },
+    "type": "card_error"
+  }
+}

--- a/src/test/resources/templates/worldpay/authorisation-failed-response-user-not-present-payment-non-retriable.xml
+++ b/src/test/resources/templates/worldpay/authorisation-failed-response-user-not-present-payment-non-retriable.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <reply>
+        <orderStatus orderCode="MyUniqueTransactionId!12">
+            <payment>
+                <paymentMethod>VISA-SSL</paymentMethod>
+                <paymentMethodDetail>
+                    <card type="creditcard"/>
+                </paymentMethodDetail>
+                <amount value="500" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+                <lastEvent>REFUSED</lastEvent>
+                <ISO8583ReturnCode code="46" description="CLOSED ACCOUNT"/>
+                <CVCResultCode description="NOT CHECKED BY ACQUIRER"/>
+                <AVSResultCode description="NOT CHECKED BY ACQUIRER"/>
+                <cardHolderName>
+                    <![CDATA[REFUSED]]>
+                </cardHolderName>
+                <issuerCountryCode>N/A</issuerCountryCode>
+                <riskScore value="51"/>
+            </payment>
+        </orderStatus>
+    </reply>
+</paymentService>


### PR DESCRIPTION
## WHAT YOU DID
- for card payments failed, payment providers return the reason which we map to mapped rejected reason and if the payment can be retried.
- persist this info onto the charge for recurring payments

