### PR TITLE
PP-11152 Improve how we retrieve legacy Worldpay credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -47,27 +47,12 @@ public class WorldpayCredentials implements GatewayCredentials {
         // Janet Jackson
     }
 
-    @JsonIgnore
-    public Optional<String> getLegacyOneOffCustomerInitiatedMerchantCode() {
-        return Optional.ofNullable(legacyOneOffCustomerInitiatedMerchantCode);
-    }
-
     public void setLegacyOneOffCustomerInitiatedMerchantCode(String legacyOneOffCustomerInitiatedMerchantCode) {
         this.legacyOneOffCustomerInitiatedMerchantCode = legacyOneOffCustomerInitiatedMerchantCode;
     }
 
-    @JsonIgnore
-    public Optional<String> getLegacyOneOffCustomerInitiatedUsername() {
-        return Optional.ofNullable(legacyOneOffCustomerInitiatedUsername);
-    }
-
     public void setLegacyOneOffCustomerInitiatedUsername(String legacyOneOffCustomerInitiatedUsername) {
         this.legacyOneOffCustomerInitiatedUsername = legacyOneOffCustomerInitiatedUsername;
-    }
-
-    @JsonIgnore
-    public Optional<String> getLegacyOneOffCustomerInitiatedPassword() {
-        return Optional.ofNullable(legacyOneOffCustomerInitiatedPassword);
     }
 
     public void setLegacyOneOffCustomerInitiatedPassword(String legacyOneOffCustomerInitiatedPassword) {
@@ -76,6 +61,14 @@ public class WorldpayCredentials implements GatewayCredentials {
 
     @JsonIgnore
     public Optional<WorldpayMerchantCodeCredentials> getOneOffCustomerInitiatedCredentials() {
+        if (oneOffCustomerInitiatedCredentials == null && legacyOneOffCustomerInitiatedMerchantCode != null) {
+            return Optional.of(new WorldpayMerchantCodeCredentials(
+                    legacyOneOffCustomerInitiatedMerchantCode,
+                    legacyOneOffCustomerInitiatedUsername,
+                    legacyOneOffCustomerInitiatedPassword
+            ));
+        }
+
         return Optional.ofNullable(oneOffCustomerInitiatedCredentials);
     }
 
@@ -113,7 +106,7 @@ public class WorldpayCredentials implements GatewayCredentials {
 
     @Override
     public boolean hasCredentials() {
-        return legacyOneOffCustomerInitiatedMerchantCode != null 
+        return legacyOneOffCustomerInitiatedMerchantCode != null
                 || oneOffCustomerInitiatedCredentials != null
                 || (recurringCustomerInitiatedCredentials != null && recurringMerchantInitiatedCredentials != null);
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.SandboxCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
 import uk.gov.pay.connector.gatewayaccount.util.JsonToStringObjectMapConverter;
 import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
 

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
@@ -80,6 +80,7 @@ class AuthUtilTest {
     @Test
     void shouldGetAuthHeaderForOneOffPayment_whenOnlyLegacyCredentialsSet() {
         WorldpayCredentials credentials = new WorldpayCredentials();
+        credentials.setLegacyOneOffCustomerInitiatedMerchantCode(merchantCode);
         credentials.setLegacyOneOffCustomerInitiatedUsername(username);
         credentials.setLegacyOneOffCustomerInitiatedPassword(password);
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentialsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentialsTest.java
@@ -48,4 +48,18 @@ class WorldpayCredentialsTest {
         worldpayCredentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials("merchant-code", "username", "password"));
         assertThat(worldpayCredentials.hasCredentials(), is(true));
     }
+
+    @Test
+    void shouldReturnOneOffCredentialsPopulatedFromLegacyCredentials() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
+        worldpayCredentials.setLegacyOneOffCustomerInitiatedMerchantCode("a-merchant-code");
+        worldpayCredentials.setLegacyOneOffCustomerInitiatedUsername("a-username");
+        worldpayCredentials.setLegacyOneOffCustomerInitiatedPassword("a-password");
+        
+        assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials().isPresent(), is(true));
+        WorldpayMerchantCodeCredentials oneOffCredentials = worldpayCredentials.getOneOffCustomerInitiatedCredentials().get();
+        assertThat(oneOffCredentials.getMerchantCode(), is("a-merchant-code"));
+        assertThat(oneOffCredentials.getUsername(), is("a-username"));
+        assertThat(oneOffCredentials.getPassword(), is("a-password"));
+    }
 }


### PR DESCRIPTION
Worldpay credentials for one-off payments can be stored in the database with the "legacy" structure where the `merchant_id`, `username` and `password` are at the root of the JSON, or new structure where the credentials are in a nested `one_off_customer_initiated` JSON object.

To avoid conditionals in multiple places when retrieving the one-off payment credentials, alter
WorldpayCredentials#getOneOffCustomerInitiatedCredentials to return a WorldpayMerchantCodeCredentials populated using the legacy credentials if the credentials are stored in the database with the legacy structure.

This also affects API responses, meaning that in selfservice we will be able to only look at the `one_off_customer_initiated` credentials for displaying credentials back to users, rather than having to check whether the credentials have the new or legacy structure.