### PR TITLE
PP-11244 Stop using ChargeEntity for building JSON responses

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -153,88 +153,81 @@
         "line_number": 787
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "openapi/connector_spec.yaml",
-        "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
-        "is_verified": false,
-        "line_number": 3028
-      },
-      {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 3396
+        "line_number": 3027
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3742
+        "line_number": 3548
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3791
+        "line_number": 3597
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4396
+        "line_number": 4152
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4457
+        "line_number": 4213
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4479
+        "line_number": 4235
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4658
+        "line_number": 4414
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4661
+        "line_number": 4417
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4664
+        "line_number": 4420
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5254
+        "line_number": 4986
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5265
+        "line_number": 4997
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -244,15 +237,6 @@
         "hashed_secret": "423e3dd3782e3527b4f9af75dd9faf9ebbb7889c",
         "is_verified": false,
         "line_number": 60
-      }
-    ],
-    "src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java",
-        "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
-        "is_verified": false,
-        "line_number": 201
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java": [
@@ -1048,5 +1032,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-03T14:21:19Z"
+  "generated_at": "2023-07-03T16:13:16Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -2030,7 +2030,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenResponse_FrontendView'
+                $ref: '#/components/schemas/TokenResponse'
           description: OK
         "404":
           description: Not found
@@ -2345,29 +2345,6 @@ components:
         postcode:
           type: string
           example: AB1 2CD
-    AddressEntity_FrontendView:
-      type: object
-      properties:
-        city:
-          type: string
-          example: London
-        country:
-          type: string
-          example: GB
-        county:
-          type: string
-          example: London
-        line1:
-          type: string
-          example: address line 1
-        line2:
-          type: string
-          example: address line 2
-        postcode:
-          type: string
-          example: AB1 2CD
-        stateOrProvince:
-          type: string
     Address_FrontendView:
       type: object
       properties:
@@ -2532,25 +2509,6 @@ components:
           description: "When the charge is in status 'AUTHORISATION 3DS REQUIRED'\
             \ state and the 3DS data on the charge contains challenge data, Json Web\
             \ Token is calculated and returned to the frontend."
-    Auth3dsRequiredEntity_FrontendView:
-      type: object
-      properties:
-        htmlOut:
-          type: string
-        issuerUrl:
-          type: string
-        md:
-          type: string
-        paRequest:
-          type: string
-        threeDsVersion:
-          type: string
-        worldpayChallengeAcsUrl:
-          type: string
-        worldpayChallengePayload:
-          type: string
-        worldpayChallengeTransactionId:
-          type: string
     Auth3dsResult:
       type: object
       properties:
@@ -2677,49 +2635,9 @@ components:
       - cvc
       - expiry_date
       - one_time_token
-    CardBrandLabelEntity_FrontendView:
-      type: object
-      properties:
-        brand:
-          type: string
-          example: visa
-        id:
-          type: string
-          format: uuid
-          example: ac8a3abd-bcfd-4fa6-8905-321ce913e7f5
-        label:
-          type: string
-          example: Visa
-        version:
-          type: integer
-          format: int64
-    CardDetailsEntity_FrontendView:
-      type: object
-      properties:
-        billing_address:
-          $ref: '#/components/schemas/AddressEntity_FrontendView'
-        cardBrand:
-          type: string
-          example: visa
-        cardTypeDetails:
-          $ref: '#/components/schemas/CardBrandLabelEntity_FrontendView'
-        card_type:
-          type: string
-          enum:
-          - CREDIT
-          - DEBIT
-          example: credit
-        cardholder_name:
-          type: string
-          example: Joe B
-        expiry_date:
-          $ref: '#/components/schemas/CardExpiryDate_FrontendView'
-        first_digits_card_number:
-          $ref: '#/components/schemas/FirstDigitsCardNumber_FrontendView'
-        last_digits_card_number:
-          $ref: '#/components/schemas/LastDigitsCardNumber_FrontendView'
     CardExpiryDate:
       type: object
+      description: The expiry date of the card the user paid with.
       example: 01/99
       properties:
         fourDigitYear:
@@ -2730,6 +2648,7 @@ components:
           type: string
     CardExpiryDate_FrontendView:
       type: object
+      description: The expiry date of the card the user paid with.
       example: 01/99
       properties:
         fourDigitYear:
@@ -2867,283 +2786,6 @@ components:
       - amount
       - description
       - reference
