### PR TITLE
PP-11152 Use merchant_code instead of merchant_id

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -281,7 +281,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 10
+        "line_number": 11
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java": [
@@ -524,7 +524,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 773
+        "line_number": 774
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
@@ -1032,5 +1032,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-10T16:07:15Z"
+  "generated_at": "2023-07-13T12:04:14Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
@@ -53,7 +54,7 @@ public class AuthUtil {
             }
             Map<String, Object> recurringCreds = (Map<String, Object>) gatewayCredentials.get(RECURRING_MERCHANT_INITIATED);
 
-            return recurringCreds.get(CREDENTIALS_MERCHANT_ID).toString();
+            return recurringCreds.get(CREDENTIALS_MERCHANT_CODE).toString();
         }
         return gatewayCredentials.get(CREDENTIALS_MERCHANT_ID).toString();
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 public class GatewayAccount {
     public static final String CREDENTIALS_MERCHANT_ID = "merchant_id";
+    public static final String CREDENTIALS_MERCHANT_CODE = "merchant_code";
     public static final String CREDENTIALS_USERNAME = "username";
     public static final String CREDENTIALS_PASSWORD = "password";
     public static final String CREDENTIALS_SHA_IN_PASSPHRASE = "sha_in_passphrase";

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -75,6 +75,7 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORLDPAY_MACHINE_COOKIE_NAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
@@ -123,7 +124,7 @@ class WorldpayAuthoriseHandlerTest {
                         CREDENTIALS_USERNAME, "worldpay-password",
                         CREDENTIALS_PASSWORD, "password",
                         RECURRING_MERCHANT_INITIATED, Map.of(
-                                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
+                                CREDENTIALS_MERCHANT_CODE, "MERCHANTCODE",
                                 CREDENTIALS_USERNAME, "rc-worldpay-password",
                                 CREDENTIALS_PASSWORD, "rc-password")))
                 .withGatewayAccountEntity(gatewayAccountEntity)
