### PR TITLE
PP-11365 Use `payment_data` string when decrypting Apple Pay data

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,16 +118,14 @@
         "filename": "dev.yml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
         "is_verified": false,
-        "line_number": 9,
-        "is_secret": false
+        "line_number": 9
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "dev.yml",
         "hashed_secret": "ab85666a760f1a3fa02b3ac84953be727ce3dbfa",
         "is_verified": false,
-        "line_number": 10,
-        "is_secret": false
+        "line_number": 10
       },
       {
         "type": "Secret Keyword",
@@ -153,81 +151,88 @@
         "line_number": 790
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "openapi/connector_spec.yaml",
+        "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
+        "is_verified": false,
+        "line_number": 2258
+      },
+      {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 2737
+        "line_number": 2749
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 2801
+        "line_number": 2813
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3133
+        "line_number": 3145
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3169
+        "line_number": 3181
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3196
+        "line_number": 3208
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 3833
+        "line_number": 3845
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 3836
+        "line_number": 3848
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 3839
+        "line_number": 3851
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 4270
+        "line_number": 4282
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4298
+        "line_number": 4310
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4309
+        "line_number": 4321
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -354,23 +359,30 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java",
+        "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 91
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 93
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 83
+        "line_number": 95
       }
     ],
     "src/main/java/uk/gov/pay/connector/wallets/googlepay/api/EncryptedPaymentData.java": [
@@ -676,6 +688,13 @@
         "line_number": 148
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java",
+        "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
+        "is_verified": false,
+        "line_number": 149
+      },
+      {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java",
         "hashed_secret": "c272ed583c5dfbb2013e22812d200068997d5969",
@@ -808,6 +827,29 @@
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
         "line_number": 123
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayAuthRequestBuilder.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayAuthRequestBuilder.java",
+        "hashed_secret": "74ded3befed819a33b94730b9ddea58e1fc43248",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayAuthRequestBuilder.java",
+        "hashed_secret": "9c98d4fa9b3055dede39101f223aa53c2b830d95",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayAuthRequestBuilder.java",
+        "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
+        "is_verified": false,
+        "line_number": 14
       }
     ],
     "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayDecrypterTest.java": [
@@ -1101,5 +1143,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-23T13:24:11Z"
+  "generated_at": "2023-08-29T15:34:35Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -2250,6 +2250,18 @@ components:
       properties:
         encrypted_payment_data:
           $ref: '#/components/schemas/ApplePayEncryptedPaymentData'
+        payment_data:
+          type: string
+          description: "paymentData of Apple Pay payment token as String. This is\
+            \ de-serialised and decrypted for WorldPay payments. For Stripe payments,\
+            \ the value is passed as is when creating a token"
+          example: "{\"version\":\"EC_v1\",\"data\":\"MLHhOn2BXhNw9wLLDR48DyeUcuSmRJ6KnAIGTMGqsgiMpc+AoJ…\
+            LUQ6UovkfSnW0sFH6NGZ0jhoap6LYnThYb9WT6yKfEm/rDhM=\",\"signature\":\"MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFAD…\
+            ZuQFfsLJ+Nb3+7bpjfBsZAhA1sIT1XmHoGFdoCUT3AAAAAAAA\",\"header\":{\"ephemeralPublicKey\"\
+            :\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5/Qc6z4TY5HQ5n…KC3kJ4DtIWedPQ70N35PBZzJUrFjtvDZFUvs80uo2ynu+lw==\"\
+            ,\"publicKeyHash\":\"Xzn7W3vsrlKlb0QvUAviASubdtW4BotWrDo5mGG+UWY=\",\"\
+            transactionId\":\"372c3858122b6bc39c6095eca2f994a8aa012f3b025d0d72ecfd449c2a5877f9\"\
+            }}"
         payment_info:
           $ref: '#/components/schemas/WalletPaymentInfo'
       required:

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response;
 import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
 import static uk.gov.pay.connector.util.ResponseUtil.gatewayErrorResponse;
 
-
 public abstract class WalletService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WalletService.class);

