### PR TITLE
PP-11008 Cannot retry TRANSACTION_NOT_PERMITTED or PICKUP_CARD

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/MappedAuthorisationRejectedReason.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/MappedAuthorisationRejectedReason.java
@@ -22,7 +22,7 @@ public enum MappedAuthorisationRejectedReason {
     ISSUER_TEMPORARILY_UNAVAILABLE(true),
     LOST_CARD(false),
     NO_SUCH_ISSUER(true),
-    PICKUP_CARD(true),
+    PICKUP_CARD(false),
     REENTER_TRANSACTION(true),
     REFER_TO_CARD_ISSUER(true),
     REVOCATION_OF_ALL_AUTHORISATION(false),
@@ -30,7 +30,7 @@ public enum MappedAuthorisationRejectedReason {
     STOLEN_CARD(true),
     STOP_PAYMENT_ORDER(false),
     SUSPECTED_FRAUD(true),
-    TRANSACTION_NOT_PERMITTED(true),
+    TRANSACTION_NOT_PERMITTED(false),
     TRY_AGAIN_LATER(true),
     TRY_ANOTHER_CARD(true),
     UNCATEGORISED(true);


### PR DESCRIPTION
Change the authorisation rejected reasons `TRANSACTION_NOT_PERMITTED` and `PICKUP_CARD` so they indicate that the payment cannot be automatically retried.

For `TRANSACTION_NOT_PERMITTED`, Worldpay have already advised us this cannot be retried. Stripe often accompany it with the message “Your card does not support this type of purchase”, which suggests it will never work. (Indeed, for the use case of recurring card payments, it seems unlikely that the initial customer-initiated payment would succeed so we’ll probably never get this for a subsequent merchant-initiated payment.)

For `PICKUP_CARD`, Worldpay have already advised us this cannot be retried. Searching online (be careful when doing this: we use `PICKUP_CARD` specifically for decline code 07 but some sites use similar terminology for 04, 41 and 43, which are `CAPTURE_CARD`,` LOST_CARD` and `STOLEN_CARD` respectively) brings up https://www.tidalcommerce.com/learn/card-decline-codes, which states that 07 indicates fraud and adds: “If it’s for a one-time transaction, do not run the card again, and don’t provide any more goods or services for the cardholder. If it was a recurring or scheduled transaction, follow up with your customer to make sure your business wasn’t incorrectly flagged as fraudulent. Ask that they follow up with their bank OR update their account with a newly provided card.” This suggests that we do not want to be retrying and should indicate the failure to the partner service so they can contact the paying user.

In the real world, `PICKUP_CARD` means the merchant should confiscate the card and send it back to the card network. According to https://www.reddit.com/r/TalesFromRetail/comments/17533d/has_anyone_gotten_a_pick_up_card_error_actually/ a reward is sometimes paid for this, so it’s a shame we’re missing out on that.