### PR TITLE
Pp 11154/add native prometheus metrics for some metrics

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -248,7 +248,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
     private void initialisePrometheusMetrics(Environment environment, URI ecsContainerMetadataUri) {
         logger.info("Initialising prometheus metrics.");
-        CollectorRegistry collectorRegistry = new CollectorRegistry();
+        CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
         collectorRegistry.register(new DropwizardExports(environment.metrics(), new PrometheusDefaultLabelSampleBuilder(ecsContainerMetadataUri)));
         environment.admin().addServlet("prometheusMetrics", new MetricsServlet(collectorRegistry)).addMapping("/metrics");
     }

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -243,18 +243,18 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
                 .scheduleAtFixedRate(metricsService::updateMetricData, 0, GRAPHITE_SENDING_PERIOD_SECONDS / 2, TimeUnit.SECONDS);
 
         initialiseGraphiteMetrics(configuration, environment);
-        configuration.getEcsContainerMetadataUriV4().ifPresent(uri -> initialisePrometheusMetrics(environment, uri));
-    }
 
-    private void initialisePrometheusMetrics(Environment environment, URI ecsContainerMetadataUri) {
         logger.info("Initialising prometheus metrics.");
         CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
-        collectorRegistry.register(new DropwizardExports(environment.metrics(), new PrometheusDefaultLabelSampleBuilder(ecsContainerMetadataUri)));
+        configuration.getEcsContainerMetadataUriV4().ifPresentOrElse(
+                uri -> collectorRegistry.register(new DropwizardExports(environment.metrics(), new PrometheusDefaultLabelSampleBuilder(uri))),
+                () -> collectorRegistry.register(new DropwizardExports(environment.metrics()))
+        );
         environment.admin().addServlet("prometheusMetrics", new MetricsServlet(collectorRegistry)).addMapping("/metrics");
     }
 
     /**
-     * Graphtie metric config to be deleted when we've completely moved to Prometheus
+     * Graphite metric config to be deleted when we've completely moved to Prometheus
      */
     private void initialiseGraphiteMetrics(ConnectorConfiguration configuration, Environment environment) {
         GraphiteSender graphiteUDP = new GraphiteUDP(configuration.getGraphiteHost(), Integer.parseInt(configuration.getGraphitePort()));

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -207,7 +207,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(injector.getInstance(LoggingMDCResponseFilter.class));
         environment.jersey().register(injector.getInstance(AgreementsApiResource.class));
 
-        if(configuration.getCaptureProcessConfig().getBackgroundProcessingEnabled()) {
+        if (configuration.getCaptureProcessConfig().getBackgroundProcessingEnabled()) {
             setupSchedulers(environment, injector);
         }
         environment.lifecycle().manage(injector.getInstance(PayoutReconcileMessageReceiver.class));

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -41,15 +41,15 @@ public class GatewayClient {
     private final MetricRegistry metricRegistry;
 
     private static final Counter gatewayOperationsFailures = Counter.build()
-        .name("gateway_operations_failures_total")
-        .help("Number of failed gateway operations")
-        .labelNames("gatewayName", "gatewayAccountType", "requestType")
-        .register();
+            .name("gateway_operations_failures_total")
+            .help("Number of failed gateway operations")
+            .labelNames("gatewayName", "gatewayAccountType", "requestType")
+            .register();
     private static final Histogram gatewayOperationsResponseTime = Histogram.build()
-        .name("gateway_operations_response_time_seconds")
-        .help("Response times for gateway operations in seconds")
-        .labelNames("gatewayName", "gatewayAccountType", "requestType")
-        .register();
+            .name("gateway_operations_response_time_seconds")
+            .help("Response times for gateway operations in seconds")
+            .labelNames("gatewayName", "gatewayAccountType", "requestType")
+            .register();
 
     public GatewayClient(Client client, MetricRegistry metricRegistry) {
         this.client = client;
@@ -101,7 +101,7 @@ public class GatewayClient {
                                                 Map<String, String> headers,
                                                 Map<String, String> queryParams)
             throws GatewayException.GenericGatewayException, GatewayConnectionTimeoutException, GatewayErrorException {
-        
+
         String metricsPrefix = format("gateway-operations.get.%s.%s.%s", gatewayName.getName(), gatewayAccountType, orderRequestType);
 
         Supplier<javax.ws.rs.core.Response> requestCallable = () -> {
@@ -187,7 +187,7 @@ public class GatewayClient {
     }
 
     private void incrementPrometheusFailureCounter(PaymentGatewayName gatewayName, String gatewayAccountType, OrderRequestType orderRequestType) {
-        this.gatewayOperationsFailures.labels(
+        gatewayOperationsFailures.labels(
                 gatewayName.toString().toLowerCase(),
                 gatewayAccountType.toLowerCase(),
                 orderRequestType.toString().toLowerCase()

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -43,12 +43,12 @@ public class GatewayClient {
     private static final Counter gatewayOperationsFailures = Counter.build()
         .name("gateway_operations_failures_total")
         .help("Number of failed gateway operations")
-        .labelNames("gatewayName", "gatewayAccountType", "orderRequestType")
+        .labelNames("gatewayName", "gatewayAccountType", "requestType")
         .register();
     private static final Histogram gatewayOperationsResponseTime = Histogram.build()
         .name("gateway_operations_response_time_seconds")
         .help("Response times for gateway operations in seconds")
-        .labelNames("gatewayName", "gatewayAccountType", "orderRequestType")
+        .labelNames("gatewayName", "gatewayAccountType", "requestType")
         .register();
 
     public GatewayClient(Client client, MetricRegistry metricRegistry) {

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.gateway;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Stopwatch;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Histogram;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
@@ -38,6 +40,17 @@ public class GatewayClient {
     private final Client client;
     private final MetricRegistry metricRegistry;
 
+    private static final Counter gatewayOperationsFailures = Counter.build()
+        .name("gateway_operations_failures_total")
+        .help("Number of failed gateway operations")
+        .labelNames("gatewayName", "gatewayAccountType", "orderRequestType")
+        .register();
+    private static final Histogram gatewayOperationsResponseTime = Histogram.build()
+        .name("gateway_operations_response_time_seconds")
+        .help("Response times for gateway operations in seconds")
+        .labelNames("gatewayName", "gatewayAccountType", "orderRequestType")
+        .register();
+
     public GatewayClient(Client client, MetricRegistry metricRegistry) {
         this.client = client;
         this.metricRegistry = metricRegistry;
@@ -71,8 +84,7 @@ public class GatewayClient {
             cookies.forEach(cookie -> requestBuilder.header("Cookie", cookie.getName() + "=" + cookie.getValue()));
             return requestBuilder.post(Entity.entity(request.getPayload(), request.getMediaType()));
         };
-
-        return executeRequest(url, gatewayAccountType, request.getOrderRequestType(), metricsPrefix, requestCallable);
+        return executeRequest(url, gatewayName, gatewayAccountType, request.getOrderRequestType(), metricsPrefix, requestCallable);
     }
 
     public GatewayClient.Response getRequestFor(GatewayClientGetRequest request)
@@ -105,10 +117,11 @@ public class GatewayClient {
             return requestBuilder.get();
         };
 
-        return executeRequest(url, gatewayAccountType, orderRequestType, metricsPrefix, requestCallable);
+        return executeRequest(url, gatewayName, gatewayAccountType, orderRequestType, metricsPrefix, requestCallable);
     }
 
     private GatewayClient.Response executeRequest(URI url,
+                                                  PaymentGatewayName gatewayName,
                                                   String gatewayAccountType,
                                                   OrderRequestType orderRequestType,
                                                   String metricsPrefix,
@@ -117,6 +130,12 @@ public class GatewayClient {
         javax.ws.rs.core.Response response = null;
 
         Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
+        Histogram.Timer responseTimeTimer = gatewayOperationsResponseTime.labels(
+                gatewayName.toString().toLowerCase(),
+                gatewayAccountType.toLowerCase(),
+                orderRequestType.toString().toLowerCase()
+        ).startTimer();
+
         try {
             response = requestCallable.get();
             int statusCode = response.getStatus();
@@ -128,6 +147,7 @@ public class GatewayClient {
                     LOGGER.warn("Gateway returned unexpected status code: {}, for gateway url={} with type {} with order request type {}",
                             statusCode, url, gatewayAccountType, orderRequestType);
                     incrementFailureCounter(metricRegistry, metricsPrefix);
+                    incrementPrometheusFailureCounter(gatewayName, gatewayAccountType, orderRequestType);
                 } else {
                     LOGGER.warn("Gateway returned non-success status code: {}, for gateway url={} with type {} with order request type {}",
                             statusCode, url, gatewayAccountType, orderRequestType);
@@ -136,6 +156,7 @@ public class GatewayClient {
             }
         } catch (ProcessingException pe) {
             incrementFailureCounter(metricRegistry, metricsPrefix);
+            incrementPrometheusFailureCounter(gatewayName, gatewayAccountType, orderRequestType);
             if (pe.getCause() != null) {
                 if (pe.getCause() instanceof SocketTimeoutException) {
                     LOGGER.warn(format("Connection timed out error for gateway url=%s", url), pe);
@@ -148,11 +169,13 @@ public class GatewayClient {
             throw e;
         } catch (Exception e) {
             incrementFailureCounter(metricRegistry, metricsPrefix);
+            incrementPrometheusFailureCounter(gatewayName, gatewayAccountType, orderRequestType);
             LOGGER.error(format("Exception for gateway url=%s", url), e);
             throw new GatewayException.GenericGatewayException(e.getMessage());
         } finally {
             responseTimeStopwatch.stop();
             metricRegistry.histogram(metricsPrefix + ".response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
+            responseTimeTimer.observeDuration();
             if (response != null) {
                 response.close();
             }
@@ -161,6 +184,14 @@ public class GatewayClient {
 
     private void incrementFailureCounter(MetricRegistry metricRegistry, String metricsPrefix) {
         metricRegistry.counter(metricsPrefix + ".failures").inc();
+    }
+
+    private void incrementPrometheusFailureCounter(PaymentGatewayName gatewayName, String gatewayAccountType, OrderRequestType orderRequestType) {
+        this.gatewayOperationsFailures.labels(
+                gatewayName.toString().toLowerCase(),
+                gatewayAccountType.toLowerCase(),
+                orderRequestType.toString().toLowerCase()
+        ).inc();
     }
 
     public static class Response {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.paymentprocessor.service;
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
+import io.prometheus.client.Counter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -49,6 +50,11 @@ import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Pre
 public class CardAuthoriseService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CardAuthoriseService.class);
+    private static final Counter authorisationResultCounter = Counter.build()
+      .name("gateway_operations_authorisation_result_total")
+      .help("Counter of results of card authorisations")
+      .labelNames("paymentProvider", "gatewayAccountType", "billingAddressPresent", "authorisationResult")
+      .register();
 
     private final CardTypeDao cardTypeDao;
     private final AuthorisationService authorisationService;
@@ -230,6 +236,12 @@ public class CardAuthoriseService {
     }
 
     private void incrementMetricsPostAuthorisation(ChargeStatus newStatus, ChargeEntity updatedCharge, AuthorisationRequestSummary authorisationRequestSummary) {
+        authorisationResultCounter.labels(
+                updatedCharge.getPaymentProvider().toString().toLowerCase(),
+                updatedCharge.getGatewayAccount().getType().toString().toLowerCase(),
+                authorisationRequestSummary.billingAddress() == PRESENT ? "with-billing-address" : "without-billing-address",
+                newStatus.toString().toLowerCase()).inc();
+
         metricRegistry.counter(String.format(
                 "gateway-operations.%s.%s.authorise.%s.result.%s",
                 updatedCharge.getPaymentProvider(),

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -51,10 +51,10 @@ public class CardAuthoriseService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CardAuthoriseService.class);
     private static final Counter authorisationResultCounter = Counter.build()
-      .name("gateway_operations_authorisation_result_total")
-      .help("Counter of results of card authorisations")
-      .labelNames("paymentProvider", "gatewayAccountType", "billingAddressPresent", "authorisationResult")
-      .register();
+            .name("gateway_operations_authorisation_result_total")
+            .help("Counter of results of card authorisations")
+            .labelNames("paymentProvider", "gatewayAccountType", "billingAddressPresent", "authorisationResult")
+            .register();
 
     private final CardTypeDao cardTypeDao;
     private final AuthorisationService authorisationService;

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -145,7 +145,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     private final String chargeExternalId = charge.getExternalId();
 
     private final CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
-    private static final String[] labelNames = new String[] {"paymentProvider", "gatewayAccountType", "billingAddressPresent", "authorisationResult"};
+    private static final String[] labelNames = new String[]{"paymentProvider", "gatewayAccountType", "billingAddressPresent", "authorisationResult"};
 
     @Mock
     private CardExecutorService mockExecutorService;
@@ -582,7 +582,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         mockRecordAuthorisationResult();
         providerWillReject(charge.getPaymentGatewayName());
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation rejected"
         });
 
@@ -595,7 +595,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
 
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation rejected"
         });
         assertThat(counterAfter, is(counterBefore + 1));
@@ -609,7 +609,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         mockRecordAuthorisationResult();
         providerWillRespondToAuthoriseWith(authResponse, charge.getPaymentGatewayName());
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation cancelled"
         });
 
@@ -622,7 +622,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_CANCELLED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
 
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation cancelled"
         });
         assertThat(counterAfter, is(counterBefore + 1));
@@ -633,7 +633,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         mockRecordAuthorisationResult();
         providerWillError(charge.getPaymentGatewayName());
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation error"
         });
 
@@ -646,7 +646,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_ERROR.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(nullValue()));
 
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation error"
         });
         assertThat(counterAfter, is(counterBefore + 1));
@@ -765,7 +765,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         mockRecordAuthorisationResult();
         providerWillRespondWithError(new GatewayException.GatewayConnectionTimeoutException("Connection timed out"));
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation timeout"
         });
 
@@ -777,7 +777,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
 
         assertThat(charge.getStatus(), is(AUTHORISATION_TIMEOUT.getValue()));
 
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation timeout"
         });
         assertThat(counterAfter, is(counterBefore + 1));
@@ -788,7 +788,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         mockRecordAuthorisationResult();
         providerWillRespondWithError(new GatewayException.GatewayErrorException("Malformed response received"));
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation unexpected error"
         });
 
@@ -799,7 +799,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(response.getGatewayError().get().getErrorType(), is(GATEWAY_ERROR));
         assertThat(charge.getStatus(), is(AUTHORISATION_UNEXPECTED_ERROR.getValue()));
 
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation unexpected error"
         });
         assertThat(counterAfter, is(counterBefore + 1));
@@ -856,7 +856,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         mockRecordAuthorisationResult();
         providerWillAuthoriseForMotoApiPayment();
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation success"
         });
 
