### PR TITLE
BAU: Pin to elasticmq v1.4.2

### DIFF
--- a/src/test/java/uk/gov/pay/connector/junit/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/connector/junit/SqsTestDocker.java
@@ -32,7 +32,7 @@ final class SqsTestDocker {
 
     private static void createContainer() {
         if (sqsContainer == null) {
-            sqsContainer = new GenericContainer("softwaremill/elasticmq-native")
+            sqsContainer = new GenericContainer("softwaremill/elasticmq-native:1.4.2")
                     .withExposedPorts(9324)
                     .waitingFor(Wait.forLogMessage(".*ElasticMQ server.*.*started.*", 1));
             sqsContainer.start();


### PR DESCRIPTION
## WHAT YOU DID
v1.4.3 (released today) has been failing to start during the integration tests. See equivalent PR for webhooks: https://github.com/alphagov/pay-webhooks/pull/928