-    ChargeEntity_FrontendView:
-      type: object
-      description: The charge associated with the token
-      properties:
-        amount:
-          type: integer
-          format: int64
-          example: 100
-        authorisationMode:
-          type: string
-          enum:
-          - web
-          - moto_api
-          - agreement
-          - external
-        canRetry:
-          type: boolean
-        captureSubmitTime:
-          type: string
-          format: date-time
-        capturedTime:
-          type: string
-          format: date-time
-        cardDetails:
-          $ref: '#/components/schemas/CardDetailsEntity_FrontendView'
-        chargeStatus:
-          type: string
-          enum:
-          - UNDEFINED
-          - CREATED
-          - PAYMENT NOTIFICATION CREATED
-          - ENTERING CARD DETAILS
-          - AUTHORISATION ABORTED
-          - AUTHORISATION READY
-          - AUTHORISATION 3DS REQUIRED
-          - AUTHORISATION 3DS READY
-          - AUTHORISATION SUBMITTED
-          - AUTHORISATION SUCCESS
-          - AUTHORISATION REJECTED
-          - AUTHORISATION CANCELLED
-          - AUTHORISATION ERROR
-          - AUTHORISATION TIMEOUT
-          - AUTHORISATION UNEXPECTED ERROR
-          - AWAITING CAPTURE REQUEST
-          - CAPTURE APPROVED
-          - CAPTURE APPROVED RETRY
-          - CAPTURE READY
-          - CAPTURED
-          - CAPTURE SUBMITTED
-          - CAPTURE ERROR
-          - CAPTURE QUEUED
-          - AUTHORISATION USER NOT PRESENT QUEUED
-          - EXPIRE CANCEL READY
-          - EXPIRE CANCEL FAILED
-          - EXPIRE CANCEL SUBMITTED
-          - EXPIRED
-          - SYSTEM CANCEL READY
-          - SYSTEM CANCEL ERROR
-          - SYSTEM CANCEL SUBMITTED
-          - SYSTEM CANCELLED
-          - USER CANCEL READY
-          - USER CANCEL SUBMITTED
-          - USER CANCELLED
-          - USER CANCEL ERROR
-          - AUTHORISATION ERROR CANCELLED
-          - AUTHORISATION ERROR REJECTED
-          - AUTHORISATION ERROR CHARGE MISSING
-        corporateSurcharge:
-          type: integer
-          format: int64
-        createdDate:
-          type: string
-          format: date-time
-        delayedCapture:
-          type: boolean
-        description:
-          type: string
-          example: payment description
-        email:
-          type: string
-          example: joe.blogs@example.org
-        events:
-          type: array
-          items:
-            $ref: '#/components/schemas/ChargeEventEntity_FrontendView'
-        exemption3ds:
-          type: string
-          enum:
-          - EXEMPTION_NOT_REQUESTED
-          - EXEMPTION_HONOURED
-          - EXEMPTION_REJECTED
-          - EXEMPTION_OUT_OF_SCOPE
-        externalId:
-          type: string
-          example: 5t2rupktnsk0a3mu800st7irts
-        externalMetadata:
-          $ref: '#/components/schemas/ExternalMetadata_FrontendView'
-        feeAmount:
-          type: integer
-          format: int64
-        fees:
-          type: array
-          items:
-            $ref: '#/components/schemas/FeeEntity_FrontendView'
-        gatewayAccount:
-          $ref: '#/components/schemas/GatewayAccountEntity_FrontendView'
-        gatewayAccountCredentialsEntity:
-          $ref: '#/components/schemas/GatewayAccountCredentialsEntity_FrontendView'
-        gatewayTransactionId:
-          type: string
-          example: bba59957-5155-4f59-8c69-a839f71772d3
-        get3dsRequiredDetails:
-          $ref: '#/components/schemas/Auth3dsRequiredEntity_FrontendView'
-        language:
-          type: string
-          enum:
-          - en
-          - cy
-          example: en
-        moto:
-          type: boolean
-        netAmount:
-          type: integer
-          format: int64
-        parityCheckDate:
-          type: string
-          format: date-time
-        parityCheckStatus:
-          type: string
-          enum:
-          - SKIPPED
-          - EXISTS_IN_LEDGER
-          - MISSING_IN_LEDGER
-          - DATA_MISMATCH
-        paymentGatewayName:
-          type: string
-          enum:
-          - SANDBOX
-          - SMARTPAY
-          - WORLDPAY
-          - EPDQ
-          - STRIPE
-        paymentInstrument:
-          $ref: '#/components/schemas/PaymentInstrumentEntity_FrontendView'
-        paymentProvider:
-          type: string
-          example: stripe
-        providerSessionId:
-          type: string
-        reference:
-          $ref: '#/components/schemas/ServicePaymentReference_FrontendView'
-        returnUrl:
-          type: string
-          example: https://service-name.gov.uk/transactions/12345
-        savePaymentInstrumentToAgreement:
-          type: boolean
-        serviceId:
-          type: string
-          example: 46eb1b601348499196c99de90482ee68
-        source:
-          type: string
-          enum:
-          - CARD_API
-          - CARD_PAYMENT_LINK
-          - CARD_AGENT_INITIATED_MOTO
-          - CARD_EXTERNAL_TELEPHONE
-          example: CARD_API
-        status:
-          type: string
-          example: AUTHORISATION SUCCESS
-        statusIgnoringValidTransitions:
-          type: string
-          enum:
-          - UNDEFINED
-          - CREATED
-          - PAYMENT NOTIFICATION CREATED
-          - ENTERING CARD DETAILS
-          - AUTHORISATION ABORTED
-          - AUTHORISATION READY
-          - AUTHORISATION 3DS REQUIRED
-          - AUTHORISATION 3DS READY
-          - AUTHORISATION SUBMITTED
-          - AUTHORISATION SUCCESS
-          - AUTHORISATION REJECTED
-          - AUTHORISATION CANCELLED
-          - AUTHORISATION ERROR
-          - AUTHORISATION TIMEOUT
-          - AUTHORISATION UNEXPECTED ERROR
-          - AWAITING CAPTURE REQUEST
-          - CAPTURE APPROVED
-          - CAPTURE APPROVED RETRY
-          - CAPTURE READY
-          - CAPTURED
-          - CAPTURE SUBMITTED
-          - CAPTURE ERROR
-          - CAPTURE QUEUED
-          - AUTHORISATION USER NOT PRESENT QUEUED
-          - EXPIRE CANCEL READY
-          - EXPIRE CANCEL FAILED
-          - EXPIRE CANCEL SUBMITTED
-          - EXPIRED
-          - SYSTEM CANCEL READY
-          - SYSTEM CANCEL ERROR
-          - SYSTEM CANCEL SUBMITTED
-          - SYSTEM CANCELLED
-          - USER CANCEL READY
-          - USER CANCEL SUBMITTED
-          - USER CANCELLED
-          - USER CANCEL ERROR
-          - AUTHORISATION ERROR CANCELLED
-          - AUTHORISATION ERROR REJECTED
-          - AUTHORISATION ERROR CHARGE MISSING
-          writeOnly: true
-        version:
-          type: integer
-          format: int64
-        walletType:
-          type: string
-          enum:
-          - APPLE_PAY
-          - GOOGLE_PAY
-    ChargeEventEntity_FrontendView:
-      type: object
-      properties:
-        gatewayEventDate:
-          type: string
-          format: date-time
-          example: 2022-05-27T09:17:19.162Z
-        status:
-          type: string
-          enum:
-          - UNDEFINED
-          - CREATED
-          - PAYMENT NOTIFICATION CREATED
-          - ENTERING CARD DETAILS
-          - AUTHORISATION ABORTED
-          - AUTHORISATION READY
-          - AUTHORISATION 3DS REQUIRED
-          - AUTHORISATION 3DS READY
-          - AUTHORISATION SUBMITTED
-          - AUTHORISATION SUCCESS
-          - AUTHORISATION REJECTED
-          - AUTHORISATION CANCELLED
-          - AUTHORISATION ERROR
-          - AUTHORISATION TIMEOUT
-          - AUTHORISATION UNEXPECTED ERROR
-          - AWAITING CAPTURE REQUEST
-          - CAPTURE APPROVED
-          - CAPTURE APPROVED RETRY
-          - CAPTURE READY
-          - CAPTURED
-          - CAPTURE SUBMITTED
-          - CAPTURE ERROR
-          - CAPTURE QUEUED
-          - AUTHORISATION USER NOT PRESENT QUEUED
-          - EXPIRE CANCEL READY
-          - EXPIRE CANCEL FAILED
-          - EXPIRE CANCEL SUBMITTED
-          - EXPIRED
-          - SYSTEM CANCEL READY
-          - SYSTEM CANCEL ERROR
-          - SYSTEM CANCEL SUBMITTED
-          - SYSTEM CANCELLED
-          - USER CANCEL READY
-          - USER CANCEL SUBMITTED
-          - USER CANCELLED
-          - USER CANCEL ERROR
-          - AUTHORISATION ERROR CANCELLED
-          - AUTHORISATION ERROR REJECTED
-          - AUTHORISATION ERROR CHARGE MISSING
-          example: CAPTURED
-        updated:
-          type: string
-          format: date-time
-        version:
-          type: integer
-          format: int64
     ChargeEventsResponse:
       type: object
       properties:
