### PR TITLE
PP-11152 Use credentials object for google pay merchant ID

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -572,14 +572,14 @@
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidatorTest.java",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 194
+        "line_number": 197
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidatorTest.java",
         "hashed_secret": "d951d773b511b017529f9c2188b43e8518f24b56",
         "is_verified": false,
-        "line_number": 246
+        "line_number": 240
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java": [

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/EpdqCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/EpdqCredentials.java
@@ -64,4 +64,9 @@ public class EpdqCredentials implements GatewayCredentials {
     public void setShaOutPassphrase(String shaOutPassphrase) {
         this.shaOutPassphrase = shaOutPassphrase;
     }
+
+    @Override
+    public boolean hasCredentials() {
+        return merchantId != null;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/FrontendGatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/FrontendGatewayAccountResponse.java
@@ -90,7 +90,7 @@ public class FrontendGatewayAccountResponse {
         this.id = gatewayAccountEntity.getId();
         this.externalId = gatewayAccountEntity.getExternalId();
         this.paymentProvider = gatewayAccountEntity.getGatewayName();
-        this.gatewayMerchantId = gatewayAccountEntity.getGatewayMerchantId();
+        this.gatewayMerchantId = gatewayAccountEntity.getGooglePayMerchantId();
         this.type = gatewayAccountEntity.getType();
         this.serviceName = gatewayAccountEntity.getServiceName();
         this.serviceId = gatewayAccountEntity.getServiceId();

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -253,7 +253,8 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     
     public String getGooglePayMerchantId() {
         return getCurrentOrActiveGatewayAccountCredential()
-                .map(credentialsEntity -> credentialsEntity.getCredentialsObject().getGooglePayMerchantId())
+                .map(GatewayAccountCredentialsEntity::getCredentialsObject)
+                .flatMap(GatewayCredentials::getGooglePayMerchantId)
                 .orElse(null);
     }
     

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -251,16 +251,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
                                 getId(), paymentProvider))));
     }
     
