### PR TITLE
PP-11167 Reject payment links payments with card number in reference

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,70 +164,70 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3548
+        "line_number": 3549
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3597
+        "line_number": 3598
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4152
+        "line_number": 4153
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4213
+        "line_number": 4214
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4235
+        "line_number": 4236
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4414
+        "line_number": 4415
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4417
+        "line_number": 4418
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4420
+        "line_number": 4421
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4986
+        "line_number": 4987
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4997
+        "line_number": 4998
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1032,5 +1032,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-03T16:13:16Z"
+  "generated_at": "2023-07-04T11:51:51Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3065,6 +3065,7 @@ components:
           - ACCOUNT_DISABLED
           - RECURRING_CARD_PAYMENTS_NOT_ALLOWED
           - IDEMPOTENCY_KEY_USED
+          - CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED
           example: GENERIC
         message:
           type: array

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.11</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.15.2</jackson.version>
-        <pay-java-commons.version>1.0.20230601160155</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20230704093921</pay-java-commons.version>
         <surefire.version>3.0.0</surefire.version>
         <jooq.version>3.18.4</jooq.version>
         <postgresql.version>42.6.0</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -24,6 +24,7 @@ import uk.gov.pay.connector.charge.exception.AgreementIdWithIncompatibleOtherOpt
 import uk.gov.pay.connector.charge.exception.AgreementMissingPaymentInstrumentExceptionMapper;
 import uk.gov.pay.connector.charge.exception.AgreementNotFoundBadRequestExceptionMapper;
 import uk.gov.pay.connector.charge.exception.AuthorisationModeAgreementRequiresAgreementIdExceptionMapper;
+import uk.gov.pay.connector.charge.exception.CardNumberInPaymentLinkReferenceExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapper;
 import uk.gov.pay.connector.charge.exception.GatewayAccountDisabledExceptionMapper;
 import uk.gov.pay.connector.charge.exception.IdempotencyKeyUsedExceptionMapper;
@@ -170,6 +171,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new MissingCredentialsForRecurringPaymentExceptionMapper());
         environment.jersey().register(new IdempotencyKeyUsedExceptionMapper());
         environment.jersey().register(new TokenNotFoundExceptionMapper());
