### PR TITLE
PP-11152 Don't allow updating legacy credentials for Worldpay

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -602,14 +602,14 @@
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidatorTest.java",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 197
+        "line_number": 179
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidatorTest.java",
         "hashed_secret": "d951d773b511b017529f9c2188b43e8518f24b56",
         "is_verified": false,
-        "line_number": 240
+        "line_number": 222
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java": [
@@ -618,7 +618,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 182
+        "line_number": 185
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java": [
@@ -1062,5 +1062,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-26T09:29:51Z"
+  "generated_at": "2023-07-31T11:13:01Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
@@ -58,6 +58,10 @@ public class GatewayAccountCredentialsRequestValidator {
 
         Map<String, String> credentials = gatewayAccountCredentialsRequest.getCredentialsAsMap();
         if (credentials != null) {
+            if (paymentGatewayName == WORLDPAY) {
+                throw new ValidationException(List.of("Field [credentials] is not supported for payment provider Worldpay"));
+            }
+            
             List<String> missingCredentialsFields = getMissingCredentialsFields(credentials, paymentGatewayName, FIELD_CREDENTIALS);
             if (!missingCredentialsFields.isEmpty()) {
                 throw new ValidationException(List.of("Field(s) missing: [" + String.join(", ", missingCredentialsFields) + ']'));
@@ -118,7 +122,7 @@ public class GatewayAccountCredentialsRequestValidator {
         switch (paymentProvider) {
             case WORLDPAY:
                 if (FIELD_CREDENTIALS.equals(path)) {
-                    return LEGACY_WORLDPAY_CREDENTIALS_KEYS;
+                    throw new UnsupportedOperationException(format("Path [%s] is not supported for updating Worldpay credentials", path));
                 }
                 return WORLDPAY_CREDENTIALS_KEYS;
             case STRIPE:


### PR DESCRIPTION
Selfservice now uses the new PATCH paths for updating Worldpay credentials:
- `credentials/worldpay/one_off_customer_initiated`
- `credentials/worldpay/recurring_customer_initiated` 
- `credentials/worldpay/recurring_merchant_initiated`

Attempting to update credentials using the `credentials` path in a PATCH request would produce unexpected results.

Return a 400 if a PATCH request to update the credentials for a Worldpay account has `"path": "credentials"`.

Also return a 400 if POST `/v1/api/accounts/{accountId}/credentials` is called for a Worldpay account and the `credentials` field is set. Credentials are only currently included for a Stripe account when we enable PSP switch. For Worldpay accounts, we do not set credentials at this point as they are entered by the service user. Ensure an appropriate error is returned in this case to ensure we don't allow setting credentials in the legacy format.