@@ -877,7 +877,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getWalletType(), is(nullValue()));
         verify(mockedChargeEventDao, times(2)).persistChargeEventOf(eq(charge), isNull());
 
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation success"
         });
         assertThat(counterAfter, is(counterBefore + 1));
@@ -904,7 +904,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     void doAuthoriseMotoApi_shouldRespondAuthorisationRejected_whenProviderAuthorisationIsRejected() throws Exception {
         charge.setAuthorisationMode(MOTO_API);
         AuthoriseRequest authoriseRequest = new AuthoriseRequest("one-time-token", "4242424242424242", "123", "11/99", "Mr Test");
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation rejected"
         });
 
@@ -920,7 +920,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
 
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation rejected"
         });
         assertThat(counterAfter, is(counterBefore + 1));
@@ -931,7 +931,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         charge.setAuthorisationMode(MOTO_API);
         AuthoriseRequest authoriseRequest = new AuthoriseRequest("one-time-token", "4242424242424242", "123", "11/99", "Mr Test");
 
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation cancelled"
         });
 
@@ -949,7 +949,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_CANCELLED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
 
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation cancelled"
         });
         assertThat(counterAfter, is(counterBefore + 1));
@@ -963,7 +963,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         providerWillErrorForMotoApiPayment();
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
 
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation error"
         });
 