+        environment.jersey().register(new CardNumberInPaymentLinkReferenceExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -189,6 +189,9 @@ public class ConnectorConfiguration extends Configuration {
         return stripeConfig;
     }
 
+    @JsonProperty("rejectPaymentLinkPaymentsWithCardNumberInReference")
+    public Boolean rejectPaymentLinkPaymentsWithCardNumberInReference;
+
     public GatewayConfig getGatewayConfigFor(PaymentGatewayName gateway) {
         switch (gateway) {
             case WORLDPAY:
@@ -288,5 +291,9 @@ public class ConnectorConfiguration extends Configuration {
 
     public TaskQueueConfig getTaskQueueConfig() {
         return taskQueueConfig;
+    }
+
+    public Boolean getRejectPaymentLinkPaymentsWithCardNumberInReference() {
+        return rejectPaymentLinkPaymentsWithCardNumberInReference;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/exception/CardNumberInPaymentLinkReferenceException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/CardNumberInPaymentLinkReferenceException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.charge.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+public class CardNumberInPaymentLinkReferenceException extends WebApplicationException {
+    public CardNumberInPaymentLinkReferenceException() {
+        super("Card number entered in a payment link reference");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/CardNumberInPaymentLinkReferenceExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/CardNumberInPaymentLinkReferenceExceptionMapper.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.connector.charge.exception;
+
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED;
+
+public class CardNumberInPaymentLinkReferenceExceptionMapper implements ExceptionMapper<CardNumberInPaymentLinkReferenceException> {
+    
+    @Override
+    public Response toResponse(CardNumberInPaymentLinkReferenceException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED, exception.getMessage());
+
+        return Response.status(400)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -282,3 +282,5 @@ authorisation3dsConfig:
 authorisationConfig:
   asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_TIMEOUT_IN_MILLISECONDS::-10000}
+
+rejectPaymentLinkPaymentsWithCardNumberInReference: ${REJECT_PAYMENT_LINK_PAYMENT_WITH_CARD_NUMBER_IN_REFERENCE_ENABLED:-false}

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
@@ -193,7 +193,7 @@ class ChargeServiceCreateAgreementTest {
                 mockConfig, mockProviders, mockStateTransitionService, mockLedgerService, mockedRefundService, mockEventService,
                 mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
                 mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao,
-                mockExternalTransactionStateFactory, objectMapper);
+                mockExternalTransactionStateFactory, objectMapper, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreatePrefilledCardholderDetailsTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreatePrefilledCardholderDetailsTest.java
@@ -173,7 +173,7 @@ class ChargeServiceCreatePrefilledCardholderDetailsTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTelephonePaymentTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTelephonePaymentTest.java
@@ -173,7 +173,7 @@ class ChargeServiceCreateTelephonePaymentTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
@@ -209,7 +209,7 @@ class ChargeServiceFindTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService,
-                mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper, null);
     }
     @Test
     void shouldNotFindCharge() {

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceIdempotencyTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceIdempotencyTest.java
@@ -167,7 +167,7 @@ class ChargeServiceIdempotencyTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, mapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, mapper, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
@@ -134,7 +134,7 @@ class ChargeServicePostAuthorisationTest {
                 mockCardTypeDao, mockAgreementDao, mockGatewayAccountDao, mockConnectorConfig, mockProviders,
                 mockStateTransitionService, mockLedgerService, mockRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -224,7 +224,7 @@ class ChargeServiceTest {
                 mockedCardTypeDao, mockedAgreementDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -726,19 +726,4 @@ public class ChargesApiResourceIT extends ChargingITestBase {
         databaseTestHelper.addToken(chargeId, "tokenId");
     }
 
-    private void createAgreement(String externalChargeId, long chargeId) {
-        databaseTestHelper.addCharge(anAddChargeParams()
-                .withChargeId(chargeId)
-                .withExternalChargeId(externalChargeId)
-                .withGatewayAccountId(accountId)
-                .withAmount(AMOUNT)
-                .withStatus(CAPTURED)
-                .withReturnUrl(RETURN_URL)
-                .build());
-        databaseTestHelper.updateChargeCardDetails(chargeId, "unknown-brand", "1234", "123456", "Mr. McPayment",
-                CardExpiryDate.valueOf("03/18"), null, "line1", null, "postcode", "city", null, "country");
-        databaseTestHelper.updateCorporateSurcharge(chargeId, 150L);
-        databaseTestHelper.addToken(chargeId, "tokenId");
-    }
-
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -126,7 +126,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
                 null, null, mockConfiguration, null, mockStateTransitionService, ledgerService,
                 mockedRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
                 mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao,
-                mockExternalTransactionStateFactory, objectMapper);
+                mockExternalTransactionStateFactory, objectMapper, null);
         AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment, mockConfiguration);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, authorisationService, mockConfiguration);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -230,7 +230,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
                 null, null, null, mockConfiguration, null,
                 stateTransitionService, ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper, null);
 
         LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService = mock(LinkPaymentInstrumentToAgreementService.class);
         CaptureQueue captureQueue = mock(CaptureQueue.class);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -142,7 +142,7 @@ class CardCaptureServiceTest extends CardServiceTest {
                 null, null, null, mockConfiguration, null,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockPaymentInstrumentService,
                 mockGatewayAccountCredentialsService, mockAuthCardDetailsToCardDetailsEntityConverter,
-                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper);
+                mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao, mockExternalTransactionStateFactory, objectMapper, null);
 
         cardCaptureService = new CardCaptureService(chargeService, mockedProviders, mockUserNotificationService, mockEnvironment,
                 GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK, mockCaptureQueue, mockEventService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -132,7 +132,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
                 mock(StateTransitionService.class), mock(LedgerService.class), mock(RefundService.class),
                 mock(EventService.class), mock(PaymentInstrumentService.class), mock(GatewayAccountCredentialsService.class),
                 mock(AuthCardDetailsToCardDetailsEntityConverter.class), mockTaskQueueService, mockWorldpay3dsFlexJwtService, mock(IdempotencyDao.class),
-                mock(ExternalTransactionStateFactory.class), objectMapper);
+                mock(ExternalTransactionStateFactory.class), objectMapper, null);
 
         when(mockConfiguration.getAuthorisationConfig()).thenReturn(mockAuthorisationConfig);
         when(mockAuthorisationConfig.getAsynchronousAuthTimeoutInMilliseconds()).thenReturn(1000);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -202,7 +202,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
                 null, null, null, mockConfiguration, null, mockStateTransitionService,
                 ledgerService, mockRefundService, mockEventService, mockPaymentInstrumentService, mockGatewayAccountCredentialsService,
                 mockAuthCardDetailsToCardDetailsEntityConverter, mockTaskQueueService, mockWorldpay3dsFlexJwtService, mockIdempotencyDao,
-                mockExternalTransactionStateFactory, objectMapper));
+                mockExternalTransactionStateFactory, objectMapper, null));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -221,3 +221,5 @@ authorisation3dsConfig:
 authorisationConfig:
   asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}
+
+rejectPaymentLinkPaymentsWithCardNumberInReference: ${REJECT_PAYMENT_LINK_PAYMENT_WITH_CARD_NUMBER_IN_REFERENCE_ENABLED:-true}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -211,3 +211,5 @@ authorisation3dsConfig:
 authorisationConfig:
   asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}
+
+rejectPaymentLinkPaymentsWithCardNumberInReference: ${REJECT_PAYMENT_LINK_PAYMENT_WITH_CARD_NUMBER_IN_REFERENCE_ENABLED:-true}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -220,3 +220,5 @@ authorisation3dsConfig:
 authorisationConfig:
   asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}
+
+rejectPaymentLinkPaymentsWithCardNumberInReference: ${REJECT_PAYMENT_LINK_PAYMENT_WITH_CARD_NUMBER_IN_REFERENCE_ENABLED:-true}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -220,3 +220,5 @@ authorisation3dsConfig:
 authorisationConfig:
   asynchronousAuthTimeoutInMilliseconds: ${AUTH_READ_TIMEOUT_MILLISECONDS:-1000}
   synchronousAuthTimeoutInMilliseconds: ${SYNCHRONOUS_AUTH_READ_TIMEOUT_IN_MILLISECONDS::-10000}
+
+rejectPaymentLinkPaymentsWithCardNumberInReference: ${REJECT_PAYMENT_LINK_PAYMENT_WITH_CARD_NUMBER_IN_REFERENCE_ENABLED:-true}


### PR DESCRIPTION
## WHAT YOU DID
- Rejects payment link payments with a card number in the reference. Currently behind a feature flag so this can be enabled when all microservices are ready to handle new error identifier.
