### PR TITLE
PP-11036 implement setting canclled date for agreements

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/agreement/AgreementCancelledByService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/agreement/AgreementCancelledByService.java
@@ -1,15 +1,16 @@
 package uk.gov.pay.connector.events.model.agreement;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
-import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
+import uk.gov.service.payments.commons.api.json.ApiResponseInstantWithMicrosecondPrecisionSerializer;
 
 import java.time.Instant;
 
 public class AgreementCancelledByService extends AgreementEvent {
 
-    public AgreementCancelledByService(String serviceId, boolean live, String resourceExternalId, Instant timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+    public AgreementCancelledByService(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, Instant timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
     public static AgreementCancelledByService from(AgreementEntity agreement, Instant timestamp) {
@@ -17,7 +18,21 @@ public class AgreementCancelledByService extends AgreementEvent {
                 agreement.getServiceId(),
                 agreement.getGatewayAccount().isLive(),
                 agreement.getExternalId(),
+                new AgreementCancelledByServiceEventDetails(timestamp),
                 timestamp
         );
+    }
+
+    static class AgreementCancelledByServiceEventDetails extends EventDetails {
+        @JsonSerialize(using = ApiResponseInstantWithMicrosecondPrecisionSerializer.class)
+        private final Instant cancelledDate;
+
+        public AgreementCancelledByServiceEventDetails(Instant cancelledDate) {
+            this.cancelledDate = cancelledDate;
+        }
+
+        public Instant getCancelledDate() {
+            return cancelledDate;
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/agreement/AgreementCancelledByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/agreement/AgreementCancelledByUser.java
@@ -1,9 +1,10 @@
 package uk.gov.pay.connector.events.model.agreement;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.connector.agreement.model.AgreementCancelRequest;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
-import uk.gov.service.payments.commons.model.agreement.AgreementStatus;
+import uk.gov.service.payments.commons.api.json.ApiResponseInstantWithMicrosecondPrecisionSerializer;
 
 import java.time.Instant;
 
@@ -18,7 +19,7 @@ public class AgreementCancelledByUser extends AgreementEvent {
                 agreement.getServiceId(),
                 agreement.getGatewayAccount().isLive(),
                 agreement.getExternalId(),
-                new AgreementCancelledByUserEventDetails(agreementCancelRequest),
+                new AgreementCancelledByUserEventDetails(agreementCancelRequest, timestamp),
                 timestamp
         );
     }
@@ -26,10 +27,13 @@ public class AgreementCancelledByUser extends AgreementEvent {
     static class AgreementCancelledByUserEventDetails extends EventDetails {
         private final String userExternalId;
         private final String userEmail;
+        @JsonSerialize(using = ApiResponseInstantWithMicrosecondPrecisionSerializer.class)
+        private final Instant cancelledDate;
 
-        public AgreementCancelledByUserEventDetails(AgreementCancelRequest agreementCancelRequest) {
+        public AgreementCancelledByUserEventDetails(AgreementCancelRequest agreementCancelRequest, Instant cancelledDate) {
             this.userExternalId = agreementCancelRequest.getUserExternalId();
             this.userEmail = agreementCancelRequest.getUserEmail();
+            this.cancelledDate = cancelledDate;
         }
 
         public String getUserExternalId() {
@@ -38,6 +42,10 @@ public class AgreementCancelledByUser extends AgreementEvent {
 
         public String getUserEmail() {
             return userEmail;
+        }
+
+        public Instant getCancelledDate() {
+            return cancelledDate;
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
@@ -57,10 +57,11 @@ public class AgreementServiceTest {
     private AgreementService agreementService;
     private TaskQueueService mockedTaskQueueService = mock(TaskQueueService.class);
 
+    String INSTANT_EXPECTED = "2022-03-03T10:15:30Z";
+
     @BeforeEach
     public void setUp() {
-        String instantExpected = "2022-03-03T10:15:30Z";
-        Clock clock = Clock.fixed(Instant.parse(instantExpected), ZoneOffset.UTC);
+        Clock clock = Clock.fixed(Instant.parse(INSTANT_EXPECTED), ZoneOffset.UTC);
         agreementService = new AgreementService(mockedAgreementDao, mockedGatewayAccountDao, mockedLedgerService, clock, mockedTaskQueueService);
     }
 
@@ -144,6 +145,7 @@ public class AgreementServiceTest {
         verify(mockedTaskQueueService).addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
         verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByUser.class));
         assertThat(paymentInstrument.getStatus(), is(PaymentInstrumentStatus.CANCELLED));
+        assertThat(agreement.getCancelledDate(), is(Instant.parse(INSTANT_EXPECTED)));
     }
 
     @Test
@@ -162,5 +164,6 @@ public class AgreementServiceTest {
         verify(mockedTaskQueueService).addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
         verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByService.class));
         assertThat(paymentInstrument.getStatus(), is(PaymentInstrumentStatus.CANCELLED));
+        assertThat(agreement.getCancelledDate(), is(Instant.parse(INSTANT_EXPECTED)));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- set cancelled date when cancelling an agreement
- extend `AgreementCancelledByUserEventDetails` to have cancelledDate
- add `AgreementCancelledByServiceEventDetails` to `AgreementCancelledByService` and include cancelledDate
- update relevant tests