@@ -975,7 +975,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_ERROR.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(nullValue()));
 
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "sandbox", "test", "without-billing-address", "authorisation error"
         });
         assertThat(counterAfter, is(counterBefore + 1));
@@ -1092,7 +1092,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     void doAuthoriseUserNotPresent_shouldRespondAuthorisationSuccess() throws Exception {
         mockRecordAuthorisationResult();
         providerWillAuthoriseForUserNotPresentPayment(WORLDPAY);
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "worldpay", "test", "without-billing-address", "authorisation success"
         });
 
@@ -1122,7 +1122,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(chargeLocal.getCardDetails(), is(cardDetailsEntity));
         assertThat(chargeLocal.getCorporateSurcharge().isPresent(), is(false));
 
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "worldpay", "test", "without-billing-address", "authorisation success"
         });
         assertThat(counterAfter, is(counterBefore + 1));
@@ -1132,7 +1132,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     void doAuthoriseWorldpayUserNotPresent_shouldRespondAuthorisationFailed() throws Exception {
         mockRecordAuthorisationResult();
         providerWillRejectUserNotPresent(WORLDPAY);
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "worldpay", "test", "without-billing-address", "authorisation rejected"
         });
 
@@ -1162,7 +1162,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(chargeLocal.get3dsRequiredDetails(), is(nullValue()));
         assertThat(chargeLocal.getCardDetails(), is(cardDetailsEntity));
         assertThat(chargeLocal.getCorporateSurcharge().isPresent(), is(false));
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "worldpay", "test", "without-billing-address", "authorisation rejected"
         });
         assertThat(counterAfter, is(counterBefore + 1));