@@ -139,7 +140,7 @@ class WorldpayAuthoriseHandlerTest {
                                 CREDENTIALS_USERNAME, "worldpay-password",
                                 CREDENTIALS_PASSWORD, "password",
                                         RECURRING_MERCHANT_INITIATED, Map.of(
-                                                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
+                                                CREDENTIALS_MERCHANT_CODE, "MERCHANTCODE",
                                                 CREDENTIALS_USERNAME, "rc-worldpay-password",
                                                 CREDENTIALS_PASSWORD, "rc-password"
                         )))

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -39,6 +39,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aVali
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
@@ -70,7 +71,7 @@ class WorldpayCaptureHandlerTest {
             CREDENTIALS_USERNAME, "worldpay-password",
             CREDENTIALS_PASSWORD, "password",
             RECURRING_MERCHANT_INITIATED, Map.of(
-                    CREDENTIALS_MERCHANT_ID, "ECURRING-MERCHANTCODE",
+                    CREDENTIALS_MERCHANT_CODE, "ECURRING-MERCHANTCODE",
                     CREDENTIALS_USERNAME, "recurring-worldpay-password",
                     CREDENTIALS_PASSWORD, "recurring-password"
             )

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -88,6 +88,7 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
 import static uk.gov.pay.connector.gateway.util.XMLUnmarshaller.unmarshall;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORLDPAY_MACHINE_COOKIE_NAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
@@ -616,7 +617,7 @@ public class WorldpayPaymentProviderTest {
                 CREDENTIALS_USERNAME, "worldpay-password",
                 CREDENTIALS_PASSWORD, "password",
                 RECURRING_MERCHANT_INITIATED, Map.of(
-                        CREDENTIALS_MERCHANT_ID, "RECURRING_MERCHANTCODE",
+                        CREDENTIALS_MERCHANT_CODE, "RECURRING_MERCHANTCODE",
                         CREDENTIALS_USERNAME, "recurring-worldpay-password",
                         CREDENTIALS_PASSWORD, "recurring-password"));
         String providerSessionId = "provider-session-id";

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandlerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
@@ -120,7 +121,7 @@ class WorldpayRefundHandlerTest {
                         CREDENTIALS_USERNAME, "worldpay-password",
                         CREDENTIALS_PASSWORD, "password",
                         RECURRING_MERCHANT_INITIATED, Map.of(
-                                CREDENTIALS_MERCHANT_ID, "ECURRING-MERCHANTCODE",
+                                CREDENTIALS_MERCHANT_CODE, "ECURRING-MERCHANTCODE",
                                 CREDENTIALS_USERNAME, "recurring-worldpay-password",
                                 CREDENTIALS_PASSWORD, "recurring-password"
                         )

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -58,12 +58,14 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_STRIPE_ACCOUNT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
 import static uk.gov.pay.connector.it.util.ChargeUtils.createNewChargeWithAccountId;
@@ -152,10 +154,10 @@ public class ChargingITestBase {
                     CREDENTIALS_MERCHANT_ID, "merchant-id",
                     CREDENTIALS_USERNAME, "test-user",
                     CREDENTIALS_PASSWORD, "test-password",
-                    "recurring_merchant_initiated", Map.of(
-                            "merchant_id", "rec-merchant-id",
-                            "username", "rec-user",
-                            "password", "rec-password")
+                    RECURRING_MERCHANT_INITIATED, Map.of(
+                            CREDENTIALS_MERCHANT_CODE, "rec-merchant-id",
+                            CREDENTIALS_USERNAME, "rec-user",
+                            CREDENTIALS_PASSWORD, "rec-password")
             );
         } else {
             credentials = Map.of(

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -82,6 +82,11 @@ import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgre
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity.Worldpay3dsFlexCredentialsEntityBuilder.aWorldpay3dsFlexCredentialsEntity;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
@@ -119,20 +124,20 @@ class WorldpayPaymentProviderTest {
     void checkThatWorldpayIsUp() throws IOException {
         try {
             var validRecurringMerchantInitiatedCredentials = Map.of(
-                    "merchant_id", envOrThrow("GDS_CONNECTOR_WORLDPAY_MERCHANT_ID"),
-                    "username", envOrThrow("GDS_CONNECTOR_WORLDPAY_USER"),
-                    "password", envOrThrow("GDS_CONNECTOR_WORLDPAY_PASSWORD"));
+                    CREDENTIALS_MERCHANT_CODE, envOrThrow("GDS_CONNECTOR_WORLDPAY_MERCHANT_ID"),
+                    CREDENTIALS_USERNAME, envOrThrow("GDS_CONNECTOR_WORLDPAY_USER"),
+                    CREDENTIALS_PASSWORD, envOrThrow("GDS_CONNECTOR_WORLDPAY_PASSWORD"));
             
             validCredentials = Map.of(
-                    "merchant_id", envOrThrow("GDS_CONNECTOR_WORLDPAY_MERCHANT_ID"),
-                    "username", envOrThrow("GDS_CONNECTOR_WORLDPAY_USER"),
-                    "password", envOrThrow("GDS_CONNECTOR_WORLDPAY_PASSWORD"),
-                    "recurring_merchant_initiated", validRecurringMerchantInitiatedCredentials);
+                    CREDENTIALS_MERCHANT_ID, envOrThrow("GDS_CONNECTOR_WORLDPAY_MERCHANT_ID"),
+                    CREDENTIALS_USERNAME, envOrThrow("GDS_CONNECTOR_WORLDPAY_USER"),
+                    CREDENTIALS_PASSWORD, envOrThrow("GDS_CONNECTOR_WORLDPAY_PASSWORD"),
+                    RECURRING_MERCHANT_INITIATED, validRecurringMerchantInitiatedCredentials);
 
             validCredentialsFor3ds = Map.of(
-                    "merchant_id", envOrThrow("GDS_CONNECTOR_WORLDPAY_MERCHANT_ID_3DS"),
-                    "username", envOrThrow("GDS_CONNECTOR_WORLDPAY_USER_3DS"),
-                    "password", envOrThrow("GDS_CONNECTOR_WORLDPAY_PASSWORD_3DS"));
+                    CREDENTIALS_MERCHANT_ID, envOrThrow("GDS_CONNECTOR_WORLDPAY_MERCHANT_ID_3DS"),
+                    CREDENTIALS_USERNAME, envOrThrow("GDS_CONNECTOR_WORLDPAY_USER_3DS"),
+                    CREDENTIALS_PASSWORD, envOrThrow("GDS_CONNECTOR_WORLDPAY_PASSWORD_3DS"));
         } catch (IllegalStateException ex) {
             assumeTrue(false, "Ignoring test since credentials not configured");
         }


### PR DESCRIPTION
We are in the process of renaming merchant_id -> merchant_code in the new nested credentials JSON structure.

A script has been run to insert a merchant_code alongside merchant_id in the recurring_merchant_initiated nested credentials for accounts that have recurring credentials on all environments.

Read recurring_merchant_initiated.merchant_code rather than recurring_merchant_initiated.merchant_id, as only the merchant_code will be added when credentials are entered in the future.