### PR TITLE
PP-11152 Fix serialising Worldpay credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -49,26 +49,36 @@ public class WorldpayCredentials implements GatewayCredentials {
 
     public void setLegacyOneOffCustomerInitiatedMerchantCode(String legacyOneOffCustomerInitiatedMerchantCode) {
         this.legacyOneOffCustomerInitiatedMerchantCode = legacyOneOffCustomerInitiatedMerchantCode;
+        if (oneOffCustomerInitiatedCredentials == null) {
+            oneOffCustomerInitiatedCredentials = new WorldpayMerchantCodeCredentials();
+        }
+        if (oneOffCustomerInitiatedCredentials.getMerchantCode() == null) {
+            oneOffCustomerInitiatedCredentials.setMerchantCode(legacyOneOffCustomerInitiatedMerchantCode);
+        }
     }
 
     public void setLegacyOneOffCustomerInitiatedUsername(String legacyOneOffCustomerInitiatedUsername) {
         this.legacyOneOffCustomerInitiatedUsername = legacyOneOffCustomerInitiatedUsername;
+        if (oneOffCustomerInitiatedCredentials == null) {
+            oneOffCustomerInitiatedCredentials = new WorldpayMerchantCodeCredentials();
+        }
+        if (oneOffCustomerInitiatedCredentials.getUsername() == null) {
+            oneOffCustomerInitiatedCredentials.setUsername(legacyOneOffCustomerInitiatedUsername);
+        }
     }
 
     public void setLegacyOneOffCustomerInitiatedPassword(String legacyOneOffCustomerInitiatedPassword) {
         this.legacyOneOffCustomerInitiatedPassword = legacyOneOffCustomerInitiatedPassword;
+        if (oneOffCustomerInitiatedCredentials == null) {
+            oneOffCustomerInitiatedCredentials = new WorldpayMerchantCodeCredentials();
+        }
+        if (oneOffCustomerInitiatedCredentials.getPassword() == null) {
+            oneOffCustomerInitiatedCredentials.setPassword(legacyOneOffCustomerInitiatedPassword);
+        }
     }
 
     @JsonIgnore
     public Optional<WorldpayMerchantCodeCredentials> getOneOffCustomerInitiatedCredentials() {
-        if (oneOffCustomerInitiatedCredentials == null && legacyOneOffCustomerInitiatedMerchantCode != null) {
-            return Optional.of(new WorldpayMerchantCodeCredentials(
-                    legacyOneOffCustomerInitiatedMerchantCode,
-                    legacyOneOffCustomerInitiatedUsername,
-                    legacyOneOffCustomerInitiatedPassword
-            ));
-        }
-
         return Optional.ofNullable(oneOffCustomerInitiatedCredentials);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayMerchantCodeCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayMerchantCodeCredentials.java
@@ -41,6 +41,18 @@ public class WorldpayMerchantCodeCredentials {
         return password;
     }
 
+    public void setMerchantCode(String merchantCode) {
+        this.merchantCode = merchantCode;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (this == other) {


### PR DESCRIPTION
07a376be488195a3b2b673a72043018bc70595ee intended to make it so that Worldpay credentials stored in the database in the legacy format are serialised in API responses with the credentials duplicated in a nested `one_off_customer_initiated` field so that selfservice doesn't have to check whether the credentials use the legacy structure or not, and always consume the nested `one_off_customer_initiated` credentials.

07a376be488195a3b2b673a72043018bc70595ee didn't make this the case for API responses due to the fact
WorldpayCredentials#getOneOffCustomerInitiatedCredentials has the `@JsonIgnore` annotation so that we don't serialise the Optional in a strange way.

Instead, populate the `one_off_customer_initiated` credentials when deserializing the credentials from the database using the legacy credentials if they exist and `one_off_customer_initiated` nested credentials do not exist.

Add an integration test for this behaviour.