### PR TITLE
PP-11152 Don't include null credentials fields

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentialsApiSerializer.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentialsApiSerializer.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.MapperFeature;
@@ -10,8 +11,13 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 import java.io.IOException;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 public class GatewayCredentialsApiSerializer extends JsonSerializer<GatewayCredentials> {
-    private final ObjectMapper objectMapper = JsonMapper.builder().disable(MapperFeature.DEFAULT_VIEW_INCLUSION).addModule(new Jdk8Module()).build();
+    private final ObjectMapper objectMapper = JsonMapper.builder().disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+            .addModule(new Jdk8Module())
+            .serializationInclusion(NON_NULL)
+            .build();
     
     @Override
     public void serialize(GatewayCredentials credentials, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -33,6 +33,8 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 @Entity
 @Table(name = "gateway_account_credentials")
 @SequenceGenerator(name = "gateway_account_credentials_id_seq",
@@ -40,7 +42,10 @@ import java.util.Optional;
 @Customizer(HistoryCustomizer.class)
 public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
-    private static final ObjectMapper objectMapper = JsonMapper.builder().addModule(new Jdk8Module()).build();
+    private static final ObjectMapper objectMapper = JsonMapper.builder()
+            .addModule(new Jdk8Module())
+            .serializationInclusion(NON_NULL)
+            .build();
     
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "gateway_account_credentials_id_seq")

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -298,7 +298,9 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .body("gateway_account_credentials[0].credentials", hasKey("one_off_customer_initiated"))
                 .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", hasEntry("merchant_code", "legacy-merchant-code"))
                 .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", hasEntry("username", "legacy-username"))
-                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", not(hasKey("password")));
+                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", not(hasKey("password")))
+                .body("gateway_account_credentials[0].credentials", not(hasKey("recurring_customer_initiated")))
+                .body("gateway_account_credentials[0].credentials", not(hasKey("recurring_merchant_initiated")));
     }
 
     @Test


### PR DESCRIPTION
When serializing GatewayCredentials for API responses or for storing in the database, don't include fields that have a null value. This serialization is done by ObjectMappers configured in `GatewayCredentialsApiSerializer` for API serialization and `GatewayAccountCredentialsEntity` for database serialization.