### PR TITLE
PP-11152 Add isForRecurringPayment to GatewayRequest

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.charge.model.domain;
 
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
@@ -28,11 +29,13 @@ public class Charge {
     private boolean live;
     private Boolean disputed;
     private AuthorisationMode authorisationMode;
+    private String agreementId;
 
     public Charge(String externalId, Long amount, String status, String externalStatus, String gatewayTransactionId,
                   String credentialExternalId, Long corporateSurcharge, String refundAvailabilityStatus, String reference,
                   String description, Instant createdDate, String email, Long gatewayAccountId, String paymentGatewayName,
-                  boolean historic, String serviceId, boolean live, Boolean disputed, AuthorisationMode authorisationMode) {
+                  boolean historic, String serviceId, boolean live, Boolean disputed, AuthorisationMode authorisationMode,
+                  String agreementId) {
         this.externalId = externalId;
         this.amount = amount;
         this.status = status;
@@ -52,6 +55,7 @@ public class Charge {
         this.live = live;
         this.disputed = disputed;
         this.authorisationMode = authorisationMode;
+        this.agreementId = agreementId;
     }
 
     public static Charge from(ChargeEntity chargeEntity) {
@@ -81,7 +85,8 @@ public class Charge {
                 chargeEntity.getServiceId(),
                 chargeEntity.getGatewayAccount().isLive(), 
                 null,
-                chargeEntity.getAuthorisationMode());
+                chargeEntity.getAuthorisationMode(),
+                chargeEntity.getAgreement().map(AgreementEntity::getExternalId).orElse(null));
     }
 
     public static Charge from(LedgerTransaction transaction) {
@@ -115,7 +120,8 @@ public class Charge {
                 transaction.getServiceId(),
                 transaction.getLive(),
                 transaction.isDisputed(),
-                transaction.getAuthorisationMode()
+                transaction.getAuthorisationMode(),
+                transaction.getAgreementId()
         );
     }
 
@@ -205,6 +211,14 @@ public class Charge {
 
     public void setAuthorisationMode(AuthorisationMode authorisationMode) {
         this.authorisationMode = authorisationMode;
+    }
+
+    public Optional<String> getAgreementId() {
+        return Optional.ofNullable(agreementId);
+    }
+
+    public void setAgreementId(String agreementId) {
+        this.agreementId = agreementId;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
@@ -6,11 +6,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.connector.charge.model.ChargeResponse;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.SupportedLanguageJsonDeserializer;
-import uk.gov.pay.connector.charge.model.ChargeResponse;
 
 import java.util.Map;
 
@@ -54,9 +54,9 @@ public class LedgerTransaction {
     private AuthorisationSummary authorisationSummary;
     private boolean disputed;
     private AuthorisationMode authorisationMode;
+    private String agreementId;
 
     public LedgerTransaction() {
-
     }
 
     public Long getAmount() {
@@ -324,5 +324,13 @@ public class LedgerTransaction {
     public LedgerTransaction setAuthorisationMode(AuthorisationMode authorisationMode) {
         this.authorisationMode = authorisationMode;
         return this;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    public void setAgreementId(String agreementId) {
+        this.agreementId = agreementId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryGatewayRequest.java
@@ -15,14 +15,16 @@ public class ChargeQueryGatewayRequest implements GatewayRequest {
     private final String chargeExternalId;
     private final String transactionId;
     private final AuthorisationMode authorisationMode;
+    private boolean isForRecurringPayment;
 
     public ChargeQueryGatewayRequest(GatewayAccountEntity gatewayAccountEntity, GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity,
-                                     String chargeExternalId, String transactionId, AuthorisationMode authorisationMode) {
+                                     String chargeExternalId, String transactionId, AuthorisationMode authorisationMode, boolean isForRecurringPayment) {
         this.gatewayAccountEntity = gatewayAccountEntity;
         this.gatewayAccountCredentialsEntity = gatewayAccountCredentialsEntity;
         this.chargeExternalId = chargeExternalId;
         this.transactionId = transactionId;
         this.authorisationMode = authorisationMode;
+        this.isForRecurringPayment = isForRecurringPayment;
     }
 
     @Override
@@ -51,14 +53,20 @@ public class ChargeQueryGatewayRequest implements GatewayRequest {
     public Map<String, Object> getGatewayCredentials() {
         return gatewayAccountCredentialsEntity.getCredentials();
     }
-    
+
+    @Override
+    public boolean isForRecurringPayment() {
+        return isForRecurringPayment;
+    }
+
     public static ChargeQueryGatewayRequest valueOf(Charge charge, GatewayAccountEntity gatewayAccountEntity, GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity) {
         return new ChargeQueryGatewayRequest(
                 gatewayAccountEntity,
                 gatewayAccountCredentialsEntity,
                 charge.getExternalId(),
                 charge.getGatewayTransactionId(),
-                charge.getAuthorisationMode()
+                charge.getAuthorisationMode(),
+                charge.getAgreementId().isPresent()
         );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
@@ -61,6 +61,11 @@ public class Auth3dsResponseGatewayRequest implements GatewayRequest {
         return charge.getAuthorisationMode();
     }
 
+    @Override
+    public boolean isForRecurringPayment() {
+        return charge.getAgreement().isPresent();
+    }
+
     public static Auth3dsResponseGatewayRequest valueOf(ChargeEntity charge, Auth3dsResult auth3DsResult) {
         return new Auth3dsResponseGatewayRequest(charge, auth3DsResult);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -134,4 +134,8 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         return agreement;
     }
 
+    @Override
+    public boolean isForRecurringPayment() {
+        return agreement.isPresent();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CancelGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CancelGatewayRequest.java
@@ -50,4 +50,9 @@ public class CancelGatewayRequest implements GatewayRequest {
     public boolean isLiveAccount() {
         return charge.getGatewayAccount().isLive();
     }
+
+    @Override
+    public boolean isForRecurringPayment() {
+        return charge.getAgreement().isPresent();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
@@ -68,6 +68,11 @@ public class CaptureGatewayRequest implements GatewayRequest {
         return charge.getAuthorisationMode();
     }
 
+    @Override
+    public boolean isForRecurringPayment() {
+        return charge.getAgreement().isPresent();
+    }
+
     public static CaptureGatewayRequest valueOf(ChargeEntity charge) {
         return new CaptureGatewayRequest(charge);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayRequest.java
@@ -14,4 +14,6 @@ public interface GatewayRequest {
     Map<String, Object> getGatewayCredentials();
 
     AuthorisationMode getAuthorisationMode();
+    
+    boolean isForRecurringPayment();
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RecurringPaymentAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RecurringPaymentAuthorisationGatewayRequest.java
@@ -94,4 +94,9 @@ public class RecurringPaymentAuthorisationGatewayRequest implements GatewayReque
     public AuthorisationMode getAuthorisationMode() {
         return AuthorisationMode.AGREEMENT;
     }
+
+    @Override
+    public boolean isForRecurringPayment() {
+        return true;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
@@ -18,11 +18,12 @@ public class RefundGatewayRequest implements GatewayRequest {
     private final String chargeExternalId;
     private final GatewayAccountCredentialsEntity credentialsEntity;
     private final AuthorisationMode authorisationMode;
+    private boolean isForRecurringPayment;
 
     private RefundGatewayRequest(String transactionId, GatewayAccountEntity gatewayAccount,
                                  String amount, String refundExternalId, String chargeExternalId,
                                  GatewayAccountCredentialsEntity credentialsEntity,
-                                 AuthorisationMode authorisationMode) {
+                                 AuthorisationMode authorisationMode, boolean isForRecurringPayment) {
         this.transactionId = transactionId;
         this.gatewayAccountEntity = gatewayAccount;
         this.amount = amount;
@@ -30,6 +31,7 @@ public class RefundGatewayRequest implements GatewayRequest {
         this.chargeExternalId = chargeExternalId;
         this.credentialsEntity = credentialsEntity;
         this.authorisationMode = authorisationMode;
+        this.isForRecurringPayment = isForRecurringPayment;
     }
 
     public String getAmount() {
@@ -67,7 +69,12 @@ public class RefundGatewayRequest implements GatewayRequest {
     public String getRefundExternalId() {
         return refundExternalId;
     }
-    
+
+    @Override
+    public boolean isForRecurringPayment() {
+        return isForRecurringPayment;
+    }
+
     /**
      * <p>
      * For Worldpay ->
@@ -87,7 +94,8 @@ public class RefundGatewayRequest implements GatewayRequest {
                 refundEntity.getExternalId(),
                 charge.getExternalId(),
                 gatewayAccountCredentialsEntity,
-                charge.getAuthorisationMode()
+                charge.getAuthorisationMode(),
+                charge.getAgreementId().isPresent()
         );
     }
     

--- a/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
@@ -54,6 +54,18 @@ public class LedgerServiceConsumerTest {
 
     @Test
     @PactVerification("ledger")
+    @Pacts(pacts = {"connector-ledger-get-recurring-payment-transaction"})
+    public void getTransaction_shouldSerialiseLedgerRecurringPaymentTransactionCorrectly() {
+        String externalId = "e8eq11mi2ndmauvb51qsg8hccn";
+        Optional<LedgerTransaction> mayBeTransaction = ledgerService.getTransaction(externalId);
+
+        assertThat(mayBeTransaction.isPresent(), is(true));
+        LedgerTransaction transaction = mayBeTransaction.get();
+        assertThat(transaction.getAgreementId(), is("r4ou8b7fb52is55fp4iiav5bon"));
+    }
+
+    @Test
+    @PactVerification("ledger")
     @Pacts(pacts = {"connector-ledger-get-payment-transaction"})
     public void getTransaction_shouldSerialiseLedgerPaymentTransactionCorrectly() {
         String externalId = "e8eq11mi2ndmauvb51qsg8hccn";

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
@@ -245,6 +245,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     private Charge getCharge(boolean isHistoric){
         return new Charge("external-id", 10L, null, null, "transaction-id",
                 "credential-external-id", 10L, null, "ref-1", "desc", Instant.now(),
-                "test@example.org", 123L, "epdq", isHistoric, "service-id", true, false, AuthorisationMode.WEB);
+                "test@example.org", 123L, "epdq", isHistoric, "service-id", true, false, AuthorisationMode.WEB,
+                null);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderIT.java
@@ -55,7 +55,8 @@ public class StripePaymentProviderIT {
         String chargeExternalId = "a-charge-external-id";
         stripeMockClient.mockSearchPaymentIntentsByMetadata(chargeExternalId);
 
-        ChargeQueryGatewayRequest request = new ChargeQueryGatewayRequest(gatewayAccountEntity, gatewayAccountCredentialsEntity, chargeExternalId, chargeExternalId, AuthorisationMode.WEB);
+        ChargeQueryGatewayRequest request = new ChargeQueryGatewayRequest(gatewayAccountEntity, 
+                gatewayAccountCredentialsEntity, chargeExternalId, chargeExternalId, AuthorisationMode.WEB, false);
         ChargeQueryResponse chargeQueryResponse = stripePaymentProvider.queryPaymentStatus(request);
         
         assertThat(chargeQueryResponse.foundCharge(), is(true));

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -77,6 +77,7 @@ public class LedgerTransactionFixture {
     private String serviceId;
     private boolean disputed;
     private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
+    private String agreementId;
 
     public static LedgerTransactionFixture aValidLedgerTransaction() {
         return new LedgerTransactionFixture();
@@ -238,6 +239,7 @@ public class LedgerTransactionFixture {
         ledgerTransaction.setAuthorisationSummary(authorisationSummary);
         ledgerTransaction.setDisputed(disputed);
         ledgerTransaction.setAuthorisationMode(authorisationMode);
+        ledgerTransaction.setAgreementId(agreementId);
 
         return ledgerTransaction;
     }
@@ -404,6 +406,11 @@ public class LedgerTransactionFixture {
 
     public LedgerTransactionFixture withAuthorisationMode(AuthorisationMode authorisationMode) {
         this.authorisationMode = authorisationMode;
+        return this;
+    }
+    
+    public LedgerTransactionFixture withAgreementId(String agreementId) {
+        this.agreementId = agreementId;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
@@ -157,6 +157,7 @@ class DefaultExternalRefundAvailabilityCalculatorTest {
     private Charge getHistoricCharge(ExternalChargeRefundAvailability availability) {
         return new Charge("external-id", 500L, null, "success", "transaction-id",
                 "credentials_external_id", 0L, availability.getStatus(), "ref-1", "desc", Instant.now(),
-                "test@example.org", 123L, "epdq", true, "service-id", true, false, AuthorisationMode.WEB);
+                "test@example.org", 123L, "epdq", true, "service-id", true, false, AuthorisationMode.WEB,
+                null);
     }
 }

--- a/src/test/resources/pacts/connector-ledger-get-recurring-payment-transaction.json
+++ b/src/test/resources/pacts/connector-ledger-get-recurring-payment-transaction.json
@@ -1,0 +1,121 @@
+{
+  "consumer": {
+    "name": "connector"
+  },
+  "provider": {
+    "name": "ledger"
+  },
+  "interactions": [
+    {
+      "description": "get a recurring payment transaction request",
+      "providerStates": [
+        {
+          "name": "a recurring card payment exists for agreement",
+          "params": {
+            "account_id": "3",
+            "transaction_external_id": "e8eq11mi2ndmauvb51qsg8hccn",
+            "agreement_id": "r4ou8b7fb52is55fp4iiav5bon"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/transaction/e8eq11mi2ndmauvb51qsg8hccn",
+        "query": {
+          "override_account_id_restriction": [
+            "true"
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "gateway_account_id": "3",
+          "amount": 12000,
+          "state": {
+            "status": "success"
+          },
+          "description": "New passport application",
+          "reference": "1_86",
+          "language": "cy",
+          "return_url": "https://service-name.gov.uk/transactions/12345",
+          "payment_provider": "sandbox",
+          "credential_external_id": "credential-external-id",
+          "created_date": "2020-02-13T16:26:04.204Z",
+          "delayed_capture": false,
+          "transaction_type": "PAYMENT",
+          "moto": false,
+          "live": false,
+          "transaction_id": "e8eq11mi2ndmauvb51qsg8hccn",
+          "disputed": false,
+          "authorisation_mode": "agreement",
+          "agreement_id": "r4ou8b7fb52is55fp4iiav5bon"
+        },
+        "matchingRules": {
+          "body": {
+            "$.reference": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.description": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.return_url": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.created_date": {
+              "matchers": [
+                {
+                  "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                }
+              ]
+            },
+            "$.state.status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.amount": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.language": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
We are adding in `recurring_customer_initiated` nested credentials to the credentials JSON for Worldpay accounts, to use instead of the credentials at the root level for payments to set up a recurring payment agreement.

In order to determine whether to get the one-off or recurring customer initiated credentials, we need to know whether a payment is recurring or not. Add `isForRecurringPayment` method to GatewayRequest interface to tell us this.

We determine whether a payment is recurring or not by whether it has an agreement ID set. This means that for query and refund requests, where we get the payment from ledger, we need to consume the `agreement_id` field on returned transactions. Add a Pact test for getting a recurring payment from ledger to test the contract for this.