### PR TITLE
PP-11244 Add new GatewayAccountWithCredentialsResponse model

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,70 +164,70 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 2960
+        "line_number": 2947
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3285
+        "line_number": 3272
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3321
+        "line_number": 3308
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3354
+        "line_number": 3341
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3403
+        "line_number": 3391
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4073
+        "line_number": 4023
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4076
+        "line_number": 4026
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4079
+        "line_number": 4029
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4536
+        "line_number": 4480
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4547
+        "line_number": 4491
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -272,14 +272,14 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/FrontendGatewayAccountResponse.java",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 17
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/FrontendGatewayAccountResponse.java",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 37
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java": [
@@ -300,20 +300,20 @@
         "line_number": 23
       }
     ],
-    "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java": [
+    "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java",
+        "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
         "line_number": 25
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java",
+        "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 46
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsRequest.java": [
@@ -1048,5 +1048,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-05T08:31:22Z"
+  "generated_at": "2023-07-06T10:32:58Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -176,7 +176,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GatewayAccountResourceDTO'
+                $ref: '#/components/schemas/GatewayAccountResponse'
           description: OK
         "404":
           description: Not found
@@ -1463,7 +1463,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GatewayAccountEntity'
+                $ref: '#/components/schemas/GatewayAccountWithCredentialsResponse'
           description: OK
         "404":
           description: Not found
@@ -1490,7 +1490,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GatewayAccountEntity_ApiView'
+                $ref: '#/components/schemas/GatewayAccountWithCredentialsResponse'
           description: OK
         "404":
           description: Not found
@@ -2935,19 +2935,6 @@ components:
         version:
           type: integer
           format: int64
-    EmailNotificationEntity_ApiView:
-      type: object
-      properties:
-        enabled:
-          type: boolean
-          description: Indicates whether emails are enabled for notifications type
-          example: true
-        template_body:
-          type: string
-          description: Custom paragraph for the email template
-        version:
-          type: integer
-          format: int64
     EncryptedPaymentData:
       type: object
       properties:
@@ -3378,56 +3365,7 @@ components:
           example: ACTIVE
     GatewayAccountCredentialsEntity:
       type: object
-      properties:
-        active_end_date:
-          type: string
-          format: date-time
-        active_start_date:
-          type: string
-          format: date-time
-          example: 2022-05-27T09:17:19.162Z
-        created_date:
-          type: string
-          format: date-time
-          example: 2022-05-27T09:17:19.162Z
-        credentials:
-          type: object
-          additionalProperties:
-            type: object
-            example:
-              stripe_account_id: an-id
-          example:
-            stripe_account_id: an-id
-        external_id:
-          type: string
-          example: 731193f990064e698ca1b89775b70bcc
-        gateway_account_credential_id:
-          type: integer
-          format: int64
-          example: 11
-        gateway_account_id:
-          type: integer
-          format: int64
-          example: 1
-        last_updated_by_user_external_id:
-          type: string
-        payment_provider:
-          type: string
-          example: stripe
-        state:
-          type: string
-          enum:
-          - CREATED
-          - ENTERED
-          - VERIFIED_WITH_LIVE_PAYMENT
-          - ACTIVE
-          - RETIRED
-          example: ACTIVE
-        version:
-          type: integer
-          format: int64
-    GatewayAccountCredentialsEntity_ApiView:
-      type: object
+      description: Array of the credentials configured for this account
       properties:
         active_end_date:
           type: string
@@ -3491,208 +3429,6 @@ components:
           type: string
           description: "Payment provider. Accepted values - stripe, worldpay"
           example: stripe
-    GatewayAccountEntity:
-      type: object
-      properties:
-        allow_apple_pay:
-          type: boolean
-        allow_authorisation_api:
-          type: boolean
-        allow_google_pay:
-          type: boolean
-        allow_moto:
-          type: boolean
-        allow_telephone_payment_notifications:
-          type: boolean
-        allow_zero_amount:
-          type: boolean
-        analytics_id:
-          type: string
-        block_prepaid_cards:
-          type: boolean
-        corporateCreditCardSurchargeAmount:
-          type: integer
-          format: int64
-          writeOnly: true
-        corporateDebitCardSurchargeAmount:
-          type: integer
-          format: int64
-          writeOnly: true
-        corporate_credit_card_surcharge_amount:
-          type: integer
-          format: int64
-        corporate_debit_card_surcharge_amount:
-          type: integer
-          format: int64
-        corporate_prepaid_debit_card_surcharge_amount:
-          type: integer
-          format: int64
-        description:
-          type: string
-        disabled:
-          type: boolean
-        disabled_reason:
-          type: string
-        email_collection_mode:
-          type: string
-          enum:
-          - MANDATORY
-          - OPTIONAL
-          - "OFF"
-        email_notifications:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/EmailNotificationEntity'
-        external_id:
-          type: string
-        gateway_account_credentials:
-          type: array
-          items:
-            $ref: '#/components/schemas/GatewayAccountCredentialsEntity'
-        gateway_account_id:
-          type: integer
-          format: int64
-        integration_version_3ds:
-          type: integer
-          format: int32
-        live:
-          type: boolean
-        moto_mask_card_number_input:
-          type: boolean
-        moto_mask_card_security_code_input:
-          type: boolean
-        notificationCredentials:
-          $ref: '#/components/schemas/NotificationCredentials'
-        notifySettings:
-          type: object
-          additionalProperties:
-            type: string
-        payment_provider:
-          type: string
-        provider_switch_enabled:
-          type: boolean
-        recurring_enabled:
-          type: boolean
-        requires3ds:
-          type: boolean
-        send_payer_email_to_gateway:
-          type: boolean
-        send_payer_ip_address_to_gateway:
-          type: boolean
-        send_reference_to_gateway:
-          type: boolean
-        service_id:
-          type: string
-        service_name:
-          type: string
-        type:
-          type: string
-        version:
-          type: integer
-          format: int64
-        worldpay_3ds_flex:
-          $ref: '#/components/schemas/Worldpay3dsFlexCredentials'
-    GatewayAccountEntity_ApiView:
-      type: object
-      properties:
-        allow_apple_pay:
-          type: boolean
-        allow_authorisation_api:
-          type: boolean
-        allow_google_pay:
-          type: boolean
-        allow_moto:
-          type: boolean
-        allow_telephone_payment_notifications:
-          type: boolean
-        allow_zero_amount:
-          type: boolean
-        analytics_id:
-          type: string
-        block_prepaid_cards:
-          type: boolean
-        corporateCreditCardSurchargeAmount:
-          type: integer
-          format: int64
-          writeOnly: true
-        corporateDebitCardSurchargeAmount:
-          type: integer
-          format: int64
-          writeOnly: true
-        corporate_credit_card_surcharge_amount:
-          type: integer
-          format: int64
-        corporate_debit_card_surcharge_amount:
-          type: integer
-          format: int64
-        corporate_prepaid_debit_card_surcharge_amount:
-          type: integer
-          format: int64
-        description:
-          type: string
-        disabled:
-          type: boolean
-        disabled_reason:
-          type: string
-        email_collection_mode:
-          type: string
-          enum:
-          - MANDATORY
-          - OPTIONAL
-          - "OFF"
-        email_notifications:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/EmailNotificationEntity_ApiView'
-        external_id:
-          type: string
-        gateway_account_credentials:
-          type: array
-          items:
-            $ref: '#/components/schemas/GatewayAccountCredentialsEntity_ApiView'
-        gateway_account_id:
-          type: integer
-          format: int64
-        integration_version_3ds:
-          type: integer
-          format: int32
-        live:
-          type: boolean
-        moto_mask_card_number_input:
-          type: boolean
-        moto_mask_card_security_code_input:
-          type: boolean
-        notificationCredentials:
-          $ref: '#/components/schemas/NotificationCredentials_ApiView'
-        notifySettings:
-          type: object
-          additionalProperties:
-            type: string
-        payment_provider:
-          type: string
-        provider_switch_enabled:
-          type: boolean
-        recurring_enabled:
-          type: boolean
-        requires3ds:
-          type: boolean
-        send_payer_email_to_gateway:
-          type: boolean
-        send_payer_ip_address_to_gateway:
-          type: boolean
-        send_reference_to_gateway:
-          type: boolean
-        service_id:
-          type: string
-        service_name:
-          type: string
-        type:
-          type: string
-        version:
-          type: integer
-          format: int64
-        worldpay_3ds_flex:
-          $ref: '#/components/schemas/Worldpay3dsFlexCredentials_ApiView'
     GatewayAccountRequest:
       type: object
       discriminator:
@@ -3731,7 +3467,7 @@ components:
           description: Account type for this provider (test/live)
           example: live
           writeOnly: true
-    GatewayAccountResourceDTO:
+    GatewayAccountResponse:
       type: object
       properties:
         _links:
@@ -3861,6 +3597,10 @@ components:
           format: int32
           description: 3DS version used for payments for the gateway account
           example: 2
+        live:
+          type: boolean
+          description: Whether the account is live
+          example: true
         moto_mask_card_number_input:
           type: boolean
           default: false
@@ -3935,13 +3675,223 @@ components:
           description: User external ID switching payment service provider
           example: vfrg4245bd0e7453c9b1b0d7e6999f11b
           writeOnly: true
+    GatewayAccountWithCredentialsResponse:
+      type: object
+      properties:
+        _links:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
+              format: uri
+              example: "{        {            \"href\": \"https://connector.url/v1/api/accounts/1\"\
+                ,            \"rel\": \"self\",            \"method\": \"GET\"   \
+                \     }    }"
+            example: "{        {            \"href\": \"https://connector.url/v1/api/accounts/1\"\
+              ,            \"rel\": \"self\",            \"method\": \"GET\"     \
+              \   }    }"
+          example: "{        {            \"href\": \"https://connector.url/v1/api/accounts/1\"\
+            ,            \"rel\": \"self\",            \"method\": \"GET\"       \
+            \ }    }"
+        allow_apple_pay:
+          type: boolean
+          default: false
+          description: Set to true to enable Apple Pay
+          example: true
+        allow_authorisation_api:
+          type: boolean
+          default: false
+          description: Flag to indicate whether the account is allowed to initiate
+            MOTO payments that are authorised via an API request rather than the web
+            interface
+          example: true
+        allow_google_pay:
+          type: boolean
+          default: false
+          description: Set to true to enable Google Pay
+          example: true
+        allow_moto:
+          type: boolean
+          default: false
+          description: Indicates whether the Mail Order and Telephone Order (MOTO)
+            payments are allowed
+        allow_telephone_payment_notifications:
+          type: boolean
+          default: false
+          description: Indicates if the account is used for telephone payments reporting
+        allow_zero_amount:
+          type: boolean
+          default: false
+          description: Set to true to support charges with a zero amount
+          example: true
+        analytics_id:
+          type: string
+          description: An identifier used to identify the service in Google Analytics.
+            The default value is null
+        block_prepaid_cards:
+          type: boolean
+          default: false
+          description: Whether pre-paid cards are allowed as a payment method for
+            this gateway account
+          example: true
+        corporate_credit_card_surcharge_amount:
+          type: integer
+          format: int64
+          default: 0
+          description: A corporate credit card surcharge amount in pence
+          example: 250
+        corporate_debit_card_surcharge_amount:
+          type: integer
+          format: int64
+          default: 0
+          description: A corporate debit card surcharge amount in pence
+          example: 250
+        corporate_prepaid_debit_card_surcharge_amount:
+          type: integer
+          format: int64
+          description: A corporate prepaid debit card surcharge amount in pence
+          example: 0
+        description:
+          type: string
+          default: "null"
+          description: An internal description to identify the gateway account. The
+            default value is null.
+          example: Account for service xxx
+        disabled:
+          type: boolean
+          default: false
+          description: Flag to indicate whether the account is allowed to take payments
+            and make refunds
+          example: false
+        disabled_reason:
+          type: string
+          description: "The reason the account is disabled, if applicable"
+          example: No longer required
+        email_collection_mode:
+          type: string
+          description: "Whether email address is required from paying users. Can be\
+            \ MANDATORY, OPTIONAL or OFF"
+          enum:
+          - MANDATORY
+          - OPTIONAL
+          - "OFF"
+        email_notifications:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/EmailNotificationEntity'
+          description: The settings for the different emails (payments/refunds) that
+            are sent out
+          example:
+            PAYMENT_CONFIRMED:
+              enabled: true
+              template_body: null
+              version: 1
+            REFUND_ISSUED:
+              enabled: true
+              template_body: null
+              version: 1
+        external_id:
+          type: string
+          description: External ID for the gateway account
+          example: fbf905a3f7ea416c8c252410eb45ddbd
+        gateway_account_credentials:
+          type: array
+          description: Array of the credentials configured for this account
+          items:
+            $ref: '#/components/schemas/GatewayAccountCredentialsEntity'
+        gateway_account_id:
+          type: integer
+          format: int64
+          description: The account ID
+          example: 1
+        integration_version_3ds:
+          type: integer
+          format: int32
+          description: 3DS version used for payments for the gateway account
+          example: 2
+        live:
+          type: boolean
+          description: Whether the account is live
+          example: true
+        moto_mask_card_number_input:
+          type: boolean
+          default: false
+          description: Indicates whether the card number is masked when being input
+            for MOTO payments. The default value is false.
+        moto_mask_card_security_code_input:
+          type: boolean
+          default: false
+          description: Indicates whether the card security code is masked when being
+            input for MOTO payments.
+        notificationCredentials:
+          $ref: '#/components/schemas/NotificationCredentials'
+        notifySettings:
+          type: object
+          additionalProperties:
+            type: string
+            description: An object containing the Notify credentials and configuration
+              for sending custom branded emails
+          description: An object containing the Notify credentials and configuration
+            for sending custom branded emails
+        payment_provider:
+          type: string
+          description: The payment provider for which this account is created
+          example: sandbox
+        provider_switch_enabled:
+          type: boolean
+          default: false
+          description: Flag to enable payment provider switching
+          example: false
+        recurring_enabled:
+          type: boolean
+          default: false
+          description: Flag to indicate whether the account is allowed to take recurring
+            card payments
+          example: true
+        requires3ds:
+          type: boolean
+          description: Flag to indicate whether 3DS is enabled
+          example: true
+        send_payer_email_to_gateway:
+          type: boolean
+          default: false
+          description: "If enabled, user email address is included in the authorisation\
+            \ request to gateway"
+          example: true
+        send_payer_ip_address_to_gateway:
+          type: boolean
+          default: false
+          description: "If enabled, user IP address is sent to to gateway"
+          example: true
+        send_reference_to_gateway:
+          type: boolean
+          default: false
+          description: "If enabled, service payment reference is sent to gateway as\
+            \ description. Otherwise payment description is sent to the gateway. Only\
+            \ applicable for Worldpay accounts. Default value is 'false'"
+          example: true
+        service_id:
+          type: string
+          description: Service external ID
+          example: cd1b871207a94a7fa157dee678146acd
+        service_name:
+          type: string
+          description: The service name for the account
+          example: service name
+        type:
+          type: string
+          description: Account type for the payment provider (test/live)
+          example: test
+        worldpay_3ds_flex:
+          $ref: '#/components/schemas/Worldpay3dsFlexCredentials'
     GatewayAccountsListDTO:
       type: object
       properties:
         accounts:
           type: array
           items:
-            $ref: '#/components/schemas/GatewayAccountResourceDTO'
+            $ref: '#/components/schemas/GatewayAccountResponse'
     GatewayStatusComparison:
       type: object
       properties:
@@ -4096,14 +4046,8 @@ components:
       - new_status
     NotificationCredentials:
       type: object
-      properties:
-        userName:
-          type: string
-        version:
-          type: integer
-          format: int64
-    NotificationCredentials_ApiView:
-      type: object
+      description: The gateway credentials for receiving notifications. Only present
+        for Smartpay accounts
       properties:
         userName:
           type: string
@@ -4547,18 +4491,6 @@ components:
           example: 57992a087a0c4849895ab8a2
           maxLength: 24
           minLength: 24
-    Worldpay3dsFlexCredentials_ApiView:
-      type: object
-      properties:
-        exemption_engine_enabled:
-          type: boolean
-          example: true
-        issuer:
-          type: string
-          example: issuer
-        organisational_unit_id:
-          type: string
-          example: org_unit_id
     WorldpayValidatableCredentials:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/FrontendGatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/FrontendGatewayAccountResponse.java
@@ -6,8 +6,6 @@ import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 
 import java.util.List;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
 @Schema(description = "Representation of a gateway account for use by the card frontend application")
 public class FrontendGatewayAccountResponse {
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -1,10 +1,5 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
@@ -40,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static java.util.Comparator.comparing;
@@ -63,7 +57,6 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "gateway_accounts_gateway_account_id_seq")
-    @JsonIgnore
     private Long id;
 
     @Column(name = "external_id")
@@ -128,7 +121,6 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @OneToMany(mappedBy = "accountEntity", cascade = CascadeType.PERSIST)
     @MapKeyColumn(name = "type")
     @MapKeyEnumerated(value = EnumType.STRING)
-    @JsonManagedReference
     private Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
 
     @Column(name = "email_collection_mode")
@@ -184,21 +176,15 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     public GatewayAccountEntity(GatewayAccountType type) {
         this.type = type;
     }
-
-    @JsonProperty("gateway_account_id")
-    @JsonView({Views.ApiView.class})
+    
     public Long getId() {
         return this.id;
     }
-
-    @JsonProperty("external_id")
-    @JsonView({Views.ApiView.class})
+    
     public String getExternalId() {
         return externalId;
     }
-
-    @JsonProperty("payment_provider")
-    @JsonView(value = {Views.ApiView.class})
+    
     public String getGatewayName() {
         return getCurrentOrActiveGatewayAccountCredential()
                 .map(GatewayAccountCredentialsEntity::getPaymentProvider)
@@ -206,8 +192,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
                         serviceErrorResponse(format("Active or current credential not found for gateway account [%s]",
                                 getId()))));
     }
