### PR TITLE
PP-11152 Fix exception thrown for Smartpay credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -113,10 +113,10 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
                 return objectMapper.convertValue(credentialsMap, StripeCredentials.class);
             case EPDQ:
                 return objectMapper.convertValue(credentialsMap, EpdqCredentials.class);
+            case SMARTPAY:
             case SANDBOX:
-                return objectMapper.convertValue(credentialsMap, SandboxCredentials.class);
             default:
-                throw new IllegalArgumentException("Unsupported payment provider: " + paymentProvider);
+                return objectMapper.convertValue(credentialsMap, SandboxCredentials.class);
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
@@ -135,19 +135,21 @@ class GatewayAccountCredentialsEntityTest {
     }
 
     @Test
+    void getCredentialsObject_shouldReturnSandboxCredentialsForSmartpay() {
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(SMARTPAY.getName())
+                .build();
+        GatewayCredentials credentials = credentialsEntity.getCredentialsObject();
+        assertThat(credentials, isA(SandboxCredentials.class));
+        assertThat(credentials.hasCredentials(), is(true));
+    }
+
+    @Test
     void getCredentialsObject_shouldThrowForUnrecognisedProvider() {
         GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
                 .withPaymentProvider("foo")
                 .build();
         assertThrows(PaymentGatewayName.Unsupported.class, credentialsEntity::getCredentialsObject);
-    }
-
-    @Test
-    void getCredentialsObject_shouldThrowForUnsupportedProvider() {
-        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
-                .withPaymentProvider(SMARTPAY.getName())
-                .build();
-        assertThrows(IllegalArgumentException.class, credentialsEntity::getCredentialsObject);
     }
 
     @Test


### PR DESCRIPTION
An exception was thrown when a Gateway Account was retrieved that has historic Smartpay credentials, meaning pages in selfservice could not be loaded.

Do not throw an exception when reading the gateway credentials into an object, and instead read them as SandboxCredentials, which will be serialised in API responses containing credentials as an empty JSON object.