### PR TITLE
BAU update openapi specs

### DIFF
--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -314,7 +314,7 @@ paths:
       responses:
         default:
           content:
-            application/json: {}
+            '*/*': {}
           description: default response
   /v1/api/accounts/{accountId}/charges:
     post:

--- a/src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java
@@ -61,7 +61,6 @@ public class AgreementsApiResource {
 
     @POST
     @Path("/v1/api/accounts/{accountId}/agreements/{agreementId}/cancel")
-    @Produces("application/json")
     @Consumes("application/json")
     public Response cancelAgreement(
             @Parameter(example = "1", description = "Gateway account ID")


### PR DESCRIPTION
## WHAT YOU DID
Cancel agreement endpoint returns a no content response but it states that it produces `application/json`

- remove incorrect mark up