-
-    @JsonIgnore
+    
     public Optional<GatewayAccountCredentialsEntity> getCurrentOrActiveGatewayAccountCredential() {
         List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntities = getGatewayAccountCredentials();
         if (getGatewayAccountCredentials().size() == 1) {
@@ -246,8 +231,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
                         format("Credentials not found for gateway account [%s] and payment_provider [%s] ",
                                 getId(), paymentProvider))));
     }
-
-    @JsonIgnore
+    
     public GatewayAccountCredentialsEntity getGatewayAccountCredentialsEntity(String paymentProvider) {
         return gatewayAccountCredentials.stream()
                 .filter(entity -> entity.getPaymentProvider().equals(paymentProvider))
@@ -256,8 +240,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
                         format("Credentials not found for gateway account [%s] and payment_provider [%s] ",
                                 getId(), paymentProvider))));
     }
-
-    @JsonIgnore
+    
     public GatewayAccountCredentialsEntity getRecentNonRetiredGatewayAccountCredentialsEntity(String paymentProvider) {
         return gatewayAccountCredentials.stream()
                 .filter(entity -> entity.getPaymentProvider().equals(paymentProvider))
@@ -267,8 +250,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
                         format("Credentials not found for gateway account [%s] and payment_provider [%s] ",
                                 getId(), paymentProvider))));
     }
