### PR TITLE
PP-10981 Add can_retry inside state for get charge response

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -171,70 +171,70 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3756
+        "line_number": 3764
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3805
+        "line_number": 3813
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4410
+        "line_number": 4418
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4471
+        "line_number": 4479
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4493
+        "line_number": 4501
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4672
+        "line_number": 4680
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4675
+        "line_number": 4683
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4678
+        "line_number": 4686
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5268
+        "line_number": 5276
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5279
+        "line_number": 5287
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -270,7 +270,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java",
         "hashed_secret": "423e3dd3782e3527b4f9af75dd9faf9ebbb7889c",
         "is_verified": false,
-        "line_number": 92
+        "line_number": 98
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java": [
@@ -1078,5 +1078,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-16T10:32:42Z"
+  "generated_at": "2023-05-19T12:48:53Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3486,6 +3486,10 @@ components:
       description: A structure representing the current state of the payment in its
         lifecycle
       properties:
+        can_retry:
+          type: boolean
+          description: "If a failed payment, whether it may be possible to retry it"
+          example: true
         code:
           type: string
           description: Error code for failed payments
@@ -3495,7 +3499,7 @@ components:
           example: true
         message:
           type: string
-          description: Message describing erro code if Payment failed
+          description: Message describing error code if payment failed
           example: Payment method rejected
         status:
           type: string
@@ -3505,6 +3509,10 @@ components:
       description: A structure representing the current state of the payment in its
         lifecycle
       properties:
+        can_retry:
+          type: boolean
+          description: "If a failed payment, whether it may be possible to retry it"
+          example: true
         code:
           type: string
           description: Error code for failed payments
@@ -3514,7 +3522,7 @@ components:
           example: true
         message:
           type: string
-          description: Message describing erro code if Payment failed
+          description: Message describing error code if payment failed
           example: Payment method rejected
         status:
           type: string

--- a/src/main/java/uk/gov/pay/connector/charge/model/FrontendChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/FrontendChargeResponse.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import uk.gov.pay.connector.agreement.model.AgreementResponse;
 import uk.gov.pay.connector.charge.model.builder.AbstractChargeResponseBuilder;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.common.model.api.ExternalChargeState;
