### PR TITLE
PP-11157 Finish adding support for patching Worldpay credentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -618,7 +618,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 336
+        "line_number": 182
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java": [
@@ -1062,5 +1062,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-24T16:38:36Z"
+  "generated_at": "2023-07-26T09:29:51Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/EpdqCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/EpdqCredentials.java
@@ -1,10 +1,15 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import io.swagger.v3.oas.annotations.media.Schema;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EpdqCredentials implements GatewayCredentials {
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/SandboxCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/SandboxCredentials.java
@@ -1,7 +1,12 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SandboxCredentials implements GatewayCredentials {
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
@@ -1,11 +1,16 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.Map;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StripeCredentials implements GatewayCredentials {
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -6,13 +6,16 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import io.swagger.v3.oas.annotations.media.Schema;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator;
 
 import java.util.Objects;
 import java.util.Optional;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WorldpayCredentials implements GatewayCredentials {
 
     @JsonProperty(GatewayAccount.CREDENTIALS_MERCHANT_ID)

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -64,9 +64,7 @@ public class GatewayAccountCredentialsService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GatewayAccountCredentialsService.class);
 
-    private enum WorldpayUpdatableCredentials {ONE_OFF_CIT, RECURRING_CIT, RECURRING_MIT}
-
-    ;
+    private enum WorldpayUpdatableCredentials {ONE_OFF_CIT, RECURRING_CIT, RECURRING_MIT};
 
     private final GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
 
@@ -153,6 +151,7 @@ public class GatewayAccountCredentialsService {
                 break;
             case FIELD_CREDENTIALS_WORLDPAY_ONE_OFF_CUSTOMER_INITIATED:
                 updateWorldpayCredentials(patchRequest, WorldpayUpdatableCredentials.ONE_OFF_CIT, gatewayAccountCredentialsEntity);
+                break;
             case FIELD_CREDENTIALS_WORLDPAY_RECURRING_CUSTOMER_INITIATED:
                 updateWorldpayCredentials(patchRequest, WorldpayUpdatableCredentials.RECURRING_CIT, gatewayAccountCredentialsEntity);
                 break;

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
@@ -1,15 +1,11 @@
 package uk.gov.pay.connector.gatewayaccountcredentials.resource;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
 import com.google.gson.Gson;
 import io.restassured.specification.RequestSpecification;
-import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.postgresql.util.PGobject;
-import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
@@ -18,7 +14,6 @@ import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.junit.DropwizardTestContext;
 import uk.gov.pay.connector.junit.TestContext;
-import uk.gov.pay.connector.rules.WorldpayMockClient;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
@@ -29,10 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
@@ -45,10 +36,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
-import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
@@ -56,33 +45,20 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class GatewayAccountCredentialsResourceIT {
     private DatabaseFixtures.TestAccount testAccount;
-
-    private static final String UPDATE_3DS_FLEX_CREDENTIALS_URL = "/v1/api/accounts/%s/3ds-flex-credentials";
-    private static final String VALIDATE_3DS_FLEX_CREDENTIALS_URL = "/v1/api/accounts/%s/worldpay/check-3ds-flex-config";
-    private static final String VALIDATE_WORLDPAY_CREDENTIALS_URL = "/v1/api/accounts/%s/worldpay/check-credentials";
     private static final String PATCH_CREDENTIALS_URL = "/v1/api/accounts/%s/credentials/%s";
-
-    public static final String VALID_ISSUER = "53f0917f101a4428b69d5fb0"; // pragma: allowlist secret`
-    public static final String VALID_ORG_UNIT_ID = "57992a087a0c4849895ab8a2"; // pragma: allowlist secret`
-    public static final String VALID_JWT_MAC_KEY = "4cabd5d2-0133-4e82-b0e5-2024dbeddaa9"; // pragma: allowlist secret`
 
     @DropwizardTestContext
     protected TestContext testContext;
 
     private DatabaseTestHelper databaseTestHelper;
-    private WireMockServer wireMockServer;
-    private WorldpayMockClient worldpayMockClient;
     private DatabaseFixtures databaseFixtures;
     private Long credentialsId;
     private String credentialsExternalId;
     private Long accountId;
-    private ObjectMapper objectMapper = new ObjectMapper();
 
     @Before
     public void setUp() {
         databaseTestHelper = testContext.getDatabaseTestHelper();
-        wireMockServer = testContext.getWireMockServer();
-        worldpayMockClient = new WorldpayMockClient(wireMockServer);
         databaseFixtures = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper);
 
         testAccount = addGatewayAccountAndCredential("worldpay", ACTIVE, TEST);
@@ -97,138 +73,8 @@ public class GatewayAccountCredentialsResourceIT {
     }
 
     @Test
-    public void validate_valid_3ds_flex_credentials() throws Exception {
-        wireMockServer.stubFor(post("/shopper/3ds/ddc.html").willReturn(ok()));
-
-        givenSetup()
-                .body(getCheck3dsConfigPayloadForValidCredentials())
-                .post(format(VALIDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
-                .then()
-                .statusCode(200)
-                .body("result", is("valid"));
-    }
-
-    @Test
-    public void validate_invalid_3ds_flex_credentials() throws Exception {
-        wireMockServer.stubFor(post("/shopper/3ds/ddc.html").willReturn(badRequest()));
-
-        var invalidIssuer = "54a0917b10ca4428b69d5ed0"; // pragma: allowlist secret`
-        var invalidOrgUnitId = "57002a087a0c4849895ab8a2"; // pragma: allowlist secret`
-        var invalidJwtMacKey = "3751b5f1-4fef-4306-bc09-99df6320d5b8"; // pragma: allowlist secret`
-        var payload = objectMapper.writeValueAsString(Map.of(
-                "issuer", invalidIssuer,
-                "organisational_unit_id", invalidOrgUnitId,
-                "jwt_mac_key", invalidJwtMacKey));
-
-        givenSetup()
-                .body(payload)
-                .post(format(VALIDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
-                .then()
-                .statusCode(200)
-                .body("result", is("invalid"));
-    }
-
-    @Test
-    public void should_return_503_if_error_communicating_with_3ds_flex_ddc_endpoint() throws Exception {
-        wireMockServer.stubFor(post("/shopper/3ds/ddc.html").willReturn(serverError()));
-
-        givenSetup()
-                .body(getCheck3dsConfigPayloadForValidCredentials())
-                .post(format(VALIDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
-                .then()
-                .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE);
-    }
-
-    @Test
-    public void setWorldpay3dsFlexCredentialsWhenThereAreNonExisting() throws JsonProcessingException {
-        String payload = objectMapper.writeValueAsString(Map.of(
-                "issuer", VALID_ISSUER,
-                "organisational_unit_id", VALID_ORG_UNIT_ID,
-                "jwt_mac_key", VALID_JWT_MAC_KEY
-        ));
-        givenSetup()
-                .body(payload)
-                .post(format(UPDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
-                .then()
-                .statusCode(200);
-        var result = databaseTestHelper.getWorldpay3dsFlexCredentials(accountId);
-        assertThat(result.get("issuer"), is(VALID_ISSUER));
-        assertThat(result.get("organisational_unit_id"), is(VALID_ORG_UNIT_ID));
-        assertThat(result.get("jwt_mac_key"), is(VALID_JWT_MAC_KEY));
-    }
-
-    @Test
-    public void updateFlexCredentialsShouldSetGatewayAccountCredentialsStateToActiveForLiveAccount() throws JsonProcessingException {
-        DatabaseFixtures.TestAccount testAccount = addGatewayAccountAndCredential("worldpay", CREATED, LIVE);
-        String payload = objectMapper.writeValueAsString(Map.of(
-                "issuer", VALID_ISSUER,
-                "organisational_unit_id", VALID_ORG_UNIT_ID,
-                "jwt_mac_key", VALID_JWT_MAC_KEY
-        ));
-        givenSetup()
-                .body(payload)
-                .post(format(UPDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
-                .then()
-                .statusCode(200);
-
-        var result = databaseTestHelper.getWorldpay3dsFlexCredentials(testAccount.getAccountId());
-        assertThat(result.get("issuer"), is(VALID_ISSUER));
-        assertThat(result.get("organisational_unit_id"), is(VALID_ORG_UNIT_ID));
-        assertThat(result.get("jwt_mac_key"), is(VALID_JWT_MAC_KEY));
-
-        List<Map<String, Object>> gatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentialsForAccount(testAccount.getAccountId());
-        assertThat(gatewayAccountCredentials.get(0).get("state"), is("ACTIVE"));
-    }
-
-    @Test
-    public void overrideSetWorldpay3dsCredentials() throws JsonProcessingException {
-        String payload = objectMapper.writeValueAsString(Map.of(
-                "issuer", "53f0917f101a4428b69d5fb0", // pragma: allowlist secret`
-                "organisational_unit_id", "57992a087a0c4849895ab8a2", // pragma: allowlist secret`
-                "jwt_mac_key", "3751b5f1-4fef-4306-bc09-99df6320d5b8" // pragma: allowlist secret`
-        ));
-        givenSetup()
-                .body(payload)
-                .post(format(UPDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
-                .then()
-                .statusCode(200);
-
-        String newIssuer = "43f0917f101a4428b69d5fb9"; // pragma: allowlist secret`
-        String newOrgUnitId = "44992a087a0c4849895cc9a3"; // pragma: allowlist secret`
-        String updatedJwtMacKey = "512ee2a9-4a3e-46d4-86df-8e2ac3d6a6a8"; // pragma: allowlist secret`
-        payload = objectMapper.writeValueAsString(Map.of(
-                "issuer", newIssuer,
-                "organisational_unit_id", newOrgUnitId,
-                "jwt_mac_key", updatedJwtMacKey
-        ));
-        givenSetup()
-                .body(payload)
-                .post(format(UPDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
-                .then()
-                .statusCode(200);
-        var result = databaseTestHelper.getWorldpay3dsFlexCredentials(accountId);
-        assertThat(result.get("issuer"), is(newIssuer));
-        assertThat(result.get("organisational_unit_id"), is(newOrgUnitId));
-        assertThat(result.get("jwt_mac_key"), is(updatedJwtMacKey));
-    }
-
-    @Test
-    public void checkWorldpayCredentials_returns500WhenWorldpayReturnsUnexpectedResponse() throws JsonProcessingException {
-        worldpayMockClient.mockCredentialsValidationUnexpectedResponse();
-
-        long accountId = nextLong(2, 10000);
-        databaseFixtures.aTestAccount().withAccountId(accountId).withPaymentProvider("worldpay").insert();
-        givenSetup()
-                .body(getValidWorldpayCredentials())
-                .post(format(VALIDATE_WORLDPAY_CREDENTIALS_URL, accountId))
-                .then()
-                .statusCode(500)
-                .body("message[0]", is("Worldpay returned an unexpected response when validating credentials"));
-    }
-
-    @Test
     public void createGatewayAccountsCredentialsWithCredentials_responseShouldBe200_Ok() {
-        Map credentials = Map.of("stripe_account_id", "some-account-id");
+        Map<String, String> credentials = Map.of("stripe_account_id", "some-account-id");
         givenSetup()
                 .body(toJson(Map.of("payment_provider", "stripe", "credentials", credentials)))
                 .post("/v1/api/accounts/" + accountId + "/credentials")
@@ -413,21 +259,6 @@ public class GatewayAccountCredentialsResourceIT {
         assertThat(updatedCredentials, hasEntry("password", "new-password"));
         assertThat(updatedCredentials, hasEntry("merchant_id", "new-merchant-id"));
         assertThat(updatedCredentials, hasEntry("gateway_merchant_id", "abcdef123abcdef"));
-    }
-
-    private String getCheck3dsConfigPayloadForValidCredentials() throws JsonProcessingException {
-        return objectMapper.writeValueAsString(Map.of(
-                "issuer", VALID_ISSUER,
-                "organisational_unit_id", VALID_ORG_UNIT_ID,
-                "jwt_mac_key", VALID_JWT_MAC_KEY));
-    }
-
-    private String getValidWorldpayCredentials() throws JsonProcessingException {
-        return objectMapper.writeValueAsString(Map.of(
-                "username", "valid-user-name",
-                "password", "valid-password",
-                "merchant_id", "valid-merchant-id"
-        ));
     }
 
     private DatabaseFixtures.TestAccount addGatewayAccountAndCredential(String paymentProvider, GatewayAccountCredentialState state,

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpay3dsFlexIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpay3dsFlexIT.java
@@ -1,0 +1,233 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.resource;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.restassured.specification.RequestSpecification;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.junit.DropwizardTestContext;
+import uk.gov.pay.connector.junit.TestContext;
+import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
+import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class GatewayAccountCredentialsResourceWorldpay3dsFlexIT {
+    private DatabaseFixtures.TestAccount testAccount;
+
+    private static final String UPDATE_3DS_FLEX_CREDENTIALS_URL = "/v1/api/accounts/%s/3ds-flex-credentials";
+    private static final String VALIDATE_3DS_FLEX_CREDENTIALS_URL = "/v1/api/accounts/%s/worldpay/check-3ds-flex-config";
+
+    public static final String VALID_ISSUER = "53f0917f101a4428b69d5fb0"; // pragma: allowlist secret
+    public static final String VALID_ORG_UNIT_ID = "57992a087a0c4849895ab8a2"; // pragma: allowlist secret
+    public static final String VALID_JWT_MAC_KEY = "4cabd5d2-0133-4e82-b0e5-2024dbeddaa9"; // pragma: allowlist secret
+
+    @DropwizardTestContext
+    protected TestContext testContext;
+
+    private DatabaseTestHelper databaseTestHelper;
+    private WireMockServer wireMockServer;
+    private DatabaseFixtures databaseFixtures;
+    private Long accountId;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Before
+    public void setUp() {
+        databaseTestHelper = testContext.getDatabaseTestHelper();
+        wireMockServer = testContext.getWireMockServer();
+        databaseFixtures = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper);
+
+        testAccount = addGatewayAccountAndCredential("worldpay", ACTIVE, TEST);
+        accountId = testAccount.getAccountId();
+    }
+
+    protected RequestSpecification givenSetup() {
+        return given().port(testContext.getPort()).contentType(JSON);
+    }
+
+    @Test
+    public void validate_valid_3ds_flex_credentials() throws Exception {
+        wireMockServer.stubFor(post("/shopper/3ds/ddc.html").willReturn(ok()));
+
+        givenSetup()
+                .body(getCheck3dsConfigPayloadForValidCredentials())
+                .post(format(VALIDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
+                .then()
+                .statusCode(200)
+                .body("result", is("valid"));
+    }
+
+    @Test
+    public void validate_invalid_3ds_flex_credentials() throws Exception {
+        wireMockServer.stubFor(post("/shopper/3ds/ddc.html").willReturn(badRequest()));
+
+        var invalidIssuer = "54a0917b10ca4428b69d5ed0"; // pragma: allowlist secret`
+        var invalidOrgUnitId = "57002a087a0c4849895ab8a2"; // pragma: allowlist secret`
+        var invalidJwtMacKey = "3751b5f1-4fef-4306-bc09-99df6320d5b8"; // pragma: allowlist secret`
+        var payload = objectMapper.writeValueAsString(Map.of(
+                "issuer", invalidIssuer,
+                "organisational_unit_id", invalidOrgUnitId,
+                "jwt_mac_key", invalidJwtMacKey));
+
+        givenSetup()
+                .body(payload)
+                .post(format(VALIDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
+                .then()
+                .statusCode(200)
+                .body("result", is("invalid"));
+    }
+
+    @Test
+    public void should_return_503_if_error_communicating_with_3ds_flex_ddc_endpoint() throws Exception {
+        wireMockServer.stubFor(post("/shopper/3ds/ddc.html").willReturn(serverError()));
+
+        givenSetup()
+                .body(getCheck3dsConfigPayloadForValidCredentials())
+                .post(format(VALIDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
+                .then()
+                .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    public void setWorldpay3dsFlexCredentialsWhenThereAreNonExisting() throws JsonProcessingException {
+        String payload = objectMapper.writeValueAsString(Map.of(
+                "issuer", VALID_ISSUER,
+                "organisational_unit_id", VALID_ORG_UNIT_ID,
+                "jwt_mac_key", VALID_JWT_MAC_KEY
+        ));
+        givenSetup()
+                .body(payload)
+                .post(format(UPDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
+                .then()
+                .statusCode(200);
+        var result = databaseTestHelper.getWorldpay3dsFlexCredentials(accountId);
+        assertThat(result.get("issuer"), is(VALID_ISSUER));
+        assertThat(result.get("organisational_unit_id"), is(VALID_ORG_UNIT_ID));
+        assertThat(result.get("jwt_mac_key"), is(VALID_JWT_MAC_KEY));
+    }
+
+    @Test
+    public void updateFlexCredentialsShouldSetGatewayAccountCredentialsStateToActiveForLiveAccount() throws JsonProcessingException {
+        DatabaseFixtures.TestAccount testAccount = addGatewayAccountAndCredential("worldpay", CREATED, LIVE);
+        String payload = objectMapper.writeValueAsString(Map.of(
+                "issuer", VALID_ISSUER,
+                "organisational_unit_id", VALID_ORG_UNIT_ID,
+                "jwt_mac_key", VALID_JWT_MAC_KEY
+        ));
+        givenSetup()
+                .body(payload)
+                .post(format(UPDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
+                .then()
+                .statusCode(200);
+
+        var result = databaseTestHelper.getWorldpay3dsFlexCredentials(testAccount.getAccountId());
+        assertThat(result.get("issuer"), is(VALID_ISSUER));
+        assertThat(result.get("organisational_unit_id"), is(VALID_ORG_UNIT_ID));
+        assertThat(result.get("jwt_mac_key"), is(VALID_JWT_MAC_KEY));
+
+        List<Map<String, Object>> gatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentialsForAccount(testAccount.getAccountId());
+        assertThat(gatewayAccountCredentials.get(0).get("state"), is("ACTIVE"));
+    }
+
+    @Test
+    public void overrideSetWorldpay3dsCredentials() throws JsonProcessingException {
+        String payload = objectMapper.writeValueAsString(Map.of(
+                "issuer", "53f0917f101a4428b69d5fb0", // pragma: allowlist secret`
+                "organisational_unit_id", "57992a087a0c4849895ab8a2", // pragma: allowlist secret`
+                "jwt_mac_key", "3751b5f1-4fef-4306-bc09-99df6320d5b8" // pragma: allowlist secret`
+        ));
+        givenSetup()
+                .body(payload)
+                .post(format(UPDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
+                .then()
+                .statusCode(200);
+
+        String newIssuer = "43f0917f101a4428b69d5fb9"; // pragma: allowlist secret`
+        String newOrgUnitId = "44992a087a0c4849895cc9a3"; // pragma: allowlist secret`
+        String updatedJwtMacKey = "512ee2a9-4a3e-46d4-86df-8e2ac3d6a6a8"; // pragma: allowlist secret`
+        payload = objectMapper.writeValueAsString(Map.of(
+                "issuer", newIssuer,
+                "organisational_unit_id", newOrgUnitId,
+                "jwt_mac_key", updatedJwtMacKey
+        ));
+        givenSetup()
+                .body(payload)
+                .post(format(UPDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
+                .then()
+                .statusCode(200);
+        var result = databaseTestHelper.getWorldpay3dsFlexCredentials(accountId);
+        assertThat(result.get("issuer"), is(newIssuer));
+        assertThat(result.get("organisational_unit_id"), is(newOrgUnitId));
+        assertThat(result.get("jwt_mac_key"), is(updatedJwtMacKey));
+    }
+
+
+    private String getCheck3dsConfigPayloadForValidCredentials() throws JsonProcessingException {
+        return objectMapper.writeValueAsString(Map.of(
+                "issuer", VALID_ISSUER,
+                "organisational_unit_id", VALID_ORG_UNIT_ID,
+                "jwt_mac_key", VALID_JWT_MAC_KEY));
+    }
+
+
+    private DatabaseFixtures.TestAccount addGatewayAccountAndCredential(String paymentProvider, GatewayAccountCredentialState state,
+                                                                        GatewayAccountType gatewayAccountType) {
+        long accountId = nextLong(2, 10000);
+        LocalDateTime createdDate = LocalDate.parse("2021-01-01").atStartOfDay();
+        LocalDateTime activeStartDate = LocalDate.parse("2021-02-01").atStartOfDay();
+        LocalDateTime activeEndDate = LocalDate.parse("2021-03-01").atStartOfDay();
+
+        AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
+                .withGatewayAccountId(accountId)
+                .withPaymentProvider(paymentProvider)
+                .withCreatedDate(createdDate.toInstant(ZoneOffset.UTC))
+                .withActiveStartDate(activeStartDate.toInstant(ZoneOffset.UTC))
+                .withActiveEndDate(activeEndDate.toInstant(ZoneOffset.UTC))
+                .withState(state)
+                .withCredentials(Map.of(
+                        "merchant_id", "a-merchant-id",
+                        "username", "a-username",
+                        "password", "a-password"))
+                .build();
+
+        return databaseFixtures.aTestAccount().withPaymentProvider(paymentProvider)
+                .withIntegrationVersion3ds(2)
+                .withAccountId(accountId)
+                .withType(gatewayAccountType)
+                .withGatewayAccountCredentials(Collections.singletonList(credentialsParams))
+                .insert();
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpayIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpayIT.java
@@ -1,0 +1,291 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.resource;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.google.gson.Gson;
+import io.restassured.specification.RequestSpecification;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.postgresql.util.PGobject;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.junit.DropwizardTestContext;
+import uk.gov.pay.connector.junit.TestContext;
+import uk.gov.pay.connector.rules.WorldpayMockClient;
+import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
+import static uk.gov.pay.connector.util.JsonEncoder.toJson;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class GatewayAccountCredentialsResourceWorldpayIT {
+    private DatabaseFixtures.TestAccount testAccount;
+
+    private static final String PATCH_CREDENTIALS_URL = "/v1/api/accounts/%s/credentials/%s";
+    private static final String VALIDATE_WORLDPAY_CREDENTIALS_URL = "/v1/api/accounts/%s/worldpay/check-credentials";
+
+    @DropwizardTestContext
+    protected TestContext testContext;
+
+    private DatabaseTestHelper databaseTestHelper;
+    private WireMockServer wireMockServer;
+    private WorldpayMockClient worldpayMockClient;
+    private DatabaseFixtures databaseFixtures;
+    private Long credentialsId;
+    private Long accountId;
+
+    @Before
+    public void setUp() {
+        databaseTestHelper = testContext.getDatabaseTestHelper();
+        wireMockServer = testContext.getWireMockServer();
+        worldpayMockClient = new WorldpayMockClient(wireMockServer);
+        databaseFixtures = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper);
+
+        testAccount = addGatewayAccountAndCredential("worldpay", ACTIVE, TEST);
+        accountId = testAccount.getAccountId();
+
+        credentialsId = testAccount.getCredentials().get(0).getId();
+    }
+
+    protected RequestSpecification givenSetup() {
+        return given().port(testContext.getPort()).contentType(JSON);
+    }
+
+    @Test
+    public void addingOneOffCustomerInitiatedUpdatesOnlyThoseButRemovesLegacyCredentials() {
+        Map<String, Object> existingGatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentialsById(credentialsId);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> existingCredentials = new Gson().fromJson(((PGobject) existingGatewayAccountCredentials.get("credentials")).getValue(), Map.class);
+        assertThat(existingCredentials, hasEntry("merchant_id", "a-merchant-id"));
+        assertThat(existingCredentials, hasEntry("username", "a-username"));
+        assertThat(existingCredentials, hasEntry("password", "a-password"));
+
+        givenSetup()
+                .body(toJson(List.of(
+                        Map.of("op", "replace",
+                                "path", "credentials/worldpay/one_off_customer_initiated",
+                                "value", Map.of("merchant_code", "new-merchant-code",
+                                                    "username", "new-username",
+                                                    "password", "new-password")))))
+                .patch(format(PATCH_CREDENTIALS_URL, accountId, credentialsId))
+                .then()
+                .statusCode(200)
+                .body("$", hasKey("credentials"))
+                .body("credentials", hasKey("one_off_customer_initiated"))
+                .body("credentials.one_off_customer_initiated", hasEntry("merchant_code", "new-merchant-code"))
+                .body("credentials.one_off_customer_initiated", hasEntry("username", "new-username"))
+                .body("credentials.one_off_customer_initiated", not(hasKey("password")));
+
+        Map<String, Object> updatedGatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentialsById(credentialsId);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> updatedCredentials = new Gson().fromJson(((PGobject) updatedGatewayAccountCredentials.get("credentials")).getValue(), Map.class);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> updatedOneOffCustomerInitiated = (Map<String, String>) updatedCredentials.get("one_off_customer_initiated");
+        assertThat(updatedOneOffCustomerInitiated, hasEntry("merchant_code", "new-merchant-code"));
+        assertThat(updatedOneOffCustomerInitiated, hasEntry("username", "new-username"));
+        assertThat(updatedOneOffCustomerInitiated, hasEntry("password", "new-password"));
+
+        assertThat(updatedCredentials, not(hasKey("merchant_id")));
+        assertThat(updatedCredentials, not(hasKey("username")));
+        assertThat(updatedCredentials, not(hasKey("password")));
+
+        assertThat(updatedCredentials, not(hasKey("recurring_customer_initiated")));
+        assertThat(updatedCredentials, not(hasKey("recurring_merchant_initiated")));
+    }
+
+    @Test
+    public void existingOneOffCredentialsCanBeReplaced() {
+        givenSetup()
+                .body(toJson(List.of(
+                        Map.of("op", "replace",
+                                "path", "credentials/worldpay/one_off_customer_initiated",
+                                "value", Map.of("merchant_code", "new-merchant-code",
+                                        "username", "new-username",
+                                        "password", "new-password")))))
+                .patch(format(PATCH_CREDENTIALS_URL, accountId, credentialsId))
+                .then()
+                .statusCode(200)
+                .body("$", hasKey("credentials"))
+                .body("credentials", hasKey("one_off_customer_initiated"))
+                .body("credentials.one_off_customer_initiated", hasEntry("merchant_code", "new-merchant-code"))
+                .body("credentials.one_off_customer_initiated", hasEntry("username", "new-username"))
+                .body("credentials.one_off_customer_initiated", not(hasKey("password")));
+
+        Map<String, Object> updatedGatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentialsById(credentialsId);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> updatedCredentials = new Gson().fromJson(((PGobject) updatedGatewayAccountCredentials.get("credentials")).getValue(), Map.class);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> updatedOneOffCustomerInitiated = (Map<String, String>) updatedCredentials.get("one_off_customer_initiated");
+        assertThat(updatedOneOffCustomerInitiated, hasEntry("merchant_code", "new-merchant-code"));
+        assertThat(updatedOneOffCustomerInitiated, hasEntry("username", "new-username"));
+        assertThat(updatedOneOffCustomerInitiated, hasEntry("password", "new-password"));
+
+        givenSetup()
+                .body(toJson(List.of(
+                        Map.of("op", "replace",
+                                "path", "credentials/worldpay/one_off_customer_initiated",
+                                "value", Map.of("merchant_code", "newer-merchant-code",
+                                        "username", "newer-username",
+                                        "password", "newer-password")))))
+                .patch(format(PATCH_CREDENTIALS_URL, accountId, credentialsId))
+                .then()
+                .statusCode(200)
+                .body("$", hasKey("credentials"))
+                .body("credentials", hasKey("one_off_customer_initiated"))
+                .body("credentials.one_off_customer_initiated", hasEntry("merchant_code", "newer-merchant-code"))
+                .body("credentials.one_off_customer_initiated", hasEntry("username", "newer-username"))
+                .body("credentials.one_off_customer_initiated", not(hasKey("password")));
+
+        Map<String, Object> moreUpdatedGatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentialsById(credentialsId);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> moreUpdatedCredentials = new Gson().fromJson(((PGobject) moreUpdatedGatewayAccountCredentials.get("credentials")).getValue(), Map.class);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> moreUpdatedOneOffCustomerInitiated = (Map<String, String>) moreUpdatedCredentials.get("one_off_customer_initiated");
+        assertThat(moreUpdatedOneOffCustomerInitiated, hasEntry("merchant_code", "newer-merchant-code"));
+        assertThat(moreUpdatedOneOffCustomerInitiated, hasEntry("username", "newer-username"));
+        assertThat(moreUpdatedOneOffCustomerInitiated, hasEntry("password", "newer-password"));
+    }
+
+    @Test
+    public void addingRecurringCredentialsCanBeDoneInStages() {
+        givenSetup()
+                .body(toJson(List.of(
+                        Map.of("op", "replace",
+                                "path", "credentials/worldpay/recurring_customer_initiated",
+                                "value", Map.of("merchant_code", "new-recurring-cit-merchant-code",
+                                        "username", "new-recurring-cit-username",
+                                        "password", "new-recurring-cit-password")))))
+                .patch(format(PATCH_CREDENTIALS_URL, accountId, credentialsId))
+                .then()
+                .statusCode(200)
+                .body("$", hasKey("credentials"))
+                .body("credentials", hasKey("recurring_customer_initiated"))
+                .body("credentials.recurring_customer_initiated", hasEntry("merchant_code", "new-recurring-cit-merchant-code"))
+                .body("credentials.recurring_customer_initiated", hasEntry("username", "new-recurring-cit-username"))
+                .body("credentials.recurring_customer_initiated", not(hasKey("password")));
+
+        Map<String, Object> updatedGatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentialsById(credentialsId);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> updatedCredentials = new Gson().fromJson(((PGobject) updatedGatewayAccountCredentials.get("credentials")).getValue(), Map.class);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> updatedOneOffCustomerInitiated = (Map<String, String>) updatedCredentials.get("recurring_customer_initiated");
+        assertThat(updatedOneOffCustomerInitiated, hasEntry("merchant_code", "new-recurring-cit-merchant-code"));
+        assertThat(updatedOneOffCustomerInitiated, hasEntry("username", "new-recurring-cit-username"));
+        assertThat(updatedOneOffCustomerInitiated, hasEntry("password", "new-recurring-cit-password"));
+
+        assertThat(updatedCredentials, not(hasKey("recurring_merchant_initiated")));
+
+        givenSetup()
+                .body(toJson(List.of(
+                        Map.of("op", "replace",
+                                "path", "credentials/worldpay/recurring_merchant_initiated",
+                                "value", Map.of("merchant_code", "new-recurring-mit-merchant-code",
+                                        "username", "new-recurring-mit-username",
+                                        "password", "new-recurring-mit-password")))))
+                .patch(format(PATCH_CREDENTIALS_URL, accountId, credentialsId))
+                .then()
+                .statusCode(200)
+                .body("$", hasKey("credentials"))
+                .body("credentials", hasKey("recurring_merchant_initiated"))
+                .body("credentials.recurring_merchant_initiated", hasEntry("merchant_code", "new-recurring-mit-merchant-code"))
+                .body("credentials.recurring_merchant_initiated", hasEntry("username", "new-recurring-mit-username"))
+                .body("credentials.recurring_merchant_initiated", not(hasKey("password")));
+
+        Map<String, Object> moreUpdatedGatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentialsById(credentialsId);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> moreUpdatedCredentials = new Gson().fromJson(((PGobject) moreUpdatedGatewayAccountCredentials.get("credentials")).getValue(), Map.class);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> moreUpdatedOneOffCustomerInitiated = (Map<String, String>) moreUpdatedCredentials.get("recurring_customer_initiated");
+        assertThat(moreUpdatedOneOffCustomerInitiated, hasEntry("merchant_code", "new-recurring-cit-merchant-code"));
+        assertThat(moreUpdatedOneOffCustomerInitiated, hasEntry("username", "new-recurring-cit-username"));
+        assertThat(moreUpdatedOneOffCustomerInitiated, hasEntry("password", "new-recurring-cit-password"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> moreUpdatedOneOffMerchantInitiated = (Map<String, String>) moreUpdatedCredentials.get("recurring_merchant_initiated");
+        assertThat(moreUpdatedOneOffMerchantInitiated, hasEntry("merchant_code", "new-recurring-mit-merchant-code"));
+        assertThat(moreUpdatedOneOffMerchantInitiated, hasEntry("username", "new-recurring-mit-username"));
+        assertThat(moreUpdatedOneOffMerchantInitiated, hasEntry("password", "new-recurring-mit-password"));
+    }
+
+    @Test
+    public void checkWorldpayCredentials_returns500WhenWorldpayReturnsUnexpectedResponse() throws JsonProcessingException {
+        worldpayMockClient.mockCredentialsValidationUnexpectedResponse();
+
+        long accountId = nextLong(2, 10000);
+        databaseFixtures.aTestAccount().withAccountId(accountId).withPaymentProvider("worldpay").insert();
+        givenSetup()
+                .body(Map.of(
+                        "username", "valid-user-name",
+                        "password", "valid-password",
+                        "merchant_id", "valid-merchant-id"
+                ))
+                .post(format(VALIDATE_WORLDPAY_CREDENTIALS_URL, accountId))
+                .then()
+                .statusCode(500)
+                .body("message[0]", is("Worldpay returned an unexpected response when validating credentials"));
+    }
+
+    private DatabaseFixtures.TestAccount addGatewayAccountAndCredential(String paymentProvider, GatewayAccountCredentialState state,
+                                                                        GatewayAccountType gatewayAccountType) {
+        long accountId = nextLong(2, 10000);
+        LocalDateTime createdDate = LocalDate.parse("2021-01-01").atStartOfDay();
+        LocalDateTime activeStartDate = LocalDate.parse("2021-02-01").atStartOfDay();
+        LocalDateTime activeEndDate = LocalDate.parse("2021-03-01").atStartOfDay();
+
+        AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
+                .withGatewayAccountId(accountId)
+                .withPaymentProvider(paymentProvider)
+                .withCreatedDate(createdDate.toInstant(ZoneOffset.UTC))
+                .withActiveStartDate(activeStartDate.toInstant(ZoneOffset.UTC))
+                .withActiveEndDate(activeEndDate.toInstant(ZoneOffset.UTC))
+                .withState(state)
+                .withCredentials(Map.of(
+                        "merchant_id", "a-merchant-id",
+                        "username", "a-username",
+                        "password", "a-password"))
+                .build();
+
+        return databaseFixtures.aTestAccount().withPaymentProvider(paymentProvider)
+                .withIntegrationVersion3ds(2)
+                .withAccountId(accountId)
+                .withType(gatewayAccountType)
+                .withGatewayAccountCredentials(Collections.singletonList(credentialsParams))
+                .insert();
+    }
+}


### PR DESCRIPTION
- Add a missing break statement that could have caused a nasty overwriting bug
- Make credentials for the different gateways serialise consistently, excluding null values
- Add integration tests for Worldpay credentials, splitting them out from `GatewayAccountCredentialsResourceIT` to a new `GatewayAccountCredentialsResourceWorldpayIT` class (which also includes some existing Worldpay-specific tests), which now lives alongside a `GatewayAccountCredentialsResourceWorldpay3dsFlexIT` class — while a lot of tests have moved around, only `GatewayAccountCredentialsResourceWorldpayIT` contains new tests.