### PR TITLE
PP-11364 deserialise additional applay pay fields

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -211,16 +211,23 @@
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
+        "is_verified": false,
+        "line_number": 4270
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4289
+        "line_number": 4298
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4300
+        "line_number": 4309
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -373,6 +380,15 @@
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
         "line_number": 26
+      }
+    ],
+    "src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java",
+        "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
+        "is_verified": false,
+        "line_number": 39
       }
     ],
     "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java": [
@@ -1085,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-18T10:31:46Z"
+  "generated_at": "2023-08-23T13:24:11Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -4248,6 +4248,9 @@ components:
           type: string
           example: Joe B
           maxLength: 255
+        display_name:
+          type: string
+          example: MasterCard 1234
         email:
           type: string
           example: mr@payment.test
@@ -4259,6 +4262,12 @@ components:
           type: string
           description: last digits card number
           example: "4242"
+        network:
+          type: string
+          example: MasterCard
+        transaction_identifier:
+          type: string
+          example: 372C3858122B6BC39C6095ECA2F994A8AA012F3B025D0D72ECFD449C2A5877F9
         user_agent_header:
           type: string
           example: Mozilla/5.0

--- a/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
@@ -32,6 +32,12 @@ public class WalletPaymentInfo {
     private String userAgentHeader;
     @Schema(example = "203.0.113.1")
     private String ipAddress;
+    @Schema(example = "MasterCard 1234")
+    private String displayName;
+    @Schema(example = "MasterCard")
+    private String network;
+    @Schema(example = "372C3858122B6BC39C6095ECA2F994A8AA012F3B025D0D72ECFD449C2A5877F9")
+    private String transactionIdentifier;
 
     @Schema(example = "1f1154b7-620d-4654-801b-893b5bb22db1", description = "SessionId returned by Worldpay/CardinalCommerce as part of device data collection. Applicable for Google Pay payments only")
     @JsonProperty("worldpay_3ds_flex_ddc_result")
@@ -92,6 +98,18 @@ public class WalletPaymentInfo {
 
     public String getIpAddress() {
         return ipAddress;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getNetwork() {
+        return network;
+    }
+
+    public String getTransactionIdentifier() {
+        return transactionIdentifier;
     }
 
     public Optional<String> getWorldpay3dsFlexDdcResult() {


### PR DESCRIPTION
## WHAT YOU DID

Stripe requires us to send some additional data from PKPaymentToken when we create a token for Apple Pay.

- deserialise additional fields coming from frontend
