### PR TITLE
PP-11157 WorldpayCredentials → WorldpayValidatableCredentials

### DIFF
--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1030,7 +1030,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WorldpayCredentials'
+              $ref: '#/components/schemas/WorldpayValidatableCredentials'
       responses:
         "200":
           content:
@@ -5311,7 +5311,7 @@ components:
         organisational_unit_id:
           type: string
           example: org_unit_id
-    WorldpayCredentials:
+    WorldpayValidatableCredentials:
       type: object
       properties:
         merchant_id:

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
@@ -3,12 +3,11 @@ package uk.gov.pay.connector.gateway.util;
 import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
-import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayValidatableCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.exception.MissingCredentialsForRecurringPaymentException;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -86,8 +85,8 @@ public class AuthUtil {
         return ImmutableMap.of(AUTHORIZATION, value);
     }
     
-    public static Map<String, String> getWorldpayCredentialsCheckAuthHeader(WorldpayCredentials worldpayCredentials) {
-        String value = encode(worldpayCredentials.getUsername(), worldpayCredentials.getPassword());
+    public static Map<String, String> getWorldpayCredentialsCheckAuthHeader(WorldpayValidatableCredentials worldpayValidatableCredentials) {
+        String value = encode(worldpayValidatableCredentials.getUsername(), worldpayValidatableCredentials.getPassword());
         return ImmutableMap.of(AUTHORIZATION, value);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationService.java
@@ -9,7 +9,7 @@ import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.worldpay.exception.UnexpectedValidateCredentialsResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayValidatableCredentials;
 
 import javax.inject.Named;
 import java.net.URI;
@@ -41,10 +41,10 @@ public class WorldpayCredentialsValidationService implements WorldpayGatewayResp
         this.gatewayClient = gatewayClient;
     }
 
-    public boolean validateCredentials(GatewayAccountEntity gatewayAccountEntity, WorldpayCredentials worldpayCredentials) {
+    public boolean validateCredentials(GatewayAccountEntity gatewayAccountEntity, WorldpayValidatableCredentials worldpayValidatableCredentials) {
         GatewayOrder order = aWorldpayInquiryRequestBuilder()
                 .withTransactionId("an-order-id-that-will-not-exist")
-                .withMerchantCode(worldpayCredentials.getMerchantId())
+                .withMerchantCode(worldpayValidatableCredentials.getMerchantId())
                 .build();
 
         try {
@@ -54,7 +54,7 @@ public class WorldpayCredentialsValidationService implements WorldpayGatewayResp
                     gatewayAccountEntity.getType(),
                     order,
                     Collections.emptyList(),
-                    getWorldpayCredentialsCheckAuthHeader(worldpayCredentials)
+                    getWorldpayCredentialsCheckAuthHeader(worldpayValidatableCredentials)
             );
 
             // There is no Worldpay endpoint to explicitly check credentials, so we make a query for a non-existent 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayValidatableCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayValidatableCredentials.java
@@ -4,11 +4,10 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 import java.util.Objects;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class WorldpayCredentials {
+public class WorldpayValidatableCredentials {
     
     @NotEmpty(message = "Field [merchant_id] is required")
     private String merchantId;
@@ -19,11 +18,11 @@ public class WorldpayCredentials {
     @NotEmpty(message = "Field [password] is required")
     private String password;
     
-    public WorldpayCredentials() {
+    public WorldpayValidatableCredentials() {
         // Blank constructor needed for deserialization
     }
 
-    public WorldpayCredentials(String merchantId, String username, String password) {
+    public WorldpayValidatableCredentials(String merchantId, String username, String password) {
         this.merchantId = merchantId;
         this.username = username;
         this.password = password;
@@ -45,7 +44,7 @@ public class WorldpayCredentials {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        WorldpayCredentials that = (WorldpayCredentials) o;
+        WorldpayValidatableCredentials that = (WorldpayValidatableCredentials) o;
         return Objects.equals(merchantId, that.merchantId) &&
                 Objects.equals(username, that.username) &&
                 Objects.equals(password, that.password);

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
@@ -18,7 +18,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsRequest;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsRequest;
-import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayValidatableCredentials;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccount.service.Worldpay3dsFlexCredentialsService;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
@@ -137,9 +137,9 @@ public class GatewayAccountCredentialsResource {
             }
     )
     public ValidationResult validateWorldpayCredentials(@PathParam("accountId") Long gatewayAccountId,
-                                                        @Valid WorldpayCredentials worldpayCredentials) {
+                                                        @Valid WorldpayValidatableCredentials worldpayValidatableCredentials) {
         return gatewayAccountService.getGatewayAccount(gatewayAccountId)
-                .map(gatewayAccountEntity -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials))
+                .map(gatewayAccountEntity -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayValidatableCredentials))
                 .map(ValidationResult::new)
                 .orElseThrow(() -> new GatewayAccountNotFoundException(gatewayAccountId));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayValidatableCredentialsValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayValidatableCredentialsValidationServiceTest.java
@@ -10,7 +10,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.worldpay.exception.UnexpectedValidateCredentialsResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayValidatableCredentials;
 
 import java.net.URI;
 import java.util.Map;
@@ -33,7 +33,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_INQU
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 @ExtendWith(MockitoExtension.class)
-class WorldpayCredentialsValidationServiceTest {
+class WorldpayValidatableCredentialsValidationServiceTest {
 
     private static final URI WORLDPAY_URL = URI.create("http://worldpay.url");
     private static final Map<String, URI> GATEWAY_URL_MAP = Map.of(TEST.toString(), WORLDPAY_URL);
@@ -51,7 +51,7 @@ class WorldpayCredentialsValidationServiceTest {
             .withType(TEST)
             .build();
 
-    private final WorldpayCredentials worldpayCredentials = new WorldpayCredentials("A_MERCHANT_ID", "user123", "test");
+    private final WorldpayValidatableCredentials worldpayValidatableCredentials = new WorldpayValidatableCredentials("A_MERCHANT_ID", "user123", "test");
 
     @BeforeEach
     void setUp() {
@@ -67,7 +67,7 @@ class WorldpayCredentialsValidationServiceTest {
         when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenReturn(response);
 
-        boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
+        boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayValidatableCredentials);
         assertThat(valid, is(true));
     }
 
@@ -78,7 +78,7 @@ class WorldpayCredentialsValidationServiceTest {
         when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenReturn(response);
 
-        boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
+        boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayValidatableCredentials);
         assertThat(valid, is(false));
     }
 
@@ -87,7 +87,7 @@ class WorldpayCredentialsValidationServiceTest {
         when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenThrow(new GatewayException.GatewayErrorException("Error", "Error", 401));
 
-        boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
+        boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayValidatableCredentials);
         assertThat(valid, is(false));
     }
 
@@ -98,7 +98,7 @@ class WorldpayCredentialsValidationServiceTest {
         when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenReturn(response);
 
-        assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));
+        assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayValidatableCredentials));
     }
 
     @Test
@@ -106,7 +106,7 @@ class WorldpayCredentialsValidationServiceTest {
         when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenThrow(new GatewayException.GatewayErrorException("Error", "Error", 403));
 
-        assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));
+        assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayValidatableCredentials));
     }
 
     @Test
@@ -114,6 +114,6 @@ class WorldpayCredentialsValidationServiceTest {
         when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenThrow(GatewayException.GenericGatewayException.class);
 
-        assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));
+        assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayValidatableCredentials));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceTest.java
@@ -11,7 +11,7 @@ import uk.gov.pay.connector.common.exception.ValidationExceptionMapper;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsFlexCredentialsValidationService;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayCredentialsValidationService;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayValidatableCredentials;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccount.service.Worldpay3dsFlexCredentialsService;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
@@ -290,20 +290,20 @@ public class GatewayAccountCredentialsResourceTest {
 
     @Test
     void checkWorldpayCredentials_returnsValid() {
-        WorldpayCredentials worldpayCredentials = new WorldpayCredentials(
+        WorldpayValidatableCredentials worldpayValidatableCredentials = new WorldpayValidatableCredentials(
                 validCheckWorldpayCredentialsPayload.get("merchant_id"),
                 validCheckWorldpayCredentialsPayload.get("username"),
                 validCheckWorldpayCredentialsPayload.get("password"));
 
         when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(gatewayAccountEntity));
-        when(worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials)).thenReturn(true);
+        when(worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayValidatableCredentials)).thenReturn(true);
 
         Response response = resources
                 .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
                 .request()
                 .post(Entity.json(validCheckWorldpayCredentialsPayload));
 