-
-    @JsonIgnore
+    
     public String getGatewayMerchantId() {
         return getCurrentOrActiveGatewayAccountCredential()
                 .map(credentialsEntity -> {
@@ -280,69 +262,51 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
                     return null;
                 }).orElse(null);
     }
-
-    @JsonProperty("gateway_account_credentials")
-    @JsonView(Views.ApiView.class)
+    
     public List<GatewayAccountCredentialsEntity> getGatewayAccountCredentials() {
         return gatewayAccountCredentials;
     }
-
-    @JsonView(Views.ApiView.class)
+    
     public String getDescription() {
         return description;
     }
-
-    @JsonView(value = {Views.ApiView.class})
-    @JsonProperty("analytics_id")
+    
     public String getAnalyticsId() {
         return analyticsId;
     }
-
-    @JsonProperty("type")
-    @JsonView(value = {Views.ApiView.class})
+    
     public String getType() {
         return type.toString();
     }
-
-    @JsonProperty("service_name")
-    @JsonView(value = {Views.ApiView.class})
+    
     public String getServiceName() {
         return serviceName;
     }
-
-    @JsonProperty("service_id")
-    @JsonView(value = {Views.ApiView.class})
+    
     public String getServiceId() {
         return serviceId;
     }
-
-    @JsonIgnore
+    
     public List<CardTypeEntity> getCardTypes() {
         return cardTypes;
     }
