### PR TITLE
PP-11319 Return allow_google_pay flag correctly for Stripe

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -39,7 +39,6 @@ import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static java.util.Comparator.comparing;
 import static net.logstash.logback.argument.StructuredArguments.kv;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
@@ -245,7 +244,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
                 .flatMap(GatewayCredentials::getGooglePayMerchantId)
                 .orElse(null);
     }
-    
+
     public List<GatewayAccountCredentialsEntity> getGatewayAccountCredentials() {
         return gatewayAccountCredentials;
     }
@@ -299,7 +298,11 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     }
     
     public boolean isAllowGooglePay() {
-        return allowGooglePay && isNotBlank(getGooglePayMerchantId());
+        Boolean hasCredentialsConfiguredForGooglePay = getCurrentOrActiveGatewayAccountCredential()
+                .map(GatewayAccountCredentialsEntity::getCredentialsObject)
+                .map(GatewayCredentials::isConfiguredForGooglePayPayments)
+                .orElse(false);
+        return allowGooglePay && hasCredentialsConfiguredForGooglePay;
     }
     
     public boolean isAllowApplePay() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayCredentials.java
@@ -14,6 +14,11 @@ public interface GatewayCredentials {
         return Optional.empty();
     }
 
+    @JsonIgnore
+    default boolean isConfiguredForGooglePayPayments() {
+        return true;
+    }
+    
     boolean hasCredentials();
 
     public class Views {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -83,6 +83,12 @@ public class WorldpayCredentials implements GatewayCredentials {
         return Optional.ofNullable(googlePayMerchantId);
     }
 
+    @Override
+    @JsonIgnore
+    public boolean isConfiguredForGooglePayPayments() {
+        return googlePayMerchantId != null;
+    }
+
     @JsonProperty(GatewayAccountCredentialsRequestValidator.FIELD_GATEWAY_MERCHANT_ID)
     @JsonView({Views.Api.class})
     private String getGooglePayMerchantIdForSerialization() {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
@@ -127,7 +127,7 @@ class GatewayAccountEntityTest {
     }
 
     @Test
-    void isAllowGooglePayShouldReturnFalseIfFlagIsEnabledAndMerchantAccountIdIsNotAvailableOnCredentials() {
+    void isAllowGooglePayShouldReturnFalseForWorldpayAccountIfFlagIsEnabledAndMerchantAccountIdIsNotAvailableOnCredentials() {
         GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
                 .withPaymentProvider("worldpay")
                 .build();
@@ -138,7 +138,7 @@ class GatewayAccountEntityTest {
     }
 
     @Test
-    void isAllowGooglePayShouldReturnTrueIfFlagIsEnabledAndMerchantAccountIdIsAvailableOnCredentials() {
+    void isAllowGooglePayShouldReturnTrueForWorldpayAccountIfFlagIsEnabledAndMerchantAccountIdIsAvailableOnCredentials() {
         GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
                 .withPaymentProvider("worldpay")
                 .withCredentials(Map.of("gateway_merchant_id", "some-id"))
@@ -150,7 +150,7 @@ class GatewayAccountEntityTest {
     }
 
     @Test
-    void isAllowGooglePayShouldReturnFalseIfFlagIsDisabledAndMerchantAccountIdIsAvailableOnCredentials() {
+    void isAllowGooglePayShouldReturnFalseForWorldpayAccountIfFlagIsDisabledAndMerchantAccountIdIsAvailableOnCredentials() {
         GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
                 .withPaymentProvider("worldpay")
                 .withCredentials(Map.of("gateway_merchant_id", "some-id"))
@@ -159,6 +159,17 @@ class GatewayAccountEntityTest {
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay));
 
         assertThat(gatewayAccountEntity.isAllowGooglePay(), is(false));
+    }
+
+    @Test
+    void isAllowGooglePayShouldReturnTrueForStripeAccountIfFlagIsEnabled() {
+        GatewayAccountCredentialsEntity credentialsEntityStripe = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider("stripe")
+                .build();
+        gatewayAccountEntity.setAllowGooglePay(true);
+        gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityStripe));
+        
+        assertThat(gatewayAccountEntity.isAllowGooglePay(), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentialsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentialsTest.java
@@ -41,4 +41,17 @@ class WorldpayCredentialsTest {
         worldpayCredentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials("merchant-code", "username", "password"));
         assertThat(worldpayCredentials.hasCredentials(), is(true));
     }
+
+    @Test
+    void isConfiguredForGooglePayPaymentsShouldReturnTrueIfGatewayMerchantIdSet() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
+        worldpayCredentials.setGooglePayMerchantId("a-google-pay-merchant-id");
+        assertThat(worldpayCredentials.isConfiguredForGooglePayPayments(), is(true));
+    }
+
+    @Test
+    void isConfiguredForGooglePayPaymentsShouldReturnFalseIfGatewayMerchantIdNotSet() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
+        assertThat(worldpayCredentials.isConfiguredForGooglePayPayments(), is(false));
+    }
 }


### PR DESCRIPTION
For Worldpay accounts, we require a `gateway_merchant_id` to be set on the credentials for Google Pay to be enabled, and so only return `"allow_google_pay"=true`in API responses for a gateway account if the `allow_google_pay` flag is set to true AND the `gateway_merchant_id` is set.

Stripe does not require the credentials to be configured in a particular way, so only look at the `allow_google_pay` flag on the gateway account when returning this flag in API responses.