@@ -1172,7 +1172,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     void doAuthoriseWorldpayUserNotPresent_shouldRespondAuthorisationSuccess() throws Exception {
         mockRecordAuthorisationResult();
         providerWillAuthoriseForUserNotPresentPayment(WORLDPAY);
-        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterBefore = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "worldpay", "test", "without-billing-address", "authorisation success"
         });
 
@@ -1203,7 +1203,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(chargeLocal.getCardDetails(), is(cardDetailsEntity));
         assertThat(chargeLocal.getCorporateSurcharge().isPresent(), is(false));
 
-        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[] {
+        double counterAfter = getMetricSample("gateway_operations_authorisation_result_total", new String[]{
                 "worldpay", "test", "without-billing-address", "authorisation success"
         });
         assertThat(counterAfter, is(counterBefore + 1));

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
@@ -53,7 +53,7 @@ public class GatewayClientTest {
     private MediaType mediaType = MediaType.APPLICATION_XML_TYPE;
 
     private final CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
-    private String[] labelNames = new String[] {"gatewayName", "gatewayAccountType", "requestType"};
+    private String[] labelNames = new String[]{"gatewayName", "gatewayAccountType", "requestType"};
 
     @Mock
     private Client mockClient;
@@ -85,14 +85,14 @@ public class GatewayClientTest {
         setupPostRequestMocks();
         when(mockResponse.getStatus()).thenReturn(500);
         when(mockMetricRegistry.counter("gateway-operations.worldpay.test.authorise.failures")).thenReturn(mockFailureCounter);
-        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "authorise"});
-        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
+        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[]{"worldpay", "test", "authorise"});
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "authorise"});
 
         assertThrows(GatewayException.GatewayErrorException.class,
                 () -> gatewayClient.postRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", mockGatewayOrder, emptyMap()));
 
-        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "authorise"});
-        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
+        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[]{"worldpay", "test", "authorise"});
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "authorise"});
         assertEquals(failureCounterBefore + 1, failureCounterAfter);
         assertEquals(histogramCountBefore + 1, histogramCountAfter);
         verify(mockResponse).close();
