### PR TITLE
PP-11152 Use credentials POJO for building gateway requests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -524,28 +524,28 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 130
+        "line_number": 131
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "fd9f851472586dc75f7a60ee311842ec64ecf527",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "9367c8305bd1afe815ffc0cc3ebf95af9cb6d157",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 137
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 783
+        "line_number": 784
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -554,7 +554,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 83
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
@@ -1062,5 +1062,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-17T10:30:25Z"
+  "generated_at": "2023-07-17T16:52:04Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -520,11 +520,41 @@
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
+        "hashed_secret": "fd9f851472586dc75f7a60ee311842ec64ecf527",
+        "is_verified": false,
+        "line_number": 133
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
+        "hashed_secret": "9367c8305bd1afe815ffc0cc3ebf95af9cb6d157",
+        "is_verified": false,
+        "line_number": 136
+      },
+      {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 774
+        "line_number": 783
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 82
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
@@ -627,28 +657,28 @@
         "filename": "src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java",
         "hashed_secret": "0eb769315deba70a52cf0292f6f163580aed36ab",
         "is_verified": false,
-        "line_number": 44
+        "line_number": 46
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java",
         "hashed_secret": "3faa7b358a992ffcff0150d4c3ceb26f6556c11e",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 48
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java",
         "hashed_secret": "508779dbbaa9267286609a2ed45a5c8bdfa489b8",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 48
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java",
         "hashed_secret": "a2a95d1ffa553770c0859718c31faf251ca7306f",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 48
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java": [
@@ -1032,5 +1062,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-13T14:27:30Z"
+  "generated_at": "2023-07-17T10:30:25Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryGatewayRequest.java
@@ -3,10 +3,9 @@ package uk.gov.pay.connector.gateway;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.gateway.model.request.GatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
-
-import java.util.Map;
 
 public class ChargeQueryGatewayRequest implements GatewayRequest {
     
@@ -50,8 +49,8 @@ public class ChargeQueryGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, Object> getGatewayCredentials() {
-        return gatewayAccountCredentialsEntity.getCredentials();
+    public GatewayCredentials getGatewayCredentials() {
+        return gatewayAccountCredentialsEntity.getCredentialsObject();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationService.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
 import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
+import uk.gov.pay.connector.gatewayaccount.model.EpdqCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
@@ -38,7 +39,6 @@ import static uk.gov.pay.connector.charge.service.StatusFlow.SYSTEM_CANCELLATION
 import static uk.gov.pay.connector.charge.service.StatusFlow.USER_CANCELLATION_FLOW;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.SHASIGN_KEY;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_ERROR;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
@@ -207,7 +207,7 @@ public class EpdqNotificationService {
     }
 
     private String getShaOutPassphrase(GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity) {
-        return gatewayAccountCredentialsEntity.getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE).toString();
+        return ((EpdqCredentials)gatewayAccountCredentialsEntity.getCredentialsObject()).getShaOutPassphrase();
     }
 
     private static Optional<ChargeStatus> newChargeStateForChargeNotification(String notificationStatus, Charge charge) {

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.gateway.epdq.model.response.EpdqRefundResponse;
 import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForRefundOrder;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
+import uk.gov.pay.connector.gatewayaccount.model.EpdqCredentials;
 
 import java.net.URI;
 import java.util.Map;
@@ -18,11 +19,7 @@ import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshal
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider.ROUTE_FOR_MAINTENANCE_ORDER;
 import static uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse.RefundState.PENDING;
-import static uk.gov.pay.connector.gateway.util.AuthUtil.getGatewayAccountCredentialsAsAuthHeader;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gateway.util.AuthUtil.getEpdqAuthHeader;
 
 public class EpdqRefundHandler implements RefundHandler {
 
@@ -42,8 +39,8 @@ public class EpdqRefundHandler implements RefundHandler {
                     url,
                     EPDQ,
                     request.getGatewayAccount().getType(),
-                    buildRefundOrder(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
+                    buildRefundOrder(request), 
+                    getEpdqAuthHeader(request.getGatewayCredentials()));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, EpdqRefundResponse.class), PENDING);
         } catch (GenericGatewayException | GatewayException.GatewayConnectionTimeoutException | GatewayErrorException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());
@@ -51,13 +48,14 @@ public class EpdqRefundHandler implements RefundHandler {
     }
 
     private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
+        EpdqCredentials credentials = (EpdqCredentials) request.getGatewayCredentials();
         var epdqPayloadDefinitionForRefundOrder = new EpdqPayloadDefinitionForRefundOrder();
-        epdqPayloadDefinitionForRefundOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME).toString());
-        epdqPayloadDefinitionForRefundOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD).toString());
-        epdqPayloadDefinitionForRefundOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID).toString());
+        epdqPayloadDefinitionForRefundOrder.setUserId(credentials.getUsername());
+        epdqPayloadDefinitionForRefundOrder.setPassword(credentials.getPassword());
+        epdqPayloadDefinitionForRefundOrder.setPspId(credentials.getMerchantId());
         epdqPayloadDefinitionForRefundOrder.setPayId(request.getTransactionId());
         epdqPayloadDefinitionForRefundOrder.setAmount(request.getAmount());
-        epdqPayloadDefinitionForRefundOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE).toString());
+        epdqPayloadDefinitionForRefundOrder.setShaInPassphrase(credentials.getShaInPassphrase());
         return epdqPayloadDefinitionForRefundOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