@@ -3336,17 +2978,6 @@ components:
           example: APPLE_PAY
     EmailNotificationEntity:
       type: object
-      description: The settings for the different emails (payments/refunds) that are
-        sent out
-      example:
-        REFUND_ISSUED:
-          version: 1
-          enabled: true
-          template_body: null
-        PAYMENT_CONFIRMED:
-          version: 1
-          enabled: true
-          template_body: null
       properties:
         enabled:
           type: boolean
@@ -3453,7 +3084,7 @@ components:
             type: object
     ExternalMetadata_FrontendView:
       type: object
-      example: {}
+      example: "{\"property1\": \"value1\", \"property2\": \"value2\"}\""
       properties:
         metadata:
           type: object
@@ -3505,28 +3136,203 @@ components:
         status:
           type: string
           example: success
-    FeeEntity_FrontendView:
-      type: object
-      properties:
-        amountCollected:
-          type: integer
-          format: int64
-        createdDate:
-          type: string
-          format: date-time
-        feeType:
-          type: string
-          enum:
-          - radar
-          - three_ds
-          - transaction
     FirstDigitsCardNumber:
       type: object
       description: The first 6 digits of the card the user paid with.
       example: 424242
     FirstDigitsCardNumber_FrontendView:
       type: object
+      description: The first 6 digits of the card the user paid with.
       example: 424242