--- a/src/main/java/uk/gov/pay/connector/wallets/applepay/ApplePayPaymentData.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/applepay/ApplePayPaymentData.java
@@ -1,0 +1,77 @@
+package uk.gov.pay.connector.wallets.applepay;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApplePayPaymentData {
+
+    @JsonProperty("data")
+    private String data;
+
+    @JsonProperty("version")
+    private String version;
+    @JsonProperty("header")
+    private Header header;
+    @JsonProperty("signature")
+    private String signature;
+
+    public ApplePayPaymentData() {
+
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Header getHeader() {
+        return header;
+    }
+
+    public String getSignature() {
+        return signature;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Header {
+        @JsonProperty("publicKeyHash")
+        private String publicKeyHash;
+        @JsonProperty("ephemeralPublicKey")
+        private String ephemeralPublicKey;
+        @JsonProperty("transactionId")
+        private String transactionId;
+        @JsonProperty("applicationData")
+        private String applicationData;
+        @JsonProperty("wrappedKey")
+        private String wrappedKey;
+
+        public Header() {
+
+        }
+
+        public String getPublicKeyHash() {
+            return publicKeyHash;
+        }
+
+        public String getEphemeralPublicKey() {
+            return ephemeralPublicKey;
+        }
+
+        public String getTransactionId() {
+            return transactionId;
+        }
+
+        public String getApplicationData() {
+            return applicationData;
+        }
+
+        public String getWrappedKey() {
+            return wrappedKey;
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/wallets/applepay/InvalidApplePayPaymentDataException.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/applepay/InvalidApplePayPaymentDataException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.wallets.applepay;
+
+import javax.ws.rs.BadRequestException;
+
+public class InvalidApplePayPaymentDataException extends BadRequestException {
+    public InvalidApplePayPaymentDataException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java
@@ -14,9 +14,16 @@ import javax.validation.constraints.NotNull;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ApplePayAuthRequest implements WalletAuthorisationRequest {
-    @NotNull @Valid private WalletPaymentInfo paymentInfo;
+    @NotNull
+    @Valid
+    private WalletPaymentInfo paymentInfo;
     @Schema(name = "encrypted_payment_data")
     private ApplePayEncryptedPaymentData encryptedPaymentData;
+
+    @Schema(description = "paymentData of Apple Pay payment token as String. " +
+            "This is de-serialised and decrypted for WorldPay payments. For Stripe payments, the value is passed as is when creating a token",
+            example = "{\"version\":\"EC_v1\",\"data\":\"MLHhOn2BXhNw9wLLDR48DyeUcuSmRJ6KnAIGTMGqsgiMpc+AoJ…LUQ6UovkfSnW0sFH6NGZ0jhoap6LYnThYb9WT6yKfEm/rDhM=\",\"signature\":\"MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFAD…ZuQFfsLJ+Nb3+7bpjfBsZAhA1sIT1XmHoGFdoCUT3AAAAAAAA\",\"header\":{\"ephemeralPublicKey\":\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5/Qc6z4TY5HQ5n…KC3kJ4DtIWedPQ70N35PBZzJUrFjtvDZFUvs80uo2ynu+lw==\",\"publicKeyHash\":\"Xzn7W3vsrlKlb0QvUAviASubdtW4BotWrDo5mGG+UWY=\",\"transactionId\":\"372c3858122b6bc39c6095eca2f994a8aa012f3b025d0d72ecfd449c2a5877f9\"}}")
+    private String paymentData;
 
     @JsonProperty("payment_info")
     public WalletPaymentInfo getPaymentInfo() {
@@ -27,11 +34,16 @@ public class ApplePayAuthRequest implements WalletAuthorisationRequest {
         return encryptedPaymentData;
     }
 
+    public String getPaymentData() {
+        return paymentData;
+    }
+
     public ApplePayAuthRequest() {
     }
 
-    public ApplePayAuthRequest(WalletPaymentInfo paymentInfo, ApplePayEncryptedPaymentData encryptedPaymentData) {
+    public ApplePayAuthRequest(WalletPaymentInfo paymentInfo, String paymentData, ApplePayEncryptedPaymentData encryptedPaymentData) {
         this.paymentInfo = paymentInfo;
+        this.paymentData = paymentData;
         this.encryptedPaymentData = encryptedPaymentData;
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
@@ -144,11 +144,11 @@ public class JsonRequestHelper {
     
     public static String buildJsonApplePayAuthorisationDetails(String cardHolderName, String email) {
         JsonObject header = new JsonObject();
-        header.addProperty("public_key_hash", "LbsUwAT6w1JV9tFXocU813TCHks+LSuFF0R/eBkrWnQ=");
-        header.addProperty("ephemeral_public_key", "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMwliotf2ICjiMwREdqyHSilqZzuV2fZey86nBIDlTY8sNMJv9CPpL5/DKg4bIEMe6qaj67mz4LWdr7Er0Ld5qA==");
-        header.addProperty("transaction_id", "2686f5297f123ec7fd9d31074d43d201953ca75f098890375f13aed2737d92f2");
-        header.addProperty("application_data", "some");
-        header.addProperty("wrapped_key", "some");
+        header.addProperty("publicKeyHash", "LbsUwAT6w1JV9tFXocU813TCHks+LSuFF0R/eBkrWnQ=");
+        header.addProperty("ephemeralPublicKey", "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMwliotf2ICjiMwREdqyHSilqZzuV2fZey86nBIDlTY8sNMJv9CPpL5/DKg4bIEMe6qaj67mz4LWdr7Er0Ld5qA==");
+        header.addProperty("transactionId", "2686f5297f123ec7fd9d31074d43d201953ca75f098890375f13aed2737d92f2");
+        header.addProperty("applicationData", "some");
+        header.addProperty("wrappedKey", "some");
 
         JsonObject encryptedPaymentData = new JsonObject();
         encryptedPaymentData.addProperty("version", "EC_v1");
@@ -165,7 +165,7 @@ public class JsonRequestHelper {
 
         JsonObject payload = new JsonObject();
         payload.add("payment_info", paymentInfo);
-        payload.add("encrypted_payment_data", encryptedPaymentData);
+        payload.addProperty("payment_data", encryptedPaymentData.toString());
         return toJson(payload);
     }
 

--- a/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayAuthRequestBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayAuthRequestBuilder.java
@@ -9,21 +9,28 @@ import java.io.IOException;
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 
 public class ApplePayAuthRequestBuilder {
-    private String data;
-    private String ephemeralPublicKey;
+    private String paymentData = "{\"data\":\"{{data}}\",\"version\":\"EC_v1\",\"header\":{\"publicKeyHash\":\"LbsUwAT6w1JV9tFXocU813TCHks+LSuFF0R/eBkrWnQ=\",\"ephemeralPublicKey\":\"{{ephemeralPublicKey}}\",\"transactionId\":\"2686f5297f123ec7fd9d31074d43d201953ca75f098890375f13aed2737d92f2\",\"application_data\":null,\"wrappedKey\":null},\"signature\":\"signature\"}";
+    private String data = "4OZho15e9Yp5K0EtKergKzeRpPAjnKHwmSNnagxhjwhKQ5d29sfTXjdbh1CtTJ4DYjsD6kfulNUnYmBTsruphBz7RRVI1WI8P0LrmfTnImjcq1mi+BRN7EtR2y6MkDmAr78anff91hlc+x8eWD/NpO/oZ1ey5qV5RBy/Jp5zh6ndVUVq8MHHhvQv4pLy5Tfi57Yo4RUhAsyXyTh4x/p1360BZmoWomK15NcJfUmoUCuwEYoi7xUkRwNr1z4MKnzMfneSRpUgdc0wADMeB6u1jcuwqQnnh2cusiagOTCfD6jO6tmouvu6KO54uU7bAbKz6cocIOEAOc6keyFXG5dfw8i3hJg6G2vIefHCwcKu1zFCHr4P7jLnYFDEhvxLm1KskDcuZeQHAkBMmLRSgj9NIcpBa94VN/JTga8W75IWAA==";
+    private String ephemeralPublicKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMwliotf2ICjiMwREdqyHSilqZzuV2fZey86nBIDlTY8sNMJv9CPpL5/DKg4bIEMe6qaj67mz4LWdr7Er0Ld5qA==";
     private ApplePayAuthRequest.ApplePayEncryptedPaymentData validEncryptedPaymentData;
-    
+
     private ApplePayAuthRequestBuilder() throws IOException {
         this.validEncryptedPaymentData = new ObjectMapper().readValue(fixture("applepay/token.json"), ApplePayAuthRequest.ApplePayEncryptedPaymentData.class);
         this.data = validEncryptedPaymentData.getData();
         this.ephemeralPublicKey = validEncryptedPaymentData.getHeader().getEphemeralPublicKey();
     }
-    
+
     public static ApplePayAuthRequestBuilder anApplePayToken() throws IOException {
         return new ApplePayAuthRequestBuilder();
     }
+
     public ApplePayAuthRequestBuilder withData(String data) {
         this.data = data;
+        return this;
+    }
+
+    public ApplePayAuthRequestBuilder withPaymentData(String paymentData) {
+        this.paymentData = paymentData;
         return this;
     }
 
@@ -32,9 +39,16 @@ public class ApplePayAuthRequestBuilder {
         return this;
     }
 
+    public String getPaymentData() {
+        return paymentData
+                .replace("{{data}}", data)
+                .replace("{{ephemeralPublicKey}}", ephemeralPublicKey);
+    }
+
     public ApplePayAuthRequest build() {
         return new ApplePayAuthRequest(
                 new WalletPaymentInfo(),
+                getPaymentData(),
                 new ApplePayAuthRequest.ApplePayEncryptedPaymentData(
                         validEncryptedPaymentData.getVersion(),
                         this.data,

--- a/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayDecrypterTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayDecrypterTest.java
@@ -62,8 +62,10 @@ class ApplePayDecrypterTest {
     private static final byte[] ALG_IDENTIFIER_BYTES = "id-aes256-GCM".getBytes(UTF_8);
     private static final String MERCHANT_ID_CERTIFICATE_OID = "1.2.840.113635.100.6.32";
 
-    @Mock private WorldpayConfig mockWorldpayConfig;
-    @Mock private ApplePayConfig mockApplePayConfig;
+    @Mock
+    private WorldpayConfig mockWorldpayConfig;
+    @Mock
+    private ApplePayConfig mockApplePayConfig;
     private ObjectMapper objectMapper = new ObjectMapper();
     private ApplePayAuthRequest applePayAuthRequest;
     private ApplePayDecrypter applePayDecrypter;
@@ -89,15 +91,15 @@ class ApplePayDecrypterTest {
         when(mockApplePayConfig.getPrimaryPublicCertificate()).thenReturn(invalidPrimaryCert);
         var applePayDecrypterWithInvalidPrimaryAndMissingSecondaryKeyCerts = new ApplePayDecrypter(mockWorldpayConfig, objectMapper);
 
-        assertThrows(InvalidKeyException.class, () -> 
+        assertThrows(InvalidKeyException.class, () ->
                 applePayDecrypterWithInvalidPrimaryAndMissingSecondaryKeyCerts.performDecryptOperation(applePayAuthRequest));
     }
-    
+
     @Test
     void should_decrypt_data_with_secondary_keys_when_primary_private_key_and_public_certificate_are_invalid() {
         String invalidPrimaryKey = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgjyo3fzxT7j+CFxC7I4B5iVee2FUyn2vfOSjcgp2/g6qhRANCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvy"; //pragma: allowlist secret
         String invalidPrimaryCert = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVlVENDQkNDZ0F3SUJBZ0lJVWtJS3NpWXhhS293Q2dZSUtvWkl6ajBFQXdJd2dZRXhPekE1QmdOVkJBTU1NbFJsYzNRZ1FYQndiR1VnVjI5eWJHUjNhV1JsSUVSbGRtVnNiM0JsY25NZ1VtVnNZWFJwYjI1eklFTkJJQzBnUlVORE1TQXdIZ1lEVlFRTERCZERaWEowYVdacFkyRjBhVzl1SUVGMWRHaHZjbWwwZVRFVE1CRUdBMVVFQ2d3S1FYQndiR1VnU1c1akxqRUxNQWtHQTFVRUJoTUNWVk13SGhjTk1UWXdOekkxTVRVeU1ETTRXaGNOTVRnd09ESTBNVFV5TURNNFdqQ0JsekVyTUNrR0NnbVNKb21UOGl4a0FRRU1HMjFsY21Ob1lXNTBMbkpsWkhSbFlXMHVkMkZ5YzJGM0xteGliekV4TUM4R0ExVUVBd3dvVFdWeVkyaGhiblFnU1VRNklHMWxjbU5vWVc1MExuSmxaSFJsWVcwdWQyRnljMkYzTG14aWJ6RVRNQkVHQTFVRUN3d0tUVmxVVlRoWk5VUlJUVEVUTUJFR0ExVUVDZ3dLUVhCd2JHVWdTVzVqTGpFTE1Ba0dBMVVFQmhNQ1ZWTXdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBUmRvQkZFdG51YXBYRkt3NERZV3NXMHlWNGJhdnBkV0tzemtlZmkxOUFobElSRTNXU05XU24yNVc1dFpORmpNV3RMSVNCbXFBTnl1ZngyeFAxOW9SdnlvNElDYURDQ0FtUXdUd1lJS3dZQkJRVUhBUUVFUXpCQk1EOEdDQ3NHQVFVRkJ6QUJoak5vZEhSd09pOHZiMk56Y0MxMVlYUXVZMjl5Y0M1aGNIQnNaUzVqYjIwdmIyTnpjREEwTFhSbGMzUjNkMlJ5WTJGbFkyTXdIUVlEVlIwT0JCWUVGQVY3blM0bU5ETHkxZ3h2T0FjQ1MxaE9nWTRsTUF3R0ExVWRFd0VCL3dRQ01BQXdId1lEVlIwakJCZ3dGb0FVMXRiVld1WC8vY0o4Tk1ORDNyMW9kbHcycWI0d2dnRWRCZ05WSFNBRWdnRVVNSUlCRURDQ0FRd0dDU3FHU0liM1kyUUZBVENCL2pDQnd3WUlLd1lCQlFVSEFnSXdnYllNZ2JOU1pXeHBZVzVqWlNCdmJpQjBhR2x6SUdObGNuUnBabWxqWVhSbElHSjVJR0Z1ZVNCd1lYSjBlU0JoYzNOMWJXVnpJR0ZqWTJWd2RHRnVZMlVnYjJZZ2RHaGxJSFJvWlc0Z1lYQndiR2xqWVdKc1pTQnpkR0Z1WkdGeVpDQjBaWEp0Y3lCaGJtUWdZMjl1WkdsMGFXOXVjeUJ2WmlCMWMyVXNJR05sY25ScFptbGpZWFJsSUhCdmJHbGplU0JoYm1RZ1kyVnlkR2xtYVdOaGRHbHZiaUJ3Y21GamRHbGpaU0J6ZEdGMFpXMWxiblJ6TGpBMkJnZ3JCZ0VGQlFjQ0FSWXFhSFIwY0RvdkwzZDNkeTVoY0hCc1pTNWpiMjB2WTJWeWRHbG1hV05oZEdWaGRYUm9iM0pwZEhrdk1FRUdBMVVkSHdRNk1EZ3dOcUEwb0RLR01HaDBkSEE2THk5amNtd3RkV0YwTG1OdmNuQXVZWEJ3YkdVdVkyOXRMMkZ3Y0d4bGQzZGtjbU5oWldOakxtTnliREFPQmdOVkhROEJBZjhFQkFNQ0F5Z3dUd1lKS29aSWh2ZGpaQVlnQkVJTVFEVTRNREpFTVVNM056UkdNRGsyTWtZNE1URXlORGhGTlRNNFJFVXpRa1ZHTmpnd1F6YzVPRFpDUWpWQ05FUkRSVEJDTlRZeU5EbEdNemREUWtJNU5ETXdDZ1lJS29aSXpqMEVBd0lEUndBd1JBSWdUanRpWWprL0JLcDNWOERnNm1JbGNtNUZDT0YwNnp1YjdKc3I2d0NzdktBQ0lIOFUxMTRESTVIbm1mY052d000UlhGRFBUb29wNCtqak1BUHZpZGlwS2tnCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0="; //pragma: allowlist secret
-        
+
         when(mockWorldpayConfig.getApplePayConfig()).thenReturn(mockApplePayConfig);
         when(mockApplePayConfig.getPrimaryPrivateKey()).thenReturn(invalidPrimaryKey);
         when(mockApplePayConfig.getPrimaryPublicCertificate()).thenReturn(invalidPrimaryCert);
@@ -115,7 +117,7 @@ class ApplePayDecrypterTest {
                 .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
                 .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
 
-        AppleDecryptedPaymentData paymentDataToEncrypt =  anApplePayDecryptedPaymentData().withAmount(9999L).build();
+        AppleDecryptedPaymentData paymentDataToEncrypt = anApplePayDecryptedPaymentData().withAmount(9999L).build();
         String paymentDataToEncryptAsJson = objectMapper.writeValueAsString(paymentDataToEncrypt);
 
         KeyPair ephemeralKeyPair = createEphemeralKeyPair();
@@ -129,7 +131,7 @@ class ApplePayDecrypterTest {
         AppleDecryptedPaymentData result = applePayDecrypter.performDecryptOperation(authRequest);
         assertThat(result.getTransactionAmount(), is(9999L));
     }
-    
+
     @Test
     void shouldDecrypt_withSecondaryKeys_aPayloadEncryptedWithOurSecondaryPublicKey() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper()
@@ -137,7 +139,7 @@ class ApplePayDecrypterTest {
                 .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
                 .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
 
-        AppleDecryptedPaymentData paymentDataToEncrypt =  anApplePayDecryptedPaymentData().withAmount(88888L).build();
+        AppleDecryptedPaymentData paymentDataToEncrypt = anApplePayDecryptedPaymentData().withAmount(88888L).build();
         String paymentDataToEncryptAsJson = objectMapper.writeValueAsString(paymentDataToEncrypt);
 
         KeyPair ephemeralKeyPair = createEphemeralKeyPair();
@@ -187,6 +189,15 @@ class ApplePayDecrypterTest {
     }
 
     @Test
+    void shouldThrowException_whenPaymentDataIsInvalidJSONString() {
+        var exception = assertThrows(InvalidApplePayPaymentDataException.class, () -> {
+            ApplePayAuthRequest applePayAuthRequest = anApplePayToken().withPaymentData("nope").build();
+            applePayDecrypter = new ApplePayDecrypter(mockWorldpayConfig, objectMapper);
+            applePayDecrypter.performDecryptOperation(applePayAuthRequest);
+        });
+    }
+
+    @Test
     void shouldThrowException_whenEphemeralKeyIsInvalid() {
         assertThrows(InvalidKeyException.class, () -> {
             ApplePayAuthRequest applePayAuthRequest = anApplePayToken().withEphemeralPublicKey("nope").build();
@@ -194,7 +205,6 @@ class ApplePayDecrypterTest {
             applePayDecrypter.performDecryptOperation(applePayAuthRequest);
         });
     }
-
     @Test
     void shouldThrowException_whenDataIsInvalid() {
         assertThrows(InvalidKeyException.class, () -> {


### PR DESCRIPTION
## WHAT YOU DID
- Currently, connector uses `encrypted_payment_data` values when decrypting Apple Pay data. Frontend is sending both JSON (in `encrypted_payment_data`) and JSON as a string (`payment_data`). See https://github.com/alphagov/pay-frontend/pull/3635.
- We are going to use `payment_data` (String) to avoid any issues when deserialising encrypted_payment_data and then serialising data to send to Stripe.
-  `encrypted_payment_data` field is to be removed in a separate PR.
