### PR TITLE
BAU: Add a check to make sure pacts were generated

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,3 +51,9 @@ jobs:
           fi
       - name: Run unit and integration tests
         run: mvn verify
+      - name: Check for generated pacts
+        run: |
+          if [ ! -d target/pacts ]; then
+            echo "The pact files were not generated, this means that no pact results will be published and this build will fail to deploy"
+            exit 1
+          fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,7 +51,7 @@ jobs:
           fi
       - name: Run unit and integration tests
         run: mvn verify
-      - name: Check for generated pacts
+      - name: Check for generated pact files
         run: |
           if [ ! -d target/pacts ]; then
             echo "The pact files were not generated, this means that no pact results will be published and this build will fail to deploy"

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-dependencies</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.4</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <liquibase.version>4.21.1</liquibase.version>
-        <dropwizard.version>2.1.6</dropwizard.version>
+        <dropwizard.version>2.1.4</dropwizard.version>
         <wiremock.version>2.35.0</wiremock.version>
         <eclipselink.version>2.7.11</eclipselink.version>
         <guice.version>5.1.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-dependencies</artifactId>
-        <version>2.1.4</version>
+        <version>2.1.6</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <liquibase.version>4.21.1</liquibase.version>
-        <dropwizard.version>2.1.4</dropwizard.version>
+        <dropwizard.version>2.1.6</dropwizard.version>
         <wiremock.version>2.35.0</wiremock.version>
         <eclipselink.version>2.7.11</eclipselink.version>
         <guice.version>5.1.0</guice.version>


### PR DESCRIPTION
## WHAT YOU DID
Add a check after the unit tests which checks to see if the pact files were generated.

If the pact files aren't generated then pacts will not be published and the build will fail after merge and passed e2e tests which it's trying to deploy into test.

## How to test

I pushed the check which passed
In a second commit i updated dropwizard to 2.1.6 which we know breaks the pact file generation, you can see the unit test failed
I reverted the dropwizard change