### PR TITLE
PP-11394 Add google/worldpay endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -157,77 +157,77 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 2737
+        "line_number": 2786
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 2801
+        "line_number": 2850
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3133
+        "line_number": 3182
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3169
+        "line_number": 3218
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3196
+        "line_number": 3245
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 3833
+        "line_number": 3882
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 3836
+        "line_number": 3885
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 3839
+        "line_number": 3888
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 4270
+        "line_number": 4319
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4298
+        "line_number": 4347
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4309
+        "line_number": 4358
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-23T13:24:11Z"
+  "generated_at": "2023-08-30T07:11:48Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1822,6 +1822,55 @@ paths:
       summary: Authorise GooglePay payment
       tags:
       - Charge operations
+  /v1/frontend/charges/{chargeId}/wallets/google/worldpay:
+    post:
+      operationId: authoriseChargeGooglePayWorldpay
+      parameters:
+      - description: Charge external ID
+        example: b02b63b370fd35418ad66b0101
+        in: path
+        name: chargeId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GooglePayAuthRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+        "202":
+          description: Accepted - payment has been submitted for authorisation and
+            awaiting response from Worldpay
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request - invalid payload or the payment has been declined
+        "402":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Gateway error
+        "404":
+          description: Not found
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unprocessable Entity - Invalid payload or missing mandatory
+            attributes
+        "500":
+          description: Internal server error
+      summary: Authorise GooglePay payment for Worldpay
+      tags:
+      - Charge operations
   /v1/frontend/charges/{chargeId}/worldpay/3ds-flex/ddc:
     get:
       operationId: getWorldpay3dsFlexDdcJwt

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -111,6 +111,7 @@ public class CardResource {
         return applePayService.authorise(chargeId, applePayAuthRequest);
     }
 
+    //PP-11394 This endpoint will be removed when frontend has been pointed to the new Worldpay-specific endpoint for Google Pay
     @POST
     @Path("/v1/frontend/charges/{chargeId}/wallets/google")
     @Consumes(APPLICATION_JSON)
