### PR TITLE
PP-11152 Don't serialize nulls for WorldpayCredentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -290,7 +290,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 21
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java": [
@@ -1062,5 +1062,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-19T09:43:44Z"
+  "generated_at": "2023-07-24T16:38:36Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
@@ -10,8 +10,6 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
 
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GatewayAccountCredentials {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentialsApiSerializer.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentialsApiSerializer.java
@@ -6,13 +6,12 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 import java.io.IOException;
 
 public class GatewayCredentialsApiSerializer extends JsonSerializer<GatewayCredentials> {
-    private final ObjectMapper objectMapper = JsonMapper.builder().disable(MapperFeature.DEFAULT_VIEW_INCLUSION).addModule(new Jdk8Module()).build();
-    
+    private final ObjectMapper objectMapper = JsonMapper.builder().disable(MapperFeature.DEFAULT_VIEW_INCLUSION).build();
+
     @Override
     public void serialize(GatewayCredentials credentials, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         objectMapper.writerWithView(GatewayCredentials.Views.Api.class)

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -26,21 +26,13 @@ public class WorldpayCredentials implements GatewayCredentials {
     @JsonProperty(GatewayAccount.CREDENTIALS_PASSWORD)
     @Schema(hidden = true)
     private String legacyOneOffCustomerInitiatedPassword;
-
-    @JsonProperty(GatewayAccount.ONE_OFF_CUSTOMER_INITIATED)
-    @JsonView({Views.Api.class})
+    
     private WorldpayMerchantCodeCredentials oneOffCustomerInitiatedCredentials;
-
-    @JsonProperty(GatewayAccount.RECURRING_CUSTOMER_INITIATED)
-    @JsonView({Views.Api.class})
+    
     private WorldpayMerchantCodeCredentials recurringCustomerInitiatedCredentials;
-
-    @JsonProperty(GatewayAccount.RECURRING_MERCHANT_INITIATED)
-    @JsonView({Views.Api.class})
+    
     private WorldpayMerchantCodeCredentials recurringMerchantInitiatedCredentials;
-
-    @JsonProperty(GatewayAccountCredentialsRequestValidator.FIELD_GATEWAY_MERCHANT_ID)
-    @JsonView({Views.Api.class})
+    
     private String googlePayMerchantId;
 
     public WorldpayCredentials() {
@@ -59,6 +51,7 @@ public class WorldpayCredentials implements GatewayCredentials {
         this.legacyOneOffCustomerInitiatedPassword = legacyOneOffCustomerInitiatedPassword;
     }
     
+    @JsonIgnore
     public Optional<WorldpayMerchantCodeCredentials> getOneOffCustomerInitiatedCredentials() {
         if (oneOffCustomerInitiatedCredentials == null && legacyOneOffCustomerInitiatedMerchantCode != null) {
             return Optional.of(new WorldpayMerchantCodeCredentials(
@@ -71,31 +64,62 @@ public class WorldpayCredentials implements GatewayCredentials {
         return Optional.ofNullable(oneOffCustomerInitiatedCredentials);
     }
 
+    @JsonProperty(GatewayAccount.ONE_OFF_CUSTOMER_INITIATED)
+    @JsonView({Views.Api.class})
+    private WorldpayMerchantCodeCredentials getOneOffCustomerInitiatedCredentialsForSerialization() {
+        return getOneOffCustomerInitiatedCredentials().orElse(null);
+    }
+
+    @JsonProperty(GatewayAccount.ONE_OFF_CUSTOMER_INITIATED)
     public void setOneOffCustomerInitiatedCredentials(WorldpayMerchantCodeCredentials oneOffCustomerInitiatedCredentials) {
         this.oneOffCustomerInitiatedCredentials = oneOffCustomerInitiatedCredentials;
     }
     
+    @JsonIgnore
     public Optional<WorldpayMerchantCodeCredentials> getRecurringCustomerInitiatedCredentials() {
         return Optional.ofNullable(recurringCustomerInitiatedCredentials);
     }
 
+    @JsonProperty(GatewayAccount.RECURRING_CUSTOMER_INITIATED)
+    @JsonView({Views.Api.class})
+    private WorldpayMerchantCodeCredentials getRecurringCustomerInitiatedCredentialsForSerialization() {
+        return getRecurringCustomerInitiatedCredentials().orElse(null);
+    }
+
+    @JsonProperty(GatewayAccount.RECURRING_CUSTOMER_INITIATED)
     public void setRecurringCustomerInitiatedCredentials(WorldpayMerchantCodeCredentials recurringCustomerInitiatedCredentials) {
         this.recurringCustomerInitiatedCredentials = recurringCustomerInitiatedCredentials;
     }
     
+    @JsonIgnore
     public Optional<WorldpayMerchantCodeCredentials> getRecurringMerchantInitiatedCredentials() {
         return Optional.ofNullable(recurringMerchantInitiatedCredentials);
     }
 
+    @JsonProperty(GatewayAccount.RECURRING_MERCHANT_INITIATED)
+    @JsonView({Views.Api.class})
+    private WorldpayMerchantCodeCredentials getRecurringMerchantInitiatedCredentialsForSerialization() {
+        return getRecurringMerchantInitiatedCredentials().orElse(null);
+    }
+
+    @JsonProperty(GatewayAccount.RECURRING_MERCHANT_INITIATED)
     public void setRecurringMerchantInitiatedCredentials(WorldpayMerchantCodeCredentials recurringMerchantInitiatedCredentials) {
         this.recurringMerchantInitiatedCredentials = recurringMerchantInitiatedCredentials;
     }
 
     @Override
+    @JsonIgnore
     public Optional<String> getGooglePayMerchantId() {
         return Optional.ofNullable(googlePayMerchantId);
     }
 
+    @JsonProperty(GatewayAccountCredentialsRequestValidator.FIELD_GATEWAY_MERCHANT_ID)
+    @JsonView({Views.Api.class})
+    private String getGooglePayMerchantIdForSerialization() {
+        return getGooglePayMerchantId().orElse(null);
+    }
+
+    @JsonProperty(GatewayAccountCredentialsRequestValidator.FIELD_GATEWAY_MERCHANT_ID)
     public void setGooglePayMerchantId(String googlePayMerchantId) {
         this.googlePayMerchantId = googlePayMerchantId;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayMerchantCodeCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayMerchantCodeCredentials.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -10,6 +11,7 @@ import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorldpayMerchantCodeCredentials {
 
     @JsonView({GatewayCredentials.Views.Api.class})

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -33,6 +33,8 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 @Entity
 @Table(name = "gateway_account_credentials")
 @SequenceGenerator(name = "gateway_account_credentials_id_seq",
@@ -40,7 +42,7 @@ import java.util.Optional;
 @Customizer(HistoryCustomizer.class)
 public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
-    private static final ObjectMapper objectMapper = JsonMapper.builder().addModule(new Jdk8Module()).build();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
     
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "gateway_account_credentials_id_seq")

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
@@ -192,6 +192,18 @@ class GatewayAccountCredentialsEntityTest {
     }
 
     @Test
+    void setCredentials_shouldSerializeWorldpayCredentialsToMapForWritingToDatabase_shouldNotIncludeNullValues() {
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(WORLDPAY.getName())
+                .build();
+
+        var worldpayCredentials = (WorldpayCredentials)credentialsEntity.getCredentialsObject();
+        credentialsEntity.setCredentials(worldpayCredentials);
+
+        assertThat(credentialsEntity.getCredentials().entrySet(), hasSize(0));
+    }
+
+    @Test
     void setCredentials_shouldSerializeEpdqCredentialsToMapForWritingToDatabase() {
         GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
                 .withPaymentProvider(EPDQ.getName())

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -53,7 +53,7 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
 
-    private static ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private DatabaseFixtures.TestAccount defaultTestAccount;
 
@@ -298,7 +298,9 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .body("gateway_account_credentials[0].credentials", hasKey("one_off_customer_initiated"))
                 .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", hasEntry("merchant_code", "legacy-merchant-code"))
                 .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", hasEntry("username", "legacy-username"))
-                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", not(hasKey("password")));
+                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", not(hasKey("password")))
+                .body("gateway_account_credentials[0].credentials", not(hasKey("recurring_customer_initiated")))
+                .body("gateway_account_credentials[0].credentials", not(hasKey("recurring_merchant_initiated")));
     }
 
     @Test


### PR DESCRIPTION
Using the Jdk8Module to serialize the Optional getters sensibly caused did not obey the `@JsonInclude(JsonInclude.Include.NON_NULL)` annotation for fields with getters that return Optionals.

We don't want to include null fields, particularly when serializing the JSON for writing to the database. We also prefer this for API responses to maintain consistency.

Instead of registering the Jdk8Module on the ObjectMapper, add additional getters to WorldpayCredentials that don't return Optionals for Optional fields. Add `@JsonIgnore` to the Optional getters so the other getters are used instead.