### PR TITLE
PP-11152 Fix serialising Worldpay credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
@@ -64,19 +64,6 @@ public class GatewayAccountCredentials {
         this.credentials = entity.getCredentialsObject();
     }
 
-    private static Map<String, Object> removePasswords(Map<String, Object> credentials) {
-        HashMap<String, Object> clonedCredentials = new HashMap<>(credentials);
-        clonedCredentials.remove("password");
-        credentials.forEach((key, value) -> {
-            if (value instanceof Map<?, ?>) {
-                var clonedNestedMap = new HashMap<>((Map<?, ?>) value);
-                clonedNestedMap.remove("password");
-                clonedCredentials.put(key, clonedNestedMap);
-            }
-        });
-        return clonedCredentials;
-    }
-
     public Long getId() {
         return id;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentialsApiSerializer.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentialsApiSerializer.java
@@ -6,11 +6,12 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 import java.io.IOException;
 
 public class GatewayCredentialsApiSerializer extends JsonSerializer<GatewayCredentials> {
-    private final ObjectMapper objectMapper = JsonMapper.builder().disable(MapperFeature.DEFAULT_VIEW_INCLUSION).build();
+    private final ObjectMapper objectMapper = JsonMapper.builder().disable(MapperFeature.DEFAULT_VIEW_INCLUSION).addModule(new Jdk8Module()).build();
     
     @Override
     public void serialize(GatewayCredentials credentials, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -58,8 +58,7 @@ public class WorldpayCredentials implements GatewayCredentials {
     public void setLegacyOneOffCustomerInitiatedPassword(String legacyOneOffCustomerInitiatedPassword) {
         this.legacyOneOffCustomerInitiatedPassword = legacyOneOffCustomerInitiatedPassword;
     }
-
-    @JsonIgnore
+    
     public Optional<WorldpayMerchantCodeCredentials> getOneOffCustomerInitiatedCredentials() {
         if (oneOffCustomerInitiatedCredentials == null && legacyOneOffCustomerInitiatedMerchantCode != null) {
             return Optional.of(new WorldpayMerchantCodeCredentials(
@@ -75,8 +74,7 @@ public class WorldpayCredentials implements GatewayCredentials {
     public void setOneOffCustomerInitiatedCredentials(WorldpayMerchantCodeCredentials oneOffCustomerInitiatedCredentials) {
         this.oneOffCustomerInitiatedCredentials = oneOffCustomerInitiatedCredentials;
     }
-
-    @JsonIgnore
+    
     public Optional<WorldpayMerchantCodeCredentials> getRecurringCustomerInitiatedCredentials() {
         return Optional.ofNullable(recurringCustomerInitiatedCredentials);
     }
@@ -84,8 +82,7 @@ public class WorldpayCredentials implements GatewayCredentials {
     public void setRecurringCustomerInitiatedCredentials(WorldpayMerchantCodeCredentials recurringCustomerInitiatedCredentials) {
         this.recurringCustomerInitiatedCredentials = recurringCustomerInitiatedCredentials;
     }
-
-    @JsonIgnore
+    
     public Optional<WorldpayMerchantCodeCredentials> getRecurringMerchantInitiatedCredentials() {
         return Optional.ofNullable(recurringMerchantInitiatedCredentials);
     }
@@ -95,7 +92,6 @@ public class WorldpayCredentials implements GatewayCredentials {
     }
 
     @Override
-    @JsonIgnore
     public Optional<String> getGooglePayMerchantId() {
         return Optional.ofNullable(googlePayMerchantId);
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.gatewayaccountcredentials.model;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.eclipse.persistence.annotations.Customizer;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
 import uk.gov.pay.connector.common.model.domain.HistoryCustomizer;
@@ -12,7 +14,6 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.SandboxCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
-import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
 import uk.gov.pay.connector.gatewayaccount.util.JsonToStringObjectMapConverter;
 import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
 
@@ -39,7 +40,7 @@ import java.util.Optional;
 @Customizer(HistoryCustomizer.class)
 public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = JsonMapper.builder().addModule(new Jdk8Module()).build();
     
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "gateway_account_credentials_id_seq")

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -269,6 +269,39 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     }
 
     @Test
+    public void shouldReturnAccountInformationForGetAccountById_forLegacyCredentials() {
+        long accountId = RandomUtils.nextInt();
+        AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
+                .withPaymentProvider(WORLDPAY.getName())
+                .withGatewayAccountId(accountId)
+                .withState(ACTIVE)
+                .withCredentials(Map.of(
+                        CREDENTIALS_MERCHANT_ID, "legacy-merchant-code",
+                        CREDENTIALS_USERNAME, "legacy-username",
+                        CREDENTIALS_PASSWORD, "legacy-password"))
+                .build();
+
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .withAccountId(accountId)
+                .withGatewayAccountCredentials(List.of(credentialsParams))
+                .insert();
+
+        givenSetup()
+                .get(ACCOUNTS_API_URL + accountId)
+                .then()
+                .statusCode(200)
+                .body("gateway_account_credentials[0].credentials", hasEntry("merchant_id", "legacy-merchant-code"))
+                .body("gateway_account_credentials[0].credentials", hasEntry("username", "legacy-username"))
+                .body("gateway_account_credentials[0].credentials", not(hasKey("password")))
+                .body("gateway_account_credentials[0].credentials", hasKey("one_off_customer_initiated"))
+                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", hasEntry("merchant_code", "legacy-merchant-code"))
+                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", hasEntry("username", "legacy-username"))
+                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", not(hasKey("password")));
+    }
+
+    @Test
     public void shouldReturnAccountInformationForGetAccountById_withStripeCredentials() {
         long accountId = RandomUtils.nextInt();
         AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()


### PR DESCRIPTION
07a376b intended to make it so that Worldpay credentials stored in the database in the legacy format are serialised in API responses with the credentials duplicated in a nested one_off_customer_initiated field so that selfservice doesn't have to check whether the credentials use the legacy structure or not, and always consume the nested one_off_customer_initiated credentials.

07a376b didn't make this the case for API responses due to the fact WorldpayCredentials#getOneOffCustomerInitiatedCredentials has the `@JsonIgnore` annotation so that we don't serialise the Optional in a strange way.

Remove the `@JsonIgnore` annotations on the getters that return optionals and instead use an ObjectMapper with the Jdk8Module registered for serialization so that we serialize Optionals sensibly.