### PR TITLE
PP-11152 Convert credentials map into POJO

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,14 +213,14 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4305
+        "line_number": 4304
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4316
+        "line_number": 4315
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1032,5 +1032,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-13T12:04:14Z"
+  "generated_at": "2023-07-13T14:27:30Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -4072,7 +4072,6 @@ components:
       properties:
         stripe_account_id:
           type: string
-          writeOnly: true
     StripeGatewayAccountRequest:
       type: object
       allOf:

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/EpdqCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/EpdqCredentials.java
@@ -1,0 +1,67 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EpdqCredentials implements GatewayCredentials {
+
+    @JsonProperty("merchant_id")
+    private String merchantId;
+    
+    @JsonProperty("username")
+    private String username;
+    
+    @JsonProperty("password")
+    private String password;
+    
+    @JsonProperty("sha_in_passphrase")
+    private String shaInPassphrase;
+    
+    @JsonProperty("sha_out_passphrase")
+    private String shaOutPassphrase;
+    
+    public EpdqCredentials() {
+        // For Jackson
+    }
+
+    public String getMerchantId() {
+        return merchantId;
+    }
+
+    public void setMerchantId(String merchantId) {
+        this.merchantId = merchantId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getShaInPassphrase() {
+        return shaInPassphrase;
+    }
+
+    public void setShaInPassphrase(String shaInPassphrase) {
+        this.shaInPassphrase = shaInPassphrase;
+    }
+
+    public String getShaOutPassphrase() {
+        return shaOutPassphrase;
+    }
+
+    public void setShaOutPassphrase(String shaOutPassphrase) {
+        this.shaOutPassphrase = shaOutPassphrase;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
@@ -114,7 +114,7 @@ public class GatewayAccountCredentials {
     public Instant getActiveEndDate() {
         return activeEndDate;
     }
-
+    
     public Long getGatewayAccountId() {
         return gatewayAccountId;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentials.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public interface GatewayCredentials {
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/SandboxCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/SandboxCredentials.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SandboxCredentials implements GatewayCredentials {
+
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.gatewayaccount.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
@@ -14,8 +13,8 @@ public class StripeCredentials implements GatewayCredentials {
     @JsonProperty(STRIPE_ACCOUNT_ID_KEY)
     private String stripeAccountId;
 
-    public StripeCredentials(@JsonProperty(STRIPE_ACCOUNT_ID_KEY) String stripeAccountId) {
-        this.stripeAccountId = stripeAccountId;
+    public StripeCredentials() {
+        // for Jackson
     }
 
     public String getStripeAccountId() {
@@ -23,7 +22,7 @@ public class StripeCredentials implements GatewayCredentials {
     }
 
     public Map<String, String> toMap() {
-        return ImmutableMap.of(STRIPE_ACCOUNT_ID_KEY, stripeAccountId);
+        return Map.of(STRIPE_ACCOUNT_ID_KEY, stripeAccountId);
     }
     
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
@@ -1,20 +1,29 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
-public class StripeCredentials {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripeCredentials implements GatewayCredentials {
 
     public static final String STRIPE_ACCOUNT_ID_KEY = "stripe_account_id";
-    private String accountId;
+    
+    @JsonProperty(STRIPE_ACCOUNT_ID_KEY)
+    private String stripeAccountId;
 
-    public StripeCredentials(@JsonProperty(STRIPE_ACCOUNT_ID_KEY) String accountId) {
-        this.accountId = accountId;
+    public StripeCredentials(@JsonProperty(STRIPE_ACCOUNT_ID_KEY) String stripeAccountId) {
+        this.stripeAccountId = stripeAccountId;
+    }
+
+    public String getStripeAccountId() {
+        return stripeAccountId;
     }
 
     public Map<String, String> toMap() {
-        return ImmutableMap.of(STRIPE_ACCOUNT_ID_KEY, accountId);
+        return ImmutableMap.of(STRIPE_ACCOUNT_ID_KEY, stripeAccountId);
     }
+    
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator;
 
 import java.util.Objects;
 
-public class WorldpayCredentials {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WorldpayCredentials implements GatewayCredentials {
 
     @JsonProperty(GatewayAccount.CREDENTIALS_MERCHANT_ID)
     private String legacyOneOffCustomerInitiatedMerchantCode;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayMerchantCodeCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayMerchantCodeCredentials.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class WorldpayMerchantCodeCredentials {
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -1,9 +1,17 @@
 package uk.gov.pay.connector.gatewayaccountcredentials.model;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.persistence.annotations.Customizer;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
 import uk.gov.pay.connector.common.model.domain.HistoryCustomizer;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.EpdqCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.SandboxCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
 import uk.gov.pay.connector.gatewayaccount.util.JsonToStringObjectMapConverter;
 import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
 
@@ -21,6 +29,9 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Map.entry;
 
 @Entity
 @Table(name = "gateway_account_credentials")
@@ -29,6 +40,15 @@ import java.util.Map;
 @Customizer(HistoryCustomizer.class)
 public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    
+    private static final Map<PaymentGatewayName, Class<? extends GatewayCredentials>> GATEWAY_CREDENTIALS_TYPE_MAP = Map.ofEntries(
+            entry(PaymentGatewayName.WORLDPAY, WorldpayCredentials.class),
+            entry(PaymentGatewayName.STRIPE, StripeCredentials.class),
+            entry(PaymentGatewayName.EPDQ, EpdqCredentials.class),
+            entry(PaymentGatewayName.SANDBOX, SandboxCredentials.class)
+    );
+    
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "gateway_account_credentials_id_seq")
     private Long id;
@@ -65,7 +85,7 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
     @Column(name = "external_id")
     private String externalId;
-
+    
     public GatewayAccountCredentialsEntity() {
     }
 
@@ -88,6 +108,13 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
     public Map<String, Object> getCredentials() {
         return credentials;
+    }
+
+    // This will replace `getCredentials()` when all usages have been updated
+    public GatewayCredentials getCredentialsObject() {
+        return Optional.ofNullable(GATEWAY_CREDENTIALS_TYPE_MAP.get(PaymentGatewayName.valueFrom(paymentProvider)))
+                .map(type -> objectMapper.convertValue(this.getCredentials(), type))
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported payment provider: " + paymentProvider));
     }
 
     public GatewayAccountCredentialState getState() {
@@ -140,6 +167,10 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
     public void setCredentials(Map<String, Object> credentials) {
         this.credentials = credentials;
+    }
+
+    public void setCredentials(GatewayCredentials credentials) {
+        this.credentials = objectMapper.convertValue(credentials, new TypeReference<Map<String, Object>>() {});
     }
 
     public void setState(GatewayAccountCredentialState state) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -72,6 +72,7 @@ public class GatewayAccountCredentialsService {
     private final Set<GatewayAccountCredentialState> USABLE_STATES = EnumSet.of(ENTERED, VERIFIED_WITH_LIVE_PAYMENT, ACTIVE);
 
     private final ObjectMapper objectMapper;
+
     @Inject
     public GatewayAccountCredentialsService(GatewayAccountCredentialsDao gatewayAccountCredentialsDao, ObjectMapper objectMapper) {
         this.gatewayAccountCredentialsDao = gatewayAccountCredentialsDao;
@@ -185,7 +186,7 @@ public class GatewayAccountCredentialsService {
     private void updateWorldpayCredentials(JsonPatchRequest patchRequest, WorldpayUpdatableCredentials updatableCredentials,
                                            GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity) {
         var worldpayMerchantCodeCredentials = objectMapper.convertValue(patchRequest.valueAsObject(), WorldpayMerchantCodeCredentials.class);
-        var worldpayCredentials = objectMapper.convertValue(gatewayAccountCredentialsEntity.getCredentials(), WorldpayCredentials.class);
+        var worldpayCredentials = (WorldpayCredentials) gatewayAccountCredentialsEntity.getCredentialsObject();
         switch (updatableCredentials) {
             case ONE_OFF_CIT:
                 worldpayCredentials.setOneOffCustomerInitiatedCredentials(worldpayMerchantCodeCredentials);
@@ -200,7 +201,7 @@ public class GatewayAccountCredentialsService {
                 worldpayCredentials.setRecurringMerchantInitiatedCredentials(worldpayMerchantCodeCredentials);
                 break;
         }
-        gatewayAccountCredentialsEntity.setCredentials(objectMapper.convertValue(worldpayCredentials, Map.class));
+        gatewayAccountCredentialsEntity.setCredentials(worldpayCredentials);
     }
 
     @Transactional

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponseTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity.Worldpay3dsFlexCredentialsEntityBuilder.aWorldpay3dsFlexCredentialsEntity;
 
 class GatewayAccountResponseTest {
@@ -51,7 +52,7 @@ class GatewayAccountResponseTest {
         entity.setGatewayAccountCredentials(List.of(
                 GatewayAccountCredentialsEntityFixture.
                         aGatewayAccountCredentialsEntity()
-                        .withPaymentProvider("testGatewayName")
+                        .withPaymentProvider(SANDBOX.getName())
                         .withState(GatewayAccountCredentialState.ACTIVE)
                         .build()
         ));

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
@@ -1,0 +1,135 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.model;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.EpdqCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.SandboxCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.isA;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
+import static uk.gov.pay.connector.gatewayaccount.model.StripeCredentials.STRIPE_ACCOUNT_ID_KEY;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
+
+class GatewayAccountCredentialsEntityTest {
+
+    @Test
+    void getCredentialsObject_shouldReturnEmptyWorldpayCredentials_whenCredentialsEmpty() {
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(WORLDPAY.getName())
+                .withCredentials(Map.of())
+                .build();
+        GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
+        assertThat(credentials, not(nullValue()));
+        assertThat(credentials, isA(WorldpayCredentials.class));
+        assertThat(((WorldpayCredentials) credentials).getOneOffCustomerInitiatedCredentials(), is(nullValue()));
+    }
+
+    @Test
+    void getCredentialsObject_shouldReturnPopulatedWorldpayCredentials() {
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(WORLDPAY.getName())
+                .withCredentials(Map.of(ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                        "merchant_code", "a-merchant-code",
+                        "username", "a-username",
+                        "password", "a-password")))
+                .build();
+
+        GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
+        assertThat(credentials, isA(WorldpayCredentials.class));
+        var worldpayCredentials = (WorldpayCredentials) credentials;
+        assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials(), not(nullValue()));
+        assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials().getMerchantCode(), is("a-merchant-code"));
+    }
+
+    @Test
+    void getCredentialsObject_shouldReturnEmptyStripeCredentials_whenCredentialsEmpty() {
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(STRIPE.getName())
+                .withCredentials(Map.of())
+                .build();
+        GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
+        assertThat(credentials, not(nullValue()));
+        assertThat(credentials, isA(StripeCredentials.class));
+        assertThat(((StripeCredentials) credentials).getStripeAccountId(), is(nullValue()));
+    }
+
+    @Test
+    void getCredentialsObject_shouldReturnPopulatedStripeCredentials() {
+        String stripeAccountId = "a-stripe-account";
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(STRIPE.getName())
+                .withCredentials(Map.of(STRIPE_ACCOUNT_ID_KEY, stripeAccountId))
+                .build();
+
+        GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
+        assertThat(credentials, isA(StripeCredentials.class));
+        StripeCredentials stripeCredentials = (StripeCredentials) credentials;
+        assertThat(stripeCredentials.getStripeAccountId(), is(stripeAccountId));
+    }
+
+    @Test
+    void getCredentialsObject_shouldReturnEmptyEpdqCredentials_whenCredentialsEmpty() {
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(EPDQ.getName())
+                .withCredentials(Map.of())
+                .build();
+        GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
+        assertThat(credentials, not(nullValue()));
+        assertThat(credentials, isA(EpdqCredentials.class));
+        assertThat(((EpdqCredentials) credentials).getMerchantId(), is(nullValue()));
+    }
+
+    @Test
+    void getCredentialsObject_shouldReturnPopulatedEpdqCredentials() {
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(EPDQ.getName())
+                .withCredentials(Map.of("merchant_id", "a-merchant-id"))
+                .build();
+
+        GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
+        assertThat(credentials, isA(EpdqCredentials.class));
+        EpdqCredentials epdqCredentials = (EpdqCredentials) credentials;
+        assertThat(epdqCredentials.getMerchantId(), is("a-merchant-id"));
+    }
+
+    @Test
+    void getCredentialsObject_shouldReturnSandboxCredentials() {
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(SANDBOX.getName())
+                .withCredentials(Map.of())
+                .build();
+        GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
+        assertThat(credentials, isA(SandboxCredentials.class));
+    }
+
+    @Test
+    void getCredentialsObject_shouldThrowForUnrecognisedProvider() {
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider("foo")
+                .build();
+        assertThrows(PaymentGatewayName.Unsupported.class, credentialsEntity::getCredentialsObject);
+    }
+
+    @Test
+    void getCredentialsObject_shouldThrowForUnsupportedProvider() {
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(SMARTPAY.getName())
+                .build();
+        assertThrows(IllegalArgumentException.class, credentialsEntity::getCredentialsObject);
+    }
+}


### PR DESCRIPTION
Add a GatewayCredentials interface, which the types representing the credentials structure for each payment gateway inherit. Add implementations for Worldpay, Stripe and ePDQ. Also add an implementation for Sandbox to avoid returning null/Optional when getting the credentials for a Sandbox account, even though there are no credentials that can be entered for Sandbox.

Add a getter to GatewayAccountCredentialsEntity to convert the credentials JSON map to a POJO that represents the credentials structure for the payment gateway the credentials are for.

Add a setter to GatewayAccountCredentialsEntity to allow serializing implementations of GatewayCredentials to a JSON map to insert into the database.

Start using the GatewayCredentials representation rather than the credentials map when updating Worldpay credentials.