-
-    @JsonProperty("email_notifications")
+    
     public Map<EmailNotificationType, EmailNotificationEntity> getEmailNotifications() {
         return emailNotifications;
     }
-
-    @JsonProperty("email_collection_mode")
+    
     public EmailCollectionMode getEmailCollectionMode() {
         return emailCollectionMode;
     }
-
-    @JsonView(Views.ApiView.class)
+    
     public NotificationCredentials getNotificationCredentials() {
         return notificationCredentials;
     }
-
-    @JsonIgnore
+    
     public Optional<Worldpay3dsFlexCredentialsEntity> getWorldpay3dsFlexCredentialsEntity() {
         return Optional.ofNullable(worldpay3dsFlexCredentialsEntity);
     }
-
-    @JsonInclude(NON_NULL)
-    @JsonProperty("worldpay_3ds_flex")
+    
     public Optional<Worldpay3dsFlexCredentials> getWorldpay3dsFlexCredentials() {
         return Optional.ofNullable(worldpay3dsFlexCredentialsEntity).map(Worldpay3dsFlexCredentials::fromEntity);
     }
@@ -350,117 +314,79 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     public boolean isRequires3ds() {
         return requires3ds;
     }
-
-    @JsonProperty("allow_google_pay")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isAllowGooglePay() {
         return allowGooglePay && isNotBlank(getGatewayMerchantId());
     }
