### PR TITLE
PP-10964 Handle Handle Stripe card_decline_rate_limit_exceeded error code as authorisation rejected

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
@@ -44,7 +44,9 @@ public class StripeAuthorisationFailedResponse implements BaseAuthoriseResponse 
            (https://stripe.com/docs/api/errors#errors-card_error)
          */
         if (errorResponse != null && errorResponse.getError() != null
-                && "card_error".equals(errorResponse.getError().getType())) {
+                && ("card_error".equals(errorResponse.getError().getType())
+                || ("invalid_request_error".equals(errorResponse.getError().getType())
+                && "card_decline_rate_limit_exceeded".equals(errorResponse.getError().getCode())))) {
             return REJECTED;
         }
         return ERROR;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -215,9 +215,11 @@ class StripeCaptureHandlerTest {
 
     @Test
     void shouldNotCaptureIfPaymentProviderReturns4xxHttpStatusCode() throws Exception {
-        GatewayErrorException exception = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", load(STRIPE_ERROR_RESPONSE), SC_UNAUTHORIZED);
+        String errorMessage = load(STRIPE_ERROR_RESPONSE).replace("{{code}}", "resource_missing");
+        GatewayErrorException exception = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", errorMessage, SC_UNAUTHORIZED);
         when(gatewayClient.postRequestFor(any(StripeCaptureRequest.class))).thenThrow(exception);
         CaptureResponse response = stripeCaptureHandler.capture(captureGatewayRequest);
+
         assertThat(response.isSuccessful(), is(false));
         assertThat(response.getError().isPresent(), is(true));
         assertThat(response.state(), is(nullValue()));
@@ -243,7 +245,8 @@ class StripeCaptureHandlerTest {
         when(gatewayCaptureResponse.getEntity()).thenReturn(load(STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE));
         when(gatewayClient.postRequestFor(any(StripeCaptureRequest.class))).thenReturn(gatewayCaptureResponse);
 
-        GatewayErrorException exception = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", load(STRIPE_ERROR_RESPONSE), SC_UNAUTHORIZED);
+        String errorMessage = load(STRIPE_ERROR_RESPONSE).replace("{{code}}", "resource_missing");
+        GatewayErrorException exception = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", errorMessage, SC_UNAUTHORIZED);
         when(gatewayClient.postRequestFor(any(StripeTransferOutRequest.class))).thenThrow(exception);
 
         CaptureResponse response = stripeCaptureHandler.capture(captureGatewayRequest);

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -179,7 +179,8 @@ class StripeRefundHandlerTest {
     }
 
     private void mockRefund4xxResponse() throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
-        GatewayErrorException gatewayClientException = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", load(STRIPE_ERROR_RESPONSE), 402);
+        String errorMessage = load(STRIPE_ERROR_RESPONSE).replace("{{code}}", "resource_missing");
+        GatewayErrorException gatewayClientException = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", errorMessage, 402);
         when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenThrow(gatewayClientException);
     }
 
@@ -195,7 +196,8 @@ class StripeRefundHandlerTest {
     }
 
     private void mockTransfer4xxResponse() throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
-        GatewayErrorException gatewayClientException = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", load(STRIPE_ERROR_RESPONSE), 402);
+        String errorMessage = load(STRIPE_ERROR_RESPONSE).replace("{{code}}", "resource_missing");
+        GatewayErrorException gatewayClientException = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", errorMessage, 402);
         when(gatewayClient.postRequestFor(any(StripeTransferInRequest.class))).thenThrow(gatewayClientException);
     }
 

--- a/src/test/resources/templates/stripe/error_response.json
+++ b/src/test/resources/templates/stripe/error_response.json
@@ -1,7 +1,7 @@
 {
   "error": {
     "charge": "ch_aaaaaaaaaaaaaaaaaaaaaaaa",
-    "code": "resource_missing",
+    "code": "{{code}}",
     "decline_code": "generic_decline",
     "doc_url": "https://stripe.com/docs/error-codes/card-declined",
     "message": "No such charge: ch_123456 or something similar",


### PR DESCRIPTION
## WHAT YOU DID
- Updated the Stripe authorisation error handling logic to handle errors with type ``` invalid_request_error ``` and code ```
card_decline_rate_limit_exceeded ``` by updating the state to ```AUTHORISATION_REJECTED ```