+    FrontendChargeResponse:
+      type: object
+      description: The charge associated with the token
+      properties:
+        agreement:
+          $ref: '#/components/schemas/AgreementResponse'
+        agreement_id:
+          type: string
+          description: 'Application for Recurring card payments. Agreement ID that
+            the payment is associated with '
+          example: md1mjge8gb6p4qndfs8mf8gto5
+        amount:
+          type: integer
+          format: int64
+          description: Amount of this charge
+          example: 100
+        auth_3ds_data:
+          $ref: '#/components/schemas/Auth3dsData'
+        auth_code:
+          type: string
+          description: Only applicable for telephone payments reported. Authorisation
+            ID received from payment provider when the payment was authorised
+          example: "91011"
+        authorisation_mode:
+          type: string
+          default: web
+          description: How the payment will be authorised. Payments created in `web`
+            mode require the paying user to visit the `next_url` to complete the payment.
+          enum:
+          - web
+          - moto_api
+          - agreement
+          - external
+          example: web
+        authorisation_summary:
+          $ref: '#/components/schemas/AuthorisationSummary'
+        authorised_date:
+          type: string
+          format: date-time
+          description: 'Only applicable for telephone payments reported. Date and
+            time Payment service provider authorised the payment. '
+          example: 2022-06-28T16:05:33Z
+        card_brand:
+          type: string
+          example: Visa
+        card_details:
+          $ref: '#/components/schemas/PersistedCard'
+        charge_id:
+          type: string
+          description: Unique identifier for the charge
+          example: b02b63b370fd35418ad66b0101
+        corporate_card_surcharge:
+          type: integer
+          format: int64
+        created_date:
+          type: string
+          format: date-time
+          example: 2022-06-28T09:24:45.715Z
+        delayed_capture:
+          type: boolean
+          description: "Set to true, if payment is to be captured separately"
+        description:
+          type: string
+          description: The payment description
+          example: payment description
+        email:
+          type: string
+          example: Joe.Bogs@example.org
+        fee:
+          type: integer
+          format: int64
+          description: "processing fee taken by the GOV.UK Pay platform, in pence.\
+            \ Only available depending on payment service provider"
+          example: 10
+        gateway_account:
+          $ref: '#/components/schemas/GatewayAccountEntity'
+        gateway_transaction_id:
+          type: string
+          description: The reference number the payment gateway associated with the
+            payment.
+          example: 5422624d-12b1-4821-8b26-d0383ecf1602
+        language:
+          type: string
+          description: The language of the user’s payment page.
+          enum:
+          - en
+          - cy
+          example: en
+        links:
+          type: array
+          description: Array of relevant resource references related to this charge
+          example:
+          - href: https://connector.example.com/v1/api/charges/b02b63b370fd35418ad66b0101
+            method: GET
+            rel: self
+          - href: https://frontend.example.com/charges/1?chargeTokenId=82347
+            method: GET
+            rel: next_url
+          - href: https://connector.example.com//v1/api/accounts/1/charges/b02b63b370fd35418ad66b0101/refunds
+            method: GET
+            rel: refunds
+          items:
+            type: object
+            additionalProperties:
+              type: object
+              description: Array of relevant resource references related to this charge
+              example:
+              - href: https://connector.example.com/v1/api/charges/b02b63b370fd35418ad66b0101
+                method: GET
+                rel: self
+              - href: https://frontend.example.com/charges/1?chargeTokenId=82347
+                method: GET
+                rel: next_url
+              - href: https://connector.example.com//v1/api/accounts/1/charges/b02b63b370fd35418ad66b0101/refunds
+                method: GET
+                rel: refunds
+            description: Array of relevant resource references related to this charge
+            example:
+            - href: https://connector.example.com/v1/api/charges/b02b63b370fd35418ad66b0101
+              method: GET
+              rel: self
+            - href: https://frontend.example.com/charges/1?chargeTokenId=82347
+              method: GET
+              rel: next_url
+            - href: https://connector.example.com//v1/api/accounts/1/charges/b02b63b370fd35418ad66b0101/refunds
+              method: GET
+              rel: refunds
+        metadata:
+          $ref: '#/components/schemas/ExternalMetadata'
+        moto:
+          type: boolean
+          description: Mail Order / Telephone Order (MOTO) payment flag
+        net_amount:
+          type: integer
+          format: int64
+          description: "amount including all surcharges and less all fees, in pence.\
+            \ Available depending on payment service provider"
+          example: 90
+        payment_outcome:
+          $ref: '#/components/schemas/PaymentOutcome'
+        payment_provider:
+          type: string
+          description: The payment provider used for this transaction
+          example: sandbox
+        processor_id:
+          type: string
+          description: Only applicable for telephone payments reported. unique supplier
+            internal reference number associated with the payment
+          example: "12345"
+        provider_id:
+          type: string
+          description: Only applicable for telephone payments reported. Gateway transaction
+            ID
+          example: "45678"
+        reference:
+          $ref: '#/components/schemas/ServicePaymentReference'
+        refund_summary:
+          $ref: '#/components/schemas/RefundSummary'
+        return_url:
+          type: string
+          description: service return url
+          example: https://service-name.gov.uk/transactions/12345
+        save_payment_instrument_to_agreement:
+          type: boolean
+        settlement_summary:
+          $ref: '#/components/schemas/SettlementSummary'
+        state:
+          $ref: '#/components/schemas/ExternalTransactionState'
+        status:
+          type: string
+        telephone_number:
+          type: string
+          description: Only applicable for telephone payments reported. User's telephone
+            number
+          example: +44000000000
+        total_amount:
+          type: integer
+          format: int64
+          description: "Amount your user paid in pence, including corporate card fees.\
+            \ total_amount only appears if corporate card surcharge is applied to\
+            \ the payment."
+        wallet_type:
+          type: string
+          description: Indicates if the payment was completed using wallet payment
+            (GOOGLE_PAY or APPLE_PAY)
+          enum:
+          - APPLE_PAY
+          - GOOGLE_PAY
+          example: APPLE_PAY
     FrontendChargeResponse_FrontendView:
       type: object
       properties:
