### PR TITLE
PP-10528: Add some missing test coverage

### DIFF
--- a/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceTest.java
@@ -254,6 +254,16 @@ public class UserNotificationServiceTest {
     }
 
     @Test
+    void shouldNotSendPaymentConfirmedEmailSynchronously_IfNotifyIsDisabled() throws Exception {
+        when(mockNotifyConfiguration.isEmailNotifyEnabled()).thenReturn(false);
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        userNotificationService = new UserNotificationService(mockNotifyClientFactory, mockConfig, mockEnvironment);
+        userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, chargeEntity.getGatewayAccount());
+
+        verifyNoInteractions(mockNotifyClient);
+    }
+
+    @Test
     void shouldNotSendRefundIssuedEmail_IfNotifyIsDisabled() throws Exception {
         when(mockNotifyConfiguration.isEmailNotifyEnabled()).thenReturn(false);
         RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity().build();
@@ -284,6 +294,18 @@ public class UserNotificationServiceTest {
 
         userNotificationService = new UserNotificationService(mockNotifyClientFactory, mockConfig, mockEnvironment);
         userNotificationService.sendPaymentConfirmedEmail(chargeEntity, chargeEntity.getGatewayAccount());
+        verifyNoInteractions(mockNotifyClient);
+    }
+
+    @Test
+    void shouldNotSendPaymentConfirmedEmailSynchronously_whenConfirmationEmailNotificationsAreDisabledForService() {
+        chargeEntity.getGatewayAccount()
+                .getEmailNotifications()
+                .get(EmailNotificationType.PAYMENT_CONFIRMED)
+                .setEnabled(false);
+
+        userNotificationService = new UserNotificationService(mockNotifyClientFactory, mockConfig, mockEnvironment);
+        userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, chargeEntity.getGatewayAccount());
         verifyNoInteractions(mockNotifyClient);
     }
 


### PR DESCRIPTION
Need coverage for unhappy paths of UserNotificationService#sendPaymentConfirmedEmailSynchronously.

Stephen D added the following comment on #4679  -

> We probably just need some additional unit tests for the cases when the email won't be sent. It would just be duplicating all the tests like `shouldNotSendEmail_IfEmailEnabledButChargeDoesNotHaveAnEmailAddress` for this method.
> We should do this because although the code for this is shared in a private method for this class, if any modifications are made to the public method under test to change how this code is called, we might break this functionality and not be able to tell.

The comment no longer seems to show up for some reason, which is why I missed it, but it does sound like it's worth doing, so I'm raising this follow-up PR.