### PR TITLE
PP-11244 Remove OpenApi tag

### DIFF
--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1372,7 +1372,7 @@ paths:
           description: Not found
       summary: Find gateway account by gateway account external ID
       tags:
-      - Gateway accounts - frontend
+      - Gateway accounts
   /v1/frontend/accounts/{accountId}/3ds-toggle:
     patch:
       operationId: updateGatewayAccount3dsToggle
@@ -1407,7 +1407,7 @@ paths:
           description: Conflict - 3ds cannot be disabled for account
       summary: Set requires3ds flag on a gateway account
       tags:
-      - Gateway accounts - frontend
+      - Gateway accounts
   /v1/frontend/accounts/{accountId}/card-types:
     get:
       operationId: getGatewayAccountAcceptedCardTypes
@@ -1438,7 +1438,7 @@ paths:
           description: Not found
       summary: Get card types for gateway account
       tags:
-      - Gateway accounts - frontend
+      - Gateway accounts
     post:
       operationId: updateGatewayAccountAcceptedCardTypes
       parameters:
@@ -1477,7 +1477,7 @@ paths:
             one card type requires 3DS to be enabled. '
       summary: Update accepted card types for a gateway account
       tags:
-      - Gateway accounts - frontend
+      - Gateway accounts
   /v1/frontend/accounts/{accountId}/servicename:
     patch:
       operationId: updateGatewayAccountServiceName
@@ -1512,7 +1512,7 @@ paths:
           description: Not found
       summary: Update service name of a gateway account
       tags:
-      - Gateway accounts - frontend
+      - Gateway accounts
   /v1/frontend/charges/{chargeId}:
     get:
       operationId: getCharge_1

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -166,7 +166,7 @@ public class GatewayAccountResource {
     @Operation(
             summary = "Find gateway account by gateway account external ID",
             description = "Get gateway account by external ID. Also returns notifications credentials, gateway account credentials (without password)",
-            tags = {"Gateway accounts - frontend"},
+            tags = {"Gateway accounts"},
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(name = "accounts", implementation = GatewayAccountWithCredentialsResponse.class))),
@@ -186,7 +186,7 @@ public class GatewayAccountResource {
     @Produces(APPLICATION_JSON)
     @Operation(
             summary = "Get card types for gateway account",
-            tags = {"Gateway accounts - frontend"},
+            tags = {"Gateway accounts"},
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(example = "{" +
@@ -276,7 +276,7 @@ public class GatewayAccountResource {
     @Transactional
     @Operation(
             summary = "Update service name of a gateway account",
-            tags = {"Gateway accounts - frontend"},
+            tags = {"Gateway accounts"},
             requestBody = @RequestBody(content = @Content(schema = @Schema(example = "{" +
                     "  \"service_name\": \"a new service name\"" +
                     "}", requiredProperties = {"service_name"}))),
@@ -316,7 +316,7 @@ public class GatewayAccountResource {
     @Transactional
     @Operation(
             summary = "Set requires3ds flag on a gateway account",
-            tags = {"Gateway accounts - frontend"},
+            tags = {"Gateway accounts"},
             requestBody = @RequestBody(content = @Content(schema = @Schema(example = "{" +
                     "  \"toggle_3ds\": \"true\"" +
                     "}"))),
@@ -356,7 +356,7 @@ public class GatewayAccountResource {
     @Transactional
     @Operation(
             summary = "Update accepted card types for a gateway account",
-            tags = {"Gateway accounts - frontend"},
+            tags = {"Gateway accounts"},
             requestBody = @RequestBody(content = @Content(schema = @Schema(example = "{" +
                     "    \"card_types\": [" +
                     "        \"ab8a3abd-bcfd-4fa6-8905-321ce913e7f5\"," +


### PR DESCRIPTION
Remove the "Gateway accounts - frontend" OpenApi tag, and instead tag all gateway account endpoints with "Gateway accounts".

There is no meaningful reason why some endpoints are `/v1/frontend/` and others are `/v1/api/` as all of these endpoints are consumed by selfservice and toolbox. Using the same tag will group them all together when viewed in an API browser.