### PR TITLE
PP-11290 Stop reading legacy credentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -545,7 +545,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 784
+        "line_number": 777
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -554,7 +554,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 83
+        "line_number": 79
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
@@ -602,14 +602,14 @@
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidatorTest.java",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 179
+        "line_number": 180
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidatorTest.java",
         "hashed_secret": "d951d773b511b017529f9c2188b43e8518f24b56",
         "is_verified": false,
-        "line_number": 222
+        "line_number": 223
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java": [
@@ -687,7 +687,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java",
         "hashed_secret": "e9b6cb662f24d2346839fb0b797ad778c290994e",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 147
       }
     ],
     "src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java": [
@@ -714,7 +714,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/pact/ContractTest.java",
         "hashed_secret": "d5662d7353c6257f68cab2a3b0f758cc79b1ac5e",
         "is_verified": false,
-        "line_number": 343
+        "line_number": 347
       }
     ],
     "src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java": [
@@ -1062,5 +1062,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-31T11:13:01Z"
+  "generated_at": "2023-08-02T10:11:21Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
-import io.swagger.v3.oas.annotations.media.Schema;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator;
@@ -17,18 +16,6 @@ import java.util.Optional;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WorldpayCredentials implements GatewayCredentials {
-
-    @JsonProperty(GatewayAccount.CREDENTIALS_MERCHANT_ID)
-    @Schema(hidden = true)
-    private String legacyOneOffCustomerInitiatedMerchantCode;
-
-    @JsonProperty(GatewayAccount.CREDENTIALS_USERNAME)
-    @Schema(hidden = true)
-    private String legacyOneOffCustomerInitiatedUsername;
-
-    @JsonProperty(GatewayAccount.CREDENTIALS_PASSWORD)
-    @Schema(hidden = true)
-    private String legacyOneOffCustomerInitiatedPassword;
 
     private WorldpayMerchantCodeCredentials oneOffCustomerInitiatedCredentials;
 
@@ -42,28 +29,8 @@ public class WorldpayCredentials implements GatewayCredentials {
         // Janet Jackson
     }
 
-    public void setLegacyOneOffCustomerInitiatedMerchantCode(String legacyOneOffCustomerInitiatedMerchantCode) {
-        this.legacyOneOffCustomerInitiatedMerchantCode = legacyOneOffCustomerInitiatedMerchantCode;
-    }
-
-    public void setLegacyOneOffCustomerInitiatedUsername(String legacyOneOffCustomerInitiatedUsername) {
-        this.legacyOneOffCustomerInitiatedUsername = legacyOneOffCustomerInitiatedUsername;
-    }
-
-    public void setLegacyOneOffCustomerInitiatedPassword(String legacyOneOffCustomerInitiatedPassword) {
-        this.legacyOneOffCustomerInitiatedPassword = legacyOneOffCustomerInitiatedPassword;
-    }
-
     @JsonIgnore
     public Optional<WorldpayMerchantCodeCredentials> getOneOffCustomerInitiatedCredentials() {
-        if (oneOffCustomerInitiatedCredentials == null && legacyOneOffCustomerInitiatedMerchantCode != null) {
-            return Optional.of(new WorldpayMerchantCodeCredentials(
-                    legacyOneOffCustomerInitiatedMerchantCode,
-                    legacyOneOffCustomerInitiatedUsername,
-                    legacyOneOffCustomerInitiatedPassword
-            ));
-        }
-
         return Optional.ofNullable(oneOffCustomerInitiatedCredentials);
     }
 
@@ -129,8 +96,7 @@ public class WorldpayCredentials implements GatewayCredentials {
 
     @Override
     public boolean hasCredentials() {
-        return legacyOneOffCustomerInitiatedMerchantCode != null
-                || oneOffCustomerInitiatedCredentials != null
+        return oneOffCustomerInitiatedCredentials != null
                 || (recurringCustomerInitiatedCredentials != null && recurringMerchantInitiatedCredentials != null);
     }
 
@@ -146,10 +112,7 @@ public class WorldpayCredentials implements GatewayCredentials {
 
         var that = (WorldpayCredentials) other;
 
-        return Objects.equals(legacyOneOffCustomerInitiatedMerchantCode, that.legacyOneOffCustomerInitiatedMerchantCode)
-                && Objects.equals(legacyOneOffCustomerInitiatedUsername, that.legacyOneOffCustomerInitiatedUsername)
-                && Objects.equals(legacyOneOffCustomerInitiatedPassword, that.legacyOneOffCustomerInitiatedPassword)
-                && Objects.equals(oneOffCustomerInitiatedCredentials, that.oneOffCustomerInitiatedCredentials)
+        return Objects.equals(oneOffCustomerInitiatedCredentials, that.oneOffCustomerInitiatedCredentials)
                 && Objects.equals(recurringCustomerInitiatedCredentials, that.recurringCustomerInitiatedCredentials)
                 && Objects.equals(recurringMerchantInitiatedCredentials, that.recurringMerchantInitiatedCredentials)
                 && Objects.equals(googlePayMerchantId, that.googlePayMerchantId);
@@ -157,9 +120,8 @@ public class WorldpayCredentials implements GatewayCredentials {
 
     @Override
     public int hashCode() {
-        return Objects.hash(legacyOneOffCustomerInitiatedMerchantCode, legacyOneOffCustomerInitiatedUsername,
-                legacyOneOffCustomerInitiatedPassword, oneOffCustomerInitiatedCredentials,
-                recurringCustomerInitiatedCredentials, recurringMerchantInitiatedCredentials, googlePayMerchantId);
+        return Objects.hash(oneOffCustomerInitiatedCredentials, recurringCustomerInitiatedCredentials,
+                recurringMerchantInitiatedCredentials, googlePayMerchantId);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
@@ -28,8 +28,6 @@ import static uk.gov.service.payments.commons.api.validation.JsonPatchRequestVal
 public class GatewayAccountCredentialsRequestValidator {
 
     private static final Pattern WORLDPAY_MERCHANT_ID_PATTERN = Pattern.compile("[0-9a-f]{15}");
-
-    private static final List<String> LEGACY_WORLDPAY_CREDENTIALS_KEYS = List.of("merchant_id", "username", "password");
     private static final List<String> WORLDPAY_CREDENTIALS_KEYS = List.of("merchant_code", "username", "password");
     private static final List<String> STRIPE_CREDENTIALS_KEYS = List.of("stripe_account_id");
     private static final List<String> EPDQ_CREDENTIALS_KEYS = List.of("merchant_id", "username", "password",

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -190,9 +190,6 @@ public class GatewayAccountCredentialsService {
         switch (updatableCredentials) {
             case ONE_OFF_CIT:
                 worldpayCredentials.setOneOffCustomerInitiatedCredentials(worldpayMerchantCodeCredentials);
-                worldpayCredentials.setLegacyOneOffCustomerInitiatedMerchantCode(null);
-                worldpayCredentials.setLegacyOneOffCustomerInitiatedUsername(null);
-                worldpayCredentials.setLegacyOneOffCustomerInitiatedPassword(null);
                 break;
             case RECURRING_CIT:
                 worldpayCredentials.setRecurringCustomerInitiatedCredentials(worldpayMerchantCodeCredentials);

--- a/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 
 import javax.crypto.spec.SecretKeySpec;
 import java.time.Duration;
@@ -43,6 +44,10 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
@@ -335,14 +340,16 @@ class Worldpay3dsFlexJwtServiceTest {
     }
 
     private void addGatewayAccountCredentialsEntity(GatewayAccountEntity gatewayAccountEntity, String paymentProvider) {
-        var creds = aGatewayAccountCredentialsEntity()
-                .withCredentials(Map.of(
-                        "username", "theUsername",
-                        "password", "thePassword",
-                        "merchant_id", "theMerchantCode"))
-                .withGatewayAccountEntity(gatewayAccountEntity)
-                .withPaymentProvider(paymentProvider)
-                .withState(ACTIVE)
+        GatewayAccountCredentialsEntityFixture gatewayAccountCredentialsEntityFixture = aGatewayAccountCredentialsEntity();
+        gatewayAccountCredentialsEntityFixture.withCredentials(Map.of(
+                ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                        CREDENTIALS_MERCHANT_CODE, "a-merchant-code",
+                        CREDENTIALS_USERNAME, "a-username",
+                        CREDENTIALS_PASSWORD, "a-password")));
+        gatewayAccountCredentialsEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
+        gatewayAccountCredentialsEntityFixture.withPaymentProvider(paymentProvider);
+        gatewayAccountCredentialsEntityFixture.withState(ACTIVE);
+        var creds = gatewayAccountCredentialsEntityFixture
                 .build();
 
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(creds));

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
@@ -16,26 +16,12 @@ import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 
 @ExtendWith(MockitoExtension.class)
 class AuthUtilTest {
     private final String merchantCode = "MERCHANTCODE";
     private final String username = "worldpay-username";
     private final String password = "password"; //pragma: allowlist secret
-    private final Map<String, Object> worldpayRecurringCredentials = Map.of(
-            CREDENTIALS_MERCHANT_ID, merchantCode,
-            CREDENTIALS_USERNAME, username,
-            CREDENTIALS_PASSWORD, password,
-            RECURRING_MERCHANT_INITIATED, Map.of(
-                    CREDENTIALS_MERCHANT_CODE, "RC-" + merchantCode,
-                    CREDENTIALS_USERNAME, "RC-" + username,
-                    CREDENTIALS_PASSWORD, "RC-" + password
-            ));
 
     @Test
     void getWorldpayAuthHeader_shouldThrowExceptionWhenNoCredentials_forRecurringCustomerInitiated() {
@@ -73,18 +59,6 @@ class AuthUtilTest {
         credentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
         Map<String, String> encodedHeader = AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.AGREEMENT, true);
 
-        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes(StandardCharsets.UTF_8));
-        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
-    }
-
-    @Test
-    void shouldGetAuthHeaderForOneOffPayment_whenOnlyLegacyCredentialsSet() {
-        WorldpayCredentials credentials = new WorldpayCredentials();
-        credentials.setLegacyOneOffCustomerInitiatedMerchantCode(merchantCode);
-        credentials.setLegacyOneOffCustomerInitiatedUsername(username);
-        credentials.setLegacyOneOffCustomerInitiatedPassword(password);
-
-        Map<String, String> encodedHeader = AuthUtil.getWorldpayAuthHeader(credentials, AuthorisationMode.WEB, false);
         String expectedHeader = "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes(StandardCharsets.UTF_8));
         assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
     }
@@ -141,15 +115,6 @@ class AuthUtilTest {
         WorldpayCredentials credentials = new WorldpayCredentials();
         credentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
         String merchantId = AuthUtil.getWorldpayMerchantCode(credentials, AuthorisationMode.AGREEMENT, true);
-        assertThat(merchantId, is(merchantCode));
-    }
-
-    @Test
-    void shouldGetMerchantCodeForOneOffPayment_whenOnlyLegacyCredentialsSet() {
-        WorldpayCredentials credentials = new WorldpayCredentials();
-        credentials.setLegacyOneOffCustomerInitiatedMerchantCode(merchantCode);
-
-        String merchantId = AuthUtil.getWorldpayMerchantCode(credentials, AuthorisationMode.WEB, false);
         assertThat(merchantId, is(merchantCode));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -35,14 +35,16 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
@@ -61,19 +63,20 @@ class WorldpayCaptureHandlerTest {
     private Response response;
 
     private final Map<String, Object> credentials = Map.of(
-            CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
-            CREDENTIALS_USERNAME, "worldpay-password",
-            CREDENTIALS_PASSWORD, "password"
+            ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                    CREDENTIALS_MERCHANT_CODE, "MERCHANTCODE",
+                    CREDENTIALS_USERNAME, "username",
+                    CREDENTIALS_PASSWORD, "password")
     );
 
     Map<String, Object> recurringCredentials = Map.of(
-            CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
-            CREDENTIALS_USERNAME, "worldpay-password",
-            CREDENTIALS_PASSWORD, "password",
+            RECURRING_CUSTOMER_INITIATED, Map.of( CREDENTIALS_MERCHANT_CODE, "CIT-MERCHANTCODE",
+            CREDENTIALS_USERNAME, "cit-username",
+            CREDENTIALS_PASSWORD, "cit-password"),
             RECURRING_MERCHANT_INITIATED, Map.of(
-                    CREDENTIALS_MERCHANT_CODE, "ECURRING-MERCHANTCODE",
-                    CREDENTIALS_USERNAME, "recurring-worldpay-password",
-                    CREDENTIALS_PASSWORD, "recurring-password"
+                    CREDENTIALS_MERCHANT_CODE, "MIT-MERCHANTCODE",
+                    CREDENTIALS_USERNAME, "mit-password",
+                    CREDENTIALS_PASSWORD, "cit-password"
             )
     );
 
@@ -135,6 +138,7 @@ class WorldpayCaptureHandlerTest {
                         .withPaymentProvider("worldpay")
                         .withCredentials(recurringCredentials)
                         .build())
+                .withAgreementEntity(anAgreementEntity().build())
                 .build();
 
         CaptureResponse gatewayResponse = worldpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -90,9 +90,9 @@ import static uk.gov.pay.connector.gateway.util.XMLUnmarshaller.unmarshall;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORLDPAY_MACHINE_COOKIE_NAME;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
@@ -189,10 +189,11 @@ class WorldpayPaymentProviderTest {
                 .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
                         .withPaymentProvider("worldpay")
                         .withCredentials(Map.of(
-                                CREDENTIALS_MERCHANT_ID, ONE_OFF_MERCHANT_CODE,
-                                CREDENTIALS_USERNAME, ONE_OFF_USERNAME,
-                                CREDENTIALS_PASSWORD, ONE_OFF_PASSWORD
-                        ))
+                                ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                                        CREDENTIALS_MERCHANT_CODE, ONE_OFF_MERCHANT_CODE,
+                                        CREDENTIALS_USERNAME, ONE_OFF_USERNAME,
+                                        CREDENTIALS_PASSWORD, ONE_OFF_PASSWORD)
+                                ))
                         .build())
                 .withGatewayAccountEntity(gatewayAccountEntity);
 
@@ -593,14 +594,6 @@ class WorldpayPaymentProviderTest {
                 .withExternalId("uniqueSessionId")
                 .withTransactionId("MyUniqueTransactionId!")
                 .withProviderSessionId(providerSessionId)
-                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
-                        .withPaymentProvider("worldpay")
-                        .withCredentials(Map.of(
-                                CREDENTIALS_MERCHANT_ID, ONE_OFF_MERCHANT_CODE,
-                                CREDENTIALS_USERNAME, ONE_OFF_USERNAME,
-                                CREDENTIALS_PASSWORD, ONE_OFF_PASSWORD
-                        ))
-                        .build())
                 .build();
 
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyList(), anyMap()))
@@ -805,9 +798,10 @@ class WorldpayPaymentProviderTest {
 
         var creds = aGatewayAccountCredentialsEntity()
                 .withCredentials(Map.of(
-                        CREDENTIALS_MERCHANT_ID, ONE_OFF_MERCHANT_CODE,
-                        CREDENTIALS_USERNAME, ONE_OFF_USERNAME,
-                        CREDENTIALS_PASSWORD, ONE_OFF_PASSWORD,
+                        ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, ONE_OFF_MERCHANT_CODE,
+                                CREDENTIALS_USERNAME, ONE_OFF_USERNAME,
+                                CREDENTIALS_PASSWORD, ONE_OFF_PASSWORD),
                         RECURRING_CUSTOMER_INITIATED, Map.of(
                                 CREDENTIALS_MERCHANT_CODE, CIT_MERCHANT_CODE,
                                 CREDENTIALS_USERNAME, CIT_USERNAME,

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentialsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentialsTest.java
@@ -14,13 +14,6 @@ class WorldpayCredentialsTest {
     }
 
     @Test
-    void shouldReturnHasCredentialsWhenLegacyCredentialsSet() {
-        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
-        worldpayCredentials.setLegacyOneOffCustomerInitiatedMerchantCode("foo");
-        assertThat(worldpayCredentials.hasCredentials(), is(true));
-    }
-
-    @Test
     void shouldReturnHasCredentialsWhenOneOffCustomerInitiatedCredentialsSet() {
         WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
         worldpayCredentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials("merchant-code", "username", "password"));
@@ -47,19 +40,5 @@ class WorldpayCredentialsTest {
         worldpayCredentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials("merchant-code", "username", "password"));
         worldpayCredentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials("merchant-code", "username", "password"));
         assertThat(worldpayCredentials.hasCredentials(), is(true));
-    }
-
-    @Test
-    void shouldReturnOneOffCredentialsPopulatedFromLegacyCredentials() {
-        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
-        worldpayCredentials.setLegacyOneOffCustomerInitiatedMerchantCode("a-merchant-code");
-        worldpayCredentials.setLegacyOneOffCustomerInitiatedUsername("a-username");
-        worldpayCredentials.setLegacyOneOffCustomerInitiatedPassword("a-password");
-        
-        assertThat(worldpayCredentials.getOneOffCustomerInitiatedCredentials().isPresent(), is(true));
-        WorldpayMerchantCodeCredentials oneOffCredentials = worldpayCredentials.getOneOffCustomerInitiatedCredentials().get();
-        assertThat(oneOffCredentials.getMerchantCode(), is("a-merchant-code"));
-        assertThat(oneOffCredentials.getUsername(), is("a-username"));
-        assertThat(oneOffCredentials.getPassword(), is("a-password"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
@@ -159,9 +159,6 @@ class GatewayAccountCredentialsEntityTest {
                 .build();
 
         var worldpayCredentials = (WorldpayCredentials)credentialsEntity.getCredentialsObject();
-        worldpayCredentials.setLegacyOneOffCustomerInitiatedMerchantCode("legacy-merchant-code");
-        worldpayCredentials.setLegacyOneOffCustomerInitiatedUsername("legacy-username");
-        worldpayCredentials.setLegacyOneOffCustomerInitiatedPassword("legacy-password");
         worldpayCredentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials("one-off-merchant-code", "one-off-username", "one-off-password"));
         worldpayCredentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials("cit-merchant-code", "cit-username", "cit-password"));
         worldpayCredentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials("mit-merchant-code", "mit-username", "mit-password"));
@@ -169,10 +166,7 @@ class GatewayAccountCredentialsEntityTest {
         
         credentialsEntity.setCredentials(worldpayCredentials);
 
-        assertThat(credentialsEntity.getCredentials().entrySet(), hasSize(7));
-        assertThat(credentialsEntity.getCredentials(), hasEntry(CREDENTIALS_MERCHANT_ID, "legacy-merchant-code"));
-        assertThat(credentialsEntity.getCredentials(), hasEntry(CREDENTIALS_USERNAME, "legacy-username"));
-        assertThat(credentialsEntity.getCredentials(), hasEntry(CREDENTIALS_PASSWORD, "legacy-password"));
+        assertThat(credentialsEntity.getCredentials().entrySet(), hasSize(4));
         assertThat(credentialsEntity.getCredentials(), hasEntry(FIELD_GATEWAY_MERCHANT_ID, "google-pay-merchant-id"));
         assertThat(credentialsEntity.getCredentials(), hasKey(ONE_OFF_CUSTOMER_INITIATED));
         assertThat(((Map<String, String>) credentialsEntity.getCredentials().get(ONE_OFF_CUSTOMER_INITIATED)).entrySet(), hasSize(3));

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidatorTest.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.app.WorldpayConfig;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
 import uk.gov.service.payments.commons.api.exception.ValidationException;
 
 import java.util.Collections;
@@ -179,7 +180,7 @@ class GatewayAccountCredentialsRequestValidatorTest {
                                 "value", "abcdef123abcdef")
                 ));
         var existingCredentials = new WorldpayCredentials();
-        existingCredentials.setLegacyOneOffCustomerInitiatedMerchantCode("a-merchant-code");
+        existingCredentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials());
         assertDoesNotThrow(() -> validator.validatePatch(request, "worldpay", existingCredentials));
     }
 
@@ -222,7 +223,7 @@ class GatewayAccountCredentialsRequestValidatorTest {
                                 "value", "ABCDEF123abcdef")
                 ));
         var credentials = new WorldpayCredentials();
-        credentials.setLegacyOneOffCustomerInitiatedMerchantCode("a-merchant-code");
+        credentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials());
         var thrown = assertThrows(ValidationException.class, () -> validator.validatePatch(request, "worldpay", credentials));
         assertThat(thrown.getErrors().get(0), is("Field [credentials/gateway_merchant_id] value [ABCDEF123abcdef] does not match that expected for a Worldpay Merchant ID; should be 15 characters and within range [0-9a-f]"));
     }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
