### PR TITLE
PP-11157 Update nested Worldpay credentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -279,7 +279,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 10
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java": [
@@ -1048,5 +1048,5 @@
       }
     ]
   },
-  "generated_at": "2023-06-26T15:47:37Z"
+  "generated_at": "2023-06-28T16:17:22Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java
@@ -1,9 +1,7 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 
-import java.util.Map;
 import java.util.Objects;
 
 public class GatewayAccount {
@@ -11,6 +9,9 @@ public class GatewayAccount {
     public static final String CREDENTIALS_USERNAME = "username";
     public static final String CREDENTIALS_PASSWORD = "password";
     public static final String CREDENTIALS_SHA_IN_PASSPHRASE = "sha_in_passphrase";
+    public static final String ONE_OFF_CUSTOMER_INITIATED = "one_off_customer_initiated";
+
+    public static final String RECURRING_CUSTOMER_INITIATED = "recurring_customer_initiated";
     public static final String RECURRING_MERCHANT_INITIATED = "recurring_merchant_initiated";
     public static final String CREDENTIALS_SHA_OUT_PASSPHRASE = "sha_out_passphrase";
     public static final String CREDENTIALS_STRIPE_ACCOUNT_ID = "stripe_account_id";

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -1,0 +1,119 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator;
+
+import java.util.Objects;
+
+public class WorldpayCredentials {
+
+    @JsonProperty(GatewayAccount.CREDENTIALS_MERCHANT_ID)
+    private String legacyOneOffCustomerInitiatedMerchantCode;
+
+    @JsonProperty(GatewayAccount.CREDENTIALS_USERNAME)
+    private String legacyOneOffCustomerInitiatedUsername;
+
+    @JsonProperty(GatewayAccount.CREDENTIALS_PASSWORD)
+    private String legacyOneOffCustomerInitiatedPassword;
+
+    @JsonProperty(GatewayAccount.ONE_OFF_CUSTOMER_INITIATED)
+    private WorldpayMerchantCodeCredentials oneOffCustomerInitiatedCredentials;
+
+    @JsonProperty(GatewayAccount.RECURRING_CUSTOMER_INITIATED)
+    private WorldpayMerchantCodeCredentials recurringCustomerInitiatedCredentials;
+
+    @JsonProperty(GatewayAccount.RECURRING_MERCHANT_INITIATED)
+    private WorldpayMerchantCodeCredentials recurringMerchantInitiatedCredentials;
+
+    @JsonProperty(GatewayAccountCredentialsRequestValidator.FIELD_GATEWAY_MERCHANT_ID)
+    private String googlePayMerchantId;
+
+    public WorldpayCredentials() {
+            // Janet Jackson
+    }
+
+    public String getLegacyOneOffCustomerInitiatedMerchantCode() {
+        return legacyOneOffCustomerInitiatedMerchantCode;
+    }
+
+    public void setLegacyOneOffCustomerInitiatedMerchantCode(String legacyOneOffCustomerInitiatedMerchantCode) {
+        this.legacyOneOffCustomerInitiatedMerchantCode = legacyOneOffCustomerInitiatedMerchantCode;
+    }
+
+    public String getLegacyOneOffCustomerInitiatedUsername() {
+        return legacyOneOffCustomerInitiatedUsername;
+    }
+
+    public void setLegacyOneOffCustomerInitiatedUsername(String legacyOneOffCustomerInitiatedUsername) {
+        this.legacyOneOffCustomerInitiatedUsername = legacyOneOffCustomerInitiatedUsername;
+    }
+
+    public String getLegacyOneOffCustomerInitiatedPassword() {
+        return legacyOneOffCustomerInitiatedPassword;
+    }
+
+    public void setLegacyOneOffCustomerInitiatedPassword(String legacyOneOffCustomerInitiatedPassword) {
+        this.legacyOneOffCustomerInitiatedPassword = legacyOneOffCustomerInitiatedPassword;
+    }
+
+    public WorldpayMerchantCodeCredentials getOneOffCustomerInitiatedCredentials() {
+        return oneOffCustomerInitiatedCredentials;
+    }
+
+    public void setOneOffCustomerInitiatedCredentials(WorldpayMerchantCodeCredentials oneOffCustomerInitiatedCredentials) {
+        this.oneOffCustomerInitiatedCredentials = oneOffCustomerInitiatedCredentials;
+    }
+
+    public WorldpayMerchantCodeCredentials getRecurringCustomerInitiatedCredentials() {
+        return recurringCustomerInitiatedCredentials;
+    }
+
+    public void setRecurringCustomerInitiatedCredentials(WorldpayMerchantCodeCredentials recurringCustomerInitiatedCredentials) {
+        this.recurringCustomerInitiatedCredentials = recurringCustomerInitiatedCredentials;
+    }
+
+    public WorldpayMerchantCodeCredentials getRecurringMerchantInitiatedCredentials() {
+        return recurringMerchantInitiatedCredentials;
+    }
+
+    public void setRecurringMerchantInitiatedCredentials(WorldpayMerchantCodeCredentials recurringMerchantInitiatedCredentials) {
+        this.recurringMerchantInitiatedCredentials = recurringMerchantInitiatedCredentials;
+    }
+
+    public String getGooglePayMerchantId() {
+        return googlePayMerchantId;
+    }
+
+    public void setGooglePayMerchantId(String googlePayMerchantId) {
+        this.googlePayMerchantId = googlePayMerchantId;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        var that = (WorldpayCredentials) other;
+
+        return Objects.equals(legacyOneOffCustomerInitiatedMerchantCode, that.legacyOneOffCustomerInitiatedMerchantCode)
+                && Objects.equals(legacyOneOffCustomerInitiatedUsername, that.legacyOneOffCustomerInitiatedUsername)
+                && Objects.equals(legacyOneOffCustomerInitiatedPassword, that.legacyOneOffCustomerInitiatedPassword)
+                && Objects.equals(oneOffCustomerInitiatedCredentials, that.oneOffCustomerInitiatedCredentials)
+                && Objects.equals(recurringCustomerInitiatedCredentials, that.recurringCustomerInitiatedCredentials)
+                && Objects.equals(recurringMerchantInitiatedCredentials, that.recurringMerchantInitiatedCredentials)
+                && Objects.equals(googlePayMerchantId, that.googlePayMerchantId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(legacyOneOffCustomerInitiatedMerchantCode, legacyOneOffCustomerInitiatedUsername,
+                legacyOneOffCustomerInitiatedPassword, oneOffCustomerInitiatedCredentials,
+                recurringCustomerInitiatedCredentials, recurringMerchantInitiatedCredentials, googlePayMerchantId);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayMerchantCodeCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayMerchantCodeCredentials.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.Objects;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class WorldpayMerchantCodeCredentials {
+
+    private String merchantCode;
+    private String username;
+    private String password;
+
+    public WorldpayMerchantCodeCredentials() {
+        // Janet Jackson
+    }
+
+    public WorldpayMerchantCodeCredentials(String merchantCode, String username, String password) {
+        this.merchantCode = merchantCode;
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getMerchantCode() {
+        return merchantCode;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        var that = (WorldpayMerchantCodeCredentials) other;
+
+        return Objects.equals(merchantCode, that.merchantCode)
+                && Objects.equals(username, that.username)
+                && Objects.equals(password, that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(merchantCode, username, password);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayValidatableCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayValidatableCredentials.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class WorldpayValidatableCredentials {
-    
+
     @NotEmpty(message = "Field [merchant_id] is required")
     private String merchantId;
 
@@ -17,7 +17,7 @@ public class WorldpayValidatableCredentials {
 
     @NotEmpty(message = "Field [password] is required")
     private String password;
-    
+
     public WorldpayValidatableCredentials() {
         // Blank constructor needed for deserialization
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
@@ -34,6 +34,9 @@ public class GatewayAccountCredentialsRequestValidator {
     private static final Pattern WORLDPAY_MERCHANT_ID_PATTERN = Pattern.compile("[0-9a-f]{15}");
 
     public static final String FIELD_CREDENTIALS = "credentials";
+    public static final String FIELD_CREDENTIALS_WORLDPAY_ONE_OFF_CUSTOMER_INITIATED = "credentials/worldpay/one_off_customer_initiated";
+    public static final String FIELD_CREDENTIALS_WORLDPAY_RECURRING_CUSTOMER_INITIATED = "credentials/worldpay/recurring_customer_initiated";
+    public static final String FIELD_CREDENTIALS_WORLDPAY_RECURRING_MERCHANT_INITIATED = "credentials/worldpay/recurring_merchant_initiated";
     public static final String FIELD_LAST_UPDATED_BY_USER = "last_updated_by_user_external_id";
     public static final String FIELD_STATE = "state";
     public static final String FIELD_GATEWAY_MERCHANT_ID = "gateway_merchant_id";
@@ -83,6 +86,9 @@ public class GatewayAccountCredentialsRequestValidator {
     public void validatePatch(JsonNode patchRequest, String paymentProvider, Map<String, Object> credentials) {
         Map<PatchPathOperation, Consumer<JsonPatchRequest>> operationValidators = Map.of(
                 new PatchPathOperation(FIELD_CREDENTIALS, JsonPatchOp.REPLACE), operation -> validateReplaceCredentialsOperation(operation, paymentProvider),
+                new PatchPathOperation(FIELD_CREDENTIALS_WORLDPAY_ONE_OFF_CUSTOMER_INITIATED, JsonPatchOp.REPLACE), operation -> validateReplaceCredentialsOperation(operation, paymentProvider),
+                new PatchPathOperation(FIELD_CREDENTIALS_WORLDPAY_RECURRING_CUSTOMER_INITIATED, JsonPatchOp.REPLACE), operation -> validateReplaceCredentialsOperation(operation, paymentProvider),
+                new PatchPathOperation(FIELD_CREDENTIALS_WORLDPAY_RECURRING_MERCHANT_INITIATED, JsonPatchOp.REPLACE), operation -> validateReplaceCredentialsOperation(operation, paymentProvider),
                 new PatchPathOperation(FIELD_LAST_UPDATED_BY_USER, JsonPatchOp.REPLACE), JsonPatchRequestValidator::throwIfValueNotString,
                 new PatchPathOperation(FIELD_STATE, JsonPatchOp.REPLACE), this::validateReplaceStateOperation,
                 new PatchPathOperation(GATEWAY_MERCHANT_ID_PATH, JsonPatchOp.REPLACE), request -> validateGatewayMerchantId(request, paymentProvider, credentials)

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gatewayaccountcredentials.resource;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
 import org.junit.jupiter.api.Test;
@@ -51,7 +52,7 @@ public class GatewayAccountCredentialsResourceTest {
     public static ResourceExtension resources = ResourceExtension.builder()
             .addResource(new GatewayAccountCredentialsResource(
                     gatewayAccountService,
-                    new GatewayAccountCredentialsService(credentialDao),
+                    new GatewayAccountCredentialsService(credentialDao, new ObjectMapper()),
                     worldpay3dsFlexCredentialsService,
                     worldpay3dsFlexCredentialsValidationService,
                     worldpayCredentialsValidationService,


### PR DESCRIPTION
Update the gateway account credentials service to allow updating nested Worldpay credentials using specific JSON Patch paths.

For example:

```json
{
  "path": "credentials/worldpay/recurring_customer_initiated",
  "op": "replace",
  "value": {
    "merchant_code": "MERCHANTCODE",
    "username": "username",
    "password": "password"
  }
}
```

… will update (or add) the nested `recurring_customer_initiated` object:

```json
{
  "recurring_customer_initiated": {
    "merchant_code": "MERCHANTCODE",
    "username": "username",
    "password": "password"
  }
}
```

Meanwhile:

```json
{
  "path": "credentials/worldpay/recurring_merchant_initiated",
  "op": "replace",
  "value": {
    "merchant_code": "MERCHANTCODE",
    "username": "username",
    "password": "password"
  }
}
```

… will update (or add) the nested `recurring_merchant_initiated` object:

```json
{
  "recurring_merchant_initiated": {
    "merchant_code": "MERCHANTCODE",
    "username": "username",
    "password": "password"
  }
}
```

Finally:

```json
{
  "path": "credentials/worldpay/one_off_customer_initiated",
  "op": "replace",
  "value": {
    "merchant_code": "MERCHANTCODE",
    "username": "username",
    "password": "password"
  }
}
```

… will update (or add) the nested `one_off_customer_initiated` object:

```json
{
  "one_off_customer_initiated": {
    "merchant_code": "MERCHANTCODE",
    "username": "username",
    "password": "password"
  }
}
```

Existing nested credentials under other keys will be left alone (so updating, say, `recurring_merchant_initiated` will not blow away any existing `recurring_customer_initiated` credentials).

However, updating `one_off_customer_initiated` will remove any top-level legacy `merchant_id`, `username` and `password` keys in order to provide for gradual migration to the new structure.

Further changes are required to make the code read the new nested credentials but since nothing is yet setting them, this change can be made first.

As part of this change we introduce a new `WorldpayCredentials` object, which is a POJO representation of the stored credentials JSON for Worldpay (including both the nested objects — now represented by a new `WorldpayMerchantCodeCredentials` POJO — and the legacy `merchant_id`, `username` and `password` and also the Google Pay merchant ID. This should make the new structure of the credentials clearer.