### PR TITLE
PP-11394 Add new GooglePayWorldpay endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,63 +155,63 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 2256
+        "line_number": 2305
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 2733
+        "line_number": 2782
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 2797
+        "line_number": 2846
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3129
+        "line_number": 3178
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3165
+        "line_number": 3214
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3192
+        "line_number": 3241
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 4250
+        "line_number": 4299
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4278
+        "line_number": 4327
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4289
+        "line_number": 4338
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-29T17:13:31Z"
+  "generated_at": "2023-08-30T11:47:44Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1822,6 +1822,55 @@ paths:
       summary: Authorise GooglePay payment
       tags:
       - Charge operations
+  /v1/frontend/charges/{chargeId}/wallets/google/worldpay:
+    post:
+      operationId: authoriseChargeGooglePayWorldpay
+      parameters:
+      - description: Charge external ID
+        example: b02b63b370fd35418ad66b0101
+        in: path
+        name: chargeId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GooglePayAuthRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+        "202":
+          description: Accepted - payment has been submitted for authorisation and
+            awaiting response from payment service provider
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request - invalid payload or the payment has been declined
+        "402":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Gateway error
+        "404":
+          description: Not found
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unprocessable Entity - Invalid payload or missing mandatory
+            attributes
+        "500":
+          description: Internal server error
+      summary: Authorise GooglePay payment via Worldpay
+      tags:
+      - Charge operations
   /v1/frontend/charges/{chargeId}/worldpay/3ds-flex/ddc:
     get:
       operationId: getWorldpay3dsFlexDdcJwt

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -112,6 +112,33 @@ public class CardResource {
     }
 
     @POST
+    @Path("/v1/frontend/charges/{chargeId}/wallets/google/worldpay")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @Operation(
+            summary = "Authorise GooglePay payment via Worldpay",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "202", description = "Accepted - payment has been submitted for authorisation and awaiting response from payment service provider"),
+                    @ApiResponse(responseCode = "400", description = "Bad request - invalid payload or the payment has been declined",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "402", description = "Gateway error",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "422", description = "Unprocessable Entity - Invalid payload or missing mandatory attributes",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error"),
+            }
+    )
+    public Response authoriseChargeGooglePayWorldpay(@Parameter(example = "b02b63b370fd35418ad66b0101", description = "Charge external ID")
+                                    @PathParam("chargeId") String chargeId,
+                                    @NotNull @Valid GooglePayAuthRequest googlePayAuthRequest) {
+        logger.info("Received encrypted payload for charge with id {} ", chargeId);
+        logger.info("Received wallet payment info \n{} \nfor charge with id {}", googlePayAuthRequest.getPaymentInfo().toString(), chargeId);
+        return googlePayService.authorise(chargeId, googlePayAuthRequest);
+    }
+
+    @POST
     @Path("/v1/frontend/charges/{chargeId}/wallets/google")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -331,6 +331,10 @@ public class ChargingITestBase {
         return "/v1/frontend/charges/{chargeId}/wallets/google".replace("{chargeId}", chargeId);
     }
 
+    public static String authoriseChargeUrlForGooglePayWorldpay(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/wallets/google/worldpay".replace("{chargeId}", chargeId);
+    }
+
     public static String authoriseChargeUrlFor(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeId);
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayOldIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayOldIT.java
@@ -12,12 +12,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.paymentprocessor.resource.CardResource;
-import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.io.IOException;
 import java.util.List;
@@ -37,14 +37,15 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 
+//PP-11394 This test class can be removed when the endpoint "/v1/frontend/charges/{chargeId}/wallets/google" is removed 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class WorldpayAuthoriseGooglePayIT extends ChargingITestBase {
+public class WorldpayAuthoriseGooglePayOldIT extends ChargingITestBase {
 
     private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
 
-    public WorldpayAuthoriseGooglePayIT() {
+    public WorldpayAuthoriseGooglePayOldIT() {
         super("worldpay");
     }
 
@@ -66,7 +67,7 @@ public class WorldpayAuthoriseGooglePayIT extends ChargingITestBase {
 
         givenSetup()
                 .body(googlePayload)
-                .post(authoriseChargeUrlForGooglePayWorldpay(chargeId))
+                .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
                 .statusCode(200);
 
@@ -88,7 +89,7 @@ public class WorldpayAuthoriseGooglePayIT extends ChargingITestBase {
 
         givenSetup()
                 .body(googlePayload)
-                .post(authoriseChargeUrlForGooglePayWorldpay(chargeId))
+                .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
                 .statusCode(200);
 
@@ -104,7 +105,7 @@ public class WorldpayAuthoriseGooglePayIT extends ChargingITestBase {
 
         givenSetup()
                 .body(validPayload)
-                .post(authoriseChargeUrlForGooglePayWorldpay(chargeId))
+                .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
@@ -122,7 +123,7 @@ public class WorldpayAuthoriseGooglePayIT extends ChargingITestBase {
 
         givenSetup()
                 .body(invalidPayload)
-                .post(authoriseChargeUrlForGooglePayWorldpay(chargeId))
+                .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
                 .statusCode(422)
                 .body("message", contains("Field [signature] must not be empty"))


### PR DESCRIPTION
Context: Implementing Google Pay wallet payments for Stripe will require separate endpoints depending on payment processor
- Add new endpoint specifically for Google Pay authorisations via Worldpay
- Duplicate existing integration tests to cover the new endpoint
- Add validation tests

Subsequent PRs will point frontend to the new endpoint, and then remove the old endpoint and associated tests. This will allow subsequent development of a Stripe-specific endpoint under a different ticket.