### PR TITLE
PP-10983 Move Junit4 tests to Junit5 (JP)

### DIFF
--- a/src/test/java/uk/gov/pay/connector/charge/util/JwtGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/util/JwtGeneratorTest.java
@@ -4,7 +4,7 @@ package uk.gov.pay.connector.charge.util;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.crypto.spec.SecretKeySpec;
 import java.util.Map;

--- a/src/test/java/uk/gov/pay/connector/chargeevent/model/domain/LocalDateTimeConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/chargeevent/model/domain/LocalDateTimeConverterTest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.chargeevent.model.domain;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
@@ -13,7 +13,7 @@ public class LocalDateTimeConverterTest {
 
     private LocalDateTimeConverter localDateTimeConverter;
     
-    @Before
+    @BeforeEach
     public void setUp(){
         localDateTimeConverter = new LocalDateTimeConverter();
     }

--- a/src/test/java/uk/gov/pay/connector/client/GatewayClientExploratoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/GatewayClientExploratoryTest.java
@@ -3,8 +3,8 @@ package uk.gov.pay.connector.client;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import uk.gov.service.payments.commons.testing.port.PortFactory;
 
 import javax.ws.rs.ProcessingException;
@@ -21,38 +21,29 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.util.TestClientFactory.createClientWithApacheConnectorAndTimeout;
 import static uk.gov.pay.connector.util.TestClientFactory.createJerseyClient;
 
-@Ignore //this should be run manaully
+@Disabled //this should be run manually
 public class GatewayClientExploratoryTest {
 
     @Test
     public void connectionToInvalidUrlUsingDefaultJerseyConnectorProvider() {
         Client client = ClientBuilder.newClient();
         String gatewayUrl = "http://invalidone.invalid";
-        try {
-            postXMLRequestFor(client, gatewayUrl, "<request/>");
-            fail("Exception not thrown!");
-        } catch (Exception e) {
-            assertTrue(e instanceof ProcessingException);
-            assertTrue(e.getCause() instanceof UnknownHostException);
-        }
+        var ex = assertThrows(ProcessingException.class, () -> postXMLRequestFor(client, gatewayUrl, "<request/>"));
+        assertThat(UnknownHostException.class, is(ex.getCause().getClass()));
     }
 
     @Test
     public void connectionToInvalidUrlUsingApacheConnectorProvider() {
         Client client = createJerseyClient();
         String gatewayUrl = "http://invalidone.invalid";
-        try {
-            postXMLRequestFor(client, gatewayUrl, "<request/>");
-            fail("Exception not thrown!");
-        } catch (Exception e) {
-            assertTrue(e instanceof ProcessingException);
-            assertTrue(e.getCause() instanceof UnknownHostException);
-        }
+        var ex = assertThrows(ProcessingException.class, () -> postXMLRequestFor(client, gatewayUrl, "<request/>"));
+        assertThat(UnknownHostException.class, is(ex.getCause().getClass()));
     }
 
     @Test
@@ -77,15 +68,10 @@ public class GatewayClientExploratoryTest {
 
         Client client = createClientWithApacheConnectorAndTimeout(500);
 
-        try {
-            postXMLRequestFor(client, gatewayUrl, "<request/>");
-            fail("Exception not thrown!");
-        } catch (Exception e) {
-            assertTrue(e.getMessage(), e instanceof ProcessingException);
-            assertTrue(e.getMessage(), e.getCause() instanceof SocketTimeoutException);
-        } finally {
-            wireMockServer.stop();
-        }
+        var ex = assertThrows(ProcessingException.class, () -> postXMLRequestFor(client, gatewayUrl, "<request/>"));
+        assertThat(SocketTimeoutException.class, is(ex.getCause().getClass()));
+        
+        wireMockServer.stop();
     }
 
     public Response postXMLRequestFor(Client client, String gatewayUrl, String requestBody) {

--- a/src/test/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapperTest.java
@@ -1,8 +1,7 @@
 package uk.gov.pay.connector.northamericaregion;
 
-import org.junit.Before;
-import org.junit.Test;
-import uk.gov.pay.connector.charge.model.AddressEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.common.model.domain.Address;
 
 import java.util.Optional;
@@ -19,7 +18,7 @@ public class NorthAmericanRegionMapperTest {
     
     private Address address;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         address = new Address();
         address.setLine1("Line 1");


### PR DESCRIPTION
- update Junit4 imports and annotations to Junit5 equivalents
- refactor tests that assert that exceptions are thrown to use assertThrows