### PR TITLE
PP-10949 implement inactivating agreement

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -227,14 +227,14 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5268
+        "line_number": 5269
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5279
+        "line_number": 5280
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1078,5 +1078,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-10T11:54:40Z"
+  "generated_at": "2023-05-11T12:58:38Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -4736,6 +4736,7 @@ components:
           enum:
           - CREATED
           - ACTIVE
+          - INACTIVE
           - CANCELLED
           - EXPIRED
     PaymentOutcome:

--- a/src/main/java/uk/gov/pay/connector/events/model/agreement/AgreementInactivated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/agreement/AgreementInactivated.java
@@ -13,25 +13,25 @@ public class AgreementInactivated extends AgreementEvent {
         super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static AgreementInactivated from(AgreementEntity agreement, MappedAuthorisationRejectedReason mappedReason, Instant timestamp) {
+    public static AgreementInactivated from(AgreementEntity agreement, String rejectedReason, Instant timestamp) {
         return new AgreementInactivated(
                 agreement.getServiceId(),
                 agreement.getGatewayAccount().isLive(),
                 agreement.getExternalId(),
-                new AgreementInactivated.AgreementInactivatedEventDetails(agreement.getPaymentInstrument().orElse(null), mappedReason),
+                new AgreementInactivated.AgreementInactivatedEventDetails(agreement.getPaymentInstrument().orElse(null), rejectedReason),
                 timestamp
         );
     }
 
-    static class AgreementInactivatedEventDetails extends EventDetails {
+    public static class AgreementInactivatedEventDetails extends EventDetails {
         private String paymentInstrumentExternalId;
         private String reason;
 
-        public AgreementInactivatedEventDetails(PaymentInstrumentEntity paymentInstrumentEntity, MappedAuthorisationRejectedReason mappedReason) {
+        public AgreementInactivatedEventDetails(PaymentInstrumentEntity paymentInstrumentEntity, String rejectedReason) {
             this.paymentInstrumentExternalId = Optional.ofNullable(paymentInstrumentEntity)
                     .map(PaymentInstrumentEntity::getExternalId)
                     .orElse(null);
-            this.reason = mappedReason.name();
+            this.reason = rejectedReason;
         }
 
         public String getPaymentInstrumentExternalId() {

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentStatus.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentStatus.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.paymentinstrument.model;
 public enum PaymentInstrumentStatus {
     CREATED,
     ACTIVE,
+    INACTIVE,
     CANCELLED,
     EXPIRED
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -153,7 +153,9 @@ public class CardAuthoriseService {
                     null,
                     null,
                     authCardDetails,
-                    null, null);
+                    null,
+                    null,
+                    null);
 
             LOGGER.info("Attempt to authorise charge synchronously timed out.");
 
@@ -196,7 +198,9 @@ public class CardAuthoriseService {
         Optional<Boolean> mayBeCanRetry = operationResponse.getBaseResponse()
                 .flatMap(baseAuthoriseResponse ->
                         baseAuthoriseResponse.getMappedAuthorisationRejectedReason().map(MappedAuthorisationRejectedReason::canRetry));
-
+        Optional<String> mayBeRejectedReason = operationResponse.getBaseResponse()
+                .flatMap(baseAuthoriseResponse ->
+                        baseAuthoriseResponse.getMappedAuthorisationRejectedReason().map(MappedAuthorisationRejectedReason::name));
         ChargeEntity updatedCharge = chargeService.updateChargePostCardAuthorisation(
                 charge.getExternalId(),
                 newStatus,
@@ -205,7 +209,8 @@ public class CardAuthoriseService {
                 sessionIdentifier.orElse(null),
                 authCardDetails,
                 maybeToken.orElse(null),
-                mayBeCanRetry.orElse(null));
+                mayBeCanRetry.orElse(null),
+                mayBeRejectedReason.orElse(null));
 
         var authorisationRequestSummary = generateAuthorisationRequestSummary(charge, authCardDetails);
 

--- a/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceTest.java
@@ -133,7 +133,7 @@ public class LedgerServiceTest {
                 .withPaymentInstrument(paymentInstrumentEntity)
                 .withGatewayAccount(gatewayAccountEntity)
                 .build();
-        var eventThree =  AgreementInactivated.from(agreementEntity, MappedAuthorisationRejectedReason.EXPIRED_CARD, Instant.now());
+        var eventThree =  AgreementInactivated.from(agreementEntity, MappedAuthorisationRejectedReason.EXPIRED_CARD.name(), Instant.now());
 
         List<Event> list = List.of(eventOne, eventTwo, eventThree);
         when(mockResponse.getStatus()).thenReturn(SC_ACCEPTED);

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -528,12 +528,14 @@ public class ChargingITestBase {
         AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder paymentInstrumentParamsBuilder = anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)
                 .withExternalPaymentInstrumentId(String.valueOf(nextInt()))
-                .withRecurringAuthToken(recurringAuthToken);
+                .withRecurringAuthToken(recurringAuthToken)
+                .withAgreementExternalId(agreementExternalId);
 
         Optional.ofNullable(first6DigitsCardNumber).ifPresent(paymentInstrumentParamsBuilder::withFirstDigitsCardNumber);
         Optional.ofNullable(last4DigitsCardNumber).ifPresent(paymentInstrumentParamsBuilder::withLastDigitsCardNumber);
 
         databaseTestHelper.addPaymentInstrument(paymentInstrumentParamsBuilder.build());
+        databaseTestHelper.updateAgreementPaymentInstrumentId(agreementExternalId, paymentInstrumentId);
 
         long chargeId = RandomUtils.nextInt();
         ChargeUtils.ExternalChargeId externalChargeId = ChargeUtils.ExternalChargeId.fromChargeId(chargeId);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/StripeCardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/StripeCardAuthoriseServiceIT.java
@@ -82,6 +82,9 @@ public class StripeCardAuthoriseServiceIT extends ChargingITestBase {
         Map<String, Object> chargeUpdated = databaseTestHelper.getChargeByExternalId(userNotPresentChargeId.toString());
 
         assertThat(chargeUpdated.get("can_retry"), is(false));
+
+        Map<String, Object> paymentInstrument = databaseTestHelper.getPaymentInstrumentByChargeExternalId(chargeEntity.getExternalId());
+        assertThat(paymentInstrument.get("status"), is("INACTIVE"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -162,6 +162,15 @@ public class DatabaseTestHelper {
                         .execute());
     }
 
+    public void updateAgreementPaymentInstrumentId(String agreementExternalId, Long paymentInstrumentId) {
+        jdbi.withHandle(h ->
+                h.createUpdate("UPDATE agreements SET payment_instrument_id = :payment_instrument_id " +
+                                "WHERE external_id = external_id")
+                        .bind("payment_instrument_id", paymentInstrumentId)
+                        .bind("external_id", agreementExternalId)
+                        .execute());
+    }
+
     public void addPaymentInstrument(AddPaymentInstrumentParams addPaymentInstrumentParams) {
         PGobject recurringAuthTokenJson = Optional.ofNullable(addPaymentInstrumentParams.getRecurringAuthToken())
                 .map(DatabaseTestHelper::mapToJsonPGobject)


### PR DESCRIPTION
## WHAT YOU DID
When PSP returns a decline code which cannot be retried, we should inactivate the agreement to indicate that it is no longer valid. The service needs to set up a new payment or create a new agreement in this case.

- implement de-activating the matching payment instrument
- post an `AgreementInactivated` event to Ledger
- add/update relevant tests