@@ -104,15 +104,15 @@ public class GatewayClientTest {
         setupPostRequestMocks();
         when(mockBuilder.post(Entity.entity(orderPayload, mediaType))).thenThrow(new ProcessingException(new SocketException("socket failed")));
         when(mockMetricRegistry.counter("gateway-operations.worldpay.test.authorise.failures")).thenReturn(mockFailureCounter);
-        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "authorise"});
-        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
+        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[]{"worldpay", "test", "authorise"});
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "authorise"});
         doAnswer(invocationOnMock -> null).when(mockFailureCounter).inc();
-        
+
         assertThrows(GatewayException.GenericGatewayException.class,
                 () -> gatewayClient.postRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", mockGatewayOrder, emptyMap()));
 
-        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "authorise"});
-        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
+        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[]{"worldpay", "test", "authorise"});
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "authorise"});
         assertEquals(failureCounterBefore + 1, failureCounterAfter);
         assertEquals(histogramCountBefore + 1, histogramCountAfter);
         verify(mockFailureCounter).inc();
@@ -122,7 +122,7 @@ public class GatewayClientTest {
     public void shouldIncludeCookieIfSessionIdentifierAvailableInOrder() throws Exception {
         setupPostRequestMocks();
         when(mockResponse.getStatus()).thenReturn(200);
-        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "authorise"});
 
         gatewayClient.postRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", mockGatewayOrder,
                 ImmutableList.of(new HttpCookie("machine", "value")), emptyMap());
