### PR TITLE
PP-10440 add failed post event to ledger pact test

### DIFF
--- a/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
@@ -8,16 +8,17 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.RestClientFactory;
+import uk.gov.pay.connector.app.config.RestClientConfig;
+import uk.gov.pay.connector.client.ledger.exception.LedgerException;
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.connector.client.ledger.model.RefundTransactionsForPayment;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.agreement.AgreementCreated;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
-import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.app.RestClientFactory;
-import uk.gov.pay.connector.app.config.RestClientConfig;
-import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
-import uk.gov.pay.connector.client.ledger.model.RefundTransactionsForPayment;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
@@ -25,13 +26,13 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.agreement.model.AgreementEntity.AgreementEntityBuilder.anAgreementEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -127,5 +128,28 @@ public class LedgerServiceConsumerTest {
         Response response = ledgerService.postEvent(event);
 
         assertThat(response.getStatus(), is(202));
+    }
+
+    @Test
+    @PactVerification("ledger")
+    @Pacts(pacts = {"connector-ledger-post-event-failed"})
+    public void postAgreementCreatedFailedEvent() {
+        AgreementEntity agreementEntity = anAgreementEntity(Instant.parse("2023-06-27T11:23:30.000000Z"))
+                .withReference("agreement created post event")
+//                .withDescription("")
+                .withUserIdentifier("a-valid-user-identifier")
+                .withServiceId("a-valid-service-id")
+                .withLive(false)
+                .build();
+        agreementEntity.setExternalId("ureehr17f66a9ds1bg3heqkkhk");
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                .withGatewayName(STRIPE.getName())
+                .withId(3456L)
+                .build();
+        agreementEntity.setGatewayAccount(gatewayAccountEntity);
+        Event event = AgreementCreated.from(agreementEntity);
+        LedgerException exception = assertThrows(LedgerException.class, () -> ledgerService.postEvent(event));
+        assertThat(exception.getMessage(), containsString("status=400"));
+        assertThat(exception.getMessage(), containsString("reason=Bad Request"));
     }
 }

--- a/src/test/resources/pacts/connector-ledger-post-event-failed.json
+++ b/src/test/resources/pacts/connector-ledger-post-event-failed.json
@@ -1,0 +1,43 @@
+{
+  "consumer": {
+    "name": "connector"
+  },
+  "provider": {
+    "name": "ledger"
+  },
+  "interactions": [
+    {
+      "description": "a post an agreement created event",
+      "request": {
+        "method": "POST",
+        "path": "/v1/event",
+        "body": [
+          {
+            "resource_external_id": "ureehr17f66a9ds1bg3heqkkhk",
+            "event_details": {
+              "gateway_account_id": "3456",
+              "reference": "agreement created post event",
+              "user_identifier": "a-valid-user-identifier"
+            },
+            "timestamp": "2023-06-27T11:23:30.000000Z",
+            "service_id": "a-valid-service-id",
+            "live": false,
+            "resource_type": "agreement",
+            "event_type": "AGREEMENT_CREATED"
+          }
+        ]
+      },
+      "response": {
+        "status": 400
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
## WHAT YOU DID

 Interaction between ledger (provider) and connector (consumer)
 - post an event missing timestamp to /v1/event endpoint for 400 response

with @james-peacock-gds
