### PR TITLE
BAU bump `dropwizard` -> 2.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-dependencies</artifactId>
-        <version>2.1.4</version>
+        <version>2.1.6</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <liquibase.version>4.21.1</liquibase.version>
-        <dropwizard.version>2.1.4</dropwizard.version>
+        <dropwizard.version>2.1.6</dropwizard.version>
         <wiremock.version>2.35.0</wiremock.version>
         <eclipselink.version>2.7.11</eclipselink.version>
         <guice.version>5.1.0</guice.version>
@@ -518,6 +518,11 @@
             <groupId>org.glassfish.jersey.connectors</groupId>
             <artifactId>jersey-apache-connector</artifactId>
             <version>2.36</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
## WHAT YOU DID

- added `junit-vintage-engine` test scoped dependency to resolve breaking changes in `dropwizard` 2.1.5