@@ -54,7 +54,6 @@ public class GatewayAccountCredentialsResourceIT {
     private DatabaseTestHelper databaseTestHelper;
     private DatabaseFixtures databaseFixtures;
     private Long credentialsId;
-    private String credentialsExternalId;
     private Long accountId;
 
     @Before
@@ -62,14 +61,15 @@ public class GatewayAccountCredentialsResourceIT {
         databaseTestHelper = testContext.getDatabaseTestHelper();
         databaseFixtures = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper);
 
-        testAccount = addGatewayAccountAndCredential("worldpay", ACTIVE, TEST, Map.of(
-                "merchant_id", "a-merchant-id",
-                "username", "a-username",
-                "password", "a-password"));
+        Map<String, Object> credentials = Map.of(
+                "one_off_customer_initiated", Map.of(
+                        "merchant_code", "a-merchant-code",
+                        "username", "a-username",
+                        "password", "a-password"));
+        testAccount = addGatewayAccountAndCredential("worldpay", ACTIVE, TEST, credentials);
         accountId = testAccount.getAccountId();
 
         credentialsId = testAccount.getCredentials().get(0).getId();
-        credentialsExternalId = testAccount.getCredentials().get(0).getExternalId();
     }
 
     @After
@@ -269,7 +269,7 @@ public class GatewayAccountCredentialsResourceIT {
             GatewayAccountCredentialState state,
             GatewayAccountType gatewayAccountType,
             Map<String, Object> credentials) {
-        
+
         long accountId = nextLong(2, 10000);
         LocalDateTime createdDate = LocalDate.parse("2021-01-01").atStartOfDay();
         LocalDateTime activeStartDate = LocalDate.parse("2021-02-01").atStartOfDay();

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpay3dsFlexIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpay3dsFlexIT.java
@@ -36,6 +36,10 @@ import static java.lang.String.format;
 import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
@@ -217,9 +221,10 @@ public class GatewayAccountCredentialsResourceWorldpay3dsFlexIT {
                 .withActiveEndDate(activeEndDate.toInstant(ZoneOffset.UTC))
                 .withState(state)
                 .withCredentials(Map.of(
-                        "merchant_id", "a-merchant-id",
-                        "username", "a-username",
-                        "password", "a-password"))
+                        ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, "a-merchant-code",
+                                CREDENTIALS_USERNAME, "a-username",
+                                CREDENTIALS_PASSWORD, "a-password")))
                 .build();
 
         return databaseFixtures.aTestAccount().withPaymentProvider(paymentProvider)

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpayIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpayIT.java
@@ -77,51 +77,6 @@ public class GatewayAccountCredentialsResourceWorldpayIT {
     }
 
     @Test