-        verify(worldpayCredentialsValidationService).validateCredentials(gatewayAccountEntity, worldpayCredentials);
+        verify(worldpayCredentialsValidationService).validateCredentials(gatewayAccountEntity, worldpayValidatableCredentials);
 
         assertThat(response.getStatus(), is(200));
         Map<String, Object> responseBody = response.readEntity(new GenericType<HashMap>() {
@@ -313,20 +313,20 @@ public class GatewayAccountCredentialsResourceTest {
 
     @Test
     void checkWorldpayCredentials_returnsInvalid() {
-        WorldpayCredentials worldpayCredentials = new WorldpayCredentials(
+        WorldpayValidatableCredentials worldpayValidatableCredentials = new WorldpayValidatableCredentials(
                 validCheckWorldpayCredentialsPayload.get("merchant_id"),
                 validCheckWorldpayCredentialsPayload.get("username"),
                 validCheckWorldpayCredentialsPayload.get("password"));
 
         when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(gatewayAccountEntity));
-        when(worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials)).thenReturn(false);
+        when(worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayValidatableCredentials)).thenReturn(false);
 
         Response response = resources
                 .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
                 .request()
                 .post(Entity.json(validCheckWorldpayCredentialsPayload));
 
-        verify(worldpayCredentialsValidationService).validateCredentials(gatewayAccountEntity, worldpayCredentials);
+        verify(worldpayCredentialsValidationService).validateCredentials(gatewayAccountEntity, worldpayValidatableCredentials);
 
         assertThat(response.getStatus(), is(200));
         Map<String, Object> responseBody = response.readEntity(new GenericType<HashMap>() {


### PR DESCRIPTION
The `WorldpayCredentials` class is actually only used to represent requests to update Worldpay credentials, which is why it has validation annotations on it. Rename it to `WorldpayValidatableCredentials` so that we can use the name `WorldpayCredentials` for something else.
