### PR TITLE
PP-11021 Map common uncategorised Worldpay auth rejected reasons

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/MappedAuthorisationRejectedReason.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/MappedAuthorisationRejectedReason.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.model;
 public enum MappedAuthorisationRejectedReason {
 
     AUTHENTICATION_REQUESTED(true),
+    CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT(true),
     DO_NOT_HONOUR(true),
     EXCEEDS_WITHDRAWAL_AMOUNT_LIMIT(true),
     GENERIC_DECLINE(true),
@@ -11,6 +12,9 @@ public enum MappedAuthorisationRejectedReason {
     INVALID_AMOUNT(true),
     INVALID_MERCHANT(true),
     ISSUER_TEMPORARILY_UNAVAILABLE(true),
+    MASTERCARD_FRAUD_SECURITY_REASONS_OR_VISA_STIP_CANNOT_APPROVE(true),
+    MASTERCARD_POLICY_REASONS_OR_VISA_NEGATIVE_CAM_DCVV_ICVV_OR_CVV_RESULTS(true),
+    MASTERCARD_LIFECYCLE_REASONS_OR_VISA_ALREADY_REVERSED(true),
     REENTER_TRANSACTION(true),
     REFER_TO_CARD_ISSUER(true),
     SUSPECTED_FRAUD(true),
@@ -30,6 +34,7 @@ public enum MappedAuthorisationRejectedReason {
     LOST_CARD(false),
     NO_SUCH_ISSUER(false),
     PICKUP_CARD(false),
+    RESTRICTED_CARD(false),
     REVOCATION_OF_ALL_AUTHORISATION(false),
     REVOCATION_OF_AUTHORISATION(false),
     STOLEN_CARD(false),

--- a/src/main/java/uk/gov/pay/connector/gateway/model/WorldpayAuthorisationRejectedCodeMapper.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/WorldpayAuthorisationRejectedCodeMapper.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import static java.util.Map.entry;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.AUTHENTICATION_REQUESTED;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.CAPTURE_CARD;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.CLOSED_ACCOUNT;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.DO_NOT_HONOUR;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.EXCEEDS_WITHDRAWAL_AMOUNT_LIMIT;
@@ -18,9 +19,13 @@ import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReas
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.INVALID_TRANSACTION;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.ISSUER_TEMPORARILY_UNAVAILABLE;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.LOST_CARD;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.MASTERCARD_FRAUD_SECURITY_REASONS_OR_VISA_STIP_CANNOT_APPROVE;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.MASTERCARD_LIFECYCLE_REASONS_OR_VISA_ALREADY_REVERSED;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.MASTERCARD_POLICY_REASONS_OR_VISA_NEGATIVE_CAM_DCVV_ICVV_OR_CVV_RESULTS;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.NO_SUCH_ISSUER;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.PICKUP_CARD;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.REFER_TO_CARD_ISSUER;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.RESTRICTED_CARD;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.REVOCATION_OF_ALL_AUTHORISATION;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.REVOCATION_OF_AUTHORISATION;
 import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.STOLEN_CARD;
@@ -52,8 +57,13 @@ public class WorldpayAuthorisationRejectedCodeMapper {
                 entry("57", TRANSACTION_NOT_PERMITTED),
                 entry("59", SUSPECTED_FRAUD),
                 entry("61", EXCEEDS_WITHDRAWAL_AMOUNT_LIMIT),
+                entry("62", RESTRICTED_CARD),
                 entry("65", AUTHENTICATION_REQUESTED),
+                entry("76", CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT),
                 entry("78", INVALID_ACCOUNT_NUMBER),
+                entry("79", MASTERCARD_LIFECYCLE_REASONS_OR_VISA_ALREADY_REVERSED),
+                entry("82", MASTERCARD_POLICY_REASONS_OR_VISA_NEGATIVE_CAM_DCVV_ICVV_OR_CVV_RESULTS),
+                entry("83", MASTERCARD_FRAUD_SECURITY_REASONS_OR_VISA_STIP_CANNOT_APPROVE),
                 entry("91", ISSUER_TEMPORARILY_UNAVAILABLE),
                 entry("835", INVALID_CVV2),
                 entry("972", STOP_PAYMENT_ORDER),


### PR DESCRIPTION
Map some common uncategorised Worldpay authorisation rejected reasons.

83 — ‘STIP cannot approve (Visa) OR Fraud/Security related reasons (Mastercard)’ — accounts for more than half the uncategorised Worldpay authorisation rejected reasons we had last month. It annoyingly has different meanings for Visa and Mastercard. From the descriptions included in the responses Worldpay give us, it seems it’s always Mastercard fraud/security reasons for us. For Visa, it means that Visa’s stand-in processing (STIP) — which handles authorisation when the card issuer is temporarily unable to — cannot authorise the payment. Both of these reasons are things that indicate a recurring payment could be retried. We introduce a new `MappedAuthorisationRejectedReason` of
`MASTERCARD_FRAUD_SECURITY_REASONS_OR_VISA_STIP_CANNOT_APPROVE` for this.

82 — ‘Negative CAM, dCVV, iCVV, or CVV results (Visa) OR Policy reasons (Mastercard)’ — accounts for more than half of the remaining Worldpay authorisation rejected reasons. For Visa it’s something to do with the card security code or equivalent (which seems unlikely to occur for a recurring card payment). For Mastercard it could be lots of things and it’s recommended to use Mastercard’s merchant advice codes to decide what to do but we do not currently process these. For now, we introduce a new `MappedAuthorisationRejectedReason` of `MASTERCARD_POLICY_REASONS_OR_VISA_NEGATIVE_CAM_DCVV_ICVV_OR_CVV_RESULTS` and allow recurring payments with this mapped reason to be retried.

79 — ‘Already reversed (Visa) OR Lifecycle reasons (Mastercard)’ — seems to always be Mastercard lifecycle reasons for us, with examining the merchant advice code recommended. Unclear what Visa’s already reversed means. For now, we introduce a new `MappedAuthorisationRejectedReason` of `MASTERCARD_LIFECYCLE_REASONS_OR_VISA_ALREADY_REVERSED` and allow recurring payments with this mapped reason to be retried.

62 — ‘RESTRICTED CARD OR Restricted card OR Restricted card (for example in Country Exclusion table)’ — seems like something that should not be retried for recurring payments. We introduce a new `MappedAuthorisationRejectedReason` of `RESTRICTED_CARD`.

76 — ‘CARD BLOCKED OR Invalid/nonexistent To Account specified OR Invalid/nonexistent OR Invalid/nonexistent specified’ — seems to always be card blocked for us. It could be unblocked by the time we retry a recurring card payment, so we introduce a new `MappedAuthorisationRejectedReason` of `CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT` and allow recurring payments with this mapped reason to be retried.

After this, we start getting rarer reasons, some of which are not even in Worldpay’s docs, or are confusing in the context of recurring online payments (such as reasons indicating a problem with a PIN) so we leave these as uncategorised for now.