### PR TITLE
PP-10977 remove expired status from agreement

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -227,14 +227,14 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5269
+        "line_number": 5268
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5280
+        "line_number": 5279
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1078,5 +1078,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-11T12:58:38Z"
+  "generated_at": "2023-05-16T10:32:42Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -4738,7 +4738,6 @@ components:
           - ACTIVE
           - INACTIVE
           - CANCELLED
-          - EXPIRED
     PaymentOutcome:
       type: object
       description: Only applicable for telephone payments reported. Outcome after

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentStatus.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentStatus.java
@@ -4,6 +4,5 @@ public enum PaymentInstrumentStatus {
     CREATED,
     ACTIVE,
     INACTIVE,
-    CANCELLED,
-    EXPIRED
+    CANCELLED
 }


### PR DESCRIPTION
## WHAT YOU DID

We don’t have any process/code that sets the payment_instrument/agreement status to expired. Also, we don’t have any plans to set payment instruments to expired status.

- remove enum PaymentInstrumentStatus.EXPIRED.
