### PR TITLE
PP-11019 Add gateway account internal ID to event schema

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -1140,6 +1140,7 @@ public class ChargeService {
         return new RefundAvailabilityUpdated(
                 charge.getServiceId(),
                 charge.isLive(),
+                charge.getGatewayAccountId(),
                 charge.getExternalId(),
                 RefundAvailabilityUpdatedEventDetails.from(
                         charge,

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -159,9 +159,10 @@ public class EventFactory {
                 return AuthorisationRejected.from(chargeEvent);
             } else {
                 return eventClass.getConstructor(String.class,
-                        boolean.class, String.class, Instant.class).newInstance(
+                        boolean.class, Long.class, String.class, Instant.class).newInstance(
                         chargeEvent.getChargeEntity().getServiceId(),
                         chargeEvent.getChargeEntity().getGatewayAccount().isLive(),
+                        chargeEvent.getChargeEntity().getGatewayAccount().getId(),
                         chargeEvent.getChargeEntity().getExternalId(),
                         chargeEvent.getUpdated().toInstant()
                 );
@@ -178,10 +179,11 @@ public class EventFactory {
             } else if (eventClass == RefundCreatedByUser.class) {
                 return RefundCreatedByUser.from(refundHistory, charge);
             } else {
-                return eventClass.getConstructor(String.class, boolean.class, String.class, String.class,
+                return eventClass.getConstructor(String.class, boolean.class, Long.class, String.class, String.class,
                         RefundEventWithGatewayTransactionIdDetails.class, Instant.class).newInstance(
                         charge.getServiceId(),
                         charge.isLive(),
+                        charge.getGatewayAccountId(),
                         refundHistory.getExternalId(),
                         refundHistory.getChargeExternalId(),
                         new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationCancelled.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationCancelled.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 
 // Semantically same as auth rejected
 public class AuthorisationCancelled extends PaymentEventWithoutDetails {
-    public AuthorisationCancelled(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public AuthorisationCancelled(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationCancelled.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationCancelled.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 
 // Semantically same as auth rejected
 public class AuthorisationCancelled extends PaymentEventWithoutDetails {
-    public AuthorisationCancelled(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public AuthorisationCancelled(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasMissing.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasMissing.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class AuthorisationErrorCheckedWithGatewayChargeWasMissing extends PaymentEventWithoutDetails {
-    public AuthorisationErrorCheckedWithGatewayChargeWasMissing(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public AuthorisationErrorCheckedWithGatewayChargeWasMissing(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasMissing.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasMissing.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class AuthorisationErrorCheckedWithGatewayChargeWasMissing extends PaymentEventWithoutDetails {
-    public AuthorisationErrorCheckedWithGatewayChargeWasMissing(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public AuthorisationErrorCheckedWithGatewayChargeWasMissing(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasRejected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasRejected.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class AuthorisationErrorCheckedWithGatewayChargeWasRejected extends PaymentEventWithoutDetails {
-    public AuthorisationErrorCheckedWithGatewayChargeWasRejected(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public AuthorisationErrorCheckedWithGatewayChargeWasRejected(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasRejected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasRejected.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class AuthorisationErrorCheckedWithGatewayChargeWasRejected extends PaymentEventWithoutDetails {
-    public AuthorisationErrorCheckedWithGatewayChargeWasRejected(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public AuthorisationErrorCheckedWithGatewayChargeWasRejected(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationRejected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationRejected.java
@@ -13,13 +13,13 @@ import java.time.Instant;
  *
  */
 public class AuthorisationRejected extends PaymentEvent {
-    private AuthorisationRejected(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    private AuthorisationRejected(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 
-    private AuthorisationRejected(String serviceId, boolean live, String resourceExternalId,
+    private AuthorisationRejected(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId,
                                  AuthorisationRejectedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static AuthorisationRejected from(ChargeEventEntity chargeEvent) {
@@ -28,6 +28,7 @@ public class AuthorisationRejected extends PaymentEvent {
             return new AuthorisationRejected(
                     charge.getServiceId(),
                     charge.getGatewayAccount().isLive(),
+                    charge.getGatewayAccount().getId(),
                     charge.getExternalId(),
                     AuthorisationRejectedEventDetails.from(charge),
                     chargeEvent.getUpdated().toInstant()
@@ -36,6 +37,7 @@ public class AuthorisationRejected extends PaymentEvent {
         return new AuthorisationRejected(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 chargeEvent.getUpdated().toInstant()
         );

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationSucceeded.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationSucceeded.java
@@ -7,7 +7,7 @@ import java.time.Instant;
  *
  */
 public class AuthorisationSucceeded extends PaymentEventWithoutDetails {
-    public AuthorisationSucceeded(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public AuthorisationSucceeded(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationSucceeded.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationSucceeded.java
@@ -7,7 +7,7 @@ import java.time.Instant;
  *
  */
 public class AuthorisationSucceeded extends PaymentEventWithoutDetails {
-    public AuthorisationSucceeded(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public AuthorisationSucceeded(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerGatewayTransactionIdSet.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerGatewayTransactionIdSet.java
@@ -14,10 +14,11 @@ public class BackfillerGatewayTransactionIdSet extends PaymentEvent {
 
     public BackfillerGatewayTransactionIdSet(String serviceId,
                                              boolean live,
+                                             Long gatewayAccountInternalId,
                                              String resourceExternalId,
                                              BackFillerGatewayTransactionIdSetEventDetails eventDetails,
                                              Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static BackfillerGatewayTransactionIdSet from(ChargeEntity charge) {
@@ -30,6 +31,7 @@ public class BackfillerGatewayTransactionIdSet extends PaymentEvent {
         return new BackfillerGatewayTransactionIdSet(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 BackFillerGatewayTransactionIdSetEventDetails.from(charge),
                 lastEventDate.toInstant());

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerGatewayTransactionIdSet.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerGatewayTransactionIdSet.java
@@ -14,11 +14,11 @@ public class BackfillerGatewayTransactionIdSet extends PaymentEvent {
 
     public BackfillerGatewayTransactionIdSet(String serviceId,
                                              boolean live,
-                                             Long gatewayAccountInternalId,
+                                             Long gatewayAccountId,
                                              String resourceExternalId,
                                              BackFillerGatewayTransactionIdSetEventDetails eventDetails,
                                              Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static BackfillerGatewayTransactionIdSet from(ChargeEntity charge) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollected.java
@@ -21,10 +21,11 @@ public class BackfillerRecreatedUserEmailCollected extends PaymentEvent {
 
     public BackfillerRecreatedUserEmailCollected(String serviceId,
                                                  boolean live,
+                                                 Long gatewayAccountInternalId,
                                                  String resourceExternalId,
                                                  UserEmailCollectedEventDetails eventDetails,
                                                  Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static BackfillerRecreatedUserEmailCollected from(ChargeEntity charge) {
@@ -37,6 +38,7 @@ public class BackfillerRecreatedUserEmailCollected extends PaymentEvent {
         return new BackfillerRecreatedUserEmailCollected(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 UserEmailCollectedEventDetails.from(charge),
                 lastEventDate.toInstant());

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollected.java
@@ -21,11 +21,11 @@ public class BackfillerRecreatedUserEmailCollected extends PaymentEvent {
 
     public BackfillerRecreatedUserEmailCollected(String serviceId,
                                                  boolean live,
-                                                 Long gatewayAccountInternalId,
+                                                 Long gatewayAccountId,
                                                  String resourceExternalId,
                                                  UserEmailCollectedEventDetails eventDetails,
                                                  Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static BackfillerRecreatedUserEmailCollected from(ChargeEntity charge) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationFailed.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByExpirationFailed extends PaymentEventWithoutDetails {
-    public CancelByExpirationFailed(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public CancelByExpirationFailed(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationFailed.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByExpirationFailed extends PaymentEventWithoutDetails {
-    public CancelByExpirationFailed(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public CancelByExpirationFailed(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationSubmitted.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByExpirationSubmitted extends PaymentEventWithoutDetails {
-    public CancelByExpirationSubmitted(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public CancelByExpirationSubmitted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationSubmitted.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByExpirationSubmitted extends PaymentEventWithoutDetails {
-    public CancelByExpirationSubmitted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public CancelByExpirationSubmitted(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceFailed.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByExternalServiceFailed extends PaymentEventWithoutDetails {
-    public CancelByExternalServiceFailed(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public CancelByExternalServiceFailed(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceFailed.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByExternalServiceFailed extends PaymentEventWithoutDetails {
-    public CancelByExternalServiceFailed(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public CancelByExternalServiceFailed(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceSubmitted.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByExternalServiceSubmitted extends PaymentEventWithoutDetails {
-    public CancelByExternalServiceSubmitted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public CancelByExternalServiceSubmitted(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceSubmitted.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByExternalServiceSubmitted extends PaymentEventWithoutDetails {
-    public CancelByExternalServiceSubmitted(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public CancelByExternalServiceSubmitted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserFailed.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByUserFailed extends PaymentEventWithoutDetails {
-    public CancelByUserFailed(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public CancelByUserFailed(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserFailed.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByUserFailed extends PaymentEventWithoutDetails {
-    public CancelByUserFailed(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public CancelByUserFailed(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserSubmitted.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByUserSubmitted extends PaymentEventWithoutDetails {
-    public CancelByUserSubmitted(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public CancelByUserSubmitted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelByUserSubmitted.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelByUserSubmitted extends PaymentEventWithoutDetails {
-    public CancelByUserSubmitted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public CancelByUserSubmitted(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExpiration.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExpiration.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelledByExpiration extends PaymentEventWithoutDetails {
-    public CancelledByExpiration(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public CancelledByExpiration(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExpiration.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExpiration.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelledByExpiration extends PaymentEventWithoutDetails {
-    public CancelledByExpiration(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public CancelledByExpiration(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExternalService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExternalService.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelledByExternalService extends PaymentEventWithoutDetails {
-    public CancelledByExternalService(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public CancelledByExternalService(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExternalService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByExternalService.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CancelledByExternalService extends PaymentEventWithoutDetails {
-    public CancelledByExternalService(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public CancelledByExternalService(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByUser.java
@@ -7,8 +7,8 @@ import uk.gov.pay.connector.events.eventdetails.charge.CancelledByUserEventDetai
 import java.time.Instant;
 
 public class CancelledByUser extends PaymentEvent {
-    public CancelledByUser(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, CancelledByUserEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+    public CancelledByUser(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, CancelledByUserEventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static CancelledByUser from(ChargeEventEntity chargeEvent) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByUser.java
@@ -7,13 +7,13 @@ import uk.gov.pay.connector.events.eventdetails.charge.CancelledByUserEventDetai
 import java.time.Instant;
 
 public class CancelledByUser extends PaymentEvent {
-    public CancelledByUser(String serviceId, boolean live, String resourceExternalId, CancelledByUserEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    public CancelledByUser(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, CancelledByUserEventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static CancelledByUser from(ChargeEventEntity chargeEvent) {
         ChargeEntity charge = chargeEvent.getChargeEntity();
-        return new CancelledByUser(charge.getServiceId(), charge.getGatewayAccount().isLive(), charge.getExternalId(),
-                CancelledByUserEventDetails.from(charge), chargeEvent.getUpdated().toInstant());
+        return new CancelledByUser(charge.getServiceId(), charge.getGatewayAccount().isLive(), charge.getGatewayAccount().getId(),
+                charge.getExternalId(), CancelledByUserEventDetails.from(charge), chargeEvent.getUpdated().toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledWithGatewayAfterAuthorisationError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledWithGatewayAfterAuthorisationError.java
@@ -7,10 +7,10 @@ import uk.gov.pay.connector.events.eventdetails.charge.CancelledWithGatewayAfter
 import java.time.Instant;
 
 public class CancelledWithGatewayAfterAuthorisationError extends PaymentEvent {
-    public CancelledWithGatewayAfterAuthorisationError(String serviceId, boolean live, String resourceExternalId,
+    public CancelledWithGatewayAfterAuthorisationError(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
                                                        CancelledWithGatewayAfterAuthorisationErrorEventDetails eventDetails, 
                                                        Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
     
     public static CancelledWithGatewayAfterAuthorisationError from(ChargeEventEntity chargeEvent) {
@@ -19,6 +19,7 @@ public class CancelledWithGatewayAfterAuthorisationError extends PaymentEvent {
         return new CancelledWithGatewayAfterAuthorisationError(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 CancelledWithGatewayAfterAuthorisationErrorEventDetails.from(charge),
                 chargeEvent.getUpdated().toInstant()

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledWithGatewayAfterAuthorisationError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledWithGatewayAfterAuthorisationError.java
@@ -7,10 +7,10 @@ import uk.gov.pay.connector.events.eventdetails.charge.CancelledWithGatewayAfter
 import java.time.Instant;
 
 public class CancelledWithGatewayAfterAuthorisationError extends PaymentEvent {
-    public CancelledWithGatewayAfterAuthorisationError(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
+    public CancelledWithGatewayAfterAuthorisationError(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId,
                                                        CancelledWithGatewayAfterAuthorisationErrorEventDetails eventDetails, 
                                                        Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
     
     public static CancelledWithGatewayAfterAuthorisationError from(ChargeEventEntity chargeEvent) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureAbandonedAfterTooManyRetries.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureAbandonedAfterTooManyRetries.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CaptureAbandonedAfterTooManyRetries extends PaymentEventWithoutDetails {
-    public CaptureAbandonedAfterTooManyRetries(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public CaptureAbandonedAfterTooManyRetries(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureAbandonedAfterTooManyRetries.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureAbandonedAfterTooManyRetries.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CaptureAbandonedAfterTooManyRetries extends PaymentEventWithoutDetails {
-    public CaptureAbandonedAfterTooManyRetries(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public CaptureAbandonedAfterTooManyRetries(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmed.java
@@ -10,9 +10,9 @@ import java.time.Instant;
  *  Confirmed by notification from payment gateway
  **/
 public class CaptureConfirmed extends PaymentEvent {
-    public CaptureConfirmed(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
+    public CaptureConfirmed(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId,
                             CaptureConfirmedEventDetails captureConfirmedEventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, captureConfirmedEventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, captureConfirmedEventDetails, timestamp);
     }
 
     public static CaptureConfirmed from(ChargeEventEntity chargeEvent) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmed.java
@@ -10,9 +10,9 @@ import java.time.Instant;
  *  Confirmed by notification from payment gateway
  **/
 public class CaptureConfirmed extends PaymentEvent {
-    public CaptureConfirmed(String serviceId, boolean live, String resourceExternalId,
+    public CaptureConfirmed(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
                             CaptureConfirmedEventDetails captureConfirmedEventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, captureConfirmedEventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, captureConfirmedEventDetails, timestamp);
     }
 
     public static CaptureConfirmed from(ChargeEventEntity chargeEvent) {
@@ -21,6 +21,7 @@ public class CaptureConfirmed extends PaymentEvent {
         return new CaptureConfirmed(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 CaptureConfirmedEventDetails.from(chargeEvent),
                 chargeEvent.getUpdated().toInstant()

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotification.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotification.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CaptureConfirmedByGatewayNotification extends PaymentEventWithoutDetails {
-    public CaptureConfirmedByGatewayNotification(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public CaptureConfirmedByGatewayNotification(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotification.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotification.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class CaptureConfirmedByGatewayNotification extends PaymentEventWithoutDetails {
-    public CaptureConfirmedByGatewayNotification(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public CaptureConfirmedByGatewayNotification(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureErrored.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureErrored.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 
 // In rare circumstances...
 public class CaptureErrored extends PaymentEventWithoutDetails {
-    public CaptureErrored(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public CaptureErrored(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureErrored.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureErrored.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 
 // In rare circumstances...
 public class CaptureErrored extends PaymentEventWithoutDetails {
-    public CaptureErrored(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public CaptureErrored(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureSubmitted.java
@@ -8,8 +8,8 @@ import uk.gov.pay.connector.events.eventdetails.charge.CaptureSubmittedEventDeta
 import java.time.Instant;
 
 public class CaptureSubmitted extends PaymentEvent {
-    public CaptureSubmitted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+    public CaptureSubmitted(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static CaptureSubmitted from(ChargeEventEntity chargeEvent) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureSubmitted.java
@@ -8,8 +8,8 @@ import uk.gov.pay.connector.events.eventdetails.charge.CaptureSubmittedEventDeta
 import java.time.Instant;
 
 public class CaptureSubmitted extends PaymentEvent {
-    public CaptureSubmitted(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    public CaptureSubmitted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static CaptureSubmitted from(ChargeEventEntity chargeEvent) {
@@ -18,6 +18,7 @@ public class CaptureSubmitted extends PaymentEvent {
         return new CaptureSubmitted(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 CaptureSubmittedEventDetails.from(chargeEvent),
                 chargeEvent.getUpdated().toInstant()

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsExemptionResultObtained.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsExemptionResultObtained.java
@@ -7,9 +7,9 @@ import java.time.Instant;
 
 public class Gateway3dsExemptionResultObtained extends PaymentEvent {
 
-    public Gateway3dsExemptionResultObtained(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
+    public Gateway3dsExemptionResultObtained(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId,
                                              Gateway3dsExemptionResultObtainedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static Gateway3dsExemptionResultObtained from(ChargeEntity charge, Instant eventDate) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsExemptionResultObtained.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsExemptionResultObtained.java
@@ -7,15 +7,16 @@ import java.time.Instant;
 
 public class Gateway3dsExemptionResultObtained extends PaymentEvent {
 
-    public Gateway3dsExemptionResultObtained(String serviceId, boolean live, String resourceExternalId,
+    public Gateway3dsExemptionResultObtained(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
                                              Gateway3dsExemptionResultObtainedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static Gateway3dsExemptionResultObtained from(ChargeEntity charge, Instant eventDate) {
         return new Gateway3dsExemptionResultObtained(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 Gateway3dsExemptionResultObtainedEventDetails.from(charge),
                 eventDate);

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtained.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtained.java
@@ -7,9 +7,9 @@ import java.time.Instant;
 
 public class Gateway3dsInfoObtained extends PaymentEvent {
 
-    public Gateway3dsInfoObtained(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
+    public Gateway3dsInfoObtained(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId,
                                   Gateway3dsInfoObtainedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static Gateway3dsInfoObtained from(ChargeEntity charge, Instant eventDate) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtained.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtained.java
@@ -7,15 +7,16 @@ import java.time.Instant;
 
 public class Gateway3dsInfoObtained extends PaymentEvent {
 
-    public Gateway3dsInfoObtained(String serviceId, boolean live, String resourceExternalId,
+    public Gateway3dsInfoObtained(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
                                   Gateway3dsInfoObtainedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static Gateway3dsInfoObtained from(ChargeEntity charge, Instant eventDate) {
         return new Gateway3dsInfoObtained(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 Gateway3dsInfoObtainedEventDetails.from(charge),
                 eventDate);

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayErrorDuringAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayErrorDuringAuthorisation.java
@@ -7,7 +7,7 @@ import java.time.Instant;
  *
  */
 public class GatewayErrorDuringAuthorisation extends PaymentEventWithoutDetails {
-    public GatewayErrorDuringAuthorisation(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public GatewayErrorDuringAuthorisation(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayErrorDuringAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayErrorDuringAuthorisation.java
@@ -7,7 +7,7 @@ import java.time.Instant;
  *
  */
 public class GatewayErrorDuringAuthorisation extends PaymentEventWithoutDetails {
-    public GatewayErrorDuringAuthorisation(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public GatewayErrorDuringAuthorisation(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisation.java
@@ -8,10 +8,10 @@ import java.time.Instant;
 
 public class GatewayRequires3dsAuthorisation extends PaymentEvent {
     public GatewayRequires3dsAuthorisation(String serviceId, boolean live,
-                                           Long gatewayAccountInternalId, String resourceExternalId,
+                                           Long gatewayAccountId, String resourceExternalId,
                                            GatewayRequires3dsAuthorisationEventDetails eventDetails,
                                            Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static GatewayRequires3dsAuthorisation from(ChargeEventEntity chargeEvent) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisation.java
@@ -7,16 +7,17 @@ import uk.gov.pay.connector.events.eventdetails.charge.GatewayRequires3dsAuthori
 import java.time.Instant;
 
 public class GatewayRequires3dsAuthorisation extends PaymentEvent {
-    public GatewayRequires3dsAuthorisation(String serviceId, boolean live, String resourceExternalId,
+    public GatewayRequires3dsAuthorisation(String serviceId, boolean live,
+                                           Long gatewayAccountInternalId, String resourceExternalId,
                                            GatewayRequires3dsAuthorisationEventDetails eventDetails,
                                            Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static GatewayRequires3dsAuthorisation from(ChargeEventEntity chargeEvent) {
         ChargeEntity charge = chargeEvent.getChargeEntity();
         return new GatewayRequires3dsAuthorisation(charge.getServiceId(), charge.getGatewayAccount().isLive(),
-                charge.getExternalId(), GatewayRequires3dsAuthorisationEventDetails.from(charge),
+                charge.getGatewayAccount().getId(), charge.getExternalId(), GatewayRequires3dsAuthorisationEventDetails.from(charge),
                 chargeEvent.getUpdated().toInstant());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayTimeoutDuringAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayTimeoutDuringAuthorisation.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class GatewayTimeoutDuringAuthorisation extends PaymentEventWithoutDetails {
-    public GatewayTimeoutDuringAuthorisation(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public GatewayTimeoutDuringAuthorisation(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayTimeoutDuringAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayTimeoutDuringAuthorisation.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class GatewayTimeoutDuringAuthorisation extends PaymentEventWithoutDetails {
-    public GatewayTimeoutDuringAuthorisation(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public GatewayTimeoutDuringAuthorisation(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentCreated.java
@@ -8,8 +8,8 @@ import java.time.Instant;
 
 public class PaymentCreated extends PaymentEvent {
 
-    public PaymentCreated(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, PaymentCreatedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+    public PaymentCreated(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, PaymentCreatedEventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static PaymentCreated from(ChargeEventEntity event) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentCreated.java
@@ -8,14 +8,15 @@ import java.time.Instant;
 
 public class PaymentCreated extends PaymentEvent {
 
-    public PaymentCreated(String serviceId, boolean live, String resourceExternalId, PaymentCreatedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    public PaymentCreated(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, PaymentCreatedEventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static PaymentCreated from(ChargeEventEntity event) {
         return new PaymentCreated(
                 event.getChargeEntity().getServiceId(),
                 event.getChargeEntity().getGatewayAccount().isLive(),
+                event.getChargeEntity().getGatewayAccount().getId(),
                 event.getChargeEntity().getExternalId(),
                 PaymentCreatedEventDetails.from(event.getChargeEntity()),
                 event.getUpdated().toInstant()
@@ -25,7 +26,8 @@ public class PaymentCreated extends PaymentEvent {
     public static PaymentCreated from(ChargeEntity charge) {
         return new PaymentCreated(
                 charge.getServiceId(),
-                charge.getGatewayAccount().isLive(), 
+                charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 PaymentCreatedEventDetails.from(charge),
                 charge.getCreatedDate()

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEntered.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEntered.java
@@ -18,10 +18,11 @@ public class PaymentDetailsEntered extends PaymentEvent {
 
     public PaymentDetailsEntered(String serviceId,
                                  boolean live,
+                                 Long gatewayAccountInternalId,
                                  String resourceExternalId,
                                  PaymentDetailsEnteredEventDetails eventDetails,
                                  Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static PaymentDetailsEntered from(ChargeEntity charge) {
@@ -34,6 +35,7 @@ public class PaymentDetailsEntered extends PaymentEvent {
         return new PaymentDetailsEntered(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 PaymentDetailsEnteredEventDetails.from(charge),
                 lastEventDate.toInstant());
@@ -45,6 +47,7 @@ public class PaymentDetailsEntered extends PaymentEvent {
         return new PaymentDetailsEntered(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 PaymentDetailsEnteredEventDetails.from(charge),
                 chargeEvent.getUpdated().toInstant()

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEntered.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEntered.java
@@ -18,11 +18,11 @@ public class PaymentDetailsEntered extends PaymentEvent {
 
     public PaymentDetailsEntered(String serviceId,
                                  boolean live,
-                                 Long gatewayAccountInternalId,
+                                 Long gatewayAccountId,
                                  String resourceExternalId,
                                  PaymentDetailsEnteredEventDetails eventDetails,
                                  Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static PaymentDetailsEntered from(ChargeEntity charge) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsSubmittedByAPI.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsSubmittedByAPI.java
@@ -13,10 +13,11 @@ public class PaymentDetailsSubmittedByAPI extends PaymentEvent {
 
     public PaymentDetailsSubmittedByAPI(String serviceId,
                                         boolean live,
+                                        Long gatewayAccountInternalId,
                                         String resourceExternalId,
                                         PaymentDetailsSubmittedByAPIEventDetails eventDetails,
                                         Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static PaymentDetailsSubmittedByAPI from(ChargeEntity charge) {
@@ -29,6 +30,7 @@ public class PaymentDetailsSubmittedByAPI extends PaymentEvent {
         return new PaymentDetailsSubmittedByAPI(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 PaymentDetailsSubmittedByAPIEventDetails.from(charge),
                 lastEventDate.toInstant());
@@ -40,6 +42,7 @@ public class PaymentDetailsSubmittedByAPI extends PaymentEvent {
         return new PaymentDetailsSubmittedByAPI(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 PaymentDetailsSubmittedByAPIEventDetails.from(charge),
                 chargeEventEntity.getUpdated().toInstant()

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsSubmittedByAPI.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsSubmittedByAPI.java
@@ -13,11 +13,11 @@ public class PaymentDetailsSubmittedByAPI extends PaymentEvent {
 
     public PaymentDetailsSubmittedByAPI(String serviceId,
                                         boolean live,
-                                        Long gatewayAccountInternalId,
+                                        Long gatewayAccountId,
                                         String resourceExternalId,
                                         PaymentDetailsSubmittedByAPIEventDetails eventDetails,
                                         Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static PaymentDetailsSubmittedByAPI from(ChargeEntity charge) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsTakenFromPaymentInstrument.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsTakenFromPaymentInstrument.java
@@ -13,10 +13,11 @@ public class PaymentDetailsTakenFromPaymentInstrument extends PaymentEvent {
 
     public PaymentDetailsTakenFromPaymentInstrument(String serviceId,
                                                     boolean live,
+                                                    Long gatewayAccountInternalId,
                                                     String resourceExternalId,
                                                     PaymentDetailsTakenFromPaymentInstrumentEventDetails eventDetails,
                                                     Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static PaymentDetailsTakenFromPaymentInstrument from(ChargeEntity charge) {
@@ -29,6 +30,7 @@ public class PaymentDetailsTakenFromPaymentInstrument extends PaymentEvent {
         return new PaymentDetailsTakenFromPaymentInstrument(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 PaymentDetailsTakenFromPaymentInstrumentEventDetails.from(charge),
                 lastEventDate.toInstant());
@@ -40,6 +42,7 @@ public class PaymentDetailsTakenFromPaymentInstrument extends PaymentEvent {
         return new PaymentDetailsTakenFromPaymentInstrument(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 PaymentDetailsTakenFromPaymentInstrumentEventDetails.from(charge),
                 chargeEventEntity.getUpdated().toInstant()

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsTakenFromPaymentInstrument.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsTakenFromPaymentInstrument.java
@@ -13,11 +13,11 @@ public class PaymentDetailsTakenFromPaymentInstrument extends PaymentEvent {
 
     public PaymentDetailsTakenFromPaymentInstrument(String serviceId,
                                                     boolean live,
-                                                    Long gatewayAccountInternalId,
+                                                    Long gatewayAccountId,
                                                     String resourceExternalId,
                                                     PaymentDetailsTakenFromPaymentInstrumentEventDetails eventDetails,
                                                     Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static PaymentDetailsTakenFromPaymentInstrument from(ChargeEntity charge) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDisputed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDisputed.java
@@ -7,14 +7,15 @@ import uk.gov.pay.connector.events.eventdetails.charge.PaymentDisputedEventDetai
 import java.time.Instant;
 
 public class PaymentDisputed extends PaymentEvent {
-    private PaymentDisputed(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    private PaymentDisputed(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
     
     public static PaymentDisputed from(LedgerTransaction ledgerTransaction, Instant disputeCreatedDate) {
         return new PaymentDisputed(
                 ledgerTransaction.getServiceId(),
                 ledgerTransaction.getLive(),
+                Long.valueOf(ledgerTransaction.getGatewayAccountId()),
                 ledgerTransaction.getTransactionId(),
                 new PaymentDisputedEventDetails(),
                 disputeCreatedDate

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDisputed.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentDisputed.java
@@ -7,8 +7,8 @@ import uk.gov.pay.connector.events.eventdetails.charge.PaymentDisputedEventDetai
 import java.time.Instant;
 
 public class PaymentDisputed extends PaymentEvent {
-    private PaymentDisputed(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+    private PaymentDisputed(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
     
     public static PaymentDisputed from(LedgerTransaction ledgerTransaction, Instant disputeCreatedDate) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
@@ -9,21 +9,24 @@ import java.time.Instant;
 public class PaymentEvent extends Event {
     private String serviceId;
     private Boolean live;
+    private Long gatewayAccountInternalId;
     
-    public PaymentEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+    public PaymentEvent(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(timestamp, resourceExternalId, eventDetails);
         this.serviceId = serviceId;
         this.live = live;
+        this.gatewayAccountInternalId = gatewayAccountInternalId;
     }
 
     public PaymentEvent(String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(timestamp, resourceExternalId, eventDetails);
     }
 
-    public PaymentEvent(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
+    public PaymentEvent(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
         super(timestamp, resourceExternalId);
         this.serviceId = serviceId;
         this.live = live;
+        this.gatewayAccountInternalId = gatewayAccountId;
     }
 
     @Override
@@ -37,5 +40,9 @@ public class PaymentEvent extends Event {
 
     public String getServiceId() {
         return serviceId;
+    }
+
+    public Long getGatewayAccountInternalId() {
+        return gatewayAccountInternalId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
@@ -9,13 +9,13 @@ import java.time.Instant;
 public class PaymentEvent extends Event {
     private String serviceId;
     private Boolean live;
-    private Long gatewayAccountInternalId;
+    private Long gatewayAccountId;
     
-    public PaymentEvent(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+    public PaymentEvent(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
         super(timestamp, resourceExternalId, eventDetails);
         this.serviceId = serviceId;
         this.live = live;
-        this.gatewayAccountInternalId = gatewayAccountInternalId;
+        this.gatewayAccountId = gatewayAccountId;
     }
 
     public PaymentEvent(String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
@@ -26,7 +26,7 @@ public class PaymentEvent extends Event {
         super(timestamp, resourceExternalId);
         this.serviceId = serviceId;
         this.live = live;
-        this.gatewayAccountInternalId = gatewayAccountId;
+        this.gatewayAccountId = gatewayAccountId;
     }
 
     @Override
@@ -42,7 +42,7 @@ public class PaymentEvent extends Event {
         return serviceId;
     }
 
-    public Long getGatewayAccountInternalId() {
-        return gatewayAccountInternalId;
+    public Long getGatewayAccountId() {
+        return gatewayAccountId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEventWithoutDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEventWithoutDetails.java
@@ -6,8 +6,8 @@ import java.time.Instant;
 
 public class PaymentEventWithoutDetails extends PaymentEvent {
 
-    public PaymentEventWithoutDetails(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, new EmptyEventDetails(), timestamp);
+    public PaymentEventWithoutDetails(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, new EmptyEventDetails(), timestamp);
         
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEventWithoutDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEventWithoutDetails.java
@@ -6,8 +6,8 @@ import java.time.Instant;
 
 public class PaymentEventWithoutDetails extends PaymentEvent {
 
-    public PaymentEventWithoutDetails(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, new EmptyEventDetails(), timestamp);
+    public PaymentEventWithoutDetails(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, new EmptyEventDetails(), timestamp);
         
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentExpired.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentExpired.java
@@ -7,7 +7,7 @@ import java.time.Instant;
  * succeeding or failing to expire.
  */
 public class PaymentExpired extends PaymentEventWithoutDetails {
-    public PaymentExpired(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public PaymentExpired(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentExpired.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentExpired.java
@@ -7,7 +7,7 @@ import java.time.Instant;
  * succeeding or failing to expire.
  */
 public class PaymentExpired extends PaymentEventWithoutDetails {
-    public PaymentExpired(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public PaymentExpired(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreated.java
@@ -7,9 +7,9 @@ import uk.gov.pay.connector.events.eventdetails.charge.PaymentNotificationCreate
 import java.time.Instant;
 
 public class PaymentNotificationCreated extends PaymentEvent {
-    public PaymentNotificationCreated(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
+    public PaymentNotificationCreated(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId,
                                       PaymentNotificationCreatedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static PaymentNotificationCreated from(ChargeEventEntity chargeEvent) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreated.java
@@ -7,15 +7,16 @@ import uk.gov.pay.connector.events.eventdetails.charge.PaymentNotificationCreate
 import java.time.Instant;
 
 public class PaymentNotificationCreated extends PaymentEvent {
-    public PaymentNotificationCreated(String serviceId, boolean live, String resourceExternalId,
+    public PaymentNotificationCreated(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
                                       PaymentNotificationCreatedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static PaymentNotificationCreated from(ChargeEventEntity chargeEvent) {
         ChargeEntity charge = chargeEvent.getChargeEntity();
         return new  PaymentNotificationCreated(charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 PaymentNotificationCreatedEventDetails.from(charge),
                 chargeEvent.getUpdated().toInstant());

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentRefundCreatedByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentRefundCreatedByUser.java
@@ -5,7 +5,7 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import java.time.Instant;
 
 public class PaymentRefundCreatedByUser extends PaymentEvent {
-    public PaymentRefundCreatedByUser(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    public PaymentRefundCreatedByUser(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentRefundCreatedByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentRefundCreatedByUser.java
@@ -5,7 +5,7 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import java.time.Instant;
 
 public class PaymentRefundCreatedByUser extends PaymentEvent {
-    public PaymentRefundCreatedByUser(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+    public PaymentRefundCreatedByUser(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentStarted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentStarted.java
@@ -7,7 +7,7 @@ import java.time.Instant;
  *
  */
 public class PaymentStarted extends PaymentEventWithoutDetails {
-    public PaymentStarted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public PaymentStarted(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentStarted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentStarted.java
@@ -7,7 +7,7 @@ import java.time.Instant;
  *
  */
 public class PaymentStarted extends PaymentEventWithoutDetails {
-    public PaymentStarted(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public PaymentStarted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForAuthorisationWithUserNotPresent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForAuthorisationWithUserNotPresent.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class QueuedForAuthorisationWithUserNotPresent extends PaymentEventWithoutDetails {
-    public QueuedForAuthorisationWithUserNotPresent(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public QueuedForAuthorisationWithUserNotPresent(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForAuthorisationWithUserNotPresent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForAuthorisationWithUserNotPresent.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class QueuedForAuthorisationWithUserNotPresent extends PaymentEventWithoutDetails {
-    public QueuedForAuthorisationWithUserNotPresent(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public QueuedForAuthorisationWithUserNotPresent(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForCapture.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForCapture.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class QueuedForCapture extends PaymentEventWithoutDetails {
-    public QueuedForCapture(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public QueuedForCapture(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForCapture.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/QueuedForCapture.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class QueuedForCapture extends PaymentEventWithoutDetails {
-    public QueuedForCapture(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public QueuedForCapture(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
@@ -8,9 +8,9 @@ import java.time.Instant;
 
 public class RefundAvailabilityUpdated extends PaymentEvent {
 
-    public RefundAvailabilityUpdated(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
+    public RefundAvailabilityUpdated(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId,
                                      RefundAvailabilityUpdatedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static RefundAvailabilityUpdated from(LedgerTransaction ledgerTransaction,

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
@@ -8,15 +8,15 @@ import java.time.Instant;
 
 public class RefundAvailabilityUpdated extends PaymentEvent {
 
-    public RefundAvailabilityUpdated(String serviceId, boolean live, String resourceExternalId,
+    public RefundAvailabilityUpdated(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
                                      RefundAvailabilityUpdatedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static RefundAvailabilityUpdated from(LedgerTransaction ledgerTransaction,
                                                  ExternalChargeRefundAvailability externalChargeRefundAvailability, Instant timestamp) {
         var eventDetails = RefundAvailabilityUpdatedEventDetails.from(externalChargeRefundAvailability);
-        return new RefundAvailabilityUpdated(ledgerTransaction.getServiceId(), ledgerTransaction.getLive(),
+        return new RefundAvailabilityUpdated(ledgerTransaction.getServiceId(), ledgerTransaction.getLive(), Long.valueOf(ledgerTransaction.getGatewayAccountId()),
                 ledgerTransaction.getTransactionId(), eventDetails, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/ServiceApprovedForCapture.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/ServiceApprovedForCapture.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class ServiceApprovedForCapture extends PaymentEventWithoutDetails {
-    public ServiceApprovedForCapture(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public ServiceApprovedForCapture(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/ServiceApprovedForCapture.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/ServiceApprovedForCapture.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class ServiceApprovedForCapture extends PaymentEventWithoutDetails {
-    public ServiceApprovedForCapture(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public ServiceApprovedForCapture(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationErrorToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationErrorToMatchGatewayStatus.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class StatusCorrectedToAuthorisationErrorToMatchGatewayStatus extends PaymentEventWithoutDetails {
-    public StatusCorrectedToAuthorisationErrorToMatchGatewayStatus(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public StatusCorrectedToAuthorisationErrorToMatchGatewayStatus(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationErrorToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationErrorToMatchGatewayStatus.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class StatusCorrectedToAuthorisationErrorToMatchGatewayStatus extends PaymentEventWithoutDetails {
-    public StatusCorrectedToAuthorisationErrorToMatchGatewayStatus(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public StatusCorrectedToAuthorisationErrorToMatchGatewayStatus(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus extends PaymentEventWithoutDetails {
-    public StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus extends PaymentEventWithoutDetails {
-    public StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToCapturedToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToCapturedToMatchGatewayStatus.java
@@ -7,9 +7,9 @@ import uk.gov.pay.connector.events.eventdetails.charge.CaptureConfirmedEventDeta
 import java.time.Instant;
 
 public class StatusCorrectedToCapturedToMatchGatewayStatus extends PaymentEvent {
-    public StatusCorrectedToCapturedToMatchGatewayStatus(String serviceId, boolean live, String resourceExternalId,
+    public StatusCorrectedToCapturedToMatchGatewayStatus(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
                                                          CaptureConfirmedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
     
     public static StatusCorrectedToCapturedToMatchGatewayStatus from(ChargeEventEntity chargeEvent) {
@@ -18,6 +18,7 @@ public class StatusCorrectedToCapturedToMatchGatewayStatus extends PaymentEvent 
         return new StatusCorrectedToCapturedToMatchGatewayStatus(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 CaptureConfirmedEventDetails.from(chargeEvent),
                 chargeEvent.getUpdated().toInstant()

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToCapturedToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToCapturedToMatchGatewayStatus.java
@@ -7,9 +7,9 @@ import uk.gov.pay.connector.events.eventdetails.charge.CaptureConfirmedEventDeta
 import java.time.Instant;
 
 public class StatusCorrectedToCapturedToMatchGatewayStatus extends PaymentEvent {
-    public StatusCorrectedToCapturedToMatchGatewayStatus(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
+    public StatusCorrectedToCapturedToMatchGatewayStatus(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId,
                                                          CaptureConfirmedEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
     
     public static StatusCorrectedToCapturedToMatchGatewayStatus from(ChargeEventEntity chargeEvent) {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/SystemCancelled.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/SystemCancelled.java
@@ -17,7 +17,7 @@ import java.time.Instant;
  *
  */
 public class SystemCancelled extends PaymentEventWithoutDetails {
-    public SystemCancelled(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public SystemCancelled(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/SystemCancelled.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/SystemCancelled.java
@@ -17,7 +17,7 @@ import java.time.Instant;
  *
  */
 public class SystemCancelled extends PaymentEventWithoutDetails {
-    public SystemCancelled(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public SystemCancelled(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UnexpectedGatewayErrorDuringAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UnexpectedGatewayErrorDuringAuthorisation.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class UnexpectedGatewayErrorDuringAuthorisation extends PaymentEventWithoutDetails {
-    public UnexpectedGatewayErrorDuringAuthorisation(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public UnexpectedGatewayErrorDuringAuthorisation(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UnexpectedGatewayErrorDuringAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UnexpectedGatewayErrorDuringAuthorisation.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class UnexpectedGatewayErrorDuringAuthorisation extends PaymentEventWithoutDetails {
-    public UnexpectedGatewayErrorDuringAuthorisation(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public UnexpectedGatewayErrorDuringAuthorisation(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCapture.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCapture.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class UserApprovedForCapture extends PaymentEventWithoutDetails {
-    public UserApprovedForCapture(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public UserApprovedForCapture(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCapture.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCapture.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class UserApprovedForCapture extends PaymentEventWithoutDetails {
-    public UserApprovedForCapture(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public UserApprovedForCapture(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCaptureAwaitingServiceApproval.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCaptureAwaitingServiceApproval.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class UserApprovedForCaptureAwaitingServiceApproval extends PaymentEventWithoutDetails {
-    public UserApprovedForCaptureAwaitingServiceApproval(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public UserApprovedForCaptureAwaitingServiceApproval(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCaptureAwaitingServiceApproval.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCaptureAwaitingServiceApproval.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.Instant;
 
 public class UserApprovedForCaptureAwaitingServiceApproval extends PaymentEventWithoutDetails {
-    public UserApprovedForCaptureAwaitingServiceApproval(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, timestamp);
+    public UserApprovedForCaptureAwaitingServiceApproval(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UserEmailCollected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UserEmailCollected.java
@@ -7,16 +7,17 @@ import java.time.Instant;
 
 public class UserEmailCollected extends PaymentEvent {
 
-    public UserEmailCollected(String serviceId, boolean live, String resourceExternalId,
+    public UserEmailCollected(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
                               UserEmailCollectedEventDetails eventDetails,
                               Instant timestamp) {
-        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static UserEmailCollected from(ChargeEntity charge, Instant eventDate) {
         return new UserEmailCollected(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 UserEmailCollectedEventDetails.from(charge),
                 eventDate);

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UserEmailCollected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UserEmailCollected.java
@@ -7,10 +7,10 @@ import java.time.Instant;
 
 public class UserEmailCollected extends PaymentEvent {
 
-    public UserEmailCollected(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId,
+    public UserEmailCollected(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId,
                               UserEmailCollectedEventDetails eventDetails,
                               Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
     public static UserEmailCollected from(ChargeEntity charge, Instant eventDate) {

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
@@ -8,15 +8,16 @@ import java.time.Instant;
 
 public class RefundCreatedByService extends RefundEvent {
 
-    private RefundCreatedByService(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
+    private RefundCreatedByService(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
                                    RefundCreatedByServiceEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
     }
 
     public static RefundCreatedByService from(RefundHistory refundHistory, Charge charge) {
         return new RefundCreatedByService(
                 charge.getServiceId(),
                 charge.isLive(),
+                charge.getGatewayAccountId(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundCreatedByServiceEventDetails(

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
@@ -8,9 +8,9 @@ import java.time.Instant;
 
 public class RefundCreatedByService extends RefundEvent {
 
-    private RefundCreatedByService(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
+    private RefundCreatedByService(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, String parentResourceExternalId,
                                    RefundCreatedByServiceEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
     }
 
     public static RefundCreatedByService from(RefundHistory refundHistory, Charge charge) {

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
@@ -8,15 +8,16 @@ import java.time.Instant;
 
 public class RefundCreatedByUser extends RefundEvent {
 
-    private RefundCreatedByUser(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
+    private RefundCreatedByUser(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
                                 RefundCreatedByUserEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
     }
 
     public static RefundCreatedByUser from(RefundHistory refundHistory, Charge charge) {
         return new RefundCreatedByUser(
                 charge.getServiceId(),
                 charge.isLive(),
+                charge.getGatewayAccountId(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundCreatedByUserEventDetails(

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
@@ -8,9 +8,9 @@ import java.time.Instant;
 
 public class RefundCreatedByUser extends RefundEvent {
 
-    private RefundCreatedByUser(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
+    private RefundCreatedByUser(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, String parentResourceExternalId,
                                 RefundCreatedByUserEventDetails eventDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
     }
 
     public static RefundCreatedByUser from(RefundHistory refundHistory, Charge charge) {

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
@@ -8,15 +8,16 @@ import java.time.Instant;
 
 public class RefundError extends RefundEvent {
 
-    public RefundError(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
+    public RefundError(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
                        RefundEventWithGatewayTransactionIdDetails referenceDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public RefundError from(RefundHistory refundHistory, Charge charge) {
         return new RefundError(
                 charge.getServiceId(),
                 charge.isLive(),
+                charge.getGatewayAccountId(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
@@ -8,9 +8,9 @@ import java.time.Instant;
 
 public class RefundError extends RefundEvent {
 
-    public RefundError(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
+    public RefundError(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, String parentResourceExternalId,
                        RefundEventWithGatewayTransactionIdDetails referenceDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public RefundError from(RefundHistory refundHistory, Charge charge) {

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
@@ -9,16 +9,16 @@ import java.time.Instant;
 public abstract class RefundEvent extends Event {
     private String serviceId;
     private Boolean live;
-    private Long gatewayAccountInternalId;
+    private Long gatewayAccountId;
     private String parentResourceExternalId;
 
-    public RefundEvent(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
+    public RefundEvent(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, String parentResourceExternalId,
                        EventDetails eventDetails, Instant timestamp) {
         super(timestamp, resourceExternalId, eventDetails);
         this.parentResourceExternalId = parentResourceExternalId;
         this.serviceId = serviceId;
         this.live = live;
-        this.gatewayAccountInternalId = gatewayAccountInternalId;
+        this.gatewayAccountId = gatewayAccountId;
     }
 
     public RefundEvent(String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
@@ -42,7 +42,7 @@ public abstract class RefundEvent extends Event {
         return serviceId;
     }
 
-    public Long getGatewayAccountInternalId() {
-        return gatewayAccountInternalId;
+    public Long getGatewayAccountId() {
+        return gatewayAccountId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
@@ -9,14 +9,16 @@ import java.time.Instant;
 public abstract class RefundEvent extends Event {
     private String serviceId;
     private Boolean live;
+    private Long gatewayAccountInternalId;
     private String parentResourceExternalId;
 
-    public RefundEvent(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
+    public RefundEvent(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
                        EventDetails eventDetails, Instant timestamp) {
         super(timestamp, resourceExternalId, eventDetails);
         this.parentResourceExternalId = parentResourceExternalId;
         this.serviceId = serviceId;
         this.live = live;
+        this.gatewayAccountInternalId = gatewayAccountInternalId;
     }
 
     public RefundEvent(String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
@@ -38,5 +40,9 @@ public abstract class RefundEvent extends Event {
 
     public String getServiceId() {
         return serviceId;
+    }
+
+    public Long getGatewayAccountInternalId() {
+        return gatewayAccountInternalId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
@@ -8,15 +8,16 @@ import java.time.Instant;
 
 public class RefundSubmitted extends RefundEvent {
 
-    public RefundSubmitted(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
+    public RefundSubmitted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
                            RefundEventWithGatewayTransactionIdDetails referenceDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public static RefundSubmitted from(Charge charge, RefundHistory refundHistory) {
         return new RefundSubmitted(
                 charge.getServiceId(),
                 charge.isLive(),
+                charge.getGatewayAccountId(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
@@ -8,9 +8,9 @@ import java.time.Instant;
 
 public class RefundSubmitted extends RefundEvent {
 
-    public RefundSubmitted(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
+    public RefundSubmitted(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, String parentResourceExternalId,
                            RefundEventWithGatewayTransactionIdDetails referenceDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public static RefundSubmitted from(Charge charge, RefundHistory refundHistory) {

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
@@ -8,9 +8,9 @@ import java.time.Instant;
 
 public class RefundSucceeded extends RefundEvent {
 
-    public RefundSucceeded(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
+    public RefundSucceeded(String serviceId, boolean live, Long gatewayAccountId, String resourceExternalId, String parentResourceExternalId,
                            RefundEventWithGatewayTransactionIdDetails referenceDetails, Instant timestamp) {
-        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+        super(serviceId, live, gatewayAccountId, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public static RefundSucceeded from(Charge charge, RefundHistory refundHistory) {

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
@@ -8,14 +8,15 @@ import java.time.Instant;
 
 public class RefundSucceeded extends RefundEvent {
 
-    public RefundSucceeded(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
+    public RefundSucceeded(String serviceId, boolean live, Long gatewayAccountInternalId, String resourceExternalId, String parentResourceExternalId,
                            RefundEventWithGatewayTransactionIdDetails referenceDetails, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+        super(serviceId, live, gatewayAccountInternalId, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public static RefundSucceeded from(Charge charge, RefundHistory refundHistory) {
         return new RefundSucceeded(charge.getServiceId(),
                 charge.isLive(),
+                charge.getGatewayAccountId(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -104,7 +104,7 @@ public class ChargeNotificationProcessor {
                 kv(GATEWAY_ACCOUNT_ID, gatewayAccount.getId()),
                 kv(PROVIDER, charge.getPaymentGatewayName()));
         
-        Event event = new CaptureConfirmedByGatewayNotification(charge.getServiceId(), charge.isLive(), charge.getExternalId(), Instant.now());
+        Event event = new CaptureConfirmedByGatewayNotification(charge.getServiceId(), charge.isLive(), charge.getGatewayAccountId(), charge.getExternalId(), Instant.now());
         eventService.emitEvent(event);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
@@ -86,9 +86,9 @@ public class PaymentGatewayStateTransitionsTest {
     @Test
     public void isValidTransition_deniesTransitionWithInvalidEvent() {
         assertThat(PaymentGatewayStateTransitions.isValidTransition(CAPTURE_READY, CAPTURE_SUBMITTED,
-                new CaptureSubmitted("id", true, "a", new EmptyEventDetails(), Instant.now())), is(true));
+                new CaptureSubmitted("id", true, 100L, "a", new EmptyEventDetails(), Instant.now())), is(true));
         assertThat(PaymentGatewayStateTransitions.isValidTransition(CAPTURE_READY, CAPTURE_SUBMITTED,
-                new CaptureErrored("id", true, "a", Instant.now())), is(false));
+                new CaptureErrored("id", true, 100L, "a", Instant.now())), is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
@@ -33,14 +33,14 @@ class EventServiceTest {
 
     @Test
     void emitEvent() throws QueueException {
-        Event event = new PaymentEvent("service-id", true, "external-id", now());
+        Event event = new PaymentEvent("service-id", true, 100L, "external-id", now());
         eventService.emitEvent(event);
         verify(eventQueue).emitEvent(event);
     }
 
     @Test
     void emitEventShouldRecordEvent() throws QueueException {
-        Event event = new PaymentEvent("service-id", true, "external-id", now());
+        Event event = new PaymentEvent("service-id", true, 100L, "external-id", now());
         eventService.emitEvent(event, false);
 
         verify(eventQueue).emitEvent(event);
@@ -48,14 +48,14 @@ class EventServiceTest {
 
     @Test
     void emitEventShouldThrowExceptionIfSwallowExceptionIsFalse() throws QueueException {
-        Event event = new PaymentEvent("service-id", true,"external-id", now());
+        Event event = new PaymentEvent("service-id", true, 100L, "external-id", now());
         doThrow(QueueException.class).when(eventQueue).emitEvent(event);
         assertThrows(QueueException.class, ()-> eventService.emitEvent(event, false));
     }
 
     @Test
     void emitEventShouldNotThrowExceptionIfSwallowExceptionIsFalse() throws QueueException {
-        Event event = new PaymentEvent("service-id", true,"external-id", now());
+        Event event = new PaymentEvent("service-id", true, 100L, "external-id", now());
         doThrow(QueueException.class).when(eventQueue).emitEvent(event);
         eventService.emitEvent(event, true);
         verify(eventQueue).emitEvent(event);
@@ -63,7 +63,7 @@ class EventServiceTest {
 
     @Test
     void emitAndRecordEvent_shouldRecordEmission() throws QueueException {
-        Event event = new PaymentEvent("service-id", true,"external-id", now());
+        Event event = new PaymentEvent("service-id", true, 100L,"external-id", now());
         eventService.emitAndRecordEvent(event);
 
         verify(emittedEventDao).recordEmission(event, null);
@@ -72,7 +72,7 @@ class EventServiceTest {
 
     @Test
     void emitAndRecordEvent_shouldRecordEmissionWithDoNotRetryEmitUntilDate() throws QueueException {
-        Event event = new PaymentEvent("service-id", true,"external-id", now());
+        Event event = new PaymentEvent("service-id", true,100L,"external-id", now());
         ZonedDateTime doNotRetryEmitUntilDate = ZonedDateTime.now(UTC);
         eventService.emitAndRecordEvent(event, doNotRetryEmitUntilDate);
 
@@ -82,7 +82,7 @@ class EventServiceTest {
 
     @Test
     void emitAndRecordEvent_shouldRecordEmissionWithoutEmittedDateForQueueException() throws QueueException {
-        Event event = new PaymentCreated("service-id", true,"external-id", null, now());
+        Event event = new PaymentCreated("service-id", true, 100L, "external-id", null, now());
         doThrow(QueueException.class).when(eventQueue).emitEvent(event);
         eventService.emitAndRecordEvent(event);
 
@@ -94,7 +94,7 @@ class EventServiceTest {
 
     @Test
     void emitAndMarkEventAsEmitted() throws QueueException {
-        Event event = new PaymentEvent("service-id", true, "external-id", now());
+        Event event = new PaymentEvent("service-id", true, 100L, "external-id", now());
         eventService.emitAndMarkEventAsEmitted(event);
 
         verify(eventQueue).emitEvent(event);

--- a/src/test/java/uk/gov/pay/connector/events/StateTransitionEmitterProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/StateTransitionEmitterProcessTest.java
@@ -51,7 +51,9 @@ class StateTransitionEmitterProcessTest {
     void shouldEmitPaymentEventGivenStateTransitionMessageOnQueue() throws Exception {
         PaymentStateTransition paymentStateTransition = new PaymentStateTransition(100L, PaymentCreated.class);
         when(eventFactory.createEvents(any(PaymentStateTransition.class))).thenReturn(List.of(
-                new PaymentCreated("service-id", true,
+                new PaymentCreated("service-id",
+                        true,
+                        100L,
                         "id",
                         mock(PaymentCreatedEventDetails.class),
                         Instant.now()
@@ -81,7 +83,9 @@ class StateTransitionEmitterProcessTest {
         ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
         when(stateTransitionQueue.poll(anyLong(), any(TimeUnit.class))).thenReturn(paymentStateTransition);
         when(eventFactory.createEvents(any(PaymentStateTransition.class))).thenReturn(List.of(
-                new PaymentCreated("service-id", true,
+                new PaymentCreated("service-id",
+                        true,
+                        100L,
                         "id",
                         mock(PaymentCreatedEventDetails.class),
                         Instant.now()

--- a/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
@@ -210,12 +210,12 @@ public class EmittedEventDaoIT extends DaoITestBase {
                 .withDelayedCapture(false)
                 .withLive(false)
                 .build();
-        return new PaymentCreated("service-id", true, "my-resource-external-id", eventDetails,
+        return new PaymentCreated("service-id", true, 100L, "my-resource-external-id", eventDetails,
                 Instant.parse("2019-01-01T14:00:00Z"));
     }
 
     private RefundSubmitted aRefundSubmittedEvent(Instant eventTimestamp) {
-        return new RefundSubmitted("service-id", true, "my-resource-external-id",
+        return new RefundSubmitted("service-id", true, 100L, "my-resource-external-id",
                 "parent-external-id",
                 null, eventTimestamp);
     }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByUserTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByUserTest.java
@@ -39,8 +39,8 @@ class CancelledByUserTest {
     void whenAllTheDataIsAvailable() throws JsonProcessingException {
         ChargeEntity chargeEntity = chargeEntityFixture.build();
 
-        String actual = new CancelledByUser(chargeEntity.getServiceId(), chargeEntity.getGatewayAccount().isLive(), transactionId,
-                CancelledByUserEventDetails.from(chargeEntity), Instant.parse(time)).toJsonString();
+        String actual = new CancelledByUser(chargeEntity.getServiceId(), chargeEntity.getGatewayAccount().isLive(), chargeEntity.getGatewayAccount().getId(),
+                transactionId, CancelledByUserEventDetails.from(chargeEntity), Instant.parse(time)).toJsonString();
 
         assertThat(actual, hasJsonPath("$.event_type", equalTo("CANCELLED_BY_USER")));
         assertThat(actual, hasJsonPath("event_details.gateway_transaction_id", equalTo(gatewayTransactionId)));
@@ -51,7 +51,7 @@ class CancelledByUserTest {
         ChargeEntity charge = new ChargeEntity();
         charge.setExternalId(transactionId);
         charge.setGatewayTransactionId(null);
-        String actual = new CancelledByUser(charge.getServiceId(), live, transactionId,
+        String actual = new CancelledByUser(charge.getServiceId(), live, 100L, transactionId,
                 CancelledByUserEventDetails.from(charge), Instant.parse(time)).toJsonString();
 
         assertThat(actual, hasJsonPath("$.event_type", equalTo("CANCELLED_BY_USER")));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
@@ -27,6 +27,7 @@ class RefundAvailabilityUpdatedTest {
         String event = new RefundAvailabilityUpdated(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 charge.getExternalId(),
                 RefundAvailabilityUpdatedEventDetails.from(Charge.from(charge), List.of(), ExternalChargeRefundAvailability.EXTERNAL_FULL),
                 Instant.now()

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -95,6 +95,7 @@ public class QueueMessageContractTest {
         PaymentCreated paymentCreatedEvent = new PaymentCreated(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 resourceId,
                 PaymentCreatedEventDetails.from(charge),
                 Instant.now()
@@ -119,6 +120,7 @@ public class QueueMessageContractTest {
         CaptureConfirmed captureConfirmedEvent = new CaptureConfirmed(
                 chargeEventEntity.getChargeEntity().getServiceId(),
                 chargeEventEntity.getChargeEntity().getGatewayAccount().isLive(),
+                chargeEventEntity.getChargeEntity().getGatewayAccount().getId(),
                 resourceId,
                 CaptureConfirmedEventDetails.from(chargeEventEntity),
                 Instant.now()
@@ -138,6 +140,7 @@ public class QueueMessageContractTest {
         PaymentDetailsEntered captureConfirmedEvent = new PaymentDetailsEntered(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 resourceId,
                 PaymentDetailsEnteredEventDetails.from(charge),
                 Instant.now()
@@ -157,6 +160,7 @@ public class QueueMessageContractTest {
         PaymentDetailsSubmittedByAPI paymentDetailsSubmittedByAPIEvent = new PaymentDetailsSubmittedByAPI(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 resourceId,
                 PaymentDetailsSubmittedByAPIEventDetails.from(charge),
                 Instant.now()
@@ -175,6 +179,7 @@ public class QueueMessageContractTest {
         UserEmailCollected userEmailCollected = new UserEmailCollected(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 resourceId,
                 UserEmailCollectedEventDetails.from(charge),
                 Instant.now()
@@ -192,6 +197,7 @@ public class QueueMessageContractTest {
         CaptureSubmitted captureSubmittedEvent = new CaptureSubmitted(
                 chargeEventEntity.getChargeEntity().getServiceId(),
                 chargeEventEntity.getChargeEntity().getGatewayAccount().isLive(),
+                chargeEventEntity.getChargeEntity().getGatewayAccount().getId(),
                 resourceId,
                 CaptureSubmittedEventDetails.from(chargeEventEntity),
                 Instant.now()
@@ -338,6 +344,7 @@ public class QueueMessageContractTest {
         var gateway3dsExemptionResultObtained = new Gateway3dsExemptionResultObtained(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 resourceId,
                 Gateway3dsExemptionResultObtainedEventDetails.from(charge),
                 Instant.now()
@@ -357,6 +364,7 @@ public class QueueMessageContractTest {
         var gateway3dsInfoObtained = new Gateway3dsInfoObtained(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 resourceId,
                 Gateway3dsInfoObtainedEventDetails.from(charge),
                 Instant.now()
@@ -376,6 +384,7 @@ public class QueueMessageContractTest {
         var gatewayRequires3dsAuthorisation = new GatewayRequires3dsAuthorisation(
                 charge.getServiceId(),
                 charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getId(),
                 resourceId,
                 GatewayRequires3dsAuthorisationEventDetails.from(charge),
                 Instant.now());
@@ -398,6 +407,7 @@ public class QueueMessageContractTest {
         StatusCorrectedToCapturedToMatchGatewayStatus event = new StatusCorrectedToCapturedToMatchGatewayStatus(
                 chargeEventEntity.getChargeEntity().getServiceId(),
                 chargeEventEntity.getChargeEntity().getGatewayAccount().isLive(),
+                chargeEventEntity.getChargeEntity().getGatewayAccount().getId(),
                 resourceId,
                 CaptureConfirmedEventDetails.from(chargeEventEntity),
                 Instant.now()


### PR DESCRIPTION
Adds `gateway_account_internal_id` to the top level paymetns and refund events schema. For the time being, this will allow dependent services to process events based on the gateway account ID (used by the data model across Pay services).