-
-    @JsonProperty("allow_apple_pay")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isAllowApplePay() {
         return allowApplePay;
     }
-
-    @JsonProperty("allow_zero_amount")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isAllowZeroAmount() {
         return allowZeroAmount;
     }
-
-    @JsonProperty("block_prepaid_cards")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isBlockPrepaidCards() {
         return blockPrepaidCards;
     }
-
-    @JsonProperty("allow_moto")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isAllowMoto() {
         return allowMoto;
     }
-
-    @JsonProperty("moto_mask_card_number_input")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isMotoMaskCardNumberInput() {
         return motoMaskCardNumberInput;
     }
-
-    @JsonProperty("moto_mask_card_security_code_input")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isMotoMaskCardSecurityCodeInput() {
         return motoMaskCardSecurityCodeInput;
     }
-
-    @JsonProperty("corporate_credit_card_surcharge_amount")
-    @JsonView(value = {Views.ApiView.class})
+    
     public long getCorporateNonPrepaidCreditCardSurchargeAmount() {
         return corporateCreditCardSurchargeAmount;
     }
-
-    @JsonProperty("corporate_debit_card_surcharge_amount")
-    @JsonView(value = {Views.ApiView.class})
+    
     public long getCorporateNonPrepaidDebitCardSurchargeAmount() {
         return corporateDebitCardSurchargeAmount;
     }
