### PR TITLE
PP-11152 Don't use entity for JSON serialisation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -188,46 +188,39 @@
         "line_number": 3217
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "openapi/connector_spec.yaml",
-        "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
-        "is_verified": false,
-        "line_number": 3267
-      },
-      {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 3899
+        "line_number": 3848
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 3902
+        "line_number": 3851
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 3905
+        "line_number": 3854
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4356
+        "line_number": 4305
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4367
+        "line_number": 4316
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -339,15 +332,6 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
         "line_number": 81
-      }
-    ],
-    "src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java",
-        "hashed_secret": "f6e49af5bc530ae85699c4fb4dab97b5d7ea9fc0",
-        "is_verified": false,
-        "line_number": 83
       }
     ],
     "src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java": [
@@ -1048,5 +1032,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-10T09:48:03Z"
+  "generated_at": "2023-07-10T16:07:15Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3239,57 +3239,6 @@ components:
           - ACTIVE
           - RETIRED
           example: ACTIVE
-    GatewayAccountCredentialsEntity:
-      type: object
-      description: Array of the credentials configured for this account
-      properties:
-        active_end_date:
-          type: string
-          format: date-time
-        active_start_date:
-          type: string
-          format: date-time
-          example: 2022-05-27T09:17:19.162Z
-        created_date:
-          type: string
-          format: date-time
-          example: 2022-05-27T09:17:19.162Z
-        credentials:
-          type: object
-          additionalProperties:
-            type: object
-            example:
-              stripe_account_id: an-id
-          example:
-            stripe_account_id: an-id
-        external_id:
-          type: string
-          example: 731193f990064e698ca1b89775b70bcc
-        gateway_account_credential_id:
-          type: integer
-          format: int64
-          example: 11
-        gateway_account_id:
-          type: integer
-          format: int64
-          example: 1
-        last_updated_by_user_external_id:
-          type: string
-        payment_provider:
-          type: string
-          example: stripe
-        state:
-          type: string
-          enum:
-          - CREATED
-          - ENTERED
-          - VERIFIED_WITH_LIVE_PAYMENT
-          - ACTIVE
-          - RETIRED
-          example: ACTIVE
-        version:
-          type: integer
-          format: int64
     GatewayAccountCredentialsRequest:
       type: object
       properties:
@@ -3675,7 +3624,7 @@ components:
           type: array
           description: Array of the credentials configured for this account
           items:
-            $ref: '#/components/schemas/GatewayAccountCredentialsEntity'
+            $ref: '#/components/schemas/GatewayAccountCredentials'
         gateway_account_id:
           type: integer
           format: int64

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsResponse.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.usernotification.model.domain.NotificationCredential
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
@@ -17,20 +18,23 @@ public class GatewayAccountWithCredentialsResponse extends GatewayAccountRespons
     @JsonProperty("notifySettings")
     @Schema(description = "An object containing the Notify credentials and configuration for sending custom branded emails")
     private final Map<String, String> notifySettings;
-    
+
     @JsonProperty("notificationCredentials")
     @Schema(description = "The gateway credentials for receiving notifications. Only present for Smartpay accounts")
-    private final  NotificationCredentials notificationCredentials;
+    private final NotificationCredentials notificationCredentials;
 
     @JsonProperty("gateway_account_credentials")
     @Schema(description = "Array of the credentials configured for this account")
-    private final List<GatewayAccountCredentialsEntity> gatewayAccountCredentials;
+    private final List<GatewayAccountCredentials> gatewayAccountCredentials;
 
     public GatewayAccountWithCredentialsResponse(GatewayAccountEntity gatewayAccountEntity) {
         super(gatewayAccountEntity);
         this.notifySettings = gatewayAccountEntity.getNotifySettings();
         this.notificationCredentials = gatewayAccountEntity.getNotificationCredentials();
-        this.gatewayAccountCredentials = gatewayAccountEntity.getGatewayAccountCredentials();
+        this.gatewayAccountCredentials = gatewayAccountEntity.getGatewayAccountCredentials()
+                .stream()
+                .map(GatewayAccountCredentials::new)
+                .collect(Collectors.toList());
         gatewayAccountCredentials.forEach(credential -> credential.getCredentials().remove("password"));
     }
 
@@ -42,7 +46,7 @@ public class GatewayAccountWithCredentialsResponse extends GatewayAccountRespons
         return notificationCredentials;
     }
 