@@ -132,7 +132,7 @@ public class GatewayClientTest {
         inOrder.verify(mockBuilder).post(Entity.entity(orderPayload, mediaType));
         verify(mockResponseTimeHistogram).update(anyLong());
 
-        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "authorise"});
         assertEquals(histogramCountBefore + 1, histogramCountAfter);
     }
 
@@ -142,14 +142,14 @@ public class GatewayClientTest {
         when(mockResponse.getStatus()).thenReturn(500);
         doAnswer(invocationOnMock -> null).when(mockFailureCounter).inc();
         when(mockMetricRegistry.counter("gateway-operations.get.worldpay.test.query.failures")).thenReturn(mockFailureCounter);
-        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "query"});
-        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
+        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[]{"worldpay", "test", "query"});
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "query"});
 
         assertThrows(GatewayException.GatewayErrorException.class,
                 () -> gatewayClient.getRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", OrderRequestType.QUERY, emptyList(), emptyMap(), emptyMap()));
 
-        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "query"});
-        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
+        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[]{"worldpay", "test", "query"});
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "query"});
         assertEquals(failureCounterBefore + 1, failureCounterAfter);
         assertEquals(histogramCountBefore + 1, histogramCountAfter);
         verify(mockResponse).close();
@@ -161,15 +161,15 @@ public class GatewayClientTest {
         setupGetRequestMocks();
         when(mockMetricRegistry.counter("gateway-operations.get.worldpay.test.query.failures")).thenReturn(mockFailureCounter);
         when(mockBuilder.get()).thenThrow(new ProcessingException(new SocketException("socket failed")));
-        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "query"});
-        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
+        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[]{"worldpay", "test", "query"});
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "query"});
 
         assertThrows(GatewayException.GenericGatewayException.class,
                 () -> gatewayClient.getRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", OrderRequestType.QUERY, emptyList(), emptyMap(), emptyMap()));
         verify(mockFailureCounter).inc();
 
-        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "query"});
-        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
+        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[]{"worldpay", "test", "query"});
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "query"});
         assertEquals(failureCounterBefore + 1, failureCounterAfter);
         assertEquals(histogramCountBefore + 1, histogramCountAfter);
     }