-
-    @JsonProperty("corporate_prepaid_debit_card_surcharge_amount")
-    @JsonView(value = {Views.ApiView.class})
+    
     public long getCorporatePrepaidDebitCardSurchargeAmount() {
         return corporatePrepaidDebitCardSurchargeAmount;
     }
-
-    @JsonProperty("integration_version_3ds")
-    @JsonView(value = {Views.ApiView.class})
+    
     public int getIntegrationVersion3ds() {
         return integrationVersion3ds;
     }
-
-    @JsonProperty("allow_telephone_payment_notifications")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isAllowTelephonePaymentNotifications() {
         return allowTelephonePaymentNotifications;
     }
-
-    @JsonProperty("send_payer_ip_address_to_gateway")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isSendPayerIpAddressToGateway() {
         return sendPayerIpAddressToGateway;
     }
-
-    @JsonProperty("send_payer_email_to_gateway")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isSendPayerEmailToGateway() {
         return sendPayerEmailToGateway;
     }
-
-    @JsonProperty("send_reference_to_gateway")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isSendReferenceToGateway() {
         return sendReferenceToGateway;
     }
-
-    @JsonProperty("allow_authorisation_api")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isAllowAuthorisationApi() {
         return allowAuthorisationApi;
     }
-
-    @JsonProperty("recurring_enabled")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isRecurringEnabled() {
         return recurringEnabled;
     }
-
-    @JsonProperty("disabled")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isDisabled() {
         return disabled;
     }
-
-    @JsonProperty("disabled_reason")
-    @JsonView(value = {Views.ApiView.class})
+    
     public String getDisabledReason() {
         return disabledReason;
     }
