### PR TITLE
PP-10978 Map rejected reason for sandox payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxGatewayResponseGenerator.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.sandbox;
 
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
@@ -73,6 +74,13 @@ public class SandboxGatewayResponseGenerator {
             @Override
             public Optional<Map<String, String>> getGatewayRecurringAuthToken() {
                 return Optional.of(Map.of("token", randomUUID().toString()));
+            }
+
+            @Override
+            public Optional<MappedAuthorisationRejectedReason> getMappedAuthorisationRejectedReason() {
+                return Optional.ofNullable(authoriseStatus())
+                        .filter(authoriseStatus -> authoriseStatus == AuthoriseStatus.REJECTED)
+                        .map(authoriseStatus -> MappedAuthorisationRejectedReason.DO_NOT_RETRY);
             }
 
             @Override

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceIT.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY;
 
@@ -57,6 +58,9 @@ public class CardAuthoriseServiceIT extends ChargingITestBase {
         var successResponse = testContext.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseUserNotPresent(successCharge);
         assertThat(successResponse.getGatewayError(), is(Optional.empty()));
         assertThat(successResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED)));
+
+        Map<String, Object> chargeUpdated = databaseTestHelper.getChargeByExternalId(userNotPresentChargeId.toString());
+        assertThat(chargeUpdated.get("can_retry"), is(nullValue()));
     }
 
     @Test
@@ -84,6 +88,9 @@ public class CardAuthoriseServiceIT extends ChargingITestBase {
         assertThat(agreementSetUpResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED)));
         assertThat(recurringPaymentResponse.getGatewayError(), is(Optional.empty()));
         assertThat(recurringPaymentResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED)));
+
+        Map<String, Object> chargeUpdated = databaseTestHelper.getChargeByExternalId(userNotPresentChargeId.toString());
+        assertThat(chargeUpdated.get("can_retry"), is(false));
     }
 
 }


### PR DESCRIPTION
## WHAT YOU DID
- Map sandbox rejected reason so when user not present payments are declined, agreements can be inactivated.