@@ -3815,56 +3621,6 @@ components:
           type: integer
           format: int64
     GatewayAccountCredentialsEntity_ApiView:
-      type: object
-      properties:
-        active_end_date:
-          type: string
-          format: date-time
-        active_start_date:
-          type: string
-          format: date-time
-          example: 2022-05-27T09:17:19.162Z
-        created_date:
-          type: string
-          format: date-time
-          example: 2022-05-27T09:17:19.162Z
-        credentials:
-          type: object
-          additionalProperties:
-            type: object
-            example:
-              stripe_account_id: an-id
-          example:
-            stripe_account_id: an-id
-        external_id:
-          type: string
-          example: 731193f990064e698ca1b89775b70bcc
-        gateway_account_credential_id:
-          type: integer
-          format: int64
-          example: 11
-        gateway_account_id:
-          type: integer
-          format: int64
-          example: 1
-        last_updated_by_user_external_id:
-          type: string
-        payment_provider:
-          type: string
-          example: stripe
-        state:
-          type: string
-          enum:
-          - CREATED
-          - ENTERED
-          - VERIFIED_WITH_LIVE_PAYMENT
-          - ACTIVE
-          - RETIRED
-          example: ACTIVE
-        version:
-          type: integer
-          format: int64
-    GatewayAccountCredentialsEntity_FrontendView:
       type: object
       properties:
         active_end_date:
@@ -4672,6 +4428,7 @@ components:
       example: 4242
     LastDigitsCardNumber_FrontendView:
       type: object
+      description: The last 4 digits of the card the user paid with.
       example: 4242
     NewChargeStatusRequest_FrontendView:
       type: object
@@ -4698,32 +4455,6 @@ components:
         version:
           type: integer
           format: int64
-    PaymentInstrumentEntity_FrontendView:
-      type: object
-      properties:
-        agreementExternalId:
-          type: string
-        cardDetails:
-          $ref: '#/components/schemas/CardDetailsEntity_FrontendView'
-        createdDate:
-          type: string
-          format: date-time
-        externalId:
-          type: string
-        recurringAuthToken:
-          type: object
-          additionalProperties:
-            type: string
-        startDate:
-          type: string
-          format: date-time
-        status:
-          type: string
-          enum:
-          - CREATED
-          - ACTIVE
-          - INACTIVE
-          - CANCELLED
     PaymentOutcome:
       type: object
       description: Only applicable for telephone payments reported. Outcome after
@@ -4917,6 +4648,7 @@ components:
       example: payment reference
     ServicePaymentReference_FrontendView:
       type: object
+      description: Service reference for the payment
       example: payment reference
     SettlementSummary:
       type: object
@@ -5155,11 +4887,11 @@ components:
           type: string
           description: 3DS version used to authorise payment
           example: 2.1.0
-    TokenResponse_FrontendView:
+    TokenResponse:
       type: object
       properties:
         charge:
-          $ref: '#/components/schemas/ChargeEntity_FrontendView'
+          $ref: '#/components/schemas/FrontendChargeResponse'
         used:
           type: boolean
           description: true or false depending on whether the token has been marked

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -78,6 +78,7 @@ import uk.gov.pay.connector.queue.managed.TaskQueueMessageReceiver;
 import uk.gov.pay.connector.refund.resource.RefundsResource;
 import uk.gov.pay.connector.report.resource.ParityCheckerResource;
 import uk.gov.pay.connector.report.resource.PerformanceReportResource;
+import uk.gov.pay.connector.token.exception.TokenNotFoundExceptionMapper;
 import uk.gov.pay.connector.token.resource.SecurityTokensResource;
 import uk.gov.pay.connector.usernotification.resource.EmailNotificationResource;
 import uk.gov.pay.connector.util.DependentResourceWaitCommand;
@@ -168,6 +169,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new RecurringCardPaymentsNotAllowedExceptionMapper());
         environment.jersey().register(new MissingCredentialsForRecurringPaymentExceptionMapper());
         environment.jersey().register(new IdempotencyKeyUsedExceptionMapper());
+        environment.jersey().register(new TokenNotFoundExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -1,9 +1,5 @@
 package uk.gov.pay.connector.charge.model.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import io.swagger.v3.oas.annotations.media.Schema;
 import net.logstash.logback.argument.StructuredArgument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,31 +82,24 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "charges_charge_id_seq")
-    @JsonIgnore
     private Long id;
 
     @Column(name = "external_id")
-    @Schema(example = "5t2rupktnsk0a3mu800st7irts")
     private String externalId;
 
     @Column(name = "amount")
-    @Schema(example = "100")
     private Long amount;
 
     @Column(name = "status")
-    @Schema(example = "AUTHORISATION SUCCESS")
     private String status;
 
     @Column(name = "gateway_transaction_id")
-    @Schema(example = "bba59957-5155-4f59-8c69-a839f71772d3")
     private String gatewayTransactionId;
 
     @Column(name = "return_url")
