### PR TITLE
PP-10980 add can_retry field to AuthorisationRejected event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -252,7 +252,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
             String serviceId,
             AgreementEntity agreementEntity,
             boolean savePaymentInstrumentToAgreement,
-            AuthorisationMode authorisationMode
+            AuthorisationMode authorisationMode,
+            Boolean canRetry
     ) {
         this.amount = amount;
         this.status = status.getValue();
@@ -276,6 +277,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.agreementEntity = agreementEntity;
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
         this.authorisationMode = authorisationMode;
+        this.canRetry = canRetry;
     }
 
     public Long getId() {
@@ -743,7 +745,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
                     serviceId,
                     agreementEntity,
                     savePaymentInstrumentToAgreement,
-                    authorisationMode);
+                    authorisationMode,
+                    null);
         }
     }
 
@@ -857,7 +860,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
                     serviceId,
                     agreementEntity,
                     savePaymentInstrumentToAgreement,
-                    AuthorisationMode.EXTERNAL);
+                    AuthorisationMode.EXTERNAL,
+                    null);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/AuthorisationRejectedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/AuthorisationRejectedEventDetails.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.connector.events.eventdetails.charge;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+public class AuthorisationRejectedEventDetails extends EventDetails {
+    private final boolean canRetry;
+
+    private AuthorisationRejectedEventDetails(boolean canRetry) {
+        this.canRetry = canRetry;
+    }
+
+    public static AuthorisationRejectedEventDetails from(ChargeEntity charge) {
+        return new AuthorisationRejectedEventDetails(charge.getCanRetry());
+    }
+
+    public boolean getCanRetry() {
+        return canRetry;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.events.exception.EventCreationException;
+import uk.gov.pay.connector.events.model.charge.AuthorisationRejected;
 import uk.gov.pay.connector.events.model.charge.BackfillerRecreatedUserEmailCollected;
 import uk.gov.pay.connector.events.model.charge.CancelByExpirationSubmitted;
 import uk.gov.pay.connector.events.model.charge.CancelByExternalServiceSubmitted;
@@ -154,6 +155,8 @@ public class EventFactory {
                 return StatusCorrectedToCapturedToMatchGatewayStatus.from(chargeEvent);
             } else if (eventClass == CancelledWithGatewayAfterAuthorisationError.class) {
                 return CancelledWithGatewayAfterAuthorisationError.from(chargeEvent);
+            } else if (eventClass == AuthorisationRejected.class) {
+                return AuthorisationRejected.from(chargeEvent);
             } else {
                 return eventClass.getConstructor(String.class,
                         boolean.class, String.class, Instant.class).newInstance(

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationRejected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationRejected.java
@@ -1,5 +1,10 @@
 package uk.gov.pay.connector.events.model.charge;
 
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.charge.AuthorisationRejectedEventDetails;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+
 import java.time.Instant;
 
 /**
@@ -7,8 +12,32 @@ import java.time.Instant;
  * - action has been aborted or rejected, payment moves to final rejected state
  *
  */
-public class AuthorisationRejected extends PaymentEventWithoutDetails {
-    public AuthorisationRejected(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
+public class AuthorisationRejected extends PaymentEvent {
+    private AuthorisationRejected(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
         super(serviceId, live, resourceExternalId, timestamp);
+    }
+
+    private AuthorisationRejected(String serviceId, boolean live, String resourceExternalId,
+                                 AuthorisationRejectedEventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static AuthorisationRejected from(ChargeEventEntity chargeEvent) {
+        ChargeEntity charge = chargeEvent.getChargeEntity();
+        if (charge.getAuthorisationMode() == AuthorisationMode.AGREEMENT) {
+            return new AuthorisationRejected(
+                    charge.getServiceId(),
+                    charge.getGatewayAccount().isLive(),
+                    charge.getExternalId(),
+                    AuthorisationRejectedEventDetails.from(charge),
+                    chargeEvent.getUpdated().toInstant()
+            );
+        }
+        return new AuthorisationRejected(
+                charge.getServiceId(),
+                charge.getGatewayAccount().isLive(),
+                charge.getExternalId(),
+                chargeEvent.getUpdated().toInstant()
+        );
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -71,6 +71,7 @@ public class ChargeEntityFixture {
     private boolean savePaymentInstrumentToAgreement = false;
     private PaymentInstrumentEntity paymentInstrument = null;
     private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
+    private Boolean canRetry;
     private Instant updatedDate;
 
     public static ChargeEntityFixture aValidChargeEntity() {
@@ -157,7 +158,8 @@ public class ChargeEntityFixture {
                 serviceId,
                 agreementEntity,
                 savePaymentInstrumentToAgreement,
-                authorisationMode);
+                authorisationMode,
+                canRetry);
         chargeEntity.setId(id);
         chargeEntity.setExternalId(externalId);
         chargeEntity.setCorporateSurcharge(corporateSurcharge);
@@ -364,6 +366,11 @@ public class ChargeEntityFixture {
 
     public ChargeEntityFixture withUpdatedDate(Instant updatedDate){
         this.updatedDate = updatedDate;
+        return this;
+    }
+
+    public ChargeEntityFixture withCanRetry(Boolean canRetry) {
+        this.canRetry = canRetry;
         return this;
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- refactor `AuthorisationRejected` to have an EventDetails object
- add a new event details class `AuthorisationRejectedEventDetails`
- add relevant tests
