### PR TITLE
PP-10983 Update util and wallet tests to JUnit5

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -754,7 +754,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 123
       }
     ],
     "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayDecrypterTest.java": [
@@ -1078,5 +1078,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-22T20:57:31Z"
+  "generated_at": "2023-05-23T09:31:15Z"
 }

--- a/src/test/java/uk/gov/pay/connector/util/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
@@ -5,14 +5,14 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 
@@ -21,11 +21,14 @@ import java.sql.SQLException;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
+@ExtendWith(MockitoExtension.class)
+ class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
 
     @InjectMocks
     ApplicationStartupDependentResourceChecker applicationStartupDependentResourceChecker;
@@ -41,8 +44,8 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
     @Captor
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+     void setup() {
         Logger root = (Logger) LoggerFactory.getLogger(ApplicationStartupDependentResourceChecker.class);
         mockAppender = mockAppender();
         root.setLevel(Level.INFO);
@@ -50,7 +53,7 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
     }
 
     @Test
-    public void start_ShouldWaitAndLogUntilDatabaseIsAccessible() throws Exception {
+     void start_ShouldWaitAndLogUntilDatabaseIsAccessible() throws Exception {
 
         Connection mockConnection = mock(Connection.class);
         when(mockApplicationStartupDependentResource.getDatabaseConnection())
@@ -71,7 +74,7 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
     }
 
     @Test
-    public void start_ShouldProgressivelyIncrementSleepingTimeBetweenChecksForDBAccessibility() throws Exception {
+     void start_ShouldProgressivelyIncrementSleepingTimeBetweenChecksForDBAccessibility() throws Exception {
         Connection mockConnection = mock(Connection.class);
         when(mockApplicationStartupDependentResource.getDatabaseConnection())
                 .thenThrow(new SQLException("not there"))
@@ -96,7 +99,7 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
     }
 
     @Test
-    public void start_ShouldCloseAnyAcquiredConnectionWhenTheCheckIsDone() throws Exception {
+     void start_ShouldCloseAnyAcquiredConnectionWhenTheCheckIsDone() throws Exception {
         Connection mockConnection = mock(Connection.class);
         when(mockApplicationStartupDependentResource.getDatabaseConnection()).thenReturn(mockConnection);
 

--- a/src/test/java/uk/gov/pay/connector/util/DateTimeUtilsTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/DateTimeUtilsTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -14,12 +14,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.StringEndsWith.endsWith;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DateTimeUtilsTest {
+class DateTimeUtilsTest {
 
     @Test
-    public void shouldConvertUTCZonedISO_8601StringToADateTime() {
+    void shouldConvertUTCZonedISO_8601StringToADateTime() {
         String aDate = "2010-01-01T12:00:00Z";
         Optional<ZonedDateTime> result = DateTimeUtils.toUTCZonedDateTime(aDate);
         assertTrue(result.isPresent());
@@ -32,7 +32,7 @@ public class DateTimeUtilsTest {
     }
 
     @Test
-    public void shouldConvertNonUTCZonedISO_8601StringToADateTime() {
+    void shouldConvertNonUTCZonedISO_8601StringToADateTime() {
         String aDate = "2010-01-01T12:00:00+01:00[Europe/Paris]";
         Optional<ZonedDateTime> result = DateTimeUtils.toUTCZonedDateTime(aDate);
         assertTrue(result.isPresent());
@@ -47,7 +47,7 @@ public class DateTimeUtilsTest {
     }
 
     @Test
-    public void shouldConvertAn_UTCOffsetDateStringToADateTime() {
+    void shouldConvertAn_UTCOffsetDateStringToADateTime() {
         String aDate = "2010-01-01T12:10:10+01:00";
         Optional<ZonedDateTime> result = DateTimeUtils.toUTCZonedDateTime(aDate);
         assertTrue(result.isPresent());
@@ -56,7 +56,7 @@ public class DateTimeUtilsTest {
     }
 
     @Test
-    public void toUserFriendlyDateShouldFormatAsDateInLondonTimezone() {
+    void toUserFriendlyDateShouldFormatAsDateInLondonTimezone() {
         Instant instant = Instant.parse("2016-07-07T23:24:48Z");
 
         String result = DateTimeUtils.toUserFriendlyDate(instant);
@@ -65,7 +65,7 @@ public class DateTimeUtilsTest {
     }
 
     @Test
-    public void toDateFormatShouldNotProduceDateWithOffset() {
+    void toDateFormatShouldNotProduceDateWithOffset() {
         ZonedDateTime now1 = ZonedDateTime.of(LocalDate.of(2016, 12, 23), LocalTime.of(12, 34), ZoneOffset.UTC);
         String output1 = DateTimeUtils.toUTCDateString(now1);
         assertThat(output1, is("2016-12-23"));
@@ -76,7 +76,7 @@ public class DateTimeUtilsTest {
     }
 
     @Test
-    public void shouldConvertUnixEpochTimeToUTCZonedDateTime() {
+    void shouldConvertUnixEpochTimeToUTCZonedDateTime() {
         ZonedDateTime zonedDateTime1 = DateTimeUtils.toUTCZonedDateTime(1L);
         assertThat(zonedDateTime1.toString(), is("1970-01-01T00:00:01Z"));
 
@@ -85,7 +85,7 @@ public class DateTimeUtilsTest {
     }
 
     @Test
-    public void shouldReturnNullIfUnixEpochTimeIsNull() {
+    void shouldReturnNullIfUnixEpochTimeIsNull() {
         Long epochTime = null;
         ZonedDateTime zonedDateTime = DateTimeUtils.toUTCZonedDateTime(epochTime);
 

--- a/src/test/java/uk/gov/pay/connector/util/DnsPointerResourceRecordTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/DnsPointerResourceRecordTest.java
@@ -1,14 +1,14 @@
 package uk.gov.pay.connector.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class DnsPointerResourceRecordTest {
+class DnsPointerResourceRecordTest {
     
     @Test
-    public void getReverseIpFromIpAddress() {
+    void getReverseIpFromIpAddress() {
         assertThat(new DnsPointerResourceRecord("195.35.90.1").getReverseIp(), is("1.90.35.195.in-addr.arpa"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/EpdqXMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/EpdqXMLUnmarshallerTest.java
@@ -1,15 +1,15 @@
 package uk.gov.pay.connector.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCancelResponse;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.ERROR;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REJECTED;
@@ -24,10 +24,10 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CANCEL_E
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CANCEL_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CANCEL_WAITING_RESPONSE;
 
-public class EpdqXMLUnmarshallerTest {
+class EpdqXMLUnmarshallerTest {
 
     @Test
-    public void shouldUnmarshallAnAuthorisationSuccessResponse() throws Exception {
+    void shouldUnmarshallAnAuthorisationSuccessResponse() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_SUCCESS_RESPONSE);
         EpdqAuthorisationResponse response = XMLUnmarshaller.unmarshall(successPayload, EpdqAuthorisationResponse.class);
 
@@ -39,7 +39,7 @@ public class EpdqXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallAnAuthorisationWaitingExternalResponse() throws Exception {
+    void shouldUnmarshallAnAuthorisationWaitingExternalResponse() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_WAITING_EXTERNAL_RESPONSE);
         EpdqAuthorisationResponse response = XMLUnmarshaller.unmarshall(successPayload, EpdqAuthorisationResponse.class);
 
@@ -51,7 +51,7 @@ public class EpdqXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallAnAuthorisationWaitingResponse() throws Exception {
+    void shouldUnmarshallAnAuthorisationWaitingResponse() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_WAITING_RESPONSE);
         EpdqAuthorisationResponse response = XMLUnmarshaller.unmarshall(successPayload, EpdqAuthorisationResponse.class);
 
@@ -63,7 +63,7 @@ public class EpdqXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallAnAuthorisationFailedResponse() throws Exception {
+    void shouldUnmarshallAnAuthorisationFailedResponse() throws Exception {
         String failPayload = TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_FAILED_RESPONSE);
         EpdqAuthorisationResponse response = XMLUnmarshaller.unmarshall(failPayload, EpdqAuthorisationResponse.class);
 
@@ -75,7 +75,7 @@ public class EpdqXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallAnAuthorisationErrorResponse() throws Exception {
+    void shouldUnmarshallAnAuthorisationErrorResponse() throws Exception {
         String errorPayload = TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_ERROR_RESPONSE);
         EpdqAuthorisationResponse response = XMLUnmarshaller.unmarshall(errorPayload, EpdqAuthorisationResponse.class);
 
@@ -87,7 +87,7 @@ public class EpdqXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallAnAuthorisationOtherResponse() throws Exception {
+    void shouldUnmarshallAnAuthorisationOtherResponse() throws Exception {
         String errorPayload = TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_OTHER_RESPONSE);
         EpdqAuthorisationResponse response = XMLUnmarshaller.unmarshall(errorPayload, EpdqAuthorisationResponse.class);
 
@@ -99,7 +99,7 @@ public class EpdqXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallACaptureSuccessResponse() throws Exception {
+    void shouldUnmarshallACaptureSuccessResponse() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.EPDQ_CAPTURE_SUCCESS_RESPONSE);
         EpdqCaptureResponse response = XMLUnmarshaller.unmarshall(successPayload, EpdqCaptureResponse.class);
 
@@ -109,7 +109,7 @@ public class EpdqXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallACaptureErrorResponse() throws Exception {
+    void shouldUnmarshallACaptureErrorResponse() throws Exception {
         String errorPayload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.EPDQ_CAPTURE_ERROR_RESPONSE);
         EpdqCaptureResponse response = XMLUnmarshaller.unmarshall(errorPayload, EpdqCaptureResponse.class);
 
@@ -119,7 +119,7 @@ public class EpdqXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallACancelSuccessResponse() throws Exception {
+    void shouldUnmarshallACancelSuccessResponse() throws Exception {
         String payload = TestTemplateResourceLoader.load(EPDQ_CANCEL_SUCCESS_RESPONSE);
         EpdqCancelResponse response = XMLUnmarshaller.unmarshall(payload, EpdqCancelResponse.class);
 
@@ -131,7 +131,7 @@ public class EpdqXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallACancelWaitingResponse() throws Exception {
+    void shouldUnmarshallACancelWaitingResponse() throws Exception {
         String payload = TestTemplateResourceLoader.load(EPDQ_CANCEL_WAITING_RESPONSE);
         EpdqCancelResponse response = XMLUnmarshaller.unmarshall(payload, EpdqCancelResponse.class);
 
@@ -143,7 +143,7 @@ public class EpdqXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallACancelErrorResponse() throws Exception {
+    void shouldUnmarshallACancelErrorResponse() throws Exception {
         String payload = TestTemplateResourceLoader.load(EPDQ_CANCEL_ERROR_RESPONSE);
         EpdqCancelResponse response = XMLUnmarshaller.unmarshall(payload, EpdqCancelResponse.class);
 

--- a/src/test/java/uk/gov/pay/connector/util/IpDomainMatcherTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/IpDomainMatcherTest.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.connector.util;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
@@ -13,27 +13,27 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IpDomainMatcherTest {
+@ExtendWith(MockitoExtension.class)
+class IpDomainMatcherTest {
 
     private IpDomainMatcher ipDomainMatcher;
     
     @Mock
     private ReverseDnsLookup reverseDnsLookup;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         ipDomainMatcher = new IpDomainMatcher(reverseDnsLookup);
     }
     
     @Test
-    public void reverseDnsShouldReturnHostIfIpIsValid() {
+    void reverseDnsShouldReturnHostIfIpIsValid() {
         when(reverseDnsLookup.lookup(new DnsPointerResourceRecord("195.35.90.1"))).thenReturn(Optional.of("worldpay.com."));
         assertThat(ipDomainMatcher.ipMatchesDomain("195.35.90.1", "worldpay.com"), is(true));
     }
     
     @Test
-    public void reverseDnsShouldCorrectlyMatchValidForwardedHeaderToDomain() {
+    void reverseDnsShouldCorrectlyMatchValidForwardedHeaderToDomain() {
         when(reverseDnsLookup.lookup(new DnsPointerResourceRecord("195.35.90.1"))).thenReturn(Optional.of("worldpay.com."));
         when(reverseDnsLookup.lookup(new DnsPointerResourceRecord("8.8.8.8"))).thenReturn(Optional.of("dns.google."));
         assertThat(ipDomainMatcher.ipMatchesDomain("8.8.8.8, 195.35.90.1", "worldpay.com"), is(true));
@@ -41,7 +41,7 @@ public class IpDomainMatcherTest {
     }
 
     @Test
-    public void reverseDnsShouldFailGracefullyIfForwardedHeaderIsNotValid() {
+    void reverseDnsShouldFailGracefullyIfForwardedHeaderIsNotValid() {
         when(reverseDnsLookup.lookup(any(DnsPointerResourceRecord.class))).thenReturn(Optional.empty());
         assertThat(ipDomainMatcher.ipMatchesDomain("not-an-ip", "worldpay.com"), is(false));
         assertThat(ipDomainMatcher.ipMatchesDomain(null, "worldpay.com"), is(false));

--- a/src/test/java/uk/gov/pay/connector/util/JsonObjectMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/JsonObjectMapperTest.java
@@ -1,26 +1,21 @@
 package uk.gov.pay.connector.util;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.WebApplicationException;
-import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class JsonObjectMapperTest {
+class JsonObjectMapperTest {
     private ObjectMapper objectMapper = new ObjectMapper();
     private JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(objectMapper);
 
     @Test
-    public void shouldMapToObject() {
+    void shouldMapToObject() {
         String jsonString = "{\"id\":1}";
         LocalTestObject fromJson = jsonObjectMapper.getObject(jsonString, LocalTestObject.class);
         assertNotNull(fromJson);
@@ -28,7 +23,7 @@ public class JsonObjectMapperTest {
     }
 
     @Test()
-    public void shouldThrowException() {
+    void shouldThrowException() {
         String jsonString = "{\"id\":\"abc\"}";
         assertThrows(WebApplicationException.class, () -> jsonObjectMapper.getObject(jsonString, LocalTestObject.class));
     }
@@ -38,7 +33,7 @@ class LocalTestObject {
     @JsonProperty("id")
     private int id;
 
-    public int getId() {
+    int getId() {
         return id;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/RandomIdGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/RandomIdGeneratorTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -10,19 +10,19 @@ import java.util.stream.IntStream;
 import static com.google.common.primitives.Chars.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.pay.connector.util.RandomIdGenerator.newId;
 import static uk.gov.pay.connector.util.RandomIdGenerator.idFromExternalId;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
-public class RandomIdGeneratorTest {
+class RandomIdGeneratorTest {
 
     private static final List<Character> BASE32_DICTIONARY = asList("0123456789abcdefghijklmnopqrstuv".toCharArray());
 
     @Test
-    public void shouldGenerateUniqueRandomIds() {
+    void shouldGenerateUniqueRandomIds() {
         Set<String> randomIds = IntStream.range(0, 100)
             .parallel()
             .mapToObj(value -> newId())
@@ -32,7 +32,7 @@ public class RandomIdGeneratorTest {
     }
 
     @Test
-    public void shouldGenerateRandomIdsInBase32() {
+    void shouldGenerateRandomIdsInBase32() {
         IntStream.range(0, 100)
             .parallel()
             .mapToObj(value -> newId())
@@ -41,7 +41,7 @@ public class RandomIdGeneratorTest {
     }
 
     @Test
-    public void shouldGenerateIdsOf26CharsInLength() {
+    void shouldGenerateIdsOf26CharsInLength() {
         IntStream.range(0, 100)
             .parallel()
             .mapToObj(value -> newId())
@@ -49,13 +49,13 @@ public class RandomIdGeneratorTest {
     }
 
     @Test
-    public void randomUuid_shouldGenerateIdsOf32CharsInLength() {
+    void randomUuid_shouldGenerateIdsOf32CharsInLength() {
         String randomUuid = randomUuid();
         assertEquals(32, randomUuid.length());
     }
 
     @Test
-    public void idFromExternalEntityId_shouldGenerate26Characters() {
+    void idFromExternalEntityId_shouldGenerate26Characters() {
         for (int i = 0; i < 100; i++) {
             String randomUuid = randomUuid();
             String randomId = idFromExternalId(randomUuid);
@@ -65,7 +65,7 @@ public class RandomIdGeneratorTest {
     }
 
     @Test
-    public void idFromExternalEntityId_shouldGenerateId() {
+    void idFromExternalEntityId_shouldGenerateId() {
         String externalId = "123b456c-789d012e-345f678g";
         String randomId = idFromExternalId(externalId);
 

--- a/src/test/java/uk/gov/pay/connector/util/ReverseDnsLookupTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/ReverseDnsLookupTest.java
@@ -1,23 +1,23 @@
 package uk.gov.pay.connector.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class ReverseDnsLookupTest {
+class ReverseDnsLookupTest {
     
     private ReverseDnsLookup reverseDnsLookup = new ReverseDnsLookup();
 
     @Test
-    public void reverseDnsShouldReturnHostIfIpIsValid() {
+    void reverseDnsShouldReturnHostIfIpIsValid() {
         var pointerRecord = new DnsPointerResourceRecord("195.35.90.1");
         assertThat(reverseDnsLookup.lookup(pointerRecord).isPresent(), is(true));
         assertThat(reverseDnsLookup.lookup(pointerRecord).get(), is("hello.worldpay.com."));
     }
 
     @Test
-    public void reverseDnsShouldNotReturnHostIfIpIsNotValid() {
+    void reverseDnsShouldNotReturnHostIfIpIsNotValid() {
         assertThat(reverseDnsLookup.lookup(new DnsPointerResourceRecord("123.234.567.890")).isPresent(), is(false));
         assertThat(reverseDnsLookup.lookup(new DnsPointerResourceRecord("not-an-ip")).isPresent(), is(false));
     }

--- a/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
@@ -13,13 +13,12 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayRefundResponse;
 
 import java.time.LocalDate;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_3DS_FLEX_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_3DS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_CANCELLED_RESPONSE;
@@ -35,10 +34,10 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_NOTI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_REFUND_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_REFUND_SUCCESS_RESPONSE;
 
-public class WorldpayXMLUnmarshallerTest {
+class WorldpayXMLUnmarshallerTest {
 
     @Test
-    public void shouldUnmarshallACancelSuccessResponse() throws Exception {
+    void shouldUnmarshallACancelSuccessResponse() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(WORLDPAY_CANCEL_SUCCESS_RESPONSE);
         WorldpayCancelResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayCancelResponse.class);
         assertThat(response.getTransactionId(), is("transaction-id"));
@@ -46,9 +45,8 @@ public class WorldpayXMLUnmarshallerTest {
         assertThat(response.getErrorMessage(), is(nullValue()));
     }
 
-
     @Test
-    public void shouldUnmarshallACancelErrorResponse() throws Exception {
+    void shouldUnmarshallACancelErrorResponse() throws Exception {
         String errorPayload = TestTemplateResourceLoader.load(WORLDPAY_CANCEL_ERROR_RESPONSE);
 
         WorldpayCancelResponse response = XMLUnmarshaller.unmarshall(errorPayload, WorldpayCancelResponse.class);
@@ -58,7 +56,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallANotification() throws Exception {
+    void shouldUnmarshallANotification() throws Exception {
         String transactionId = "MyUniqueTransactionId!";
         String status = "CAPTURED";
         String successPayload = TestTemplateResourceLoader.load(WORLDPAY_NOTIFICATION)
@@ -77,7 +75,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallACaptureSuccessResponse() throws Exception {
+    void shouldUnmarshallACaptureSuccessResponse() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(WORLDPAY_CAPTURE_SUCCESS_RESPONSE);
         WorldpayCaptureResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayCaptureResponse.class);
         assertThat(response.getTransactionId(), is("transaction-id"));
@@ -86,7 +84,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallACaptureErrorResponse() throws Exception {
+    void shouldUnmarshallACaptureErrorResponse() throws Exception {
         String errorPayload = TestTemplateResourceLoader.load(WORLDPAY_CAPTURE_ERROR_RESPONSE);
         WorldpayCaptureResponse response = XMLUnmarshaller.unmarshall(errorPayload, WorldpayCaptureResponse.class);
         assertThat(response.getTransactionId(), is(nullValue()));
@@ -95,7 +93,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallAAuthorisationSuccessResponse() throws Exception {
+    void shouldUnmarshallAAuthorisationSuccessResponse() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE);
         WorldpayOrderStatusResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayOrderStatusResponse.class);
         assertTrue(response.getLastEvent().isPresent());
@@ -111,7 +109,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshall3dsResponse() throws Exception {
+    void shouldUnmarshall3dsResponse() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(WORLDPAY_3DS_RESPONSE);
         WorldpayOrderStatusResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayOrderStatusResponse.class);
 
@@ -129,7 +127,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshall3dsFlexResponse() throws Exception {
+    void shouldUnmarshall3dsFlexResponse() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(WORLDPAY_3DS_FLEX_RESPONSE);
         WorldpayOrderStatusResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayOrderStatusResponse.class);
 
@@ -149,7 +147,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallAAuthorisationFailedResponse() throws Exception {
+    void shouldUnmarshallAAuthorisationFailedResponse() throws Exception {
         String failedPayload = TestTemplateResourceLoader.load(WORLDPAY_AUTHORISATION_FAILED_RESPONSE);
         WorldpayOrderStatusResponse response = XMLUnmarshaller.unmarshall(failedPayload, WorldpayOrderStatusResponse.class);
         assertTrue(response.getLastEvent().isPresent());
@@ -165,7 +163,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallCanceledAuthorisations() throws Exception {
+    void shouldUnmarshallCanceledAuthorisations() throws Exception {
         String failedPayload = TestTemplateResourceLoader.load(WORLDPAY_AUTHORISATION_CANCELLED_RESPONSE);
         WorldpayOrderStatusResponse response = XMLUnmarshaller.unmarshall(failedPayload, WorldpayOrderStatusResponse.class);
         assertThat(response.cancelStatus(), is(BaseCancelResponse.CancelStatus.CANCELLED));
@@ -182,7 +180,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallAAuthorisationErrorResponse() throws Exception {
+    void shouldUnmarshallAAuthorisationErrorResponse() throws Exception {
         String errorPayload = TestTemplateResourceLoader.load(WORLDPAY_AUTHORISATION_ERROR_RESPONSE);
         WorldpayOrderStatusResponse response = XMLUnmarshaller.unmarshall(errorPayload, WorldpayOrderStatusResponse.class);
 
@@ -194,7 +192,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallARefundSuccessResponse() throws Exception {
+    void shouldUnmarshallARefundSuccessResponse() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(WORLDPAY_REFUND_SUCCESS_RESPONSE);
         WorldpayRefundResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayRefundResponse.class);
 
@@ -205,7 +203,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallARefundErrorResponse() throws Exception {
+    void shouldUnmarshallARefundErrorResponse() throws Exception {
         String errorPayload = TestTemplateResourceLoader.load(WORLDPAY_REFUND_ERROR_RESPONSE);
         WorldpayRefundResponse response = XMLUnmarshaller.unmarshall(errorPayload, WorldpayRefundResponse.class);
 
@@ -216,7 +214,7 @@ public class WorldpayXMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallADeleteTokenSuccessResponse() throws Exception {
+    void shouldUnmarshallADeleteTokenSuccessResponse() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(WORLDPAY_DELETE_TOKEN_SUCCESS_RESPONSE);
         WorldpayDeleteTokenResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayDeleteTokenResponse.class);
 

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
@@ -5,13 +5,13 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
@@ -52,8 +52,8 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.COMPLETED;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_3DS_RESPONSE;
 
-@RunWith(MockitoJUnitRunner.class)
-public class WalletAuthoriseServiceForGooglePay3dsTest {
+@ExtendWith(MockitoExtension.class)
+class WalletAuthoriseServiceForGooglePay3dsTest {
 
     private WalletAuthoriseService walletAuthoriseService;
     
@@ -95,8 +95,8 @@ public class WalletAuthoriseServiceForGooglePay3dsTest {
     
     private ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
     
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         when(mockedProviders.byName(any())).thenReturn(mockedPaymentProvider);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
@@ -125,7 +125,7 @@ public class WalletAuthoriseServiceForGooglePay3dsTest {
     }
 
     @Test
-    public void the_charge_service_should_be_called_with_auth3dsRequiredDetails_when_3ds_is_required_for_a_google_payment() throws Exception {
+    void the_charge_service_should_be_called_with_auth3dsRequiredDetails_when_3ds_is_required_for_a_google_payment() throws Exception {
         String successPayload = TestTemplateResourceLoader.load(WORLDPAY_3DS_RESPONSE);
         WorldpayOrderStatusResponse worldpayOrderStatusResponse = XMLUnmarshaller.unmarshall(successPayload, WorldpayOrderStatusResponse.class);
         providerRequestsFor3dsAuthorisation(worldpayOrderStatusResponse);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -10,13 +10,13 @@ import com.codahale.metrics.Counter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.config.AuthorisationConfig;
@@ -71,13 +71,15 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -99,8 +101,8 @@ import static uk.gov.pay.connector.model.domain.applepay.ApplePayPaymentInfoFixt
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.COMPLETED;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.IN_PROGRESS;
 
-@RunWith(MockitoJUnitRunner.class)
-public class WalletAuthoriseServiceTest extends CardServiceTest {
+@ExtendWith(MockitoExtension.class)
+class WalletAuthoriseServiceTest extends CardServiceTest {
 
     private static final ProviderSessionIdentifier SESSION_IDENTIFIER = ProviderSessionIdentifier.of("session-identifier");
     private static final String TRANSACTION_ID = "transaction-id";
@@ -176,23 +178,22 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     @InjectMocks
     private PaymentInstrumentService mockPaymentInstrumentService;
 
-    @Before
-    public void setUp() {
-        when(mockedProviders.byName(any())).thenReturn(mockedPaymentProvider);
-        when(mockedPaymentProvider.generateTransactionId()).thenReturn(Optional.of(TRANSACTION_ID));
-        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
-        when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
-        when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        when(mockWalletAuthorisationDataToAuthCardDetailsConverter.convert(any(WalletAuthorisationData.class))).thenReturn(mockAuthCardDetails);
-        when(mockAuthCardDetailsToCardDetailsEntityConverter.convert(mockAuthCardDetails)).thenReturn(mockCardDetailsEntity);
+    @BeforeEach
+    void setUp() {
+        lenient().when(mockedProviders.byName(any())).thenReturn(mockedPaymentProvider);
+        lenient().when(mockedPaymentProvider.generateTransactionId()).thenReturn(Optional.of(TRANSACTION_ID));
+        lenient().when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
+        lenient().when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
+        lenient().when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
+        lenient().when(mockWalletAuthorisationDataToAuthCardDetailsConverter.convert(any(WalletAuthorisationData.class))).thenReturn(mockAuthCardDetails);
+        lenient().when(mockAuthCardDetailsToCardDetailsEntityConverter.convert(mockAuthCardDetails)).thenReturn(mockCardDetailsEntity);
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
-        when(mockConfiguration.getEmitPaymentStateTransitionEvents()).thenReturn(true);
-        when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
-        when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);
+        lenient().when(mockConfiguration.getEmitPaymentStateTransitionEvents()).thenReturn(true);
+        lenient().when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
+        lenient().when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);
 
         ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
-        when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
         AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment, mockConfiguration);
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null, mockStateTransitionService,
@@ -217,7 +218,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void verifyLogging() throws Exception {
+    void verifyLogging() throws Exception {
         GatewayResponse gatewayResponse = providerWillAuthorise();
         walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
 
@@ -230,7 +231,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthoriseCard_ApplePay_shouldRespondAuthorisationSuccess() throws Exception {
+    void doAuthoriseCard_ApplePay_shouldRespondAuthorisationSuccess() throws Exception {
         providerWillAuthorise();
         ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
@@ -260,7 +261,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthoriseCard_GooglePay_shouldRespondAuthorisationSuccess() throws Exception {
+    void doAuthoriseCard_GooglePay_shouldRespondAuthorisationSuccess() throws Exception {
         providerWillAuthorise();
         ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
@@ -293,7 +294,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthoriseCard_GooglePay_shouldRespondAuthorisationSuccess_whenCardNumberIsEmptyString() throws Exception {
+    void doAuthoriseCard_GooglePay_shouldRespondAuthorisationSuccess_whenCardNumberIsEmptyString() throws Exception {
         providerWillAuthorise();
         ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
@@ -328,7 +329,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldRespondAuthorisationRejected_whenProviderAuthorisationIsRejected() throws Exception {
+    void doAuthorise_shouldRespondAuthorisationRejected_whenProviderAuthorisationIsRejected() throws Exception {
         providerWillReject();
 
         GatewayResponse response = walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -340,7 +341,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldSetProviderTransactionId_whenProviderAuthorisationIsErroredWithoutProviderId() throws Exception {
+    void doAuthorise_shouldSetProviderTransactionId_whenProviderAuthorisationIsErroredWithoutProviderId() throws Exception {
         providerWillRejectWithNoTransactionId();
 
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
@@ -354,7 +355,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldRespondAuthorisationCancelled_whenProviderAuthorisationIsCancelled() throws Exception {
+    void doAuthorise_shouldRespondAuthorisationCancelled_whenProviderAuthorisationIsCancelled() throws Exception {
         GatewayResponse authResponse = mockAuthResponse(TRANSACTION_ID, AuthoriseStatus.CANCELLED, null);
         when(mockedPaymentProvider.authoriseWallet(any(WalletAuthorisationGatewayRequest.class))).thenReturn(authResponse);
 
@@ -367,7 +368,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void shouldRespondAuthorisationError() throws Exception {
+    void shouldRespondAuthorisationError() throws Exception {
         providerWillError();
 
         GatewayResponse response = walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -379,7 +380,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldStoreCardDetails_evenIfAuthorisationRejected() throws Exception {
+    void doAuthorise_shouldStoreCardDetails_evenIfAuthorisationRejected() throws Exception {
         providerWillReject();
 
         walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -389,7 +390,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldStoreCardDetails_evenIfInAuthorisationError() throws Exception {
+    void doAuthorise_shouldStoreCardDetails_evenIfInAuthorisationError() throws Exception {
         providerWillError();
 
         walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -399,7 +400,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldStoreProviderSessionId_evenIfAuthorisationRejected() throws Exception {
+    void doAuthorise_shouldStoreProviderSessionId_evenIfAuthorisationRejected() throws Exception {
         providerWillReject();
 
         walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -408,7 +409,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldNotStoreProviderSessionId_whenAuthorisationError() throws Exception {
+    void doAuthorise_shouldNotStoreProviderSessionId_whenAuthorisationError() throws Exception {
         providerWillError();
 
         walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -417,7 +418,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldThrowAnOperationAlreadyInProgressRuntimeException_whenTimeout() {
+    void doAuthorise_shouldThrowAnOperationAlreadyInProgressRuntimeException_whenTimeout() {
         when(mockExecutorService.execute(any(), anyInt())).thenReturn(Pair.of(IN_PROGRESS, null));
 
         try {
@@ -429,39 +430,39 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         }
     }
 
-    @Test(expected = ChargeNotFoundRuntimeException.class)
-    public void doAuthorise_shouldThrowAChargeNotFoundRuntimeException_whenChargeDoesNotExist() {
+    @Test
+    void doAuthorise_shouldThrowAChargeNotFoundRuntimeException_whenChargeDoesNotExist() {
         String chargeId = "jgk3erq5sv2i4cds6qqa9f1a8a";
         when(mockedChargeDao.findByExternalId(chargeId))
                 .thenReturn(Optional.empty());
 
-        walletAuthoriseService.doAuthorise(chargeId, validApplePayDetails);
+        assertThrows(ChargeNotFoundRuntimeException.class, () -> walletAuthoriseService.doAuthorise(chargeId, validApplePayDetails));
     }
 
-    @Test(expected = OperationAlreadyInProgressRuntimeException.class)
-    public void doAuthorise_shouldThrowAnOperationAlreadyInProgressRuntimeException_whenStatusIsAuthorisationReady() {
+    @Test
+    void doAuthorise_shouldThrowAnOperationAlreadyInProgressRuntimeException_whenStatusIsAuthorisationReady() {
         ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.AUTHORISATION_READY);
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
 
-        walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
-
-        verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
-    }
-
-    @Test(expected = IllegalStateRuntimeException.class)
-    public void doAuthorise_shouldThrowAnIllegalStateRuntimeException_whenInvalidStatus() {
-        ChargeEntity charge = createNewChargeWith(1L, UNDEFINED);
-        when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
-
-        walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+        assertThrows(OperationAlreadyInProgressRuntimeException.class,
+                () -> walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails));
 
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
 
     @Test
-    public void doAuthorise_shouldReportAuthorisationTimeout_whenProviderTimeout() throws Exception {
+    void doAuthorise_shouldThrowAnIllegalStateRuntimeException_whenInvalidStatus() {
+        ChargeEntity charge = createNewChargeWith(1L, UNDEFINED);
+        when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
+
+        assertThrows(IllegalStateRuntimeException.class,
+                () -> walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails));
+
+        verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
+    }
+
+    @Test
+    void doAuthorise_shouldReportAuthorisationTimeout_whenProviderTimeout() throws Exception {
         providerWillRespondWithError(new GatewayConnectionTimeoutException("Connection timed out"));
 
         GatewayResponse response = walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -471,7 +472,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldReportUnexpectedError_whenProviderError() throws Exception {
+    void doAuthorise_shouldReportUnexpectedError_whenProviderError() throws Exception {
         providerWillRespondWithError(new GatewayException.GatewayErrorException("Malformed response received"));
 
         GatewayResponse response = walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -482,9 +483,9 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     private GatewayResponse mockAuthResponse(String TRANSACTION_ID, AuthoriseStatus authoriseStatus, String errorCode) {
         WorldpayOrderStatusResponse worldpayResponse = mock(WorldpayOrderStatusResponse.class);
-        when(worldpayResponse.getTransactionId()).thenReturn(TRANSACTION_ID);
-        when(worldpayResponse.authoriseStatus()).thenReturn(authoriseStatus);
-        when(worldpayResponse.getErrorCode()).thenReturn(errorCode);
+        lenient().when(worldpayResponse.getTransactionId()).thenReturn(TRANSACTION_ID);
+        lenient().when(worldpayResponse.authoriseStatus()).thenReturn(authoriseStatus);
+        lenient().when(worldpayResponse.getErrorCode()).thenReturn(errorCode);
         return responseBuilder()
                 .withResponse(worldpayResponse)
                 .withSessionIdentifier(SESSION_IDENTIFIER)
@@ -502,8 +503,8 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
                 .build();
     }
 
-    public void mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue() {
-        doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
+    void mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue() {
+        lenient().doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
                 .when(mockExecutorService).execute(any(Supplier.class), anyInt());
     }
 

--- a/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.connector.wallets.applepay;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
@@ -18,9 +18,9 @@ import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,8 +29,8 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
 import static uk.gov.pay.connector.model.domain.applepay.ApplePayDecryptedPaymentDataFixture.anApplePayDecryptedPaymentData;
 import static uk.gov.pay.connector.model.domain.applepay.ApplePayPaymentInfoFixture.anApplePayPaymentInfo;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ApplePayServiceTest {
+@ExtendWith(MockitoExtension.class)
+class ApplePayServiceTest {
 
     @Mock
     private ApplePayDecrypter mockedApplePayDecrypter;
@@ -44,16 +44,17 @@ public class ApplePayServiceTest {
                     .withApplePaymentInfo(
                             anApplePayPaymentInfo().build())
                     .build();
-    @Before
-    public void setUp() {
+
+    @BeforeEach
+    void setUp() {
         applePayService = new ApplePayService(mockedApplePayDecrypter, mockedApplePayAuthoriseService);
     }
-    
+
     @Test
-    public void shouldDecryptAndAuthoriseAValidCharge() throws IOException {
+    void shouldDecryptAndAuthoriseAValidCharge() throws IOException {
         String externalChargeId = "external-charge-id";
         ApplePayAuthRequest applePayAuthRequest = ApplePayAuthRequestBuilder.anApplePayToken().build();
-                
+
         WorldpayOrderStatusResponse worldpayResponse = mock(WorldpayOrderStatusResponse.class);
         GatewayResponse gatewayResponse = responseBuilder()
                 .withResponse(worldpayResponse)
@@ -71,7 +72,7 @@ public class ApplePayServiceTest {
     }
 
     @Test
-    public void shouldReturnInternalServerError_ifGatewayErrors() throws IOException {
+    void shouldReturnInternalServerError_ifGatewayErrors() throws IOException {
         String externalChargeId = "external-charge-id";
         ApplePayAuthRequest applePayAuthRequest = ApplePayAuthRequestBuilder.anApplePayToken().build();
         GatewayError gatewayError = mock(GatewayError.class);
@@ -88,7 +89,7 @@ public class ApplePayServiceTest {
 
         verify(mockedApplePayAuthoriseService).doAuthorise(externalChargeId, validData);
         assertThat(authorisationResponse.getStatus(), is(402));
-        ErrorResponse response = (ErrorResponse)authorisationResponse.getEntity();
+        ErrorResponse response = (ErrorResponse) authorisationResponse.getEntity();
         assertThat(response.getMessages(), contains("oops"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
@@ -2,11 +2,11 @@ package uk.gov.pay.connector.wallets.googlepay;
 
 import com.amazonaws.util.json.Jackson;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
@@ -20,17 +20,17 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 
-@RunWith(MockitoJUnitRunner.class)
-public class GooglePayServiceTest {
+@ExtendWith(MockitoExtension.class)
+class GooglePayServiceTest {
 
     @Mock
     private WalletAuthoriseService mockedWalletAuthoriseService;
@@ -41,15 +41,15 @@ public class GooglePayServiceTest {
     private GooglePayAuthRequest googlePayAuthRequest;
     private GooglePayAuthRequest googlePayAuth3dsRequest;
     
-    @Before
-    public void setUp() throws IOException {
+    @BeforeEach
+    void setUp() throws IOException {
         googlePayService = new GooglePayService(mockedWalletAuthoriseService);
         googlePayAuthRequest = Jackson.getObjectMapper().readValue(fixture("googlepay/example-auth-request.json"), GooglePayAuthRequest.class);
         googlePayAuth3dsRequest = Jackson.getObjectMapper().readValue(fixture("googlepay/example-3ds-auth-request.json"), GooglePayAuthRequest.class);
     }
     
     @Test
-    public void shouldAuthoriseAValidCharge() {
+    void shouldAuthoriseAValidCharge() {
         String externalChargeId = "external-charge-id";
         GatewayResponse<BaseAuthoriseResponse> gatewayResponse = responseBuilder()
                 .withResponse(worldpayResponse)
@@ -66,7 +66,7 @@ public class GooglePayServiceTest {
     }
 
     @Test
-    public void shouldReturnAuthorise3dsRequiredForAValid3dsCharge() {
+    void shouldReturnAuthorise3dsRequiredForAValid3dsCharge() {
         String externalChargeId = "external-charge-id";
         GatewayResponse<BaseAuthoriseResponse> gatewayResponse = responseBuilder()
                 .withResponse(worldpayResponse)
@@ -83,7 +83,7 @@ public class GooglePayServiceTest {
     }
 
     @Test
-    public void shouldReturnInternalServerError_ifGatewayErrors() {
+    void shouldReturnInternalServerError_ifGatewayErrors() {
         String externalChargeId = "external-charge-id";
         GatewayError gatewayError = mock(GatewayError.class);
         GatewayResponse gatewayResponse = responseBuilder()

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.wallets.googlepay.api;
 import com.amazonaws.util.json.Jackson;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -11,10 +11,10 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class GooglePayAuthRequestTest {
+class GooglePayAuthRequestTest {
 
     @Test
-    public void shouldDeserializeFromJsonCorrectly() throws IOException {
+    void shouldDeserializeFromJsonCorrectly() throws IOException {
         ObjectMapper objectMapper = Jackson.getObjectMapper();
         JsonNode expected = objectMapper.readTree(fixture("googlepay/example-3ds-auth-request.json"));
         GooglePayAuthRequest actual = objectMapper.readValue(


### PR DESCRIPTION
## WHAT YOU DID
- Updated util and wallet related tests to JUnit5.
- use lenient() in `WalletAuthoriseServiceTest` as there are a lot of tests that need to be refactored to remove unnecessary stubbing