-    @Schema(example = "https://service-name.gov.uk/transactions/12345")
     private String returnUrl;
 
     @Column(name = "email")
-    @Schema(example = "joe.blogs@example.org")
     private String email;
 
     @Column(name = "corporate_surcharge")
@@ -138,13 +127,10 @@ public class ChargeEntity extends AbstractVersionedEntity {
     private List<ChargeEventEntity> events = new ArrayList<>();
 
     @Column(name = "description")
-    @Schema(example = "payment description")
     private String description;
 
     @Column(name = "reference")
     @Convert(converter = ServicePaymentReferenceConverter.class)
-    @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(example = "payment reference")
     private ServicePaymentReference reference;
 
     @Column(name = "provider_session_id")
@@ -152,12 +138,10 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     @Column(name = "created_date")
     @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
-    @Schema(example = "1656606127.578088000")
     private Instant createdDate;
 
     @Column(name = "language", nullable = false)
     @Convert(converter = SupportedLanguageJpaConverter.class)
-    @Schema(example = "en")
     private SupportedLanguage language;
 
     @Column(name = "delayed_capture")
@@ -170,7 +154,6 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @Valid
     @Column(name = "external_metadata", columnDefinition = "jsonb")
     @Convert(converter = ExternalMetadataConverter.class)
-    @Schema(example = "{}")
     private ExternalMetadata externalMetadata;
 
     @Column(name = "parity_check_status")
@@ -183,7 +166,6 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     @Column(name = "source")
     @Enumerated(EnumType.STRING)
-    @Schema(example = "CARD_API")
     private Source source;
 
     @Column(name = "moto")
@@ -194,14 +176,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
     private Exemption3ds exemption3ds;
 
     @Column(name = "payment_provider")
-    @Schema(example = "stripe")
     private String paymentProvider;
 
     @Column(name = "service_id")
-    @Schema(example = "46eb1b601348499196c99de90482ee68")
     private String serviceId;
     
-    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "agreement_external_id", referencedColumnName="external_id", updatable = false, nullable = true)
     private AgreementEntity agreementEntity;
@@ -221,9 +200,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
     private Boolean canRetry;
 
     @Column(name = "updated_date")
-    @JsonIgnore
     @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
-    @Schema(hidden = true)
     private Instant updatedDate;
 
     public ChargeEntity() {
@@ -414,8 +391,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         logger.info(logMessage, getStructuredLoggingArgs());
         this.status = targetStatus.getValue();
     }