-import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 public class FrontendChargeResponse extends ChargeResponse {
@@ -16,10 +15,10 @@ public class FrontendChargeResponse extends ChargeResponse {
         private AgreementResponse agreement;
         private boolean savePaymentInstrumentToAgreement;
 
-        public FrontendChargeResponseBuilder withStatus(String status) {
-            this.status = status;
-            ExternalChargeState externalChargeState = ChargeStatus.fromString(status).toExternal();
-            super.withState(new ExternalTransactionState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage()));
+        public FrontendChargeResponseBuilder withStatus(ChargeEntity chargeEntity,
+                                                        ExternalTransactionStateFactory externalTransactionStateFactory) {
+            this.status = chargeEntity.getStatus();
+            super.withState(externalTransactionStateFactory.newExternalTransactionState(chargeEntity));
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -26,6 +26,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.charge.service.Worldpay3dsFlexJwtService;
 import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -67,14 +68,19 @@ public class ChargesFrontendResource {
     private final CardTypeDao cardTypeDao;
     private final Worldpay3dsFlexJwtService worldpay3dsFlexJwtService;
     private final AgreementService agreementService;
+    private final ExternalTransactionStateFactory externalTransactionStateFactory;
 
     @Inject
-    public ChargesFrontendResource(ChargeDao chargeDao, ChargeService chargeService, CardTypeDao cardTypeDao, Worldpay3dsFlexJwtService worldpay3dsFlexJwtService, AgreementService agreementService) {
+    public ChargesFrontendResource(ChargeDao chargeDao, ChargeService chargeService, CardTypeDao cardTypeDao,
+                                   Worldpay3dsFlexJwtService worldpay3dsFlexJwtService,
+                                   AgreementService agreementService,
+                                   ExternalTransactionStateFactory externalTransactionStateFactory) {
         this.chargeDao = chargeDao;
         this.chargeService = chargeService;
         this.cardTypeDao = cardTypeDao;
         this.worldpay3dsFlexJwtService = worldpay3dsFlexJwtService;
         this.agreementService = agreementService;
+        this.externalTransactionStateFactory = externalTransactionStateFactory;
     }
 
     @GET
@@ -227,7 +233,7 @@ public class ChargesFrontendResource {
         String chargeId = charge.getExternalId();
 
         FrontendChargeResponse.FrontendChargeResponseBuilder responseBuilder = aFrontendChargeResponse()
-                .withStatus(charge.getStatus())
+                .withStatus(charge, externalTransactionStateFactory)
                 .withChargeId(chargeId)
                 .withAmount(charge.getAmount())
                 .withDescription(charge.getDescription())

--- a/src/main/java/uk/gov/pay/connector/common/model/api/ExternalTransactionState.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/ExternalTransactionState.java
@@ -2,22 +2,29 @@ package uk.gov.pay.connector.common.model.api;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class ExternalTransactionState {
 
     private final String value;
     private final boolean finished;
     private final String code;
     private final String message;
+    private final Boolean canRetry;
 
     public ExternalTransactionState(String value, boolean finished) {
         this.value = value;
         this.finished = finished;
         this.code = null;
         this.message = null;
+        this.canRetry = null;
     }
 
     public ExternalTransactionState(String value, boolean finished, String code, String message) {
@@ -25,6 +32,15 @@ public class ExternalTransactionState {
         this.finished = finished;
         this.code = code;
         this.message = message;
+        this.canRetry = null;
+    }
+
+    public ExternalTransactionState(String value, boolean finished, String code, String message, boolean canRetry) {
+        this.value = value;
+        this.finished = finished;
+        this.code = code;
+        this.message = message;
+        this.canRetry = canRetry;
     }
 
     @Schema(example = "success")
@@ -42,31 +58,36 @@ public class ExternalTransactionState {
         return code;
     }
 
-    @Schema(example = "Payment method rejected", description = "Message describing erro code if Payment failed")
+    @Schema(example = "Payment method rejected", description = "Message describing error code if payment failed")
     public String getMessage() {
         return message;
     }
 
+    @Schema(example = "true", description = "If a failed payment, whether it may be possible to retry it")
+    public Boolean getCanRetry() {
+        return canRetry;
+    }
+
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ExternalTransactionState)) return false;
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
 
-        ExternalTransactionState that = (ExternalTransactionState) o;
+        if (other instanceof ExternalTransactionState) {
+            var that = (ExternalTransactionState) other;
+            return finished == that.finished
+                    && Objects.equals(code, that.code)
+                    && Objects.equals(message, that.message)
+                    && Objects.equals(canRetry, that.canRetry);
+        }
 
-        if (finished != that.finished) return false;
-        if (!value.equals(that.value)) return false;
-        if (code != null ? !code.equals(that.code) : that.code != null) return false;
-        return message != null ? message.equals(that.message) : that.message == null;
+        return false;
     }
 
     @Override
     public int hashCode() {
-        int result = value.hashCode();
-        result = 31 * result + (finished ? 1 : 0);
-        result = 31 * result + (code != null ? code.hashCode() : 0);
-        result = 31 * result + (message != null ? message.hashCode() : 0);
-        return result;
+        return Objects.hash(value, finished, code, message, canRetry);
     }
 
     @Override
@@ -76,6 +97,7 @@ public class ExternalTransactionState {
                 ", finished=" + finished +
                 ", code='" + code + '\'' +
                 ", message='" + message + '\'' +
+                ", can_retry='" + canRetry+ '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/connector/common/model/api/ExternalTransactionStateFactory.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/ExternalTransactionStateFactory.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.common.model.api;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+
+public class ExternalTransactionStateFactory {
+
+    public ExternalTransactionState newExternalTransactionState(ChargeEntity chargeEntity) {
+        ExternalChargeState externalChargeState = ChargeStatus.fromString(chargeEntity.getStatus()).toExternal();
+        String status = externalChargeState.getStatus();
+        boolean finished = externalChargeState.isFinished();
+        String code = externalChargeState.getCode();
+        String message = externalChargeState.getMessage();
+        Boolean canRetry = chargeEntity.getCanRetry();
+
+        if (chargeEntity.getAuthorisationMode() == AuthorisationMode.AGREEMENT && canRetry != null) {
+            return new ExternalTransactionState(status, finished, code, message, canRetry);
+        }
+
+        return new ExternalTransactionState(status, finished, code, message);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.charge.service.Worldpay3dsFlexJwtService;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.rules.ResourceTestRuleWithCustomExceptionMappersBuilder;
 
 import javax.ws.rs.client.Entity;
@@ -24,15 +25,17 @@ import static org.mockito.Mockito.mock;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class ChargesFrontendResourceTest {
-    private static ChargeService chargeService = mock(ChargeService.class);
-    private static ChargeDao chargeDao = mock(ChargeDao.class);
-    private static CardTypeDao cardTypeDao = mock(CardTypeDao.class);
-    private static Worldpay3dsFlexJwtService worldpay3dsFlexJwtService = mock(Worldpay3dsFlexJwtService.class);
-    private static AgreementService agreementService = mock(AgreementService.class);
+    private static final ChargeService CHARGE_SERVICE = mock(ChargeService.class);
+    private static final ChargeDao CHARGE_DAO = mock(ChargeDao.class);
+    private static final CardTypeDao CARD_TYPE_DAO = mock(CardTypeDao.class);
+    private static final Worldpay3dsFlexJwtService WORLDPAY_3DS_FLEX_JWT_SERVICE = mock(Worldpay3dsFlexJwtService.class);
+    private static final AgreementService AGREEMENT_SERVICE = mock(AgreementService.class);
+    private static final ExternalTransactionStateFactory EXTERNAL_TRANSACTION_STATE_FACTORY = mock(ExternalTransactionStateFactory.class);
 
     private static final ResourceExtension resources = ResourceTestRuleWithCustomExceptionMappersBuilder
             .getBuilder()
-            .addResource(new ChargesFrontendResource(chargeDao, chargeService, cardTypeDao, worldpay3dsFlexJwtService, agreementService))
+            .addResource(new ChargesFrontendResource(CHARGE_DAO, CHARGE_SERVICE, CARD_TYPE_DAO,
+                    WORLDPAY_3DS_FLEX_JWT_SERVICE, AGREEMENT_SERVICE, EXTERNAL_TRANSACTION_STATE_FACTORY))
             .build();
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
@@ -148,6 +149,9 @@ class ChargeServiceCreateAgreementTest {
     @Mock
     private IdempotencyDao mockIdempotencyDao;
 
+    @Mock
+    private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
+
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
 
@@ -185,7 +189,8 @@ class ChargeServiceCreateAgreementTest {
         chargeService = new ChargeService(mockTokenDao, mockChargeDao, mockChargeEventDao, mockCardTypeDao, mockAgreementDao, mockGatewayAccountDao,
                 mockConfig, mockProviders, mockStateTransitionService, mockLedgerService, mockedRefundService, mockEventService,
                 mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
-                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao, objectMapper);
+                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao,
+                mockExternalTransactionStateFactory, objectMapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreatePrefilledCardholderDetailsTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreatePrefilledCardholderDetailsTest.java
@@ -22,6 +22,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.common.model.domain.PrefilledAddress;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
@@ -128,6 +129,9 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
     @Mock
     private IdempotencyDao mockIdempotencyDao;
 
+    @Mock
+    private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
+
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
 
@@ -166,7 +170,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, objectMapper);
+                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTelephonePaymentTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTelephonePaymentTest.java
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.charge.model.telephone.TelephoneChargeCreateRequest;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
@@ -120,6 +121,9 @@ class ChargeServiceCreateTelephonePaymentTest {
     @Mock
     private IdempotencyDao mockIdempotencyDao;
 
+    @Mock
+    private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
+
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
 
@@ -165,7 +169,7 @@ class ChargeServiceCreateTelephonePaymentTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, objectMapper);
+                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceIdempotencyTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceIdempotencyTest.java
@@ -29,6 +29,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
@@ -137,6 +138,9 @@ class ChargeServiceIdempotencyTest {
     private IdempotencyDao mockIdempotencyDao;
 
     @Mock
+    private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
+
+    @Mock
     Appender<ILoggingEvent> mockAppender;
 
     @Captor
@@ -159,7 +163,7 @@ class ChargeServiceIdempotencyTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, mapper);
+                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, mapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConver
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.model.agreement.AgreementInactivated;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
@@ -91,6 +92,8 @@ class ChargeServicePostAuthorisationTest {
     @Mock private PaymentInstrumentEntity mockPaymentInstrumentEntity;
     @Mock
     private IdempotencyDao mockIdempotencyDao;
+    @Mock
+    private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
 
     @Captor
     private ArgumentCaptor<AgreementInactivated> agreementInactivatedArgumentCaptor;
@@ -129,7 +132,7 @@ class ChargeServicePostAuthorisationTest {
                 mockCardTypeDao, mockAgreementDao, mockGatewayAccountDao, mockConnectorConfig, mockProviders,
                 mockStateTransitionService, mockLedgerService, mockRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, objectMapper);
+                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -29,6 +29,7 @@ import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.common.exception.InvalidForceStateTransitionException;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
@@ -176,6 +177,9 @@ class ChargeServiceTest {
     @Mock
     private IdempotencyDao mockIdempotencyDao;
 
+    @Mock
+    private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
+
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
 
@@ -217,7 +221,7 @@ class ChargeServiceTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, objectMapper);
+                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/common/model/api/ExternalTransactionStateFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/api/ExternalTransactionStateFactoryTest.java
@@ -1,0 +1,158 @@
+package uk.gov.pay.connector.common.model.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ExternalTransactionStateFactoryTest {
+
+    @Mock
+    private ChargeEntity mockChargeEntity;
+
+    private final ExternalTransactionStateFactory factory = new ExternalTransactionStateFactory();
+
+    @BeforeEach
+    void setUp() {
+        given(mockChargeEntity.getCanRetry()).willReturn(null);
+    }
+
+    @Test
+    void createsExternalTransactionStateFromUnfinishedStatusWithoutCodeOrMessage() {
+        given(mockChargeEntity.getStatus()).willReturn(ChargeStatus.CREATED.toString());
+
+        ExternalTransactionState result = factory.newExternalTransactionState(mockChargeEntity);
+
+        assertThat(result.getStatus(), is(ExternalChargeState.EXTERNAL_CREATED.getStatus()));
+        assertThat(result.isFinished(), is(false));
+        assertThat(result.getCode(), is(nullValue()));
+        assertThat(result.getMessage(), is(nullValue()));
+        assertThat(result.getCanRetry(), is(nullValue()));
+    }
+
+    @Test
+    void createsExternalTransactionStateFromFinishedStatusWithoutCodeOrMessage() {
+        given(mockChargeEntity.getStatus()).willReturn(ChargeStatus.CAPTURED.toString());
+
+        ExternalTransactionState result = factory.newExternalTransactionState(mockChargeEntity);
+
+        assertThat(result.getStatus(), is(ExternalChargeState.EXTERNAL_SUCCESS.getStatus()));
+        assertThat(result.isFinished(), is(true));
+        assertThat(result.getCode(), is(nullValue()));
+        assertThat(result.getMessage(), is(nullValue()));
+        assertThat(result.getCanRetry(), is(nullValue()));
+    }
+
+    @Test
+    void createsExternalTransactionStateFromStatusWithCodeAndMessageButNullCanRetry() {
+        given(mockChargeEntity.getStatus()).willReturn(ChargeStatus.AUTHORISATION_REJECTED.toString());
+
+        ExternalTransactionState result = factory.newExternalTransactionState(mockChargeEntity);
+
+        assertThat(result.getStatus(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getStatus()));
+        assertThat(result.isFinished(), is(true));
+        assertThat(result.getCode(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getCode()));
+        assertThat(result.getMessage(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getMessage()));
+        assertThat(result.getCanRetry(), is(nullValue()));
+    }
+
+    @Test
+    void createsExternalTransactionThatHasNullCanRetryWhenAuthorisationModeAgreementAndNullCanRetry() {
+        given(mockChargeEntity.getStatus()).willReturn(ChargeStatus.AUTHORISATION_REJECTED.toString());
+        given(mockChargeEntity.getAuthorisationMode()).willReturn(AuthorisationMode.AGREEMENT);
+        given(mockChargeEntity.getCanRetry()).willReturn(null);
+
+        ExternalTransactionState result = factory.newExternalTransactionState(mockChargeEntity);
+
+        assertThat(result.getStatus(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getStatus()));
+        assertThat(result.isFinished(), is(true));
+        assertThat(result.getCode(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getCode()));
+        assertThat(result.getMessage(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getMessage()));
+        assertThat(result.getCanRetry(), is(nullValue()));
+    }
+
+    @Test
+    void createsExternalTransactionThatHasCanRetryNullWhenAuthorisationModeWebAndCanRetryNull() {
+        given(mockChargeEntity.getStatus()).willReturn(ChargeStatus.AUTHORISATION_REJECTED.toString());
+        given(mockChargeEntity.getAuthorisationMode()).willReturn(AuthorisationMode.WEB);
+
+        ExternalTransactionState result = factory.newExternalTransactionState(mockChargeEntity);
+
+        assertThat(result.getStatus(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getStatus()));
+        assertThat(result.isFinished(), is(true));
+        assertThat(result.getCode(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getCode()));
+        assertThat(result.getMessage(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getMessage()));
+        assertThat(result.getCanRetry(), is(nullValue()));
+    }
+
+    @Test
+    void createsExternalTransactionThatHasCanRetryTrueWhenAuthorisationModeAgreementAndCanRetryTrue() {
+        given(mockChargeEntity.getStatus()).willReturn(ChargeStatus.AUTHORISATION_REJECTED.toString());
+        given(mockChargeEntity.getAuthorisationMode()).willReturn(AuthorisationMode.AGREEMENT);
+        given(mockChargeEntity.getCanRetry()).willReturn(true);
+
+        ExternalTransactionState result = factory.newExternalTransactionState(mockChargeEntity);
+
+        assertThat(result.getStatus(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getStatus()));
+        assertThat(result.isFinished(), is(true));
+        assertThat(result.getCode(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getCode()));
+        assertThat(result.getMessage(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getMessage()));
+        assertThat(result.getCanRetry(), is(true));
+    }
+
+    @Test
+    void createsExternalTransactionThatHasCanRetryNullWhenAuthorisationModeWebAndCanRetryTrue() {
+        given(mockChargeEntity.getStatus()).willReturn(ChargeStatus.AUTHORISATION_REJECTED.toString());
+        given(mockChargeEntity.getAuthorisationMode()).willReturn(AuthorisationMode.WEB);
+        given(mockChargeEntity.getCanRetry()).willReturn(true);
+
+        ExternalTransactionState result = factory.newExternalTransactionState(mockChargeEntity);
+
+        assertThat(result.getStatus(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getStatus()));
+        assertThat(result.isFinished(), is(true));
+        assertThat(result.getCode(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getCode()));
+        assertThat(result.getMessage(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getMessage()));
+        assertThat(result.getCanRetry(), is(nullValue()));
+    }
+
+    @Test
+    void createsExternalTransactionThatHasCanRetryFalseWhenAuthorisationModeAgreementAndCanRetryFalse() {
+        given(mockChargeEntity.getStatus()).willReturn(ChargeStatus.AUTHORISATION_REJECTED.toString());
+        given(mockChargeEntity.getAuthorisationMode()).willReturn(AuthorisationMode.AGREEMENT);
+        given(mockChargeEntity.getCanRetry()).willReturn(false);
+
+        ExternalTransactionState result = factory.newExternalTransactionState(mockChargeEntity);
+
+        assertThat(result.getStatus(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getStatus()));
+        assertThat(result.isFinished(), is(true));
+        assertThat(result.getCode(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getCode()));
+        assertThat(result.getMessage(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getMessage()));
+        assertThat(result.getCanRetry(), is(false));
+    }
+
+    @Test
+    void createsExternalTransactionThatHasCanRetryNullWhenAuthorisationModeWebAndCanRetryFalse() {
+        given(mockChargeEntity.getStatus()).willReturn(ChargeStatus.AUTHORISATION_REJECTED.toString());
+        given(mockChargeEntity.getAuthorisationMode()).willReturn(AuthorisationMode.WEB);
+        given(mockChargeEntity.getCanRetry()).willReturn(false);
+
+        ExternalTransactionState result = factory.newExternalTransactionState(mockChargeEntity);
+
+        assertThat(result.getStatus(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getStatus()));
+        assertThat(result.isFinished(), is(true));
+        assertThat(result.getCode(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getCode()));
+        assertThat(result.getMessage(), is(ExternalChargeState.EXTERNAL_FAILED_REJECTED.getMessage()));
+        assertThat(result.getCanRetry(), is(nullValue()));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
@@ -89,6 +90,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     private TaskQueueService mockTaskQueueService;
     @Mock
     private IdempotencyDao mockIdempotencyDao;
+    @Mock
+    private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
 
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
@@ -120,7 +123,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
                 null, null, mockConfiguration, null, mockStateTransitionService, ledgerService,
                 mockedRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
-                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao, objectMapper);
+                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao,
+                mockExternalTransactionStateFactory, objectMapper);
         AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment, mockConfiguration);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, authorisationService, mockConfiguration);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -43,6 +43,7 @@ import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.gateway.GatewayException;
@@ -198,6 +199,9 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     @Mock
     private IdempotencyDao mockIdempotencyDao;
 
+    @Mock
+    private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
+
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
@@ -222,7 +226,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
                 null, null, null, mockConfiguration, null,
                 stateTransitionService, ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, objectMapper);
+                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
 
         LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService = mock(LinkPaymentInstrumentToAgreementService.class);
         CaptureQueue captureQueue = mock(CaptureQueue.class);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -34,6 +34,7 @@ import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.fee.model.Fee;
 import uk.gov.pay.connector.gateway.CaptureResponse;
@@ -125,6 +126,9 @@ public class CardCaptureServiceTest extends CardServiceTest {
     private TaskQueueService mockTaskQueueService;
     @Mock
     private IdempotencyDao mockIdempotencyDao;
+    @Mock
+    private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
+
     private static final Clock GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK = Clock.fixed(Instant.parse("2020-01-01T10:10:10.100Z"), ZoneOffset.UTC);
     private static ObjectMapper objectMapper = new ObjectMapper();
 
@@ -138,7 +142,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
                 null, null, null, mockConfiguration, null,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, objectMapper);
+                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
 
         cardCaptureService = new CardCaptureService(chargeService, mockedProviders, mockUserNotificationService, mockEnvironment,
                 GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK, mockCaptureQueue, mockEventService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -25,6 +25,7 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
 import uk.gov.pay.connector.charge.util.PaymentInstrumentEntityToAuthCardDetailsConverter;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -127,7 +128,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
                 mock(StateTransitionService.class), mock(LedgerService.class), mock(RefundService.class),
                 mock(EventService.class), mock(PaymentInstrumentService.class), mock(GatewayAccountCredentialsService.class),
                 mock(AuthCardDetailsToCardDetailsEntityConverter.class), mockTaskQueueService, mock(IdempotencyDao.class),
-                objectMapper);
+                mock(ExternalTransactionStateFactory.class), objectMapper);
 
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
         when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
@@ -155,6 +156,9 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     @Mock
     private IdempotencyDao mockIdempotencyDao;
 
+    @Mock
+    private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
+
     private WalletAuthoriseService walletAuthoriseService;
 
     private final AppleDecryptedPaymentData validApplePayDetails =
@@ -193,7 +197,8 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null, mockStateTransitionService,
                 ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
-                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao, objectMapper));
+                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao,
+                mockExternalTransactionStateFactory, objectMapper));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,


### PR DESCRIPTION
When getting a single charge (including for frontend), include a `can_retry` property inside the `state` object only if the following are both true:

- the charge has an authorisation mode of `AGREEMENT`
- the charge’s `canRetry` field is explicitly set to `true` or `false` (not left as `null`)

`ChargeService` is so large that adding many more lines to it runs the risk that it may cause it to achieve sentience and take over the world. Therefore, the code for creating an `ExternalTransactionState` (the Java representation of the JSON `state` object) has been moved into a factory, which contains the new logic for deciding when to include the `can_retry` property. This also makes unit testing a little easier.

`ChargesApiResourceIT` contains some new tests to check can_retry is serialised correctly when we want it.