@@ -601,9 +527,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     public void setAllowAuthorisationApi(boolean allowAuthorisationApi) {
         this.allowAuthorisationApi = allowAuthorisationApi;
     }
-
-    @JsonProperty("provider_switch_enabled")
-    @JsonView(value = {Views.ApiView.class})
+    
     public boolean isProviderSwitchEnabled() {
         return providerSwitchEnabled;
     }
@@ -626,11 +550,6 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public void setDisabledReason(String disabledReason) {
         this.disabledReason = disabledReason;
-    }
-
-    public class Views {
-        public class ApiView {
-        }
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonInclude(NON_NULL)
-public class GatewayAccountResourceDTO {
+public class GatewayAccountResponse {
 
     @JsonProperty("gateway_account_id")
     @Schema(example = "1", description = "The account ID")
@@ -31,6 +31,9 @@ public class GatewayAccountResourceDTO {
 
     @Schema(example = "test", description = "Account type for the payment provider (test/live)")
     private GatewayAccountType type;
+    
+    @Schema(example = "true", description = "Whether the account is live")
+    private boolean live;
 
     @Schema(example = "Account for service xxx", description = "An internal description to identify the gateway account. The default value is null.", defaultValue = "null")
     private String description;
@@ -166,14 +169,15 @@ public class GatewayAccountResourceDTO {
     @Schema(example = "No longer required", description = "The reason the account is disabled, if applicable")
     private String disabledReason;
 
-    public GatewayAccountResourceDTO() {
+    public GatewayAccountResponse() {
     }
 
-    public GatewayAccountResourceDTO(GatewayAccountEntity gatewayAccountEntity) {
+    public GatewayAccountResponse(GatewayAccountEntity gatewayAccountEntity) {
         this.accountId = gatewayAccountEntity.getId();
         this.externalId = gatewayAccountEntity.getExternalId();
         this.paymentProvider = gatewayAccountEntity.getGatewayName();
         this.type = GatewayAccountType.fromString(gatewayAccountEntity.getType());
+        this.live = gatewayAccountEntity.isLive();
         this.description = gatewayAccountEntity.getDescription();
         this.serviceName = gatewayAccountEntity.getServiceName();
         this.analyticsId = gatewayAccountEntity.getAnalyticsId();
@@ -218,6 +222,10 @@ public class GatewayAccountResourceDTO {
 
     public String getType() {
         return type.toString();
+    }
+
+    public boolean isLive() {
+        return live;
     }
 
     public String getDescription() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsResponse.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.usernotification.model.domain.NotificationCredentials;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+public class GatewayAccountWithCredentialsResponse extends GatewayAccountResponse {
+
+    @JsonProperty("notifySettings")
+    @Schema(description = "An object containing the Notify credentials and configuration for sending custom branded emails")
+    private final Map<String, String> notifySettings;
+    
+    @JsonProperty("notificationCredentials")
+    @Schema(description = "The gateway credentials for receiving notifications. Only present for Smartpay accounts")
+    private final  NotificationCredentials notificationCredentials;
+
+    @JsonProperty("gateway_account_credentials")
+    @Schema(description = "Array of the credentials configured for this account")
+    private final List<GatewayAccountCredentialsEntity> gatewayAccountCredentials;
+
+    public GatewayAccountWithCredentialsResponse(GatewayAccountEntity gatewayAccountEntity) {
+        super(gatewayAccountEntity);
+        this.notifySettings = gatewayAccountEntity.getNotifySettings();
+        this.notificationCredentials = gatewayAccountEntity.getNotificationCredentials();
+        this.gatewayAccountCredentials = gatewayAccountEntity.getGatewayAccountCredentials();
+        gatewayAccountCredentials.forEach(credential -> credential.getCredentials().remove("password"));
+    }
+
+    public Map<String, String> getNotifySettings() {
+        return notifySettings;
+    }
+
+    public NotificationCredentials getNotificationCredentials() {
+        return notificationCredentials;
+    }
+
+    public List<GatewayAccountCredentialsEntity> getGatewayAccountCredentials() {
+        return gatewayAccountCredentials;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountsListDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountsListDTO.java
@@ -11,14 +11,14 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 public class GatewayAccountsListDTO {
 
     @JsonProperty("accounts")
-    private final List<GatewayAccountResourceDTO> gatewayAccountsListDTOList;
+    private final List<GatewayAccountResponse> gatewayAccountsListDTOList;
 
-    private GatewayAccountsListDTO(List<GatewayAccountResourceDTO> gatewayAccountsListDTOList) {
+    private GatewayAccountsListDTO(List<GatewayAccountResponse> gatewayAccountsListDTOList) {
         this.gatewayAccountsListDTOList = gatewayAccountsListDTOList;
     }
 
 
-    public static GatewayAccountsListDTO of(List<GatewayAccountResourceDTO> gatewayAccountsListDTOList) {
+    public static GatewayAccountsListDTO of(List<GatewayAccountResponse> gatewayAccountsListDTOList) {
         return new GatewayAccountsListDTO(gatewayAccountsListDTOList);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -13,7 +13,7 @@ import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountRequest;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.CreateGatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
@@ -77,9 +77,9 @@ public class GatewayAccountService {
         return gatewayAccountDao.findById(gatewayAccountId);
     }
 
-    public List<GatewayAccountResourceDTO> searchGatewayAccounts(GatewayAccountSearchParams params) {
+    public List<GatewayAccountResponse> searchGatewayAccounts(GatewayAccountSearchParams params) {
         return gatewayAccountDao.search(params).stream()
-                .map(GatewayAccountResourceDTO::new)
+                .map(GatewayAccountResponse::new)
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponseTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity.Worldpay3dsFlexCredentialsEntityBuilder.aWorldpay3dsFlexCredentialsEntity;
 
-class GatewayAccountResourceDTOTest {
+class GatewayAccountResponseTest {
 
     @Test
     void fromEntity() {
@@ -60,11 +60,12 @@ class GatewayAccountResourceDTOTest {
         emailNotifications.put(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(new GatewayAccountEntity(), "testTemplate", true));
         entity.setEmailNotifications(emailNotifications);
         
-        GatewayAccountResourceDTO dto = new GatewayAccountResourceDTO(entity);
+        GatewayAccountResponse dto = new GatewayAccountResponse(entity);
         assertThat(dto.getAccountId(), is(entity.getId()));
         assertThat(dto.getExternalId(), is(entity.getExternalId()));
         assertThat(dto.getPaymentProvider(), is(entity.getGatewayName()));
         assertThat(dto.getType(), is(entity.getType()));
+        assertThat(dto.isLive(), is(entity.isLive()));
         assertThat(dto.getDescription(), is(entity.getDescription()));
         assertThat(dto.getServiceName(), is(entity.getServiceName()));
         assertThat(dto.getAnalyticsId(), is(entity.getAnalyticsId()));

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -320,7 +320,7 @@ public class GatewayAccountFrontendResourceIT extends GatewayAccountResourceTest
                 .get(ACCOUNTS_FRONTEND_URL + nonExistingGatewayAccount)
                 .then()
                 .statusCode(404)
-                .body("message", contains("Account with id '12345' not found"))
+                .body("message", contains("Gateway Account with id [12345] not found."))
                 .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
     }

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -16,7 +16,7 @@ import uk.gov.pay.connector.gatewayaccount.exception.NotSupportedGatewayAccountE
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
@@ -102,7 +102,7 @@ public class GatewayAccountServiceTest {
         when(mockGatewayAccountDao.search(gatewayAccountSearchParams))
                 .thenReturn(Arrays.asList(getMockGatewayAccountEntity1, getMockGatewayAccountEntity2));
 
-        List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountService.searchGatewayAccounts(gatewayAccountSearchParams);
+        List<GatewayAccountResponse> gatewayAccounts = gatewayAccountService.searchGatewayAccounts(gatewayAccountSearchParams);
 
         assertThat(gatewayAccounts, hasSize(2));
         assertThat(gatewayAccounts.get(0).getServiceName(), is("service one"));


### PR DESCRIPTION
Rename GatewayAccountResourceDTO -> GatewayAccountResponse.

GatewayAccountWithCredentialsResponse extends GatewayAccountResponse and includes the account PSP and notify credentials.

Return GatewayAccountWithCredentialsResponse instead of the API JsonView of GatewayAccountEntity for responses to:
GET `/v1/frontend/accounts/{accountId}`
GET `/v1/frontend/accounts/external-id/{externalId}`