@@ -178,7 +178,7 @@ public class GatewayClientTest {
     public void getRequestShouldIncludeCookieIfSessionIdentifierAvailableInOrder() throws Exception {
         setupGetRequestMocks();
         when(mockResponse.getStatus()).thenReturn(200);
-        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "query"});
 
         gatewayClient.getRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", OrderRequestType.QUERY,
                 ImmutableList.of(new HttpCookie("machine", "value")), emptyMap(), emptyMap());
@@ -188,7 +188,7 @@ public class GatewayClientTest {
         inOrder.verify(mockBuilder).get();
         verify(mockResponseTimeHistogram).update(anyLong());
 
-        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[]{"worldpay", "test", "query"});
         assertEquals(histogramCountBefore + 1, histogramCountAfter);
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
+import io.prometheus.client.CollectorRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,9 +28,11 @@ import java.net.HttpCookie;
 import java.net.SocketException;
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -48,6 +51,9 @@ public class GatewayClientTest {
     private String orderPayload = "a-sample-payload";
 
     private MediaType mediaType = MediaType.APPLICATION_XML_TYPE;
+
+    private final CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
+    private String[] labelNames = new String[] {"gatewayName", "gatewayAccountType", "orderRequestType"};
 
     @Mock
     private Client mockClient;
@@ -79,9 +85,16 @@ public class GatewayClientTest {
         setupPostRequestMocks();
         when(mockResponse.getStatus()).thenReturn(500);
         when(mockMetricRegistry.counter("gateway-operations.worldpay.test.authorise.failures")).thenReturn(mockFailureCounter);
-        
+        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "authorise"});
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
+
         assertThrows(GatewayException.GatewayErrorException.class,
                 () -> gatewayClient.postRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", mockGatewayOrder, emptyMap()));
+
+        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "authorise"});
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
+        assertEquals(failureCounterBefore + 1, failureCounterAfter);
+        assertEquals(histogramCountBefore + 1, histogramCountAfter);
         verify(mockResponse).close();
         verify(mockFailureCounter).inc();
     }
@@ -91,10 +104,17 @@ public class GatewayClientTest {
         setupPostRequestMocks();
         when(mockBuilder.post(Entity.entity(orderPayload, mediaType))).thenThrow(new ProcessingException(new SocketException("socket failed")));
         when(mockMetricRegistry.counter("gateway-operations.worldpay.test.authorise.failures")).thenReturn(mockFailureCounter);
+        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "authorise"});
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
         doAnswer(invocationOnMock -> null).when(mockFailureCounter).inc();
         
         assertThrows(GatewayException.GenericGatewayException.class,
                 () -> gatewayClient.postRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", mockGatewayOrder, emptyMap()));
+
+        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "authorise"});
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
+        assertEquals(failureCounterBefore + 1, failureCounterAfter);
+        assertEquals(histogramCountBefore + 1, histogramCountAfter);
         verify(mockFailureCounter).inc();
     }
 
@@ -102,6 +122,7 @@ public class GatewayClientTest {
     public void shouldIncludeCookieIfSessionIdentifierAvailableInOrder() throws Exception {
         setupPostRequestMocks();
         when(mockResponse.getStatus()).thenReturn(200);
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
 
         gatewayClient.postRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", mockGatewayOrder,
                 ImmutableList.of(new HttpCookie("machine", "value")), emptyMap());
@@ -110,6 +131,9 @@ public class GatewayClientTest {
         inOrder.verify(mockBuilder).header("Cookie", "machine=value");
         inOrder.verify(mockBuilder).post(Entity.entity(orderPayload, mediaType));
         verify(mockResponseTimeHistogram).update(anyLong());
+
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "authorise"});
+        assertEquals(histogramCountBefore + 1, histogramCountAfter);
     }
 
     @Test