@@ -6,9 +6,9 @@ import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
-import java.util.Map;
 import java.util.Optional;
 
 public class Auth3dsResponseGatewayRequest implements GatewayRequest {
@@ -52,8 +52,8 @@ public class Auth3dsResponseGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, Object> getGatewayCredentials() {
-        return charge.getGatewayAccountCredentialsEntity().getCredentials();
+    public GatewayCredentials getGatewayCredentials() {
+        return charge.getGatewayAccountCredentialsEntity().getCredentialsObject();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -6,11 +6,11 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
-import java.util.Map;
 import java.util.Optional;
 
 public abstract class AuthorisationGatewayRequest implements GatewayRequest {
@@ -22,7 +22,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     private final String description;
     private final ServicePaymentReference reference;
     private final String govUkPayPaymentId;
-    private final Map<String, Object> credentials;
+    private final GatewayCredentials credentials;
     private final GatewayAccountEntity gatewayAccount;
     private final AuthorisationMode authorisationMode;
     private final boolean savePaymentInstrumentToAgreement;
@@ -39,7 +39,9 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
         this.description = charge.getDescription();
         this.reference = charge.getReference();
         this.govUkPayPaymentId = charge.getExternalId();
-        this.credentials = Optional.ofNullable(charge.getGatewayAccountCredentialsEntity()).map(GatewayAccountCredentialsEntity::getCredentials).orElse(null);
+        this.credentials = Optional.ofNullable(charge.getGatewayAccountCredentialsEntity())
+                .map(GatewayAccountCredentialsEntity::getCredentialsObject)
+                .orElse(null);
         this.gatewayAccount = charge.getGatewayAccount();
         this.authorisationMode = charge.getAuthorisationMode();
         this.savePaymentInstrumentToAgreement = charge.isSavePaymentInstrumentToAgreement();
@@ -54,7 +56,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
                                        String description,
                                        ServicePaymentReference reference,
                                        String govUkPayPaymentId,
-                                       Map<String, Object> credentials,
+                                       GatewayCredentials credentials,
                                        GatewayAccountEntity gatewayAccount,
                                        AuthorisationMode authorisationMode,
                                        boolean savePaymentInstrumentToAgreement,
@@ -107,7 +109,7 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, Object> getGatewayCredentials() {
+    public GatewayCredentials getGatewayCredentials() {
         return credentials;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CancelGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CancelGatewayRequest.java
@@ -3,9 +3,8 @@ package uk.gov.pay.connector.gateway.model.request;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
-
-import java.util.Map;
 
 public class CancelGatewayRequest implements GatewayRequest {
 
@@ -34,8 +33,8 @@ public class CancelGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, Object> getGatewayCredentials() {
-        return charge.getGatewayAccountCredentialsEntity().getCredentials();
+    public GatewayCredentials getGatewayCredentials() {
+        return charge.getGatewayAccountCredentialsEntity().getCredentialsObject();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
@@ -6,11 +6,11 @@ import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 
 public class CaptureGatewayRequest implements GatewayRequest {
 
@@ -59,8 +59,8 @@ public class CaptureGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, Object> getGatewayCredentials() {
-        return charge.getGatewayAccountCredentialsEntity().getCredentials();
+    public GatewayCredentials getGatewayCredentials() {
+        return charge.getGatewayAccountCredentialsEntity().getCredentialsObject();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/DeleteStoredPaymentDetailsGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/DeleteStoredPaymentDetailsGatewayRequest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.model.request;
 
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 
 import java.util.Map;
@@ -10,13 +11,13 @@ public class DeleteStoredPaymentDetailsGatewayRequest {
     private Map<String, String> recurringAuthToken;
     private String gatewayAccountType;
     private boolean live;
-    private Map<String, Object> gatewayCredentials;
+    private GatewayCredentials gatewayCredentials;
 
     private DeleteStoredPaymentDetailsGatewayRequest(String agreementExternalId,
                                                      Map<String, String> recurringAuthToken,
                                                      String gatewayAccountType,
                                                      boolean live,
-                                                     Map<String, Object> gatewayCredentials) {
+                                                     GatewayCredentials gatewayCredentials) {
         this.agreementExternalId = agreementExternalId;
         this.recurringAuthToken = recurringAuthToken;
         this.gatewayAccountType = gatewayAccountType;
@@ -32,7 +33,7 @@ public class DeleteStoredPaymentDetailsGatewayRequest {
                 recurringAuthToken,
                 agreement.getGatewayAccount().getType(),
                 agreement.isLive(),
-                agreement.getGatewayAccount().getCredentials(agreement.getGatewayAccount().getGatewayName())
+                agreement.getGatewayAccount().getGatewayAccountCredentialsEntity(agreement.getGatewayAccount().getGatewayName()).getCredentialsObject()
         );
     }
 
@@ -52,7 +53,7 @@ public class DeleteStoredPaymentDetailsGatewayRequest {
         return live;
     }
 
-    public Map<String, Object> getGatewayCredentials() {
+    public GatewayCredentials getGatewayCredentials() {
         return gatewayCredentials;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayRequest.java
@@ -2,16 +2,15 @@ package uk.gov.pay.connector.gateway.model.request;
 
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
-
-import java.util.Map;
 
 public interface GatewayRequest {
     GatewayAccountEntity getGatewayAccount();
 
     GatewayOperation getRequestType();
 
-    Map<String, Object> getGatewayCredentials();
+    GatewayCredentials getGatewayCredentials();
 
     AuthorisationMode getAuthorisationMode();
     

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RecurringPaymentAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RecurringPaymentAuthorisationGatewayRequest.java
@@ -5,11 +5,11 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
-import java.util.Map;
 import java.util.Optional;
 
 public class RecurringPaymentAuthorisationGatewayRequest implements GatewayRequest{
@@ -18,12 +18,12 @@ public class RecurringPaymentAuthorisationGatewayRequest implements GatewayReque
     private String amount;
     private String gatewayTransactionId;
     private String description;
-    private Map<String, Object> credentials;
+    private GatewayCredentials credentials;
     private GatewayAccountEntity gatewayAccountEntity;
     private String govUkPayPaymentId;
 
     private RecurringPaymentAuthorisationGatewayRequest(GatewayAccountEntity gatewayAccountEntity,
-                                                        Map<String, Object> credentials,
+                                                        GatewayCredentials credentials,
                                                         String agreementId,
                                                         String amount,
                                                         String gatewayTransactionId,
@@ -42,7 +42,9 @@ public class RecurringPaymentAuthorisationGatewayRequest implements GatewayReque
 
     public static RecurringPaymentAuthorisationGatewayRequest valueOf(ChargeEntity charge) {
         return new RecurringPaymentAuthorisationGatewayRequest(charge.getGatewayAccount(),
-                Optional.ofNullable(charge.getGatewayAccountCredentialsEntity()).map(GatewayAccountCredentialsEntity::getCredentials).orElse(null),
+                Optional.ofNullable(charge.getGatewayAccountCredentialsEntity())
+                        .map(GatewayAccountCredentialsEntity::getCredentialsObject)
+                        .orElse(null),
                 charge.getAgreement().map(AgreementEntity::getExternalId).orElse(null),
                 String.valueOf(CorporateCardSurchargeCalculator.getTotalAmountFor(charge)),
                 charge.getGatewayTransactionId(),
@@ -86,7 +88,7 @@ public class RecurringPaymentAuthorisationGatewayRequest implements GatewayReque
     }
 
     @Override
-    public Map<String, Object> getGatewayCredentials() {
+    public GatewayCredentials getGatewayCredentials() {
         return credentials;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
@@ -3,11 +3,10 @@ package uk.gov.pay.connector.gateway.model.request;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
-
-import java.util.Map;
 
 public class RefundGatewayRequest implements GatewayRequest {
 
@@ -57,8 +56,8 @@ public class RefundGatewayRequest implements GatewayRequest {
     }
 
     @Override
-    public Map<String, Object> getGatewayCredentials() {
-        return credentialsEntity.getCredentials();
+    public GatewayCredentials getGatewayCredentials() {
+        return credentialsEntity.getCredentialsObject();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequest.java
@@ -5,6 +5,8 @@ import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 
 import java.util.Map;
 
@@ -25,7 +27,7 @@ public class StripeAuthoriseRequest extends StripePostRequest {
             GatewayAccountEntity gatewayAccount,
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
-            Map<String, Object> credentials) {
+            GatewayCredentials credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.amount = amount;
         this.description = description;
@@ -44,7 +46,7 @@ public class StripeAuthoriseRequest extends StripePostRequest {
                 authorisationRequest.getGatewayAccount(),
                 authorisationRequest.getGovUkPayPaymentId(),
                 stripeGatewayConfig,
-                authorisationRequest.getGatewayCredentials()
+                (StripeCredentials) authorisationRequest.getGatewayCredentials()
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequest.java
@@ -3,17 +3,17 @@ package uk.gov.pay.connector.gateway.stripe.request;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 public abstract class StripeCaptureRequest extends StripePostRequest {
     protected StripeCaptureRequest(
             GatewayAccountEntity gatewayAccount,
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
-            Map<String, Object> credentials) {
+            GatewayCredentials credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
     }
     

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequest.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
 import java.util.Map;
 
@@ -25,7 +26,7 @@ public class StripeCustomerRequest extends StripePostRequest {
             StripeGatewayConfig stripeGatewayConfig,
             AuthCardDetails authCardDetails,
             AgreementEntity agreement,
-            Map<String, Object> credentials) {
+            GatewayCredentials credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         name = authCardDetails.getCardHolder();
         description = agreement.getDescription();

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentCancelRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentCancelRequest.java
@@ -4,15 +4,14 @@ import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-
-import java.util.Map;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
 public class StripePaymentIntentCancelRequest extends StripePostRequest {
     private final String stripePaymentIntentId;
 
     private StripePaymentIntentCancelRequest(GatewayAccountEntity gatewayAccount, String stripePaymentIntentId,
                                              String idempotencyKey, StripeGatewayConfig stripeGatewayConfig,
-                                             Map<String, Object> credentials) {
+                                             GatewayCredentials credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.stripePaymentIntentId = stripePaymentIntentId;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentCaptureRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentCaptureRequest.java
@@ -3,10 +3,10 @@ package uk.gov.pay.connector.gateway.stripe.request;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 public class StripePaymentIntentCaptureRequest extends StripeCaptureRequest {
     private final String stripeIdentifier;
@@ -16,7 +16,7 @@ public class StripePaymentIntentCaptureRequest extends StripeCaptureRequest {
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             String stripeIdentifier,
-            Map<String, Object> credentials) {
+            GatewayCredentials credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.stripeIdentifier = stripeIdentifier;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,7 +37,7 @@ public class StripePaymentIntentRequest extends StripePostRequest {
             String chargeExternalId,
             String description,
             boolean moto,
-            Map<String, Object> credentials,
+            GatewayCredentials credentials,
             String customerId,
             boolean offSession) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.northamericaregion.NorthAmericaRegion;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 
@@ -15,18 +16,18 @@ import java.util.Map;
 public class StripePaymentMethodRequest extends StripePostRequest {
     private final AuthCardDetails authCardDetails;
     private final NorthAmericanRegionMapper northAmericanRegionMapper;
-    
+
     public StripePaymentMethodRequest(
             GatewayAccountEntity gatewayAccount,
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             AuthCardDetails authCardDetails,
-            Map<String, Object> credentials) {
+            GatewayCredentials credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.authCardDetails = authCardDetails;
         this.northAmericanRegionMapper = new NorthAmericanRegionMapper();
     }
-    
+
     public static StripePaymentMethodRequest of(CardAuthorisationGatewayRequest request, StripeGatewayConfig config) {
         return new StripePaymentMethodRequest(
                 request.getGatewayAccount(),
@@ -59,7 +60,7 @@ public class StripePaymentMethodRequest extends StripePostRequest {
             localParams.put("billing_details[address[country]]", address.getCountry());
             localParams.put("billing_details[address[postal_code]]", address.getPostcode());
         });
-        
+
         return Map.copyOf(localParams);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePostRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePostRequest.java
@@ -10,6 +10,8 @@ import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
 import uk.gov.pay.connector.gateway.util.AuthUtil;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 
 import java.net.URI;
 import java.util.Collections;
@@ -30,15 +32,19 @@ public abstract class StripePostRequest implements GatewayClientPostRequest {
     protected StripeGatewayConfig stripeGatewayConfig;
     protected String stripeConnectAccountId;
     protected String gatewayAccountType;
-    protected Map<String, Object> credentials;
+    protected StripeCredentials credentials;
 
     protected StripePostRequest(GatewayAccountEntity gatewayAccount, String idempotencyKey,
-                                StripeGatewayConfig stripeGatewayConfig, Map<String, Object>  credentials) {
+                                StripeGatewayConfig stripeGatewayConfig, GatewayCredentials credentials) {
         if (gatewayAccount == null) {
             throw new IllegalArgumentException("Cannot create StripeRequest without a gateway account");
         }
 
-        String stripeAccountId = credentials.get("stripe_account_id").toString();
+        if (!(credentials instanceof StripeCredentials)) {
+            throw new IllegalArgumentException("Expected provided GatewayCredentials to be of type StripeCredentials");
+        }
+        var stripeCredentials = (StripeCredentials) credentials;
+        String stripeAccountId = stripeCredentials.getStripeAccountId();
         if (stripeAccountId == null) {
             throw new IllegalArgumentException("Cannot create StripeRequest without a stripe account id in credentials");
         }
@@ -48,7 +54,7 @@ public abstract class StripePostRequest implements GatewayClientPostRequest {
         this.idempotencyKey = idempotencyKey;
         this.stripeGatewayConfig = stripeGatewayConfig;
         this.stripeConnectAccountId = stripeAccountId;
-        this.credentials = credentials;
+        this.credentials = stripeCredentials;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
 import java.util.Map;
 
@@ -17,7 +18,7 @@ public class StripeRefundRequest extends StripePostRequest {
             String idempotencyKey,
             String stripeChargeId,
             StripeGatewayConfig stripeGatewayConfig,
-            Map<String, Object> credentials) {
+            GatewayCredentials credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.stripeChargeId = stripeChargeId;
         this.amount = amount;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
 import java.util.HashMap;
@@ -24,7 +25,7 @@ public class StripeTransferInRequest extends StripeTransferRequest {
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             String govukPayTransactionExternalId,
-            Map<String, Object> credentials,
+            GatewayCredentials credentials,
             String transferGroup,
             StripeTransferMetadataReason reason) {
         super(amount, gatewayAccount, stripeChargeId, idempotencyKey, stripeGatewayConfig,
@@ -61,11 +62,11 @@ public class StripeTransferInRequest extends StripeTransferRequest {
                 chargeExternalId,
                 stripeGatewayConfig,
                 chargeExternalId,
-                gatewayAccountCredentials.getCredentials(),
+                gatewayAccountCredentials.getCredentialsObject(),
                 chargeExternalId,
                 StripeTransferMetadataReason.TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT);
     }
-    
+
     public static StripeTransferInRequest createDisputeTransferRequest(
             String amount,
             GatewayAccountEntity gatewayAccount,
@@ -81,7 +82,7 @@ public class StripeTransferInRequest extends StripeTransferRequest {
                 disputeExternalId,
                 stripeGatewayConfig,
                 disputeExternalId,
-                gatewayAccountCredentials.getCredentials(),
+                gatewayAccountCredentials.getCredentialsObject(),
                 chargeExternalId,
                 StripeTransferMetadataReason.TRANSFER_DISPUTE_AMOUNT);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,7 +17,7 @@ public class StripeTransferOutRequest extends StripeTransferRequest {
                                      String idempotencyKey,
                                      StripeGatewayConfig stripeGatewayConfig,
                                      String govukPayTransactionExternalId,
-                                     Map<String, Object> credentials) {
+                                     GatewayCredentials credentials) {
         super(amount, gatewayAccount, sourceTransactionId, idempotencyKey, stripeGatewayConfig,
                 govukPayTransactionExternalId, credentials, StripeTransferMetadataReason.TRANSFER_PAYMENT_AMOUNT);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.stripe.request;
 
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
 import java.util.HashMap;
 import java.util.List;
@@ -20,7 +21,7 @@ public abstract class StripeTransferRequest extends StripePostRequest {
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             String govukPayTransactionExternalId,
-            Map<String, Object> credentials,
+            GatewayCredentials credentials,
             StripeTransferMetadataReason reason) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.stripeChargeId = stripeChargeId;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferReversalRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferReversalRequest.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
 import java.util.Map;
 
@@ -15,7 +16,7 @@ public class StripeTransferReversalRequest extends StripePostRequest {
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             String transferId,
-            Map<String, Object> credentials) {
+            GatewayCredentials credentials) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.transferId = transferId;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
@@ -1,10 +1,14 @@
 package uk.gov.pay.connector.gateway.util;
 
-import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gatewayaccount.model.EpdqCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayValidatableCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.exception.MissingCredentialsForRecurringPaymentException;
+import uk.gov.pay.connector.gatewayaccountcredentials.exception.NoCredentialsInUsableStateException;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.util.Base64;
@@ -12,11 +16,6 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 
 public class AuthUtil {
     private static final String STRIPE_VERSION_HEADER = "Stripe-Version";
@@ -25,10 +24,6 @@ public class AuthUtil {
     // We are using a separate version as searching payment intents is only supported in newer API versions.
     // This is intended as a temporary solution, and we intend to move all requests to use the same API version.
     public static final String STRIPE_SEARCH_PAYMENT_INTENTS_API_VERSION = "2020-08-27";
-
-    private static String encode(String username, String password) {
-        return "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
-    }
 
     public static Map<String, String> getStripeAuthHeaderForPaymentIntentSearch(StripeGatewayConfig stripeGatewayConfig, boolean isLiveAccount) {
         return getStripeAuthHeaderWithApiVersion(stripeGatewayConfig, isLiveAccount, STRIPE_SEARCH_PAYMENT_INTENTS_API_VERSION);
@@ -41,53 +36,87 @@ public class AuthUtil {
     private static Map<String, String> getStripeAuthHeaderWithApiVersion(StripeGatewayConfig stripeGatewayConfig, boolean isLiveAccount, String apiVersion) {
         StripeAuthTokens authTokens = stripeGatewayConfig.getAuthTokens();
         String value = format("Bearer %s", isLiveAccount ? authTokens.getLive() : authTokens.getTest());
-        return ImmutableMap.of(
+        return Map.of(
                 AUTHORIZATION, value,
                 STRIPE_VERSION_HEADER, apiVersion
         );
     }
 
-    public static String getWorldpayMerchantCode(Map<String, Object> gatewayCredentials, AuthorisationMode authorisationMode) {
-        if (authorisationMode == AuthorisationMode.AGREEMENT) {
-            if (gatewayCredentials.get(RECURRING_MERCHANT_INITIATED) == null) {
-                throw new MissingCredentialsForRecurringPaymentException();
+    public static String getWorldpayMerchantCode(GatewayCredentials credentials, AuthorisationMode authorisationMode, boolean isRecurring) {
+        WorldpayCredentials worldpayCredentials = castGatewayCredentialsToWorldpayCredentials(credentials);
+        if (isRecurring) {
+            if (authorisationMode == AuthorisationMode.AGREEMENT) {
+                return worldpayCredentials.getRecurringMerchantInitiatedCredentials()
+                        .map(WorldpayMerchantCodeCredentials::getMerchantCode)
+                        .orElseThrow(MissingCredentialsForRecurringPaymentException::new);
             }
-            Map<String, Object> recurringCreds = (Map<String, Object>) gatewayCredentials.get(RECURRING_MERCHANT_INITIATED);
-
-            return recurringCreds.get(CREDENTIALS_MERCHANT_CODE).toString();
+            return worldpayCredentials.getRecurringCustomerInitiatedCredentials()
+                    .map(WorldpayMerchantCodeCredentials::getMerchantCode)
+                    .orElseThrow(MissingCredentialsForRecurringPaymentException::new);
         }
-        return gatewayCredentials.get(CREDENTIALS_MERCHANT_ID).toString();
+
+        return worldpayCredentials.getOneOffCustomerInitiatedCredentials()
+                .map(WorldpayMerchantCodeCredentials::getMerchantCode)
+                .orElseGet(() -> worldpayCredentials.getLegacyOneOffCustomerInitiatedMerchantCode()
+                        .orElseThrow(NoCredentialsInUsableStateException::new));
     }
 
-    public static String getWorldpayMerchantCodeForManagingTokens(Map<String, Object> gatewayCredentials) {
-        return gatewayCredentials.get(CREDENTIALS_MERCHANT_ID).toString();
-    }
+    public static Map<String, String> getWorldpayAuthHeader(GatewayCredentials credentials, AuthorisationMode authorisationMode, boolean isRecurring) {
+        WorldpayCredentials worldpayCredentials = castGatewayCredentialsToWorldpayCredentials(credentials);
 
-    public static Map<String, String> getGatewayAccountCredentialsAsAuthHeader(Map<String, Object> gatewayCredentials) {
-        String value = encode(gatewayCredentials.get(CREDENTIALS_USERNAME).toString(), gatewayCredentials.get(CREDENTIALS_PASSWORD).toString());
-        return ImmutableMap.of(AUTHORIZATION, value);
-    }
-
-    public static Map<String, String> getGatewayAccountCredentialsAsAuthHeader(Map<String, Object> gatewayCredentials, AuthorisationMode authorisationMode) {
-        if (authorisationMode == AuthorisationMode.AGREEMENT) {
-            if (gatewayCredentials.get(RECURRING_MERCHANT_INITIATED) == null) {
-                throw new MissingCredentialsForRecurringPaymentException();
+        if (isRecurring) {
+            if (authorisationMode == AuthorisationMode.AGREEMENT) {
+                return worldpayCredentials.getRecurringMerchantInitiatedCredentials()
+                        .map(AuthUtil::getWorldpayAuthHeader)
+                        .orElseThrow(MissingCredentialsForRecurringPaymentException::new);
             }
-            Map<String, Object> recurringCreds = (Map<String, Object>) gatewayCredentials.get(RECURRING_MERCHANT_INITIATED);
-            String value = encode(recurringCreds.get(CREDENTIALS_USERNAME).toString(), recurringCreds.get(CREDENTIALS_PASSWORD).toString());
-            return ImmutableMap.of(AUTHORIZATION, value);
+            return worldpayCredentials.getRecurringCustomerInitiatedCredentials()
+                    .map(AuthUtil::getWorldpayAuthHeader)
+                    .orElseThrow(MissingCredentialsForRecurringPaymentException::new);
         }
-        String value = encode(gatewayCredentials.get(CREDENTIALS_USERNAME).toString(), gatewayCredentials.get(CREDENTIALS_PASSWORD).toString());
-        return ImmutableMap.of(AUTHORIZATION, value);
+
+        return worldpayCredentials.getOneOffCustomerInitiatedCredentials()
+                .map(AuthUtil::getWorldpayAuthHeader)
+                .orElseGet(() -> {
+                    String username = worldpayCredentials.getLegacyOneOffCustomerInitiatedUsername().orElseThrow(NoCredentialsInUsableStateException::new);
+                    String password = worldpayCredentials.getLegacyOneOffCustomerInitiatedPassword().orElseThrow(NoCredentialsInUsableStateException::new);
+                    return getAuthHeader(username, password);
+                });
     }
 
-    public static Map<String, String> getGatewayAccountCredentialsForManagingTokensAsAuthHeader(Map<String, Object> gatewayCredentials) {
-        String value = encode(gatewayCredentials.get(CREDENTIALS_USERNAME).toString(), gatewayCredentials.get(CREDENTIALS_PASSWORD).toString());
-        return ImmutableMap.of(AUTHORIZATION, value);
+    private static Map<String, String> getWorldpayAuthHeader(WorldpayMerchantCodeCredentials creds) {
+        return getAuthHeader(creds.getUsername(), creds.getPassword());
     }
-    
+
+    public static Map<String, String> getGatewayAccountCredentialsForManagingTokensAsAuthHeader(GatewayCredentials credentials) {
+        WorldpayCredentials worldpayCredentials = castGatewayCredentialsToWorldpayCredentials(credentials);
+        WorldpayMerchantCodeCredentials recurringCustomerInitiatedCredentials = worldpayCredentials.getRecurringCustomerInitiatedCredentials()
+                .orElseThrow(MissingCredentialsForRecurringPaymentException::new);
+        return getWorldpayAuthHeader(recurringCustomerInitiatedCredentials);
+    }
+
+    private static WorldpayCredentials castGatewayCredentialsToWorldpayCredentials(GatewayCredentials credentials) {
+        if (!(credentials instanceof WorldpayCredentials)) {
+            throw new IllegalArgumentException("Expected provided GatewayCredentials to be of type WorldpayCredentials");
+        }
+        return (WorldpayCredentials) credentials;
+    }
+
     public static Map<String, String> getWorldpayCredentialsCheckAuthHeader(WorldpayValidatableCredentials worldpayValidatableCredentials) {
-        String value = encode(worldpayValidatableCredentials.getUsername(), worldpayValidatableCredentials.getPassword());
-        return ImmutableMap.of(AUTHORIZATION, value);
+        return getAuthHeader(worldpayValidatableCredentials.getUsername(), worldpayValidatableCredentials.getPassword());
     }
+
+    public static Map<String, String> getEpdqAuthHeader(GatewayCredentials credentials) {
+        if (!(credentials instanceof EpdqCredentials)) {
+            throw new IllegalArgumentException("Expected provided GatewayCredentials to be of type EpdqCredentials");
+        }
+        var epdqCredentials = (EpdqCredentials) credentials;
+        return getAuthHeader(epdqCredentials.getUsername(), epdqCredentials.getPassword());
+    }
+
+    private static Map<String, String> getAuthHeader(String username, String password) {
+        String value = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
+        return Map.of(AUTHORIZATION, value);
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -22,12 +22,12 @@ import static javax.ws.rs.core.Response.Status.Family.SERVER_ERROR;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
-import static uk.gov.pay.connector.gateway.util.AuthUtil.getGatewayAccountCredentialsAsAuthHeader;
+import static uk.gov.pay.connector.gateway.util.AuthUtil.getWorldpayAuthHeader;
 
 public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WorldpayAuthoriseHandler.class);
-    
+
     private final GatewayClient authoriseClient;
     private final Map<String, URI> gatewayUrlMap;
     private final AcceptLanguageHeaderParser acceptLanguageHeaderParser;
@@ -41,7 +41,7 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
         this.authoriseClient = authoriseClient;
         this.gatewayUrlMap = gatewayUrlMap;
     }
-    
+
     public GatewayResponse<WorldpayOrderStatusResponse> authoriseWithExemption(CardAuthorisationGatewayRequest request) {
         return authorise(request, true);
     }
@@ -59,7 +59,7 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
                     WorldpayOrderBuilder.buildAuthoriseRecurringOrder(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode()));
+                    getWorldpayAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()));
             return getWorldpayGatewayResponse(response);
         } catch (GatewayException.GatewayErrorException e) {
             LOGGER.error("Authorisation user not present failed due to an internal error. Reason: {}. Status code from Worldpay: {}.",
@@ -75,42 +75,42 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
             return responseBuilder().withGatewayError(e.toGatewayError()).build();
         }
     }
-    
-    private GatewayResponse<WorldpayOrderStatusResponse> authorise(CardAuthorisationGatewayRequest request, 
-                                                                  boolean withExemptionEngine) {
+
+    private GatewayResponse<WorldpayOrderStatusResponse> authorise(CardAuthorisationGatewayRequest request,
+                                                                   boolean withExemptionEngine) {
 
         logMissingDdcResultFor3dsFlexIntegration(request);
-        
+
         try {
             GatewayClient.Response response = authoriseClient.postRequestFor(
                     gatewayUrlMap.get(request.getGatewayAccount().getType()),
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
                     WorldpayOrderBuilder.buildAuthoriseOrderWithExemptionEngine(request, withExemptionEngine, acceptLanguageHeaderParser),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode()));
+                    getWorldpayAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()));
 
             if (response.getEntity().contains("request3DSecure")) {
                 LOGGER.info(format("Worldpay authorisation response when 3ds required: %s", sanitiseMessage(response.getEntity())));
             }
             return getWorldpayGatewayResponse(response);
         } catch (GatewayException.GatewayErrorException e) {
-            
+
             if (e.getStatus().isPresent() && (e.getFamily() == CLIENT_ERROR || e.getFamily() == SERVER_ERROR)) {
-                
+
                 LOGGER.error("Authorisation failed due to an internal error. Reason: {}. Status code from Worldpay: {}.",
                         e.getMessage(), e.getStatus().map(String::valueOf).orElse("no status code"));
-                
+
                 GatewayError gatewayError = gatewayConnectionError(format("Non-success HTTP status code %s from gateway", e.getStatus().get()));
 
                 return responseBuilder().withGatewayError(gatewayError).build();
             }
-            
+
             LOGGER.info("Unrecognised response status when authorising - status={}, response={}",
                     e.getStatus(), e.getResponseFromGateway());
             return responseBuilder().withGatewayError(e.toGatewayError()).build();
-            
+
         } catch (GatewayException.GatewayConnectionTimeoutException | GatewayException.GenericGatewayException e) {
-            
+
             LOGGER.error("GatewayException occurred, error:\n {}", e);
 
             return responseBuilder().withGatewayError(e.toGatewayError()).build();
@@ -120,7 +120,7 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
     private String sanitiseMessage(String message) {
         return message.replaceAll("<cardHolderName>.*</cardHolderName>", "<cardHolderName>REDACTED</cardHolderName>");
     }
-    
+
     private void logMissingDdcResultFor3dsFlexIntegration(CardAuthorisationGatewayRequest request) {
         GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
         if (gatewayAccount.isRequires3ds() && gatewayAccount.getIntegrationVersion3ds() == 2 &&

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import static uk.gov.pay.connector.gateway.CaptureResponse.ChargeState.PENDING;
 import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshallResponse;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gateway.util.AuthUtil.getGatewayAccountCredentialsAsAuthHeader;
+import static uk.gov.pay.connector.gateway.util.AuthUtil.getWorldpayAuthHeader;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCaptureOrderRequestBuilder;
 
 public class WorldpayCaptureHandler implements CaptureHandler {
@@ -41,7 +41,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
                     buildCaptureOrder(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode()));
+                    getWorldpayAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, WorldpayCaptureResponse.class), PENDING);
         } catch (GatewayException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());
@@ -51,7 +51,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
     private GatewayOrder buildCaptureOrder(CaptureGatewayRequest request) {
         return aWorldpayCaptureOrderRequestBuilder()
                 .withDate(LocalDate.now(ZoneOffset.UTC))
-                .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode()))
+                .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()))
                 .withAmount(request.getAmountAsString())
                 .withTransactionId(request.getGatewayTransactionId())
                 .build();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -15,18 +15,18 @@ import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY;
 
 public interface WorldpayOrderBuilder {
-    
+
     static WorldpayOrderRequestBuilder buildAuthoriseOrderWithExemptionEngine(WorldpayOrderRequestBuilder builder,
                                                                               CardAuthorisationGatewayRequest request,
                                                                               AcceptLanguageHeaderParser acceptLanguageHeaderParser) {
-        
+
         return buildAuthoriseOrderWithoutExemptionEngine(builder, request, acceptLanguageHeaderParser).withExemptionEngine(true);
     }
 
-    static WorldpayOrderRequestBuilder buildAuthoriseOrderWithoutExemptionEngine(WorldpayOrderRequestBuilder builder, 
+    static WorldpayOrderRequestBuilder buildAuthoriseOrderWithoutExemptionEngine(WorldpayOrderRequestBuilder builder,
                                                                                  CardAuthorisationGatewayRequest request,
                                                                                  AcceptLanguageHeaderParser acceptLanguageHeaderParser) {
-        
+
         if (request.getGatewayAccount().isSendPayerIpAddressToGateway()) {
             request.getAuthCardDetails().getIpAddress().ifPresent(builder::withPayerIpAddress);
         }
@@ -43,21 +43,21 @@ public interface WorldpayOrderBuilder {
 
         boolean is3dsRequired = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
                 request.getGatewayAccount().isRequires3ds();
-        
+
         return (WorldpayOrderRequestBuilder) builder
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getGovUkPayPaymentId()))
                 .with3dsRequired(is3dsRequired)
                 .withSavePaymentInstrumentToAgreement(request.isSavePaymentInstrumentToAgreement())
                 .withAgreementId(request.getAgreement().map(AgreementEntity::getExternalId).orElse(null))
                 .withTransactionId(request.getTransactionId().orElse(""))
-                .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode()))
+                .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()))
                 .withAmount(request.getAmount())
                 .withAuthorisationDetails(request.getAuthCardDetails())
                 .withIntegrationVersion3ds(request.getGatewayAccount().getIntegrationVersion3ds())
                 .withPaymentPlatformReference(request.getGovUkPayPaymentId())
                 .withBrowserLanguage(acceptLanguageHeaderParser.getPreferredLanguageFromAcceptLanguageHeader(request.getAuthCardDetails().getAcceptLanguageHeader()));
     }
-    
+
     static GatewayOrder buildAuthoriseOrderWithExemptionEngine(CardAuthorisationGatewayRequest request, boolean withExemptionEngine, AcceptLanguageHeaderParser acceptLanguageHeaderParser) {
         if (withExemptionEngine) {
             return buildAuthoriseOrderWithExemptionEngine(aWorldpayAuthoriseOrderRequestBuilder(), request, acceptLanguageHeaderParser).build();
@@ -70,10 +70,12 @@ public interface WorldpayOrderBuilder {
         var paymentInstrument = request.getPaymentInstrument().orElseThrow(() -> new IllegalArgumentException("Expected request to have payment instrument but it does not"));
         var recurringAuthToken = paymentInstrument.getRecurringAuthToken().orElseThrow(() -> new IllegalArgumentException("Payment instrument does not have recurring auth token set"));
 
+        String merchantCode = AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(),
+                request.getAuthorisationMode(), request.isForRecurringPayment());
         WorldpayOrderRequestBuilder builder = (WorldpayOrderRequestBuilder) aWorldpayAuthoriseRecurringOrderRequestBuilder()
                 .withAgreementId(request.getAgreementId())
                 .withPaymentTokenId(Optional.ofNullable(recurringAuthToken.get(WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY)).orElse(""))
-                .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode()))
+                .withMerchantCode(merchantCode)
                 .withAmount(request.getAmount())
                 .withTransactionId(request.getGatewayTransactionId().orElse(""))
                 .withDescription(request.getDescription());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -61,7 +61,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gateway.util.AuthUtil.getGatewayAccountCredentialsForManagingTokensAsAuthHeader;
+import static uk.gov.pay.connector.gateway.util.AuthUtil.getWorldpayAuthHeaderForManagingRecurringAuthTokens;
 import static uk.gov.pay.connector.gateway.util.AuthUtil.getWorldpayAuthHeader;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpay3dsResponseAuthOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCancelOrderRequestBuilder;
@@ -360,7 +360,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                 WORLDPAY,
                 request.getGatewayAccountType(),
                 buildDeleteTokenOrder(request),
-                getGatewayAccountCredentialsForManagingTokensAsAuthHeader(request.getGatewayCredentials()));
+                getWorldpayAuthHeaderForManagingRecurringAuthTokens(request.getGatewayCredentials()));
     }
     
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshallResponse;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse.RefundState.PENDING;
-import static uk.gov.pay.connector.gateway.util.AuthUtil.getGatewayAccountCredentialsAsAuthHeader;
+import static uk.gov.pay.connector.gateway.util.AuthUtil.getWorldpayAuthHeader;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayRefundOrderRequestBuilder;
 
 public class WorldpayRefundHandler implements RefundHandler {
@@ -39,7 +39,7 @@ public class WorldpayRefundHandler implements RefundHandler {
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
                     buildRefundOrder(request), 
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode()));
+                    getWorldpayAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, WorldpayRefundResponse.class), PENDING);
         } catch (GatewayException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());
@@ -49,7 +49,7 @@ public class WorldpayRefundHandler implements RefundHandler {
     private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
         return aWorldpayRefundOrderRequestBuilder()
                 .withReference(request.getRefundExternalId())
-                .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode()))
+                .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()))
                 .withAmount(request.getAmount())
                 .withTransactionId(request.getTransactionId())
                 .build();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gateway.util.AuthUtil.getGatewayAccountCredentialsAsAuthHeader;
+import static uk.gov.pay.connector.gateway.util.AuthUtil.getWorldpayAuthHeader;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseWalletOrderRequestBuilder;
 
 public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHandler, WorldpayGatewayResponseGenerator {
@@ -35,14 +35,14 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
 
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(WalletAuthorisationGatewayRequest request) throws GatewayException {
-        
+
         GatewayClient.Response response = authoriseClient.postRequestFor(
                 gatewayUrlMap.get(request.getGatewayAccount().getType()),
                 WORLDPAY,
                 request.getGatewayAccount().getType(),
                 buildWalletAuthoriseOrder(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode()));
-        
+                getWorldpayAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()));
+
         return getWorldpayGatewayResponse(response);
     }
 
@@ -69,7 +69,7 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
                 .withUserAgentHeader(request.getWalletAuthorisationData().getPaymentInfo().getUserAgentHeader())
                 .withUserAgentHeader(request.getWalletAuthorisationData().getPaymentInfo().getAcceptHeader())
                 .withTransactionId(request.getTransactionId().orElse(""))
-                .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode()))
+                .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()))
                 .withDescription(request.getDescription())
                 .withAmount(request.getAmount())
                 .build();

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -219,23 +219,11 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
                     .or(() -> getGatewayAccountCredentials().stream().findFirst());
         }
     }
-
-    public Map<String, Object> getCredentials(String paymentProvider) {
-        List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntities = getGatewayAccountCredentials();
-
-        return gatewayAccountCredentialsEntities.stream()
-                .filter(entity -> entity.getPaymentProvider().equals(paymentProvider))
-                .max(comparing(GatewayAccountCredentialsEntity::getActiveStartDate))
-                .map(GatewayAccountCredentialsEntity::getCredentials)
-                .orElseThrow(() -> new WebApplicationException(serviceErrorResponse(
-                        format("Credentials not found for gateway account [%s] and payment_provider [%s] ",
-                                getId(), paymentProvider))));
-    }
     
     public GatewayAccountCredentialsEntity getGatewayAccountCredentialsEntity(String paymentProvider) {
         return gatewayAccountCredentials.stream()
                 .filter(entity -> entity.getPaymentProvider().equals(paymentProvider))
-                .findFirst()
+                .max(comparing(GatewayAccountCredentialsEntity::getActiveStartDate))
                 .orElseThrow(() -> new WebApplicationException(serviceErrorResponse(
                         format("Credentials not found for gateway account [%s] and payment_provider [%s] ",
                                 getId(), paymentProvider))));

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gatewayaccount.service;
 
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountResponse;
+import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 
 import java.util.Optional;
 
@@ -10,9 +11,8 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 public class StripeAccountService {
 
     public Optional<StripeAccountResponse> buildStripeAccountResponse(GatewayAccountEntity gatewayAccountEntity) {
-        return Optional.ofNullable(gatewayAccountEntity.getCredentials(STRIPE.getName()))
-                .map(credentials -> credentials.get("stripe_account_id") != null ?
-                        credentials.get("stripe_account_id").toString() : null)
+        return Optional.ofNullable(gatewayAccountEntity.getGatewayAccountCredentialsEntity(STRIPE.getName()))
+                .map(credentials -> ((StripeCredentials)credentials.getCredentialsObject()).getStripeAccountId())
                 .map(StripeAccountResponse::new);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/MissingCredentialsForRecurringPaymentException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/MissingCredentialsForRecurringPaymentException.java
@@ -2,6 +2,6 @@ package uk.gov.pay.connector.gatewayaccountcredentials.exception;
 
 public class MissingCredentialsForRecurringPaymentException extends RuntimeException {
     public MissingCredentialsForRecurringPaymentException() {
-        super("Credentials are missing for merchant initiated recurring payment");
+        super("Credentials are missing for taking recurring payments");
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -29,6 +29,7 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 
 @Entity
 @Table(name = "gateway_account_credentials")
@@ -102,15 +103,16 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
     // This will replace `getCredentials()` when all usages have been updated
     public GatewayCredentials getCredentialsObject() {
+        Map<String, Object> credentialsMap = Optional.ofNullable(credentials).orElse(Map.of());
         switch (PaymentGatewayName.valueFrom(paymentProvider)) {
             case WORLDPAY:
-                return objectMapper.convertValue(this.getCredentials(), WorldpayCredentials.class);
+                return objectMapper.convertValue(credentialsMap, WorldpayCredentials.class);
             case STRIPE:
-                return objectMapper.convertValue(this.getCredentials(), StripeCredentials.class);
+                return objectMapper.convertValue(credentialsMap, StripeCredentials.class);
             case EPDQ:
-                return objectMapper.convertValue(this.getCredentials(), EpdqCredentials.class);
+                return objectMapper.convertValue(credentialsMap, EpdqCredentials.class);
             case SANDBOX:
-                return objectMapper.convertValue(this.getCredentials(), SandboxCredentials.class);
+                return objectMapper.convertValue(credentialsMap, SandboxCredentials.class);
             default:
                 throw new IllegalArgumentException("Unsupported payment provider: " + paymentProvider);
         }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -235,8 +235,7 @@ public class GatewayAccountCredentialsService {
         PaymentGatewayName paymentGatewayName = PaymentGatewayName.valueFrom(credentialsEntity.getPaymentProvider());
         GatewayAccountEntity gatewayAccountEntity = credentialsEntity.getGatewayAccountEntity();
 
-        if (credentialsEntity.getCredentials() == null ||
-                credentialsEntity.getCredentials().isEmpty()) {
+        if (!credentialsEntity.getCredentialsObject().hasCredentials()) {
             return false;
         }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
@@ -277,6 +277,7 @@ public abstract class BaseEpdqPaymentProviderIT {
                 .withExternalId("mq4ht90j2oir6am585afk58kml")
                 .withTransactionId("payId")
                 .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider(EPDQ.getName())
                         .withCredentials(credentials)
                         .build())
                 .build();
@@ -305,6 +306,7 @@ public abstract class BaseEpdqPaymentProviderIT {
                 .withExternalId("mq4ht90j2oir6am585afk58kml")
                 .withGatewayAccountEntity(accountEntity)
                 .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider(EPDQ.getName())
                         .withCredentials(credentials)
                         .build())
                 .build();
@@ -353,6 +355,7 @@ public abstract class BaseEpdqPaymentProviderIT {
                 .withPaymentProvider(EPDQ.getName())
                 .withTransactionId("payId")
                 .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider(EPDQ.getName())
                         .withCredentials(credentials)
                         .build())
                 .build();

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
@@ -135,6 +135,7 @@ class EpdqCaptureHandlerTest {
                 .withGatewayAccountEntity(accountEntity)
                 .withTransactionId("payId")
                 .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider(EPDQ.getName())
                         .withCredentials(Map.of(
                                 CREDENTIALS_MERCHANT_ID, "merchant-id",
                                 CREDENTIALS_USERNAME, "username",

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials
 import uk.gov.pay.connector.gatewayaccountcredentials.exception.MissingCredentialsForRecurringPaymentException;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 
@@ -62,7 +63,7 @@ class AuthUtilTest {
         credentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
         Map<String, String> encodedHeader = AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.WEB, true);
 
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes(StandardCharsets.UTF_8));
         assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
     }
 
@@ -72,7 +73,7 @@ class AuthUtilTest {
         credentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
         Map<String, String> encodedHeader = AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.AGREEMENT, true);
 
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes(StandardCharsets.UTF_8));
         assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
     }
 
@@ -81,9 +82,9 @@ class AuthUtilTest {
         WorldpayCredentials credentials = new WorldpayCredentials();
         credentials.setLegacyOneOffCustomerInitiatedUsername(username);
         credentials.setLegacyOneOffCustomerInitiatedPassword(password);
-        
+
         Map<String, String> encodedHeader = AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.WEB, false);
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes(StandardCharsets.UTF_8));
         assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
     }
 
@@ -93,7 +94,7 @@ class AuthUtilTest {
         credentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
 
         Map<String, String> encodedHeader = AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.WEB, false);
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes(StandardCharsets.UTF_8));
         assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
     }
 
@@ -101,8 +102,8 @@ class AuthUtilTest {
     void shouldGetAuthHeaderForManagingTokens() {
         WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
         worldpayCredentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
-        Map<String, String> encodedHeader = AuthUtil.getGatewayAccountCredentialsForManagingTokensAsAuthHeader(worldpayCredentials);
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes(StandardCharsets.UTF_8));
+        Map<String, String> encodedHeader = AuthUtil.getWorldpayAuthHeaderForManagingRecurringAuthTokens(worldpayCredentials);
         assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.gateway.util;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.exception.MissingCredentialsForRecurringPaymentException;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
@@ -35,65 +37,126 @@ class AuthUtilTest {
             ));
 
     @Test
-    void shouldThrowException_whenAuthModeAgreement_andNoCredentials() {
+    void getWorldpayAuthHeader_shouldThrowExceptionWhenNoCredentials_forRecurringCustomerInitiated() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+        credentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
         MissingCredentialsForRecurringPaymentException thrown = assertThrows(MissingCredentialsForRecurringPaymentException.class, () -> {
-            Map<String, Object> credentials = Map.of(
-                    CREDENTIALS_MERCHANT_ID, merchantCode,
-                    CREDENTIALS_USERNAME, username,
-                    CREDENTIALS_PASSWORD, password);
-            AuthUtil.getGatewayAccountCredentialsAsAuthHeader(credentials, AuthorisationMode.AGREEMENT);
+            AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.WEB, true);
         });
-        assertThat(thrown.getMessage(), is("Credentials are missing for merchant initiated recurring payment"));
     }
 
     @Test
-    void shouldRetrieveTheRightCredentialsForRecurringPayments() {
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String("RC-" + username + ":" + "RC-" + password).getBytes());
-        Map<String, String> encodedHeader = AuthUtil.getGatewayAccountCredentialsAsAuthHeader(worldpayRecurringCredentials, AuthorisationMode.AGREEMENT);
-        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
-    }
-
-    @Test
-    void shouldRetrieveTheRightCredentialsForNonRecurringPayments() {
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
-        Map<String, String> encodedHeader = AuthUtil.getGatewayAccountCredentialsAsAuthHeader(worldpayRecurringCredentials, AuthorisationMode.WEB);
-        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
-    }
-
-    @Test
-    void shouldRetrieveTheRightCredentialsForManagingTokens() {
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
-        Map<String, String> encodedHeader = AuthUtil.getGatewayAccountCredentialsForManagingTokensAsAuthHeader(worldpayRecurringCredentials);
-        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
-    }
-
-    @Test
-    void shouldThrowException_whenAuthModeAgreement_andNoCredentialsForMerchantId() {
+    void getWorldpayAuthHeader_shouldThrowExceptionWhenNoCredentials_forRecurringMerchantInitiated() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+        credentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
         MissingCredentialsForRecurringPaymentException thrown = assertThrows(MissingCredentialsForRecurringPaymentException.class, () -> {
-            Map<String, Object> credentials = Map.of(
-                    CREDENTIALS_MERCHANT_ID, merchantCode,
-                    CREDENTIALS_USERNAME, username,
-                    CREDENTIALS_PASSWORD, password);
-            AuthUtil.getWorldpayMerchantCode(credentials, AuthorisationMode.AGREEMENT);
+            AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.AGREEMENT, true);
         });
-        assertThat(thrown.getMessage(), is("Credentials are missing for merchant initiated recurring payment"));
     }
 
     @Test
-    void shouldRetrieveTheRightMerchantIdForRecurringPayments() {
-        String merchantId = AuthUtil.getWorldpayMerchantCode(worldpayRecurringCredentials, AuthorisationMode.AGREEMENT);
-        assertThat(merchantId, is("RC-" + merchantCode));
+    void shouldGetAuthHeaderForRecurringCustomerInitiatedPayment() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+        Map<String, String> encodedHeader = AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.WEB, true);
+
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
     }
 
     @Test
-    void shouldRetrieveTheRightMerchantIdForNonRecurringPayments() {
-        String merchantId = AuthUtil.getWorldpayMerchantCode(worldpayRecurringCredentials, AuthorisationMode.WEB);
+    void shouldGetAuthHeaderForRecurringMerchantInitiatedPayment() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+        Map<String, String> encodedHeader = AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.AGREEMENT, true);
+
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
+    }
+
+    @Test
+    void shouldGetAuthHeaderForOneOffPayment_whenOnlyLegacyCredentialsSet() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setLegacyOneOffCustomerInitiatedUsername(username);
+        credentials.setLegacyOneOffCustomerInitiatedPassword(password);
+        
+        Map<String, String> encodedHeader = AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.WEB, false);
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
+        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
+    }
+
+    @Test
+    void shouldGetAuthHeaderForOneOffPayment_whenOneOffCustomerInitiatedCredentialsSet() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+
+        Map<String, String> encodedHeader = AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.WEB, false);
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
+        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
+    }
+
+    @Test
+    void shouldGetAuthHeaderForManagingTokens() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
+        worldpayCredentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());
+        Map<String, String> encodedHeader = AuthUtil.getGatewayAccountCredentialsForManagingTokensAsAuthHeader(worldpayCredentials);
+        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
+    }
+
+    @Test
+    void getWorldpayMerchantCode_shouldThrowExceptionWhenNoCredentials_forRecurringCustomerInitiated() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+        credentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+        MissingCredentialsForRecurringPaymentException thrown = assertThrows(MissingCredentialsForRecurringPaymentException.class, () -> {
+            AuthUtil.getWorldpayMerchantCode(credentials, AuthorisationMode.WEB, true);
+        });
+    }
+
+    @Test
+    void getWorldpayMerchantCode_shouldThrowExceptionWhenNoCredentials_forRecurringMerchantInitiated() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+        credentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+        MissingCredentialsForRecurringPaymentException thrown = assertThrows(MissingCredentialsForRecurringPaymentException.class, () -> {
+            AuthUtil.getWorldpayMerchantCode(credentials, AuthorisationMode.AGREEMENT, true);
+        });
+    }
+
+    @Test
+    void shouldGetMerchantCodeForRecurringCustomerInitiatedPayment() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+        String merchantId = AuthUtil.getWorldpayMerchantCode(credentials, AuthorisationMode.WEB, true);
         assertThat(merchantId, is(merchantCode));
     }
 
     @Test
-    void shouldRetrieveTheRightMerchantIdForManagingTokens() {
-        String merchantId = AuthUtil.getWorldpayMerchantCodeForManagingTokens(worldpayRecurringCredentials);
+    void shouldGetMerchantCodeForRecurringMerchantInitiatedPayment() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+        String merchantId = AuthUtil.getWorldpayMerchantCode(credentials, AuthorisationMode.AGREEMENT, true);
+        assertThat(merchantId, is(merchantCode));
+    }
+
+    @Test
+    void shouldGetMerchantCodeForOneOffPayment_whenOnlyLegacyCredentialsSet() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setLegacyOneOffCustomerInitiatedMerchantCode(merchantCode);
+
+        String merchantId = AuthUtil.getWorldpayMerchantCode(credentials, AuthorisationMode.WEB, false);
+        assertThat(merchantId, is(merchantCode));
+    }
+
+    @Test
+    void shouldGetMerchantCodeForOneOffPayment_whenOneOffCustomerInitiatedCredentialsSet() {
+        WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
+
+        String merchantId = AuthUtil.getWorldpayMerchantCode(credentials, AuthorisationMode.WEB, false);
         assertThat(merchantId, is(merchantCode));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -79,6 +79,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity.Worldpay3dsFlexCredentialsEntityBuilder.aWorldpay3dsFlexCredentialsEntity;
@@ -123,28 +124,21 @@ class WorldpayAuthoriseHandlerTest {
                         CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
                         CREDENTIALS_USERNAME, "worldpay-password",
                         CREDENTIALS_PASSWORD, "password",
+                        RECURRING_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, "CIT-MERCHANTCODE",
+                                CREDENTIALS_USERNAME, "cit-username",
+                                CREDENTIALS_PASSWORD, "cit-password"),
                         RECURRING_MERCHANT_INITIATED, Map.of(
-                                CREDENTIALS_MERCHANT_CODE, "MERCHANTCODE",
-                                CREDENTIALS_USERNAME, "rc-worldpay-password",
-                                CREDENTIALS_PASSWORD, "rc-password")))
+                                CREDENTIALS_MERCHANT_CODE, "MIT-MERCHANTCODE",
+                                CREDENTIALS_USERNAME, "mit-username",
+                                CREDENTIALS_PASSWORD, "mit-password")))
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .withPaymentProvider(WORLDPAY.getName())
                 .withState(ACTIVE)
                 .build();
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(creds));
         chargeEntityFixture = aValidChargeEntity()
-                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
-                        .withPaymentProvider("worldpay")
-                        .withCredentials(Map.of(
-                                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
-                                CREDENTIALS_USERNAME, "worldpay-password",
-                                CREDENTIALS_PASSWORD, "password",
-                                        RECURRING_MERCHANT_INITIATED, Map.of(
-                                                CREDENTIALS_MERCHANT_CODE, "MERCHANTCODE",
-                                                CREDENTIALS_USERNAME, "rc-worldpay-password",
-                                                CREDENTIALS_PASSWORD, "rc-password"
-                        )))
-                        .build())
+                .withGatewayAccountCredentialsEntity(creds)
                 .withGatewayAccountEntity(gatewayAccountEntity);
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -47,8 +47,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CANCEL_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CAPTURE_WORLDPAY_REQUEST;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_DELETE_TOKEN_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST;
 
  class WorldpayOrderRequestBuilderTest {
 
@@ -91,7 +91,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
                 .withSchemeTransactionIdentifier("test-transaction-id-999999")
                 .withAgreementId("test-agreement-123456")
                 .withTransactionId("test-transaction-id-123")
-                .withMerchantCode("MERCHANTCODE")
+                .withMerchantCode("MIT-MERCHANTCODE")
                 .withDescription("This is the description")
                 .withAmount("500")
                 .build();
@@ -106,7 +106,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
                 .withPaymentTokenId("test-payment-token-123456")
                 .withAgreementId("test-agreement-123456")
                 .withTransactionId("test-transaction-id-123")
-                .withMerchantCode("MERCHANTCODE")
+                .withMerchantCode("MIT-MERCHANTCODE")
                 .withDescription("This is the description")
                 .withAmount("500")
                 .build();

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -52,6 +52,7 @@ import uk.gov.service.payments.commons.model.AuthorisationMode;
 import javax.ws.rs.WebApplicationException;
 import java.net.HttpCookie;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -618,7 +619,7 @@ class WorldpayPaymentProviderTest {
                 headers.capture());
 
         assertThat(headers.getValue().size(), is(1));
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(ONE_OFF_USERNAME + ":" + ONE_OFF_PASSWORD).getBytes());
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((ONE_OFF_USERNAME + ":" + ONE_OFF_PASSWORD).getBytes(StandardCharsets.UTF_8));
         assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
     }
 
@@ -660,7 +661,7 @@ class WorldpayPaymentProviderTest {
 
         assertThat(headers.getValue().size(), is(1));
 
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(MIT_USERNAME + ":" + MIT_PASSWORD).getBytes());
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((MIT_USERNAME + ":" + MIT_PASSWORD).getBytes(StandardCharsets.UTF_8));
         assertThat(headers.getValue().get(AUTHORIZATION), is(expectedHeader));
     }
 
@@ -681,7 +682,7 @@ class WorldpayPaymentProviderTest {
                 headers.capture());
 
         assertThat(headers.getValue().size(), is(1));
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(CIT_USERNAME + ":" + CIT_PASSWORD).getBytes());
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((CIT_USERNAME + ":" + CIT_PASSWORD).getBytes(StandardCharsets.UTF_8));
         assertThat(headers.getValue().get(AUTHORIZATION), is(expectedHeader));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -36,7 +36,6 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.DeleteStoredPaymentDetailsGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.gateway.util.AuthUtil;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
 import uk.gov.pay.connector.gateway.worldpay.wallets.WorldpayWalletAuthorisationHandler;
@@ -65,6 +64,7 @@ import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -92,6 +92,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
@@ -120,10 +121,19 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 @ExtendWith(MockitoExtension.class)
-public class WorldpayPaymentProviderTest {
+class WorldpayPaymentProviderTest {
 
     private static final URI WORLDPAY_URL = URI.create("http://worldpay.url");
     private static final Map<String, URI> GATEWAY_URL_MAP = Map.of(TEST.toString(), WORLDPAY_URL);
+    public static final String ONE_OFF_MERCHANT_CODE = "MERCHANTCODE";
+    public static final String ONE_OFF_USERNAME = "username";
+    public static final String ONE_OFF_PASSWORD = "password";
+    public static final String CIT_MERCHANT_CODE = "cit-merchant-code";
+    public static final String CIT_USERNAME = "cit-username";
+    public static final String CIT_PASSWORD = "cit-password";
+    public static final String MIT_MERCHANT_CODE = "mit-merchant-code";
+    public static final String MIT_USERNAME = "mit-username";
+    public static final String MIT_PASSWORD = "mit-password";
 
     @Mock
     private GatewayClient authoriseClient;
@@ -163,7 +173,7 @@ public class WorldpayPaymentProviderTest {
                 authoriseClient,
                 cancelClient,
                 inquiryClient,
-                deleteTokenClient, 
+                deleteTokenClient,
                 worldpayWalletAuthorisationHandler,
                 worldpayAuthoriseHandler,
                 worldpayCaptureHandler,
@@ -173,14 +183,14 @@ public class WorldpayPaymentProviderTest {
                 chargeDao,
                 eventService);
 
-        gatewayAccountEntity = aServiceAccount();
+        gatewayAccountEntity = aGatewayAccount();
         chargeEntityFixture = aValidChargeEntity()
                 .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
                         .withPaymentProvider("worldpay")
                         .withCredentials(Map.of(
-                                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
-                                CREDENTIALS_USERNAME, "worldpay-password",
-                                CREDENTIALS_PASSWORD, "password"
+                                CREDENTIALS_MERCHANT_ID, ONE_OFF_MERCHANT_CODE,
+                                CREDENTIALS_USERNAME, ONE_OFF_USERNAME,
+                                CREDENTIALS_PASSWORD, ONE_OFF_PASSWORD
                         ))
                         .build())
                 .withGatewayAccountEntity(gatewayAccountEntity);
@@ -522,30 +532,31 @@ public class WorldpayPaymentProviderTest {
 
     @Test
     void should_include_paymentTokenID_and_agreementId_in_delete_token_order() throws Exception {
-        PaymentInstrumentEntity paymentInstrument = setUpPaymentInstrument();
+        String token = "TESTTOKEN123456";
+        PaymentInstrumentEntity paymentInstrument = setUpPaymentInstrument(token);
         AgreementEntity agreement = setUpAgreement(paymentInstrument);
         DeleteStoredPaymentDetailsGatewayRequest request = DeleteStoredPaymentDetailsGatewayRequest.from(agreement, paymentInstrument);
 
         worldpayPaymentProvider.deleteStoredPaymentDetails(request);
-        
+
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
-        
+
         verify(deleteTokenClient).postRequestFor(
                 eq(WORLDPAY_URL),
-                eq(WORLDPAY), 
+                eq(WORLDPAY),
                 eq("test"),
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
-        
+
         String expectedRequestBody = TestTemplateResourceLoader.load(WORLDPAY_VALID_DELETE_TOKEN_REQUEST)
-                .replace("{{merchantCode}}", "MERCHANTCODE")
-                .replace("{{agreementId}}", "test-agreement-123")
-                .replace("{{paymentTokenId}}", "TESTTOKEN123456");
-        
+                .replace("{{merchantCode}}", CIT_MERCHANT_CODE)
+                .replace("{{agreementId}}", agreement.getExternalId())
+                .replace("{{paymentTokenId}}", token);
+
         assertXMLEqual(expectedRequestBody,
                 gatewayOrderArgumentCaptor.getValue().getPayload());
     }
-    
+
     @Test
     void should_include_provider_session_id_when_available_for_charge() throws Exception {
         String providerSessionId = "provider-session-id";
@@ -584,9 +595,9 @@ public class WorldpayPaymentProviderTest {
                 .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
                         .withPaymentProvider("worldpay")
                         .withCredentials(Map.of(
-                                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
-                                CREDENTIALS_USERNAME, "worldpay-password",
-                                CREDENTIALS_PASSWORD, "password"
+                                CREDENTIALS_MERCHANT_ID, ONE_OFF_MERCHANT_CODE,
+                                CREDENTIALS_USERNAME, ONE_OFF_USERNAME,
+                                CREDENTIALS_PASSWORD, ONE_OFF_PASSWORD
                         ))
                         .build())
                 .build();
@@ -607,25 +618,25 @@ public class WorldpayPaymentProviderTest {
                 headers.capture());
 
         assertThat(headers.getValue().size(), is(1));
-        assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountEntity.getGatewayAccountCredentials().get(0).getCredentials())));
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(ONE_OFF_USERNAME + ":" + ONE_OFF_PASSWORD).getBytes());
+        assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
     }
 
     @Test
     void assert_authorization_header_is_passed_to_gateway_client_when_using_recurring_payment() throws Exception {
-        var credentials = Map.of(
-                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
-                CREDENTIALS_USERNAME, "worldpay-password",
-                CREDENTIALS_PASSWORD, "password",
+        Map<String, Object> credentials = Map.of(
                 RECURRING_MERCHANT_INITIATED, Map.of(
-                        CREDENTIALS_MERCHANT_CODE, "RECURRING_MERCHANTCODE",
-                        CREDENTIALS_USERNAME, "recurring-worldpay-password",
-                        CREDENTIALS_PASSWORD, "recurring-password"));
+                        CREDENTIALS_MERCHANT_CODE, MIT_MERCHANT_CODE,
+                        CREDENTIALS_USERNAME, MIT_USERNAME,
+                        CREDENTIALS_PASSWORD, MIT_PASSWORD));
         String providerSessionId = "provider-session-id";
+        AgreementEntity agreementEntity = anAgreementEntity().build();
         ChargeEntity mockChargeEntity = chargeEntityFixture
                 .withExternalId("uniqueSessionId")
                 .withTransactionId("MyUniqueTransactionId!")
                 .withProviderSessionId(providerSessionId)
                 .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withAgreementEntity(agreementEntity)
                 .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
                         .withPaymentProvider("worldpay")
                         .withCredentials(credentials)
@@ -649,20 +660,20 @@ public class WorldpayPaymentProviderTest {
 
         assertThat(headers.getValue().size(), is(1));
 
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String("recurring-worldpay-password" + ":" + "recurring-password").getBytes());
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(MIT_USERNAME + ":" + MIT_PASSWORD).getBytes());
         assertThat(headers.getValue().get(AUTHORIZATION), is(expectedHeader));
     }
 
     @Test
     void assert_authorization_header_is_passed_to_gateway_client_when_deleting_token() throws Exception {
-        PaymentInstrumentEntity paymentInstrument = setUpPaymentInstrument();
+        PaymentInstrumentEntity paymentInstrument = setUpPaymentInstrument("TESTTOKEN123456");
         AgreementEntity agreement = setUpAgreement(paymentInstrument);
         DeleteStoredPaymentDetailsGatewayRequest request = DeleteStoredPaymentDetailsGatewayRequest.from(agreement, paymentInstrument);
 
         worldpayPaymentProvider.deleteStoredPaymentDetails(request);
-        
+
         ArgumentCaptor<Map<String, String>> headers = ArgumentCaptor.forClass(Map.class);
-        
+
         verify(deleteTokenClient).postRequestFor(
                 eq(WORLDPAY_URL),
                 eq(WORLDPAY), eq("test"),
@@ -670,25 +681,23 @@ public class WorldpayPaymentProviderTest {
                 headers.capture());
 
         assertThat(headers.getValue().size(), is(1));
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String("worldpay-password" + ":" + "password").getBytes());
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(CIT_USERNAME + ":" + CIT_PASSWORD).getBytes());
         assertThat(headers.getValue().get(AUTHORIZATION), is(expectedHeader));
     }
-    
+
     @Test
     void should_throw_exception_when_using_recurring_payment_and_no_creds() throws Exception {
-        Map<String, Object> credentials = Map.of(
-                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
-                CREDENTIALS_USERNAME, "worldpay-password",
-                CREDENTIALS_PASSWORD, "password");
         String providerSessionId = "provider-session-id";
+        AgreementEntity agreementEntity = anAgreementEntity().build();
         ChargeEntity mockChargeEntity = chargeEntityFixture
                 .withExternalId("uniqueSessionId")
                 .withTransactionId("MyUniqueTransactionId!")
                 .withProviderSessionId(providerSessionId)
                 .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withAgreementEntity(agreementEntity)
                 .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
                         .withPaymentProvider("worldpay")
-                        .withCredentials(credentials)
+                        .withCredentials(Map.of())
                         .build())
                 .build();
 
@@ -778,14 +787,14 @@ public class WorldpayPaymentProviderTest {
         assertThat(result.getProviderSessionIdentifier().isPresent(), is(true));
         assertThat(result.getProviderSessionIdentifier().get(), is(ProviderSessionIdentifier.of("new-machine-cookie-value")));
     }
-    
+
     private Auth3dsResponseGatewayRequest get3dsResponseGatewayRequest(ChargeEntity chargeEntity) {
         Auth3dsResult auth3dsResult = new Auth3dsResult();
         auth3dsResult.setPaResponse("I am an opaque 3D Secure PA response from the card issuer");
         return new Auth3dsResponseGatewayRequest(chargeEntity, auth3dsResult);
     }
 
-    private GatewayAccountEntity aServiceAccount() {
+    private GatewayAccountEntity aGatewayAccount() {
         var gatewayAccountEntity = aGatewayAccountEntity()
                 .withId(1L)
                 .withGatewayName("worldpay")
@@ -795,9 +804,14 @@ public class WorldpayPaymentProviderTest {
 
         var creds = aGatewayAccountCredentialsEntity()
                 .withCredentials(Map.of(
-                        CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
-                        CREDENTIALS_USERNAME, "worldpay-password",
-                        CREDENTIALS_PASSWORD, "password"))
+                        CREDENTIALS_MERCHANT_ID, ONE_OFF_MERCHANT_CODE,
+                        CREDENTIALS_USERNAME, ONE_OFF_USERNAME,
+                        CREDENTIALS_PASSWORD, ONE_OFF_PASSWORD,
+                        RECURRING_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, CIT_MERCHANT_CODE,
+                                CREDENTIALS_USERNAME, CIT_USERNAME,
+                                CREDENTIALS_PASSWORD, CIT_PASSWORD
+                        )))
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .withPaymentProvider(WORLDPAY.getName())
                 .withState(ACTIVE)
@@ -807,15 +821,15 @@ public class WorldpayPaymentProviderTest {
 
         return gatewayAccountEntity;
     }
-    
-    private PaymentInstrumentEntity setUpPaymentInstrument() {
+
+    private PaymentInstrumentEntity setUpPaymentInstrument(String token) {
         Map<String, String> recurringAuthToken = new HashMap<>();
-        recurringAuthToken.put(WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY, "TESTTOKEN123456");
+        recurringAuthToken.put(WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY, token);
         return aPaymentInstrumentEntity()
                 .withRecurringAuthToken(recurringAuthToken)
                 .build();
     }
-    
+
     private AgreementEntity setUpAgreement(PaymentInstrumentEntity paymentInstrument) {
         return anAgreementEntity()
                 .withExternalId("test-agreement-123")

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.Base64;
 import java.util.List;
@@ -57,7 +58,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL;
 
 @ExtendWith(MockitoExtension.class)
- class WorldpayWalletAuthorisationHandlerTest {
+class WorldpayWalletAuthorisationHandlerTest {
 
     @Mock
     private GatewayClient mockGatewayClient;
@@ -82,7 +83,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
     private static final String password = "password";
 
     @BeforeEach
-     void setUp() throws Exception {
+    void setUp() throws Exception {
         worldpayWalletAuthorisationHandler = new WorldpayWalletAuthorisationHandler(mockGatewayClient, Map.of(TEST.toString(), WORLDPAY_URL));
         chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withDescription("This is the description")
@@ -113,7 +114,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
     }
 
     @Test
-     void shouldSendApplePayRequestWhenApplePayDetailsArePresent() throws Exception {
+    void shouldSendApplePayRequestWhenApplePayDetailsArePresent() throws Exception {
         try {
             worldpayWalletAuthorisationHandler.authorise(getApplePayAuthorisationRequest(false));
         } catch (GatewayErrorException e) {
@@ -121,13 +122,13 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendApplePayRequestWithPayerEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailPresent() throws Exception {
+    void shouldSendApplePayRequestWithPayerEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailPresent() throws Exception {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authorise(getApplePayAuthorisationRequest(true));
@@ -136,13 +137,13 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendApplePayRequestWithoutPayerEmailWhenSendingPayerEmailToGatewayDisabledAndPayerEmailPresent() throws Exception {
+    void shouldSendApplePayRequestWithoutPayerEmailWhenSendingPayerEmailToGatewayDisabledAndPayerEmailPresent() throws Exception {
         gatewayAccountEntity.setSendPayerEmailToGateway(false);
         try {
             worldpayWalletAuthorisationHandler.authorise(getApplePayAuthorisationRequest(true));
@@ -151,13 +152,13 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendApplePayRequestWithoutPayerEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailNotPresent() throws Exception {
+    void shouldSendApplePayRequestWithoutPayerEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailNotPresent() throws Exception {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authorise(getApplePayAuthorisationRequest(false));
@@ -166,13 +167,13 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendGooglePayRequestWhenGooglePayDetailsArePresent() throws Exception {
+    void shouldSendGooglePayRequestWhenGooglePayDetailsArePresent() throws Exception {
         try {
             worldpayWalletAuthorisationHandler.authorise(getGooglePayAuthorisationRequest(false));
         } catch (GatewayErrorException e) {
@@ -180,13 +181,13 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendGooglePayRequestWithEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailPresent() throws Exception {
+    void shouldSendGooglePayRequestWithEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailPresent() throws Exception {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authorise(getGooglePayAuthorisationRequest(true));
@@ -195,13 +196,13 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendGooglePayRequestWithoutEmailWhenSendingPayerEmailToGatewayDisabledAndPayerEmailPresent() throws Exception {
+    void shouldSendGooglePayRequestWithoutEmailWhenSendingPayerEmailToGatewayDisabledAndPayerEmailPresent() throws Exception {
         gatewayAccountEntity.setSendPayerEmailToGateway(false);
         try {
             worldpayWalletAuthorisationHandler.authorise(getGooglePayAuthorisationRequest(true));
@@ -210,13 +211,13 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendGooglePayRequestWithoutEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailNotPresent() throws Exception {
+    void shouldSendGooglePayRequestWithoutEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailNotPresent() throws Exception {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authorise(getGooglePayAuthorisationRequest(false));
@@ -225,13 +226,13 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendGooglePay3dsRequestWithDDCResultWhenWorldpay3dsFlexResultIsAvailable() throws Exception {
+    void shouldSendGooglePay3dsRequestWithDDCResultWhenWorldpay3dsFlexResultIsAvailable() throws Exception {
         try {
             worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, true, false, true));
         } catch (GatewayErrorException e) {
@@ -239,13 +240,13 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_GOOGLE_PAY_3DS_REQUEST_WITH_DDC_RESULT),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithoutIpAddressArePresent() throws Exception {
+    void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithoutIpAddressArePresent() throws Exception {
         try {
             worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, false, false, false));
         } catch (GatewayErrorException e) {
@@ -253,39 +254,39 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithIpAddressArePresent() throws Exception {
+    void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithIpAddressArePresent() throws Exception {
         try {
             worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, true, false, false));
         } catch (GatewayErrorException e) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS), gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithout3dsEnabledArePresent() throws Exception {
+    void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithout3dsEnabledArePresent() throws Exception {
         try {
             worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(false, true, false, false));
         } catch (GatewayErrorException e) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST), gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendGooglePay3dsRequestWithEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailPresent() throws Exception {
+    void shouldSendGooglePay3dsRequestWithEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailPresent() throws Exception {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, false, true, false));
@@ -294,13 +295,13 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_EMAIL),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendGooglePay3dsRequestWithEmailWhenSendingPayerEmailToGatewayDisabledAndPayerEmailPresent() throws Exception {
+    void shouldSendGooglePay3dsRequestWithEmailWhenSendingPayerEmailToGatewayDisabledAndPayerEmailPresent() throws Exception {
         gatewayAccountEntity.setSendPayerEmailToGateway(false);
         try {
             worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, false, true, false));
@@ -309,13 +310,13 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
     @Test
-     void shouldSendGooglePay3dsRequestWithEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailNotPresent() throws Exception {
+    void shouldSendGooglePay3dsRequestWithEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailNotPresent() throws Exception {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, false, false, false));
@@ -324,7 +325,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -339,8 +340,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
                                                                                   boolean withDDCResult)
             throws IOException {
         String fixturePath = withDDCResult ? "googlepay/example-3ds-auth-request-with-ddc.json" :
-                             withPayerEmail ? "googlepay/example-3ds-auth-request.json" :
-                             "googlepay/example-3ds-auth-request-without-email.json";
+                withPayerEmail ? "googlepay/example-3ds-auth-request.json" :
+                        "googlepay/example-3ds-auth-request-without-email.json";
         GooglePayAuthRequest googlePayAuthRequest = Jackson.getObjectMapper().readValue(fixture(fixturePath), GooglePayAuthRequest.class);
         chargeEntity.getGatewayAccount().setRequires3ds(isRequires3ds);
         chargeEntity.getGatewayAccount().setSendPayerIpAddressToGateway(withIpAddress);

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -14,7 +14,6 @@ import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
-import uk.gov.pay.connector.gateway.util.AuthUtil;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
@@ -25,12 +24,15 @@ import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
 import java.io.IOException;
 import java.net.URI;
 import java.time.LocalDate;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -76,6 +78,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 
     private static final URI WORLDPAY_URL = URI.create("http://worldpay.test");
     private static final String GOOGLE_PAY_3DS_WITHOUT_IP_ADDRESS = "uniqueSessionId";
+    private static final String username = "worldpay-username";
+    private static final String password = "password";
 
     @BeforeEach
      void setUp() throws Exception {
@@ -86,8 +90,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
                         .withPaymentProvider("worldpay")
                         .withCredentials(Map.of(
                                 CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
-                                CREDENTIALS_USERNAME, "worldpay-password",
-                                CREDENTIALS_PASSWORD, "password"
+                                CREDENTIALS_USERNAME, username,
+                                CREDENTIALS_PASSWORD, password
                         ))
                         .build())
                 .build();
@@ -117,7 +121,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -131,7 +136,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -145,7 +151,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -159,7 +166,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -172,7 +180,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -186,7 +195,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -200,7 +210,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -214,7 +225,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -227,7 +239,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_GOOGLE_PAY_3DS_REQUEST_WITH_DDC_RESULT),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -240,8 +253,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(),
-                    is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -253,7 +266,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS), gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -265,7 +279,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST), gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -279,8 +294,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_EMAIL),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(),
-                    is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -294,8 +309,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(),
-                    is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 
@@ -309,8 +324,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(),
-                    is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String( username + ":" + password).getBytes());
+            assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
@@ -121,63 +121,9 @@ class GatewayAccountEntityTest {
     }
 
     @Test
-    void getGatewayNameshouldThrowWebApplicationExceptionWhenGatewayAccountCredentialsIsEmpty() {
+    void getGatewayNameShouldThrowWebApplicationExceptionWhenGatewayAccountCredentialsIsEmpty() {
         gatewayAccountEntity.setGatewayAccountCredentials(new ArrayList<>());
         assertThrows(WebApplicationException.class, () -> gatewayAccountEntity.getGatewayName());
-    }
-
-    @Test
-    void getCredentialsByProviderShouldReturnCorrectCredential() {
-        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
-                .withCredentials(Map.of("stripe-accnt-id", "some-id"))
-                .withPaymentProvider("stripe").build();
-        GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
-                .withPaymentProvider("worldpay")
-                .withCredentials(Map.of("username", "some-user-name"))
-                .build();
-        gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntity, credentialsEntityWorldpay));
-
-        Map<String, Object> actualCreds = gatewayAccountEntity.getCredentials("worldpay");
-        assertThat(actualCreds, hasEntry("username", "some-user-name"));
-    }
-
-    @Test
-    void getCredentialsByProviderShouldReturnLatestActiveCredentialIfMultipleExists() {
-        GatewayAccountCredentialsEntity credentialsEntityWorldpayLatest = aGatewayAccountCredentialsEntity()
-                .withPaymentProvider("worldpay")
-                .withCredentials(Map.of("username", "latest-creds-user-name"))
-                .withActiveStartDate(Instant.now())
-                .build();
-        GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
-                .withPaymentProvider("worldpay")
-                .withCredentials(Map.of("username", "old-creds-user-name"))
-                .withActiveStartDate(Instant.now().minus(10, DAYS))
-                .build();
-        gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay, credentialsEntityWorldpayLatest));
-
-        Map<String, Object> actualCreds = gatewayAccountEntity.getCredentials("worldpay");
-        assertThat(actualCreds, hasEntry("username", "latest-creds-user-name"));
-    }
-
-    @Test
-    void getCredentialsByProviderShouldThrowErrorIfNoCredentialsAreAvailable() {
-        gatewayAccountEntity.setGatewayAccountCredentials(List.of());
-        assertThrows(WebApplicationException.class, () -> {
-            gatewayAccountEntity.getCredentials("worldpay");
-        });
-    }
-
-    @Test
-    void getCredentialsByProviderShouldThrowErrorIfNoCredentialsForPaymentProviderIsAvailable() {
-        GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
-                .withPaymentProvider("worldpay")
-                .withCredentials(Map.of("username", "some-user-name"))
-                .build();
-        gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay));
-
-        assertThrows(WebApplicationException.class, () -> {
-            gatewayAccountEntity.getCredentials("sandbox");
-        }, "No credentials exists for payment provider");
     }
 
     @Test
@@ -263,6 +209,24 @@ class GatewayAccountEntityTest {
         GatewayAccountCredentialsEntity actualCreds = gatewayAccountEntity.getGatewayAccountCredentialsEntity("worldpay");
         assertThat(actualCreds.getPaymentProvider(), is("worldpay"));
         assertThat(actualCreds.getCredentials(), hasEntry("username", "some-user-name"));
+    }
+
+    @Test
+    void getGatewayAccountCredentialsEntityByProviderShouldReturnLatestActiveCredentialIfMultipleExists() {
+        GatewayAccountCredentialsEntity credentialsEntityWorldpayLatest = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider("worldpay")
+                .withCredentials(Map.of("username", "latest-creds-user-name"))
+                .withActiveStartDate(Instant.now())
+                .build();
+        GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider("worldpay")
+                .withCredentials(Map.of("username", "old-creds-user-name"))
+                .withActiveStartDate(Instant.now().minus(10, DAYS))
+                .build();
+        gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay, credentialsEntityWorldpayLatest));
+
+        GatewayAccountCredentialsEntity actualCreds = gatewayAccountEntity.getGatewayAccountCredentialsEntity("worldpay");
+        assertThat(actualCreds.getCredentials(), hasEntry("username", "latest-creds-user-name"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
@@ -53,7 +53,6 @@ class GatewayAccountCredentialsEntityTest {
         assertThat(credentials, isA(WorldpayCredentials.class));
         var worldpayCredentials = (WorldpayCredentials) credentials;
         assertThat(worldpayCredentials.hasCredentials(), is(true));
-        assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials(), not(nullValue()));
         assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials().isPresent(), is(true));
         assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials().get().getMerchantCode(), is("a-merchant-code"));
     }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsServiceTest.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
@@ -298,7 +299,7 @@ public class GatewayAccountCredentialsServiceTest {
             GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
                     .withGatewayAccountEntity(gatewayAccountEntity)
                     .withCredentials(Map.of(
-                            GatewayAccount.CREDENTIALS_MERCHANT_ID, "existing-merchant-code",
+                            CREDENTIALS_MERCHANT_ID, "existing-merchant-code",
                             GatewayAccount.CREDENTIALS_USERNAME, "existing-username",
                             GatewayAccount.CREDENTIALS_PASSWORD, "existing-password",
                             "recurring_customer_initiated", Map.of(
@@ -333,7 +334,7 @@ public class GatewayAccountCredentialsServiceTest {
             assertThat(recurringCustomerInitiated, hasEntry("username", "existing-username-cit"));
             assertThat(recurringCustomerInitiated, hasEntry("password", "existing-password-cit"));
 
-            assertThat(credentialsEntity.getCredentials().get(GatewayAccount.CREDENTIALS_MERCHANT_ID), is("existing-merchant-code"));
+            assertThat(credentialsEntity.getCredentials().get(CREDENTIALS_MERCHANT_ID), is("existing-merchant-code"));
             assertThat(credentialsEntity.getCredentials().get(GatewayAccount.CREDENTIALS_USERNAME), is("existing-username"));
             assertThat(credentialsEntity.getCredentials().get(GatewayAccount.CREDENTIALS_PASSWORD), is("existing-password"));
         }
@@ -344,7 +345,7 @@ public class GatewayAccountCredentialsServiceTest {
             GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
                     .withGatewayAccountEntity(gatewayAccountEntity)
                     .withCredentials(Map.of(
-                            GatewayAccount.CREDENTIALS_MERCHANT_ID, "old-merchant-code",
+                            CREDENTIALS_MERCHANT_ID, "old-merchant-code",
                             GatewayAccount.CREDENTIALS_USERNAME, "old-username",
                             GatewayAccount.CREDENTIALS_PASSWORD, "old-password"))
                     .withState(CREATED)
@@ -371,7 +372,7 @@ public class GatewayAccountCredentialsServiceTest {
             assertThat(oneOffCustomerInitiated, hasEntry("username", "new-username"));
             assertThat(oneOffCustomerInitiated, hasEntry("password", "new-password"));
 
-            assertThat(credentialsEntity.getCredentials().get(GatewayAccount.CREDENTIALS_MERCHANT_ID), is(nullValue()));
+            assertThat(credentialsEntity.getCredentials().get(CREDENTIALS_MERCHANT_ID), is(nullValue()));
             assertThat(credentialsEntity.getCredentials().get(GatewayAccount.CREDENTIALS_USERNAME), is(nullValue()));
             assertThat(credentialsEntity.getCredentials().get(GatewayAccount.CREDENTIALS_PASSWORD), is(nullValue()));
         }
@@ -592,7 +593,7 @@ public class GatewayAccountCredentialsServiceTest {
                     .build();
             GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
                     .withGatewayAccountEntity(gatewayAccountEntity)
-                    .withCredentials(Map.of("username", "some-user-name"))
+                    .withCredentials(Map.of(CREDENTIALS_MERCHANT_ID, "some-merchant-code"))
                     .withState(CREATED)
                     .build();
             gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntity));
@@ -610,7 +611,7 @@ public class GatewayAccountCredentialsServiceTest {
                     .build();
             GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
                     .withGatewayAccountEntity(gatewayAccountEntity)
-                    .withCredentials(Map.of("username", "some-user-name"))
+                    .withCredentials(Map.of(CREDENTIALS_MERCHANT_ID, "some-merchant-code"))
                     .withState(CREATED)
                     .build();
             gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntity));
@@ -628,7 +629,7 @@ public class GatewayAccountCredentialsServiceTest {
                     .build();
             GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
                     .withGatewayAccountEntity(gatewayAccountEntity)
-                    .withCredentials(Map.of("username", "some-user-name"))
+                    .withCredentials(Map.of(CREDENTIALS_MERCHANT_ID, "some-merchant-code"))
                     .withState(CREATED)
                     .build();
             gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntity));
@@ -663,7 +664,7 @@ public class GatewayAccountCredentialsServiceTest {
             GatewayAccountCredentialsEntity credentialToUpdate = aGatewayAccountCredentialsEntity()
                     .withGatewayAccountEntity(gatewayAccountEntity)
                     .withPaymentProvider(WORLDPAY.getName())
-                    .withCredentials(Map.of("username", "some-user-name"))
+                    .withCredentials(Map.of(CREDENTIALS_MERCHANT_ID, "some-merchant-code"))
                     .withState(CREATED)
                     .build();
             GatewayAccountCredentialsEntity activeCredentials = aGatewayAccountCredentialsEntity()
@@ -688,14 +689,14 @@ public class GatewayAccountCredentialsServiceTest {
                     .withGatewayAccountEntity(gatewayAccountEntity)
                     .withPaymentProvider(WORLDPAY.getName())
                     .withCreatedDate(Instant.now().minus(10, MINUTES))
-                    .withCredentials(Map.of("username", "some-user-name"))
+                    .withCredentials(Map.of(CREDENTIALS_MERCHANT_ID, "some-merchant-code"))
                     .withState(ACTIVE)
                     .build();
             GatewayAccountCredentialsEntity latestCredentials = aGatewayAccountCredentialsEntity()
                     .withGatewayAccountEntity(gatewayAccountEntity)
                     .withPaymentProvider(WORLDPAY.getName())
                     .withCreatedDate(Instant.now())
-                    .withCredentials(Map.of("username", "some-user-name"))
+                    .withCredentials(Map.of(CREDENTIALS_MERCHANT_ID, "some-merchant-code"))
                     .withState(CREATED)
                     .build();
             gatewayAccountEntity.setGatewayAccountCredentials(List.of(activeCredentials, latestCredentials));

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -65,6 +65,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_STRIPE_ACCOUNT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
@@ -154,10 +155,14 @@ public class ChargingITestBase {
                     CREDENTIALS_MERCHANT_ID, "merchant-id",
                     CREDENTIALS_USERNAME, "test-user",
                     CREDENTIALS_PASSWORD, "test-password",
+                    RECURRING_CUSTOMER_INITIATED, Map.of(
+                            CREDENTIALS_MERCHANT_CODE, "cit-merchant-id",
+                            CREDENTIALS_USERNAME, "cit-user",
+                            CREDENTIALS_PASSWORD, "cit-password"),
                     RECURRING_MERCHANT_INITIATED, Map.of(
-                            CREDENTIALS_MERCHANT_CODE, "rec-merchant-id",
-                            CREDENTIALS_USERNAME, "rec-user",
-                            CREDENTIALS_PASSWORD, "rec-password")
+                            CREDENTIALS_MERCHANT_CODE, "mit-merchant-id",
+                            CREDENTIALS_USERNAME, "mit-user",
+                            CREDENTIALS_PASSWORD, "mit-password")
             );
         } else {
             credentials = Map.of(

--- a/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
@@ -13,7 +13,9 @@ import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import javax.ws.rs.client.ClientBuilder;
 import java.net.URI;
@@ -26,7 +28,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gateway.util.AuthUtil.getGatewayAccountCredentialsAsAuthHeader;
+import static uk.gov.pay.connector.gateway.util.AuthUtil.getWorldpayAuthHeader;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
@@ -71,12 +73,13 @@ public class GooglePayForWorldpayTest {
         GatewayClient authoriseClient = getGatewayClient();
 
         GatewayOrder gatewayOrder = new GatewayOrder(OrderRequestType.AUTHORISE, payload, APPLICATION_XML_TYPE);
+        WorldpayCredentials credentials = (WorldpayCredentials)gatewayAccount.getGatewayAccountCredentialsEntity(WORLDPAY.getName()).getCredentialsObject();
         GatewayClient.Response response = authoriseClient.postRequestFor(
                 URI.create("https://secure-test.worldpay.com/jsp/merchant/xml/paymentService.jsp"),
                 WORLDPAY,
                 "test",
                 gatewayOrder,
-                getGatewayAccountCredentialsAsAuthHeader(gatewayAccount.getCredentials(WORLDPAY.getName())));
+                getWorldpayAuthHeader(credentials, AuthorisationMode.WEB, false));
         assertThat(response.getStatus(), is(HttpStatus.SC_OK));
         String entity = response.getEntity();
         System.out.println(entity);

--- a/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceIT.java
@@ -86,12 +86,12 @@ public class CreateGatewayAccountResourceIT extends GatewayAccountResourceTestBa
 
     @Test
     public void createStripeGatewayAccountWithCredentials() {
-        String StripeAccountId = "abc";
+        String stripeAccountId = "abc";
         Map<String, Object> payload = ImmutableMap.of(
                 "type", "test",
                 "payment_provider", "stripe",
                 "service_name", "My shiny new stripe service",
-                "credentials", ImmutableMap.of("stripe_account_id", StripeAccountId));
+                "credentials", ImmutableMap.of("stripe_account_id", stripeAccountId));
         String gatewayAccountId = givenSetup()
                 .body(toJson(payload))
                 .post(ACCOUNTS_API_URL)
@@ -116,8 +116,8 @@ public class CreateGatewayAccountResourceIT extends GatewayAccountResourceTestBa
         assertThat(gatewayAccountCredentialsList.size(), is(1));
         GatewayCredentials credentialsObject = gatewayAccountCredentialsList.get(0).getCredentialsObject();
         assertThat(credentialsObject, isA(StripeCredentials.class));
-        assertThat(((StripeCredentials)credentialsObject).getStripeAccountId(), is(StripeAccountId));
-        assertThat(gatewayAccountCredentialsList.get(0).getCredentials().get("stripe_account_id"), is(StripeAccountId));
+        assertThat(((StripeCredentials)credentialsObject).getStripeAccountId(), is(stripeAccountId));
+        assertThat(gatewayAccountCredentialsList.get(0).getCredentials().get("stripe_account_id"), is(stripeAccountId));
         assertThat(gatewayAccountCredentialsList.get(0).getState(), is(ACTIVE));
         assertThat(gatewayAccountCredentialsList.get(0).getPaymentProvider(), is("stripe"));
         assertThat(gatewayAccountCredentialsList.get(0).getActiveStartDate(), is(notNullValue()));

--- a/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceIT.java
@@ -10,6 +10,8 @@ import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -22,6 +24,7 @@ import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.text.IsEmptyString.isEmptyString;
@@ -83,11 +86,12 @@ public class CreateGatewayAccountResourceIT extends GatewayAccountResourceTestBa
 
     @Test
     public void createStripeGatewayAccountWithCredentials() {
+        String StripeAccountId = "abc";
         Map<String, Object> payload = ImmutableMap.of(
                 "type", "test",
                 "payment_provider", "stripe",
                 "service_name", "My shiny new stripe service",
-                "credentials", ImmutableMap.of("stripe_account_id", "abc"));
+                "credentials", ImmutableMap.of("stripe_account_id", StripeAccountId));
         String gatewayAccountId = givenSetup()
                 .body(toJson(payload))
                 .post(ACCOUNTS_API_URL)
@@ -107,11 +111,13 @@ public class CreateGatewayAccountResourceIT extends GatewayAccountResourceTestBa
                 .getString("gateway_account_id");
         Optional<GatewayAccountEntity> gatewayAccount = gatewayAccountDao.findById(Long.valueOf(gatewayAccountId));
         assertThat(gatewayAccount.isPresent(), is(true));
-        assertThat(gatewayAccount.get().getCredentials("stripe").get("stripe_account_id"), is("abc"));
 
         List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsList = gatewayAccount.get().getGatewayAccountCredentials();
         assertThat(gatewayAccountCredentialsList.size(), is(1));
-        assertThat(gatewayAccountCredentialsList.get(0).getCredentials().get("stripe_account_id"), is("abc"));
+        GatewayCredentials credentialsObject = gatewayAccountCredentialsList.get(0).getCredentialsObject();
+        assertThat(credentialsObject, isA(StripeCredentials.class));
+        assertThat(((StripeCredentials)credentialsObject).getStripeAccountId(), is(StripeAccountId));
+        assertThat(gatewayAccountCredentialsList.get(0).getCredentials().get("stripe_account_id"), is(StripeAccountId));
         assertThat(gatewayAccountCredentialsList.get(0).getState(), is(ACTIVE));
         assertThat(gatewayAccountCredentialsList.get(0).getPaymentProvider(), is("stripe"));
         assertThat(gatewayAccountCredentialsList.get(0).getActiveStartDate(), is(notNullValue()));

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-with-scheme-identifier.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-with-scheme-identifier.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
         "http://dtd.worldpay.com/paymentService_v1.dtd">
-<paymentService version="1.4" merchantCode="MERCHANTCODE">
+<paymentService version="1.4" merchantCode="MIT-MERCHANTCODE">
     <submit>
         <order orderCode="test-transaction-id-123">
             <description>This is the description</description>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-without-scheme-identifier.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-without-scheme-identifier.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
         "http://dtd.worldpay.com/paymentService_v1.dtd">
-<paymentService version="1.4" merchantCode="MERCHANTCODE">
+<paymentService version="1.4" merchantCode="MIT-MERCHANTCODE">
     <submit>
         <order orderCode="test-transaction-id-123">
             <description>This is the description</description>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-setup-agreement.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-setup-agreement.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
         "http://dtd.worldpay.com/paymentService_v1.dtd">
-<paymentService version="1.4" merchantCode="MERCHANTCODE">
+<paymentService version="1.4" merchantCode="CIT-MERCHANTCODE">
     <submit>
         <order orderCode="transaction-id">
             <description>This is a description</description>


### PR DESCRIPTION
Use the GatewayCredentials representation of the credentials when retrieving the credentials for use when making requests to the payment gateways.

As part of this, make the change to get the credentials for a customer initiated recurring Worldpay payment from the
`recurring_customer_initiated` nested credentials, rather than the root credentials. Credentials for accounts used for Worldpay recurring payments have already been updated on all environments to include `recurring_customer_initiated` credentials.