@@ -131,6 +132,33 @@ public class CardResource {
             }
     )
     public Response authoriseCharge(@Parameter(example = "b02b63b370fd35418ad66b0101", description = "Charge external ID")
+                                    @PathParam("chargeId") String chargeId,
+                                    @NotNull @Valid GooglePayAuthRequest googlePayAuthRequest) {
+        logger.info("Received encrypted payload for charge with id {} ", chargeId);
+        logger.info("Received wallet payment info \n{} \nfor charge with id {}", googlePayAuthRequest.getPaymentInfo().toString(), chargeId);
+        return googlePayService.authorise(chargeId, googlePayAuthRequest);
+    }
+
+    @POST
+    @Path("/v1/frontend/charges/{chargeId}/wallets/google/worldpay")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @Operation(
+            summary = "Authorise GooglePay payment for Worldpay",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "202", description = "Accepted - payment has been submitted for authorisation and awaiting response from Worldpay"),
+                    @ApiResponse(responseCode = "400", description = "Bad request - invalid payload or the payment has been declined",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "402", description = "Gateway error",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "422", description = "Unprocessable Entity - Invalid payload or missing mandatory attributes",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error"),
+            }
+    )
+    public Response authoriseChargeGooglePayWorldpay(@Parameter(example = "b02b63b370fd35418ad66b0101", description = "Charge external ID")
                                     @PathParam("chargeId") String chargeId,
                                     @NotNull @Valid GooglePayAuthRequest googlePayAuthRequest) {
         logger.info("Received encrypted payload for charge with id {} ", chargeId);

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -331,6 +331,10 @@ public class ChargingITestBase {
         return "/v1/frontend/charges/{chargeId}/wallets/google".replace("{chargeId}", chargeId);
     }
 
+    public static String authoriseChargeUrlForGooglePayWorldpay(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/wallets/google/worldpay".replace("{chargeId}", chargeId);
+    }
+
     public static String authoriseChargeUrlFor(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeId);
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseGooglePayWorldpayIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseGooglePayWorldpayIT.java
@@ -1,0 +1,152 @@
+package uk.gov.pay.connector.it.resources;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.paymentprocessor.resource.CardResource;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import java.io.IOException;
+import java.util.List;
+
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class CardResourceAuthoriseGooglePayWorldpayIT extends ChargingITestBase {
+    
+    private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+
+    public CardResourceAuthoriseGooglePayWorldpayIT() {
+        super("sandbox");
+    }
+
+    @Override
+    @Before
+    public void setUp() {
+        super.setUp();
+        Logger root = (Logger) LoggerFactory.getLogger(CardResource.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
+    }
+
+    @Test
+    public void authoriseGooglePayWorldpayShouldReturn422IfCardholderNameIsTooLong() throws Exception {
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+        String payload = fixture("googlepay/example-auth-request.json").replace("Example Name", "tenchars12".repeat(26));
+        JsonNode googlePayload = Jackson.getObjectMapper().readTree(payload);
+
+        givenSetup()
+                .body(googlePayload)
+                .post(authoriseChargeUrlForGooglePayWorldpay(chargeId))
+                .then()
+                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
+                .body("message", contains("Card holder name must be a maximum of 255 chars"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+
+        verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(false));
+    }
+
+    @Test
+    public void authoriseGooglePayWorldpayShouldReturn422IfEmailIsTooLong() throws Exception {
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+        String payload = fixture("googlepay/example-auth-request.json")
+                .replace("example@test.example","tenchars12".repeat(10) + "@" + "12tenchars".repeat(16));
+        JsonNode googlePayload = Jackson.getObjectMapper().readTree(payload);
+
+        givenSetup()
+                .body(googlePayload)
+                .post(authoriseChargeUrlForGooglePayWorldpay(chargeId))
+                .then()
+                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
+                .body("message", contains("Email must be a maximum of 254 chars"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+
+        verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(false));
+    }
+    
+    @Test
+    public void authoriseGooglePayWorldpayShouldReturn422IfProtocolVersionIsEmpty() throws IOException {
+        String chargeId = "a-valid-chargeId";
+        String payload = fixture("googlepay/example-auth-request.json").replace("ECv1", "");
+        JsonNode googlePayload = Jackson.getObjectMapper().readTree(payload);
+
+        givenSetup()
+                .body(googlePayload)
+                .post(authoriseChargeUrlForGooglePayWorldpay(chargeId))
+                .then()
+                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
+                .body("message", contains("Field [protocol_version] must not be empty"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+
+        verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(false));
+    }
+
+    @Test
+    public void authoriseGooglePayWorldpayShouldReturn422IfSignedMessageIsEmpty() throws IOException {
+        String chargeId = "a-valid-chargeId";
+        String payload = fixture("googlepay/example-auth-request.json").replace("aSignedMessage", "");
+        JsonNode googlePayload = Jackson.getObjectMapper().readTree(payload);
+
+        givenSetup()
+                .body(googlePayload)
+                .post(authoriseChargeUrlForGooglePayWorldpay(chargeId))
+                .then()
+                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
+                .body("message", contains("Field [signed_message] must not be empty"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+
+        verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(false));
+    }
+
+    @Test
+    public void authoriseGooglePayWorldpayShouldReturn422IfSignatureIsEmpty() throws IOException {
+        String chargeId = "a-valid-chargeId";
+        String exampleAuthRequest = fixture("googlepay/example-auth-request.json").replace("MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl", "");
+        JsonNode googlePayload = Jackson.getObjectMapper().readTree(exampleAuthRequest);
+
+        givenSetup()
+                .body(googlePayload)
+                .post(authoriseChargeUrlForGooglePayWorldpay(chargeId))
+                .then()
+                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
+                .body("message", contains("Field [signature] must not be empty"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+
+        verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(false));
+    }
+    
+    
+}


### PR DESCRIPTION
Context: Implementing Google Pay wallet payments for Stripe will require separate endpoints depending on payment processor
- Add new endpoint specifically for Google Pay authorisations via Worldpay
- Duplicate existing logic and tests for the new endpoint
- Add new tests of validation for fields that must not be empty in requests to this endpoint

Subsequent PRs will point frontend to the new endpoint, and then remove the old endpoint. This will allow subsequent development of a Stripe-specific endpoint under a different ticket.