@@ -118,9 +142,16 @@ public class GatewayClientTest {
         when(mockResponse.getStatus()).thenReturn(500);
         doAnswer(invocationOnMock -> null).when(mockFailureCounter).inc();
         when(mockMetricRegistry.counter("gateway-operations.get.worldpay.test.query.failures")).thenReturn(mockFailureCounter);
-        
+        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "query"});
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
+
         assertThrows(GatewayException.GatewayErrorException.class,
                 () -> gatewayClient.getRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", OrderRequestType.QUERY, emptyList(), emptyMap(), emptyMap()));
+
+        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "query"});
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
+        assertEquals(failureCounterBefore + 1, failureCounterAfter);
+        assertEquals(histogramCountBefore + 1, histogramCountAfter);
         verify(mockResponse).close();
         verify(mockFailureCounter).inc();
     }
@@ -130,16 +161,24 @@ public class GatewayClientTest {
         setupGetRequestMocks();
         when(mockMetricRegistry.counter("gateway-operations.get.worldpay.test.query.failures")).thenReturn(mockFailureCounter);
         when(mockBuilder.get()).thenThrow(new ProcessingException(new SocketException("socket failed")));
-        
+        double failureCounterBefore = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "query"});
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
+
         assertThrows(GatewayException.GenericGatewayException.class,
                 () -> gatewayClient.getRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", OrderRequestType.QUERY, emptyList(), emptyMap(), emptyMap()));
         verify(mockFailureCounter).inc();
+
+        double failureCounterAfter = getMetricSample("gateway_operations_failures_total", new String[] {"worldpay", "test", "query"});
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
+        assertEquals(failureCounterBefore + 1, failureCounterAfter);
+        assertEquals(histogramCountBefore + 1, histogramCountAfter);
     }
 
     @Test
     public void getRequestShouldIncludeCookieIfSessionIdentifierAvailableInOrder() throws Exception {
         setupGetRequestMocks();
         when(mockResponse.getStatus()).thenReturn(200);
+        double histogramCountBefore = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
 
         gatewayClient.getRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", OrderRequestType.QUERY,
                 ImmutableList.of(new HttpCookie("machine", "value")), emptyMap(), emptyMap());
@@ -148,6 +187,9 @@ public class GatewayClientTest {
         inOrder.verify(mockBuilder).header("Cookie", "machine=value");
         inOrder.verify(mockBuilder).get();
         verify(mockResponseTimeHistogram).update(anyLong());
+
+        double histogramCountAfter = getMetricSample("gateway_operations_response_time_seconds_count", new String[] {"worldpay", "test", "query"});
+        assertEquals(histogramCountBefore + 1, histogramCountAfter);
     }
 
     @Test
@@ -183,5 +225,9 @@ public class GatewayClientTest {
 
         when(mockWebTarget.request()).thenReturn(mockBuilder).thenReturn(mockBuilder);
         when(mockBuilder.get()).thenReturn(mockResponse);
+    }
+
+    private double getMetricSample(String name, String[] labelValues) {
+        return Optional.ofNullable(collectorRegistry.getSampleValue(name, labelNames, labelValues)).orElse(0.0);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
@@ -53,7 +53,7 @@ public class GatewayClientTest {
     private MediaType mediaType = MediaType.APPLICATION_XML_TYPE;
 
     private final CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
-    private String[] labelNames = new String[] {"gatewayName", "gatewayAccountType", "orderRequestType"};
+    private String[] labelNames = new String[] {"gatewayName", "gatewayAccountType", "requestType"};
 
     @Mock
     private Client mockClient;


### PR DESCRIPTION
## WHAT YOU DID

1. Fix the metrics to use the defaultRegistry instead of a newly created one. Using the newly created one means the metrics declared manually elsewhere never appear since they appear in the defaultRegistry
2. Fix it so that prometheus metrics are exposed when running locally, before if the ECS metadata endpoint URL wasn't specified we didn't start the prometheus metrics up, and didn't expose them to /metrics
3. Add prometheus metrics for:
    1. gateway operations failures counter
    2. gateway operations response times histogram
    3. card authorisation results

Note: Please remember this is my first real java PR so please be kind :)
 
## How to test

If you run this up with pay local you can see the metrics on /metrics on the admin port (like `curl http://127.0.0.1:9301/metrics` or visit in a web browser, and you can see the metrics in there. Make a local payment `pay local payment` and you should see metric values increase

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [x] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