-    public void addingOneOffCustomerInitiatedUpdatesOnlyThoseButRemovesLegacyCredentials() {
-        Map<String, Object> existingGatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentialsById(credentialsId);
-
-        @SuppressWarnings("unchecked")
-        Map<String, Object> existingCredentials = new Gson().fromJson(((PGobject) existingGatewayAccountCredentials.get("credentials")).getValue(), Map.class);
-        assertThat(existingCredentials, hasEntry("merchant_id", "a-merchant-id"));
-        assertThat(existingCredentials, hasEntry("username", "a-username"));
-        assertThat(existingCredentials, hasEntry("password", "a-password"));
-
-        givenSetup()
-                .body(toJson(List.of(
-                        Map.of("op", "replace",
-                                "path", "credentials/worldpay/one_off_customer_initiated",
-                                "value", Map.of("merchant_code", "new-merchant-code",
-                                                    "username", "new-username",
-                                                    "password", "new-password")))))
-                .patch(format(PATCH_CREDENTIALS_URL, accountId, credentialsId))
-                .then()
-                .statusCode(200)
-                .body("$", hasKey("credentials"))
-                .body("credentials", hasKey("one_off_customer_initiated"))
-                .body("credentials.one_off_customer_initiated", hasEntry("merchant_code", "new-merchant-code"))
-                .body("credentials.one_off_customer_initiated", hasEntry("username", "new-username"))
-                .body("credentials.one_off_customer_initiated", not(hasKey("password")));
-
-        Map<String, Object> updatedGatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentialsById(credentialsId);
-
-        @SuppressWarnings("unchecked")
-        Map<String, Object> updatedCredentials = new Gson().fromJson(((PGobject) updatedGatewayAccountCredentials.get("credentials")).getValue(), Map.class);
-
-        @SuppressWarnings("unchecked")
-        Map<String, String> updatedOneOffCustomerInitiated = (Map<String, String>) updatedCredentials.get("one_off_customer_initiated");
-        assertThat(updatedOneOffCustomerInitiated, hasEntry("merchant_code", "new-merchant-code"));
-        assertThat(updatedOneOffCustomerInitiated, hasEntry("username", "new-username"));
-        assertThat(updatedOneOffCustomerInitiated, hasEntry("password", "new-password"));
-
-        assertThat(updatedCredentials, not(hasKey("merchant_id")));
-        assertThat(updatedCredentials, not(hasKey("username")));
-        assertThat(updatedCredentials, not(hasKey("password")));
-
-        assertThat(updatedCredentials, not(hasKey("recurring_customer_initiated")));
-        assertThat(updatedCredentials, not(hasKey("recurring_merchant_initiated")));
-    }
-
-    @Test
     public void existingOneOffCredentialsCanBeReplaced() {
         givenSetup()
                 .body(toJson(List.of(

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -65,6 +65,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_STRIPE_ACCOUNT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
@@ -152,9 +153,10 @@ public class ChargingITestBase {
             credentials = Map.of(CREDENTIALS_STRIPE_ACCOUNT_ID, "stripe-account-id");
         } else if (paymentProvider.equals(WORLDPAY.getName())) {
             credentials = Map.of(
-                    CREDENTIALS_MERCHANT_ID, "merchant-id",
-                    CREDENTIALS_USERNAME, "test-user",
-                    CREDENTIALS_PASSWORD, "test-password",
+                    ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                            CREDENTIALS_MERCHANT_CODE, "merchant-id",
+                            CREDENTIALS_USERNAME, "test-user",
+                            CREDENTIALS_PASSWORD, "test-password"),
                     RECURRING_CUSTOMER_INITIATED, Map.of(
                             CREDENTIALS_MERCHANT_CODE, "cit-merchant-id",
                             CREDENTIALS_USERNAME, "cit-user",

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
@@ -46,6 +46,10 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CAR
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildCorporateJsonAuthorisationDetailsFor;
@@ -488,9 +492,10 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
                 .withGatewayAccountId(accountId)
                 .withState(ACTIVE)
                 .withCredentials(Map.of(
-                        "username", "a-username",
-                        "password", "a-password",
-                        "merchant_id", "a-merchant-if"))
+                        ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, "a-merchant-code",
+                                CREDENTIALS_USERNAME, "a-username",
+                                CREDENTIALS_PASSWORD, "a-password")))
                 .build();
         withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
@@ -509,7 +514,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
                 .then()
                 .statusCode(200)
                 .body("status", is(AUTHORISATION_SUCCESS.toString()));
-        
+
         wireMockServer.verify(postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
@@ -33,6 +33,10 @@ import static java.lang.String.format;
 import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.ACCOUNTS_FRONTEND_URL;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.createAGatewayAccountFor;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.extractGatewayAccountId;
@@ -173,9 +177,10 @@ public class ChargesApiResourceAllowWebPaymentsIT {
                 .withActiveEndDate(activeEndDate.toInstant(ZoneOffset.UTC))
                 .withState(GatewayAccountCredentialState.ACTIVE)
                 .withCredentials(Map.of(
-                        "merchant_id", "a-merchant-id",
-                        "username", "a-username",
-                        "password", "a-password"))
+                                ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                                        CREDENTIALS_MERCHANT_CODE, "a-merchant-code",
+                                        CREDENTIALS_USERNAME, "a-username",
+                                        CREDENTIALS_PASSWORD, "a-password")))
                 .build();
 
         return databaseFixtures.aTestAccount().withPaymentProvider(paymentProvider)

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -6,7 +6,6 @@ import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.postgresql.util.PGobject;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
@@ -38,7 +37,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.Assert.assertEquals;
-import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
@@ -123,9 +121,6 @@ public class GatewayAccountFrontendResourceIT extends GatewayAccountResourceTest
     public void shouldAcceptAllCardTypesNotRequiring3DSForNewlyCreatedAccountAs3dsIsDisabledByDefault() {
         String accountId = createAGatewayAccountFor("worldpay");
         String frontendCardTypeUrl = ACCOUNTS_CARD_TYPE_FRONTEND_URL.replace("{accountId}", accountId);
-        GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
-        databaseTestHelper.updateCredentialsFor(Long.parseLong(accountId), gson.toJson(gatewayAccountPayload.getCredentials()));
-        databaseTestHelper.updateServiceNameFor(Long.parseLong(accountId), gatewayAccountPayload.getServiceName());
         ValidatableResponse response = givenSetup().accept(JSON)
                 .get(frontendCardTypeUrl)
                 .then()

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -266,41 +266,6 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     }
 
     @Test
-    public void shouldReturnAccountInformationForGetAccountById_forLegacyCredentials() {
-        long accountId = RandomUtils.nextInt();
-        AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
-                .withPaymentProvider(WORLDPAY.getName())
-                .withGatewayAccountId(accountId)
-                .withState(ACTIVE)
-                .withCredentials(Map.of(
-                        CREDENTIALS_MERCHANT_ID, "legacy-merchant-code",
-                        CREDENTIALS_USERNAME, "legacy-username",
-                        CREDENTIALS_PASSWORD, "legacy-password"))
-                .build();
-
-        this.defaultTestAccount = DatabaseFixtures
-                .withDatabaseTestHelper(databaseTestHelper)
-                .aTestAccount()
-                .withAccountId(accountId)
-                .withGatewayAccountCredentials(List.of(credentialsParams))
-                .insert();
-
-        givenSetup()
-                .get(ACCOUNTS_API_URL + accountId)
-                .then()
-                .statusCode(200)
-                .body("gateway_account_credentials[0].credentials", not(hasKey("merchant_id")))
-                .body("gateway_account_credentials[0].credentials", not(hasKey("username")))
-                .body("gateway_account_credentials[0].credentials", not(hasKey("password")))
-                .body("gateway_account_credentials[0].credentials", hasKey("one_off_customer_initiated"))
-                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", hasEntry("merchant_code", "legacy-merchant-code"))
-                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", hasEntry("username", "legacy-username"))
-                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", not(hasKey("password")))
-                .body("gateway_account_credentials[0].credentials", not(hasKey("recurring_customer_initiated")))
-                .body("gateway_account_credentials[0].credentials", not(hasKey("recurring_merchant_initiated")));
-    }
-
-    @Test
     public void shouldReturnAccountInformationForGetAccountById_withStripeCredentials() {
         long accountId = RandomUtils.nextInt();
         AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
@@ -438,7 +403,6 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
         String gatewayAccountId1 = createAGatewayAccountFor("sandbox");
         String gatewayAccountId2 = createAGatewayAccountFor("sandbox");
         String serviceId = "someexternalserviceid";
-        GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
 
         databaseTestHelper.updateServiceIdFor(Long.parseLong(gatewayAccountId1), serviceId);
         databaseTestHelper.updateServiceIdFor(Long.parseLong(gatewayAccountId2), "notsearchedforserviceid");

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
@@ -200,10 +200,6 @@ public class GatewayAccountResourceTestBase {
             return credentials;
         }
 
-        Map<String, Object> buildCredentialsPayload() {
-            return ImmutableMap.of("credentials", getCredentials());
-        }
-
         Map buildServiceNamePayload() {
             return ImmutableMap.of("service_name", serviceName);
         }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
@@ -48,6 +48,10 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
 import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
@@ -142,9 +146,10 @@ public class WorldpayRefundsResourceIT extends ChargingITestBase {
                 .withGatewayAccountId(accountId)
                 .withState(RETIRED)
                 .withCredentials(Map.of(
-                        "username", "a-username",
-                        "password", "a-password",
-                        "merchant_id", "a-merchant-if"))
+                        ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, "a-merchant-code",
+                                CREDENTIALS_USERNAME, "a-username",
+                                CREDENTIALS_PASSWORD, "a-password")))
                 .build();
         DatabaseFixtures.TestAccount testAccount = withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -55,6 +55,10 @@ import static uk.gov.pay.connector.cardtype.model.domain.CardType.DEBIT;
 import static uk.gov.pay.connector.client.cardid.model.CardInformationFixture.aCardInformation;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.VERIFIED_WITH_LIVE_PAYMENT;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
@@ -598,9 +602,10 @@ public class ContractTest {
     @State("a Worldpay gateway account with id 444 with gateway account credentials with id 555 and valid credentials")
     public void aWorldpayGatewayAccountWithFilledCredentialsWithIdExists() {
         Map<String, Object> credentials = Map.of(
-                "merchant_id", "a-merchant-id",
-                "username", "a-username",
-                "password", "blablabla");
+                ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                        CREDENTIALS_MERCHANT_CODE, "a-merchant-code",
+                        CREDENTIALS_USERNAME, "a-username",
+                        CREDENTIALS_PASSWORD, "blablabla"));
 
         AddGatewayAccountCredentialsParams gatewayAccountCredentialsParams = anAddGatewayAccountCredentialsParams()
                 .withId(555)

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -25,6 +25,7 @@ import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGa
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class AddGatewayAccountParams {
+
     private String accountId;
     private String externalId;
     private List<AddGatewayAccountCredentialsParams> credentials;


### PR DESCRIPTION
We have now copied the legacy credentials into a nested `one_off_customer_initiated` object in the credentials jsonb stored in the database. We also now only set new or updated credentials in this nested object.

We can now remove code that falls back to reading the legacy credentials set at the root of the jsonb.