-    public String getGatewayMerchantId() {
+    public String getGooglePayMerchantId() {
         return getCurrentOrActiveGatewayAccountCredential()
-                .map(credentialsEntity -> {
-                    if (credentialsEntity.getCredentials() != null &&
-                            credentialsEntity.getCredentials().containsKey("gateway_merchant_id") &&
-                            credentialsEntity.getCredentials().get("gateway_merchant_id") != null) {
-                        return credentialsEntity.getCredentials().get("gateway_merchant_id").toString();
-                    }
-                    return null;
-                }).orElse(null);
+                .map(credentialsEntity -> credentialsEntity.getCredentialsObject().getGooglePayMerchantId())
+                .orElse(null);
     }
     
     public List<GatewayAccountCredentialsEntity> getGatewayAccountCredentials() {
@@ -316,7 +310,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     }
     
     public boolean isAllowGooglePay() {
-        return allowGooglePay && isNotBlank(getGatewayMerchantId());
+        return allowGooglePay && isNotBlank(getGooglePayMerchantId());
     }
     
     public boolean isAllowApplePay() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentials.java
@@ -6,4 +6,13 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface GatewayCredentials {
+    
+    // Only applies to Worldpay, but we include it as a root field in some API responses returning the gateway account.
+    // Having this as an interface method makes this easier to retrieve for this purpose.
+    @JsonIgnore
+    default String getGooglePayMerchantId() {
+        return null;
+    }
+    
+    boolean hasCredentials();
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentials.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import java.util.Optional;
+
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface GatewayCredentials {
-    
-    // Only applies to Worldpay, but we include it as a root field in some API responses returning the gateway account.
-    // Having this as an interface method makes this easier to retrieve for this purpose.
+
     @JsonIgnore
-    default String getGooglePayMerchantId() {
-        return null;
+    default Optional<String> getGooglePayMerchantId() {
+        return Optional.empty();
     }
     
     boolean hasCredentials();

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/SandboxCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/SandboxCredentials.java
@@ -5,4 +5,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SandboxCredentials implements GatewayCredentials {
 
+    @Override
+    public boolean hasCredentials() {
+        // Sandbox accounts don't have any credentials. Return true to indicate credentials are fully initialised.
+        return true;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/SandboxCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/SandboxCredentials.java
@@ -7,7 +7,6 @@ public class SandboxCredentials implements GatewayCredentials {
 
     @Override
     public boolean hasCredentials() {
-        // Sandbox accounts don't have any credentials. Return true to indicate credentials are fully initialised.
         return true;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
@@ -24,5 +24,10 @@ public class StripeCredentials implements GatewayCredentials {
     public Map<String, String> toMap() {
         return Map.of(STRIPE_ACCOUNT_ID_KEY, stripeAccountId);
     }
+
+    @Override
+    public boolean hasCredentials() {
+        return stripeAccountId != null;
+    }
     
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -1,12 +1,16 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator;
 
 import java.util.Objects;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorldpayCredentials implements GatewayCredentials {
 
     @JsonProperty(GatewayAccount.CREDENTIALS_MERCHANT_ID)
@@ -31,59 +35,67 @@ public class WorldpayCredentials implements GatewayCredentials {
     private String googlePayMerchantId;
 
     public WorldpayCredentials() {
-            // Janet Jackson
+        // Janet Jackson
     }
 
-    public String getLegacyOneOffCustomerInitiatedMerchantCode() {
-        return legacyOneOffCustomerInitiatedMerchantCode;
+    @JsonIgnore
+    public Optional<String> getLegacyOneOffCustomerInitiatedMerchantCode() {
+        return Optional.ofNullable(legacyOneOffCustomerInitiatedMerchantCode);
     }
 
     public void setLegacyOneOffCustomerInitiatedMerchantCode(String legacyOneOffCustomerInitiatedMerchantCode) {
         this.legacyOneOffCustomerInitiatedMerchantCode = legacyOneOffCustomerInitiatedMerchantCode;
     }
 
-    public String getLegacyOneOffCustomerInitiatedUsername() {
-        return legacyOneOffCustomerInitiatedUsername;
+    @JsonIgnore
+    public Optional<String> getLegacyOneOffCustomerInitiatedUsername() {
+        return Optional.ofNullable(legacyOneOffCustomerInitiatedUsername);
     }
 
     public void setLegacyOneOffCustomerInitiatedUsername(String legacyOneOffCustomerInitiatedUsername) {
         this.legacyOneOffCustomerInitiatedUsername = legacyOneOffCustomerInitiatedUsername;
     }
 
-    public String getLegacyOneOffCustomerInitiatedPassword() {
-        return legacyOneOffCustomerInitiatedPassword;
+    @JsonIgnore
+    public Optional<String> getLegacyOneOffCustomerInitiatedPassword() {
+        return Optional.ofNullable(legacyOneOffCustomerInitiatedPassword);
     }
 
     public void setLegacyOneOffCustomerInitiatedPassword(String legacyOneOffCustomerInitiatedPassword) {
         this.legacyOneOffCustomerInitiatedPassword = legacyOneOffCustomerInitiatedPassword;
     }
 
-    public WorldpayMerchantCodeCredentials getOneOffCustomerInitiatedCredentials() {
-        return oneOffCustomerInitiatedCredentials;
+    @JsonIgnore
+    public Optional<WorldpayMerchantCodeCredentials> getOneOffCustomerInitiatedCredentials() {
+        return Optional.ofNullable(oneOffCustomerInitiatedCredentials);
     }
 
     public void setOneOffCustomerInitiatedCredentials(WorldpayMerchantCodeCredentials oneOffCustomerInitiatedCredentials) {
         this.oneOffCustomerInitiatedCredentials = oneOffCustomerInitiatedCredentials;
     }
 
-    public WorldpayMerchantCodeCredentials getRecurringCustomerInitiatedCredentials() {
-        return recurringCustomerInitiatedCredentials;
+    @JsonIgnore
+    public Optional<WorldpayMerchantCodeCredentials> getRecurringCustomerInitiatedCredentials() {
+        return Optional.ofNullable(recurringCustomerInitiatedCredentials);
     }
 
     public void setRecurringCustomerInitiatedCredentials(WorldpayMerchantCodeCredentials recurringCustomerInitiatedCredentials) {
         this.recurringCustomerInitiatedCredentials = recurringCustomerInitiatedCredentials;
     }
 
-    public WorldpayMerchantCodeCredentials getRecurringMerchantInitiatedCredentials() {
-        return recurringMerchantInitiatedCredentials;
+    @JsonIgnore
+    public Optional<WorldpayMerchantCodeCredentials> getRecurringMerchantInitiatedCredentials() {
+        return Optional.ofNullable(recurringMerchantInitiatedCredentials);
     }
 
     public void setRecurringMerchantInitiatedCredentials(WorldpayMerchantCodeCredentials recurringMerchantInitiatedCredentials) {
         this.recurringMerchantInitiatedCredentials = recurringMerchantInitiatedCredentials;
     }
 
-    public String getGooglePayMerchantId() {
-        return googlePayMerchantId;
+    @Override
+    @JsonIgnore
+    public Optional<String> getGooglePayMerchantId() {
+        return Optional.ofNullable(googlePayMerchantId);
     }
 
     public void setGooglePayMerchantId(String googlePayMerchantId) {
@@ -94,8 +106,7 @@ public class WorldpayCredentials implements GatewayCredentials {
     public boolean hasCredentials() {
         return legacyOneOffCustomerInitiatedMerchantCode != null 
                 || oneOffCustomerInitiatedCredentials != null
-                || recurringCustomerInitiatedCredentials != null
-                || recurringMerchantInitiatedCredentials != null;
+                || (recurringCustomerInitiatedCredentials != null && recurringMerchantInitiatedCredentials != null);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -91,6 +91,14 @@ public class WorldpayCredentials implements GatewayCredentials {
     }
 
     @Override
+    public boolean hasCredentials() {
+        return legacyOneOffCustomerInitiatedMerchantCode != null 
+                || oneOffCustomerInitiatedCredentials != null
+                || recurringCustomerInitiatedCredentials != null
+                || recurringMerchantInitiatedCredentials != null;
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (this == other) {
             return true;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gatewayaccountcredentials.resource;
 import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.service.payments.commons.api.exception.ValidationException;
 import uk.gov.service.payments.commons.api.validation.JsonPatchRequestValidator;
 import uk.gov.service.payments.commons.api.validation.PatchPathOperation;
@@ -64,7 +65,7 @@ public class GatewayAccountCredentialsRequestValidator {
         }
     }
 
-    public void validatePatch(JsonNode patchRequest, String paymentProvider, Map<String, Object> credentials) {
+    public void validatePatch(JsonNode patchRequest, String paymentProvider, GatewayCredentials credentials) {
         var paymentGatewayName = PaymentGatewayName.valueFrom(paymentProvider);
 
         Map<PatchPathOperation, Consumer<JsonPatchRequest>> operationValidators = Map.of(
@@ -140,11 +141,11 @@ public class GatewayAccountCredentialsRequestValidator {
     }
 
     private void validateGatewayMerchantId(JsonPatchRequest request, String paymentProvider,
-                                           Map<String, Object> credentials) {
+                                           GatewayCredentials gatewayCredentials) {
         if (!WORLDPAY.getName().equals(paymentProvider)) {
             throw new ValidationException(List.of("Gateway '" + paymentProvider + "' does not support digital wallets."));
         }
-        if (credentials.isEmpty()) {
+        if (!gatewayCredentials.hasCredentials()) {
             throw new ValidationException(List.of("Account credentials are required to set a Gateway Merchant ID."));
         }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
@@ -205,7 +205,9 @@ public class GatewayAccountCredentialsResource {
                         .filter(c -> c.getId().equals(credentialsId))
                         .findFirst()
                         .map(gatewayAccountCredentialsEntity -> {
-                            gatewayAccountCredentialsRequestValidator.validatePatch(payload, gatewayAccountCredentialsEntity.getPaymentProvider(), gatewayAccountCredentialsEntity.getCredentials());
+                            gatewayAccountCredentialsRequestValidator.validatePatch(payload,
+                                    gatewayAccountCredentialsEntity.getPaymentProvider(),
+                                    gatewayAccountCredentialsEntity.getCredentialsObject());
                             List<JsonPatchRequest> updateRequests = StreamSupport.stream(payload.spliterator(), false)
                                     .map(JsonPatchRequest::from)
                                     .collect(Collectors.toList());

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -50,7 +50,6 @@ import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAcc
 import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator.FIELD_CREDENTIALS_WORLDPAY_ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator.FIELD_CREDENTIALS_WORLDPAY_RECURRING_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator.FIELD_CREDENTIALS_WORLDPAY_RECURRING_MERCHANT_INITIATED;
-import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator.FIELD_GATEWAY_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator.FIELD_LAST_UPDATED_BY_USER;
 import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator.FIELD_STATE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator.GATEWAY_MERCHANT_ID_PATH;
@@ -65,7 +64,9 @@ public class GatewayAccountCredentialsService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GatewayAccountCredentialsService.class);
 
-    private enum WorldpayUpdatableCredentials { ONE_OFF_CIT, RECURRING_CIT, RECURRING_MIT };
+    private enum WorldpayUpdatableCredentials {ONE_OFF_CIT, RECURRING_CIT, RECURRING_MIT}
+
+    ;
 
     private final GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
 
@@ -166,9 +167,9 @@ public class GatewayAccountCredentialsService {
                         GatewayAccountCredentialState.valueOf(patchRequest.valueAsString()));
                 break;
             case GATEWAY_MERCHANT_ID_PATH:
-                HashMap<String, Object> updatableMap = new HashMap<>(gatewayAccountCredentialsEntity.getCredentials());
-                updatableMap.put(FIELD_GATEWAY_MERCHANT_ID, patchRequest.valueAsString());
-                gatewayAccountCredentialsEntity.setCredentials(updatableMap);
+                var credentials = (WorldpayCredentials)gatewayAccountCredentialsEntity.getCredentialsObject();
+                credentials.setGooglePayMerchantId(patchRequest.valueAsString());
+                gatewayAccountCredentialsEntity.setCredentials(credentials);
                 break;
             default:
                 throw new BadRequestException("Unexpected path for patch operation: " + patchRequest.getPath());

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
@@ -223,7 +223,7 @@ class GatewayAccountEntityTest {
                 .build();
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay));
 
-        assertThat(gatewayAccountEntity.getGatewayMerchantId(), is("some-id"));
+        assertThat(gatewayAccountEntity.getGooglePayMerchantId(), is("some-id"));
     }
 
     @Test
@@ -233,7 +233,7 @@ class GatewayAccountEntityTest {
                 .build();
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay));
 
-        assertThat(gatewayAccountEntity.getGatewayMerchantId(), is(nullValue()));
+        assertThat(gatewayAccountEntity.getGooglePayMerchantId(), is(nullValue()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentialsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentialsTest.java
@@ -1,0 +1,51 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class WorldpayCredentialsTest {
+
+    @Test
+    void shouldReturnDoesNotHaveCredentialsWhenNoCredentialsSet() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
+        assertThat(worldpayCredentials.hasCredentials(), is(false));
+    }
+
+    @Test
+    void shouldReturnHasCredentialsWhenLegacyCredentialsSet() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
+        worldpayCredentials.setLegacyOneOffCustomerInitiatedMerchantCode("foo");
+        assertThat(worldpayCredentials.hasCredentials(), is(true));
+    }
+
+    @Test
+    void shouldReturnHasCredentialsWhenOneOffCustomerInitiatedCredentialsSet() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
+        worldpayCredentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials("merchant-code", "username", "password"));
+        assertThat(worldpayCredentials.hasCredentials(), is(true));
+    }
+
+    @Test
+    void shouldReturnDoesNotHaveCredentialsWhenOnlyRecurringCustomerInitiatedSet() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
+        worldpayCredentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials("merchant-code", "username", "password"));
+        assertThat(worldpayCredentials.hasCredentials(), is(false));
+    }
+
+    @Test
+    void shouldReturnDoesNotHaveCredentialsWhenOnlyRecurringMerchantInitiatedSet() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
+        worldpayCredentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials("merchant-code", "username", "password"));
+        assertThat(worldpayCredentials.hasCredentials(), is(false));
+    }
+
+    @Test
+    void shouldReturnHasCredentialsWhenAllRecurringCredentialsSet() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
+        worldpayCredentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials("merchant-code", "username", "password"));
+        worldpayCredentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials("merchant-code", "username", "password"));
+        assertThat(worldpayCredentials.hasCredentials(), is(true));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
@@ -52,6 +52,7 @@ class GatewayAccountCredentialsEntityTest {
         GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
         assertThat(credentials, isA(WorldpayCredentials.class));
         var worldpayCredentials = (WorldpayCredentials) credentials;
+        assertThat(worldpayCredentials.hasCredentials(), is(true));
         assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials(), not(nullValue()));
         assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials().getMerchantCode(), is("a-merchant-code"));
     }
@@ -79,6 +80,7 @@ class GatewayAccountCredentialsEntityTest {
         GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
         assertThat(credentials, isA(StripeCredentials.class));
         StripeCredentials stripeCredentials = (StripeCredentials) credentials;
+        assertThat(stripeCredentials.hasCredentials(), is(true));
         assertThat(stripeCredentials.getStripeAccountId(), is(stripeAccountId));
     }
 
@@ -104,6 +106,7 @@ class GatewayAccountCredentialsEntityTest {
         GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
         assertThat(credentials, isA(EpdqCredentials.class));
         EpdqCredentials epdqCredentials = (EpdqCredentials) credentials;
+        assertThat(epdqCredentials.hasCredentials(), is(true));
         assertThat(epdqCredentials.getMerchantId(), is("a-merchant-id"));
     }
 
@@ -115,6 +118,7 @@ class GatewayAccountCredentialsEntityTest {
                 .build();
         GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
         assertThat(credentials, isA(SandboxCredentials.class));
+        assertThat(credentials.hasCredentials(), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
@@ -36,7 +36,7 @@ class GatewayAccountCredentialsEntityTest {
         GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
         assertThat(credentials, not(nullValue()));
         assertThat(credentials, isA(WorldpayCredentials.class));
-        assertThat(((WorldpayCredentials) credentials).getOneOffCustomerInitiatedCredentials(), is(nullValue()));
+        assertThat(((WorldpayCredentials) credentials).getOneOffCustomerInitiatedCredentials().isEmpty(), is(true));
     }
 
     @Test
@@ -54,7 +54,8 @@ class GatewayAccountCredentialsEntityTest {
         var worldpayCredentials = (WorldpayCredentials) credentials;
         assertThat(worldpayCredentials.hasCredentials(), is(true));
         assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials(), not(nullValue()));
-        assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials().getMerchantCode(), is("a-merchant-code"));
+        assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials().isPresent(), is(true));
+        assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials().get().getMerchantCode(), is("a-merchant-code"));
     }
 
     @Test


### PR DESCRIPTION
Get credentials as a GatewayCredentials object for operations involving getting/updating Google Pay merchant ID.

Adds 2 methods to the GatewayCredentials interface
- hasCredentials to indicate whether any credentials have been populated
- getGooglePayMerchantId which will only ever be present for Worldpay credentials, but it is returned as a root field in the gateway account object for API responses. Having this as a method on the interface means we don't need to have PSP specific code in places we get this field.