-    public List<GatewayAccountCredentialsEntity> getGatewayAccountCredentials() {
+    public List<GatewayAccountCredentials> getGatewayAccountCredentials() {
         return gatewayAccountCredentials;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -1,17 +1,10 @@
 package uk.gov.pay.connector.gatewayaccountcredentials.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import io.swagger.v3.oas.annotations.media.Schema;
 import org.eclipse.persistence.annotations.Customizer;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
+import uk.gov.pay.connector.common.model.domain.HistoryCustomizer;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.util.JsonToStringObjectMapConverter;
-import uk.gov.pay.connector.common.model.domain.HistoryCustomizer;
-import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
 import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
 
 import javax.persistence.Column;
@@ -33,7 +26,6 @@ import java.util.Map;
 @Table(name = "gateway_account_credentials")
 @SequenceGenerator(name = "gateway_account_credentials_id_seq",
         sequenceName = "gateway_account_credentials_id_seq", allocationSize = 1)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Customizer(HistoryCustomizer.class)
 public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
@@ -42,19 +34,14 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     private Long id;
 
     @Column(name = "payment_provider")
-    @Schema(example = "stripe")
     private String paymentProvider;
 
     @Column(name = "credentials", columnDefinition = "json")
     @Convert(converter = JsonToStringObjectMapConverter.class)
-    @Schema(example = "{" +
-            "                \"stripe_account_id\": \"an-id\"" +
-            "            }")
     private Map<String, Object> credentials;
 
     @Column(name = "state", nullable = false)
     @Enumerated(EnumType.STRING)
-    @Schema(example = "ACTIVE")
     private GatewayAccountCredentialState state;
 
     @Column(name = "last_updated_by_user_external_id")
@@ -62,12 +49,10 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
     @Column(name = "created_date")
     @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
-    @Schema(example = "2022-05-27T09:17:19.162Z")
     private Instant createdDate;
 
     @Column(name = "active_start_date")
     @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
-    @Schema(example = "2022-05-27T09:17:19.162Z")
     private Instant activeStartDate;
 
     @Column(name = "active_end_date")
@@ -76,11 +61,9 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
     @ManyToOne
     @JoinColumn(name = "gateway_account_id", nullable = false)
-    @JsonIgnore
     private GatewayAccountEntity gatewayAccountEntity;
 
     @Column(name = "external_id")
-    @Schema(example = "731193f990064e698ca1b89775b70bcc")
     private String externalId;
 
     public GatewayAccountCredentialsEntity() {
@@ -94,9 +77,7 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
         this.state = state;
         this.createdDate = Instant.now();
     }
-
-    @JsonProperty("gateway_account_credential_id")
-    @Schema(example = "11")
+    
     public Long getId() {
         return id;
     }
@@ -116,18 +97,15 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     public String getLastUpdatedByUserExternalId() {
         return lastUpdatedByUserExternalId;
     }
-
-    @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    
     public Instant getCreatedDate() {
         return createdDate;
     }
-
-    @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    
     public Instant getActiveStartDate() {
         return activeStartDate;
     }
-
-    @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    
     public Instant getActiveEndDate() {
         return activeEndDate;
     }
@@ -139,9 +117,7 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     public String getExternalId() {
         return externalId;
     }
-
-    @JsonProperty("gateway_account_id")
-    @Schema(example = "1")
+    
     public Long getGatewayAccountId() {
         return gatewayAccountEntity.getId();
     }


### PR DESCRIPTION
GatewayAccountWithCredentialsResponse was using
GatewayAccountCredentialsEntity to serialise the credentials in API responses. This is a hang-over from when we were using GatewayAccountEntity to serialise responses.

Instead, map to GatewayAccountCredentials and use this to serialise the API responses.