-
-    @JsonIgnore
+    
     public Object[] getStructuredLoggingArgs() {
         ArrayList<StructuredArgument> structuredArguments = new ArrayList<>(List.of(
                 kv(PAYMENT_EXTERNAL_ID, externalId),
@@ -577,8 +553,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
     public void setServiceId(String serviceId) {
         this.serviceId = serviceId;
     }
-
-    @JsonIgnore
+    
     public Optional<AgreementEntity> getAgreement() {
         return Optional.ofNullable(agreementEntity);
     }

--- a/src/main/java/uk/gov/pay/connector/events/HistoricalEventEmitterService.java
+++ b/src/main/java/uk/gov/pay/connector/events/HistoricalEventEmitterService.java
@@ -23,11 +23,9 @@ import uk.gov.pay.connector.tasks.HistoricalEventEmitter;
 import javax.inject.Inject;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-import static uk.gov.pay.connector.tasks.EventEmitterParamUtil.getOptionalLongParam;
 import static uk.gov.service.payments.logging.LoggingKeys.MDC_REQUEST_ID_KEY;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 

--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
@@ -30,7 +30,6 @@ import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.refund.service.RefundStateEventMap;
-import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.time.ZonedDateTime;
 import java.util.Comparator;
@@ -59,7 +58,6 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCE
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.PAYMENT_NOTIFICATION_CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCEL_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_READY;
-import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 
 public class HistoricalEventEmitter {
     public static final List<ChargeStatus> TERMINAL_AUTHENTICATION_STATES = List.of(

--- a/src/main/java/uk/gov/pay/connector/token/exception/TokenNotFoundException.java
+++ b/src/main/java/uk/gov/pay/connector/token/exception/TokenNotFoundException.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.token.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+public class TokenNotFoundException extends WebApplicationException {
+
+    public TokenNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/token/exception/TokenNotFoundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/token/exception/TokenNotFoundExceptionMapper.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.connector.token.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.agreement.exception.AgreementNotFoundException;
+import uk.gov.pay.connector.agreement.exception.AgreementNotFoundExceptionMapper;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class TokenNotFoundExceptionMapper implements ExceptionMapper<TokenNotFoundException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TokenNotFoundExceptionMapper.class);
+
+    @Override
+    public Response toResponse(TokenNotFoundException exception) {
+        LOGGER.info(exception.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/token/model/domain/TokenResponse.java
+++ b/src/main/java/uk/gov/pay/connector/token/model/domain/TokenResponse.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.token.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.connector.charge.model.ChargeResponse;
+import uk.gov.pay.connector.charge.model.FrontendChargeResponse;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 
 import java.util.Objects;
@@ -14,9 +16,9 @@ public class TokenResponse {
 
     @JsonProperty("charge")
     @Schema(description = "The charge associated with the token")
-    private final ChargeEntity charge;
+    private final FrontendChargeResponse charge;
 
-    public TokenResponse(boolean used, ChargeEntity charge) {
+    public TokenResponse(boolean used, FrontendChargeResponse charge) {
         this.used = used;
         this.charge = Objects.requireNonNull(charge);
     }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
@@ -139,6 +139,9 @@ class ChargeServiceCreateAgreementTest {
 
     @Mock
     private TaskQueueService mockTaskQueueService;
+    
+    @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
 
     @Mock
     private AgreementEntity mockAgreementEntity;
@@ -189,7 +192,7 @@ class ChargeServiceCreateAgreementTest {
         chargeService = new ChargeService(mockTokenDao, mockChargeDao, mockChargeEventDao, mockCardTypeDao, mockAgreementDao, mockGatewayAccountDao,
                 mockConfig, mockProviders, mockStateTransitionService, mockLedgerService, mockedRefundService, mockEventService,
                 mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
-                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao,
+                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao,
                 mockExternalTransactionStateFactory, objectMapper);
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreatePrefilledCardholderDetailsTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreatePrefilledCardholderDetailsTest.java
@@ -127,6 +127,9 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
     private TaskQueueService mockTaskQueueService;
 
     @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
+
+    @Mock
     private IdempotencyDao mockIdempotencyDao;
 
     @Mock
@@ -170,7 +173,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTelephonePaymentTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTelephonePaymentTest.java
@@ -118,6 +118,10 @@ class ChargeServiceCreateTelephonePaymentTest {
 
     @Mock
     private TaskQueueService mockTaskQueueService;
+
+    @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
+    
     @Mock
     private IdempotencyDao mockIdempotencyDao;
 
@@ -169,7 +173,7 @@ class ChargeServiceCreateTelephonePaymentTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
@@ -186,6 +186,10 @@ class ChargeServiceCreateTest {
 
     @Mock
     private TaskQueueService mockTaskQueueService;
+
+    @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
+    
     @Mock
     private IdempotencyDao mockIdempotencyDao;
 
@@ -264,7 +268,7 @@ class ChargeServiceCreateTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, mapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, mapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
@@ -154,6 +154,10 @@ class ChargeServiceFindTest {
 
     @Mock
     private TaskQueueService mockTaskQueueService;
+
+    @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
+    
     @Mock
     private IdempotencyDao mockIdempotencyDao;
 
@@ -205,7 +209,7 @@ class ChargeServiceFindTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService,
-                mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
     }
     @Test
     void shouldNotFindCharge() {

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceIdempotencyTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceIdempotencyTest.java
@@ -134,6 +134,10 @@ class ChargeServiceIdempotencyTest {
 
     @Mock
     private TaskQueueService mockTaskQueueService;
+
+    @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
+    
     @Mock
     private IdempotencyDao mockIdempotencyDao;
 
@@ -163,7 +167,7 @@ class ChargeServiceIdempotencyTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, mapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, mapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
@@ -84,6 +84,8 @@ class ChargeServicePostAuthorisationTest {
     @Mock private StateTransitionService mockStateTransitionService;
     @Mock private EventService mockEventService;
     @Mock private TaskQueueService mockTaskQueueService;
+    @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
     @Mock private AuthCardDetailsToCardDetailsEntityConverter mockAuthCardDetailsToCardDetailsEntityConverter;
     @Mock private PaymentProviders mockProviders;
     @Mock private ConnectorConfiguration mockConnectorConfig;
@@ -132,7 +134,7 @@ class ChargeServicePostAuthorisationTest {
                 mockCardTypeDao, mockAgreementDao, mockGatewayAccountDao, mockConnectorConfig, mockProviders,
                 mockStateTransitionService, mockLedgerService, mockRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -175,6 +175,9 @@ class ChargeServiceTest {
     private TaskQueueService mockTaskQueueService;
 
     @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
+
+    @Mock
     private IdempotencyDao mockIdempotencyDao;
 
     @Mock
@@ -221,7 +224,7 @@ class ChargeServiceTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/SecurityTokensResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SecurityTokensResourceIT.java
@@ -94,9 +94,9 @@ public class SecurityTokensResourceIT {
                 .statusCode(200)
                 .contentType(JSON)
                 .body("used", is(false))
-                .body("charge.externalId", is(defaultTestCharge.getExternalChargeId()))
+                .body("charge.charge_id", is(defaultTestCharge.getExternalChargeId()))
                 .body("charge.status", is(defaultTestCharge.getChargeStatus().toString()))
-                .body("charge.gatewayAccount.service_name", is(defaultTestAccount.getServiceName()));
+                .body("charge.gateway_account.service_name", is(defaultTestAccount.getServiceName()));
     }
 
     @Test
@@ -114,9 +114,9 @@ public class SecurityTokensResourceIT {
                 .statusCode(200)
                 .contentType(JSON)
                 .body("used", is(true))
-                .body("charge.externalId", is(defaultTestCharge.getExternalChargeId()))
+                .body("charge.charge_id", is(defaultTestCharge.getExternalChargeId()))
                 .body("charge.status", is(defaultTestCharge.getChargeStatus().toString()))
-                .body("charge.gatewayAccount.service_name", is(defaultTestAccount.getServiceName()));
+                .body("charge.gateway_account.service_name", is(defaultTestAccount.getServiceName()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.charge.service.Worldpay3dsFlexJwtService;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
@@ -90,6 +91,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     @Mock
     private TaskQueueService mockTaskQueueService;
     @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
+    @Mock
     private IdempotencyDao mockIdempotencyDao;
     @Mock
     private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
@@ -122,7 +125,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
                 null, null, mockConfiguration, null, mockStateTransitionService, ledgerService,
                 mockedRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
-                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao,
+                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao,
                 mockExternalTransactionStateFactory, objectMapper);
         AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment, mockConfiguration);
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeEligibleForCaptureService;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementService;
+import uk.gov.pay.connector.charge.service.Worldpay3dsFlexJwtService;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
 import uk.gov.pay.connector.charge.util.PaymentInstrumentEntityToAuthCardDetailsConverter;
 import uk.gov.pay.connector.client.cardid.model.CardInformation;
@@ -185,6 +186,9 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     private ChargeEligibleForCaptureService mockChargeEligibleForCaptureService;
 
     @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
+
+    @Mock
     private PaymentInstrumentEntityToAuthCardDetailsConverter mockPaymentInstrumentEntityToAuthCardDetailsConverter;
 
     @Mock
@@ -226,7 +230,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
                 null, null, null, mockConfiguration, null,
                 stateTransitionService, ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
 
         LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService = mock(LinkPaymentInstrumentToAgreementService.class);
         CaptureQueue captureQueue = mock(CaptureQueue.class);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -27,6 +27,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.FeeType;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.charge.service.Worldpay3dsFlexJwtService;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
@@ -122,6 +123,8 @@ class CardCaptureServiceTest extends CardServiceTest {
     @Mock
     private TaskQueueService mockTaskQueueService;
     @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
+    @Mock
     private IdempotencyDao mockIdempotencyDao;
     @Mock
     private ExternalTransactionStateFactory mockExternalTransactionStateFactory;
@@ -139,7 +142,7 @@ class CardCaptureServiceTest extends CardServiceTest {
                 null, null, null, mockConfiguration, null,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
 
         cardCaptureService = new CardCaptureService(chargeService, mockedProviders, mockUserNotificationService, mockEnvironment,
                 GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK, mockCaptureQueue, mockEventService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.service.ChargeEligibleForCaptureService;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.charge.service.Worldpay3dsFlexJwtService;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
 import uk.gov.pay.connector.charge.util.PaymentInstrumentEntityToAuthCardDetailsConverter;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
@@ -95,6 +96,9 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
     private TaskQueueService mockTaskQueueService;
 
     @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
+    
+    @Mock
     ChargeEligibleForCaptureService mockChargeEligibleForCaptureService;
 
     @Mock
@@ -127,7 +131,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
                 null, mock(AgreementDao.class), null, mock(ConnectorConfiguration.class), null,
                 mock(StateTransitionService.class), mock(LedgerService.class), mock(RefundService.class),
                 mock(EventService.class), mock(PaymentInstrumentService.class), mock(GatewayAccountCredentialsService.class),
-                mock(AuthCardDetailsToCardDetailsEntityConverter.class), mockTaskQueueService, mock(IdempotencyDao.class),
+                mock(AuthCardDetailsToCardDetailsEntityConverter.class), mockTaskQueueService, mockWorldpay3dsFlexJwtService, mock(IdempotencyDao.class),
                 mock(ExternalTransactionStateFactory.class), objectMapper);
 
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -25,6 +25,7 @@ import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.charge.service.Worldpay3dsFlexJwtService;
 import uk.gov.pay.connector.charge.util.AuthCardDetailsToCardDetailsEntityConverter;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
@@ -78,7 +79,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -147,6 +147,9 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
     private TaskQueueService mockTaskQueueService;
 
     @Mock
+    private Worldpay3dsFlexJwtService mockWorldpay3dsFlexJwtService;
+
+    @Mock
     private AuthCardDetails mockAuthCardDetails;
 
     @Mock
@@ -198,7 +201,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, null, mockConfiguration, null, mockStateTransitionService,
                 ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
-                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockIdempotencyDao,
+                mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao,
                 mockExternalTransactionStateFactory, objectMapper));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,


### PR DESCRIPTION
The only place we still use ChargeEntity as an API response model is for the GET `/v1/frontend/tokens/{chargeTokenId}` endpoint.

Instead use the `FrontendChargeResponse` model that we use for other charge responses consumed by the card connector app.

https://github.com/alphagov/pay-frontend/pull/3551 made changes to frontend to support this change.

The diff for openapi/connector_spec.yaml is very difficult to visually parse, there's lots of things about `_FrontendView`s which exist due to the JsonViews used to serialise the correct response from a GatewayAccountEntity. This will all be sorted out in a later commit that will stop using GatewayAccountEntity to serialise JSON responses. You might just need to trust that is is all okay.

You can view the updated API spec in Swagger editor here https://editor.swagger.io/?url=https://raw.githubusercontent.com/alphagov/pay-connector/24eacd2335bda7025970adc2ce58c2d249fa14c5/openapi/connector_spec.yaml