### PR TITLE
PP-10833 Consider idempotency key records when expunging charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/idempotency/dao/IdempotencyDao.java
+++ b/src/main/java/uk/gov/pay/connector/idempotency/dao/IdempotencyDao.java
@@ -34,4 +34,16 @@ public class IdempotencyDao extends JpaDao<IdempotencyEntity> {
                 .setParameter("expiryDate", expiryDate)
                 .executeUpdate();
     }
+
+    public boolean idempotencyExistsByResourceExternalId(String resourceExternalId) {
+        String query = "SELECT COUNT(ie) FROM IdempotencyEntity ie WHERE ie.resourceExternalId = :resourceExternalId";
+
+        long count = (long) entityManager
+                .get()
+                .createQuery(query)
+                .setParameter("resourceExternalId",resourceExternalId )
+                .getSingleResult();
+
+        return count > 0;
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/IdempotencyDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/IdempotencyDaoIT.java
@@ -60,6 +60,23 @@ public class IdempotencyDaoIT extends DaoITestBase {
     }
 
     @Test
+    public void shouldReturnTrueIfIdempotencyExistsForResourceExternalId() {
+        Map<String, Object> requestBody = Map.of("foo", "bar");
+        databaseTestHelper.insertIdempotency(key, gatewayAccount.getId(), resourceExternalId, requestBody);
+
+        boolean idempotencyExists = dao.idempotencyExistsByResourceExternalId(resourceExternalId);
+        assertThat(idempotencyExists, is(true));
+    }
+
+    @Test
+    public void shouldReturnFalseIfIdempotencyDoesNotExistForResourceExternalId() {
+        String resourceExternalIdNotExisting = "resource-external-id-not-existing";
+
+        boolean idempotencyExists = dao.idempotencyExistsByResourceExternalId(resourceExternalIdNotExisting);
+        assertThat(idempotencyExists, is(false));
+    }
+
+    @Test
     public void shouldDeleteOnlyIdempotencyEntitiesMoreThan24HoursOld() {
         Map<String, Object> requestBody = Map.of("foo", "bar");
         String expiringKey = "expiring-idempotency-key";


### PR DESCRIPTION
## Context:
-  Currently we are expunging charges and idempotency keys after 24 hours
   - It is possible that the charge is expunged from the connector but the Idempotency key stays. For a new request with the same idempotency key but expunged charge, Connector will throw ChargeNotFoundException.
   -  So we need to check if the idempotency key record exists for charge before expunging from the connector database
### WHAT
- Added ```idempotencyExistsByResourceExternalId```  method to find any idempotency records for ```resourceExternalId```
