### PR TITLE
PP-11244 Prepare to reduce number of GET gateway account endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -143,91 +143,91 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "423e3dd3782e3527b4f9af75dd9faf9ebbb7889c",
         "is_verified": false,
-        "line_number": 374
+        "line_number": 377
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 787
+        "line_number": 790
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 2883
+        "line_number": 2886
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 2947
+        "line_number": 2950
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3272
+        "line_number": 3275
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3308
+        "line_number": 3311
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3341
+        "line_number": 3344
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
         "is_verified": false,
-        "line_number": 3391
+        "line_number": 3394
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 4023
+        "line_number": 4026
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 4026
+        "line_number": 4029
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 4029
+        "line_number": 4032
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4480
+        "line_number": 4483
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4491
+        "line_number": 4494
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1048,5 +1048,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-06T10:32:58Z"
+  "generated_at": "2023-07-06T12:04:46Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -161,6 +161,9 @@ paths:
       - Gateway accounts
   /v1/api/accounts/{accountId}:
     get:
+      description: "Get gateway account by internal ID. Returns notifications credentials,\
+        \ gateway account credentials (without password). Doesn't include card_types\
+        \ or gateway_merchant_id"
       operationId: getGatewayAccount
       parameters:
       - description: Gateway account ID
@@ -176,7 +179,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GatewayAccountResponse'
+                $ref: '#/components/schemas/GatewayAccountWithCredentialsResponse'
           description: OK
         "404":
           description: Not found

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -106,20 +106,20 @@ public class GatewayAccountResource {
     @Produces(APPLICATION_JSON)
     @Operation(
             summary = "Find gateway account by ID",
+            description = "Get gateway account by internal ID. Returns notifications credentials, gateway account credentials (without password). Doesn't include card_types or gateway_merchant_id",
             tags = {"Gateway accounts"},
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",
-                            content = @Content(schema = @Schema(implementation = GatewayAccountResponse.class))),
+                            content = @Content(schema = @Schema(implementation = GatewayAccountWithCredentialsResponse.class))),
                     @ApiResponse(responseCode = "404", description = "Not found")
             }
     )
-    public Response getGatewayAccount(@Parameter(example = "1", description = "Gateway account ID") @PathParam("accountId") Long accountId) {
-        logger.debug("Getting gateway account for account id {}", accountId);
-        return gatewayAccountService
-                .getGatewayAccount(accountId)
-                .map(GatewayAccountResponse::new)
-                .map(gatewayAccountDTO -> Response.ok().entity(gatewayAccountDTO).build())
-                .orElseGet(() -> notFoundResponse(format("Account with id %s not found.", accountId)));
+    public GatewayAccountWithCredentialsResponse getGatewayAccount(@Parameter(example = "1", description = "Gateway account ID")
+                                                                                  @PathParam("accountId") Long gatewayAccountId) {
+
+        return gatewayAccountService.getGatewayAccount(gatewayAccountId)
+                .map(GatewayAccountWithCredentialsResponse::new)
+                .orElseThrow(() -> new GatewayAccountNotFoundException(gatewayAccountId));
     }
 
     @GET


### PR DESCRIPTION
We have 2 endpoints for getting a Gateway Account by the internal ID:

- `/v1/frontend/accounts/{accountId}` returns the gateway account including the credentials and is called by selfservice and toolbox
- `/v1/api/accounts/{accountId}` returns the same response but without credentials. It is used sometimes on toolbox, although there is no good reason to call it over `/v1/frontend/...`

We want to remove one of these endpoints to reduce confusion. It makes more sense to remove `/v1/frontend/...` as this suggests the endpoint is called by the frontend app, which it isn't.

Prepare for this deletion by making the behaviour of the `/v1/api/accounts/{accountId}` endpoint identical to `/v1/frontend/accounts/{accountId}`.

We will then:
- update consumers to always use `/v1/api/accounts/{accountId}`
- delete `/v1/frontend/accounts/{accountId}`