### PR TITLE
PP-11465 Correct logging for expiry dates in Worldpay wallet responses

### DIFF
--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponseTest.java
@@ -1,11 +1,24 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
+import uk.gov.pay.connector.wallets.WalletAuthoriseService;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -13,6 +26,8 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
@@ -22,10 +37,22 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTH
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_FAILED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE_WITH_INVALID_EXPIRY_YEAR;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE_WITH_MISSING_EXPIRY_DATE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
+@ExtendWith(MockitoExtension.class)
 class WorldpayOrderStatusResponseTest {
 
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+    
+    @BeforeEach
+    void setup() {
+        Logger root = (Logger) LoggerFactory.getLogger(WorldpayOrderStatusResponse.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
+    }
+    
     @ParameterizedTest
     @ValueSource(strings = {"OUT_OF_SCOPE", "REJECTED"})
     void worldpay_response_should_be_soft_decline(String exemptionResponseResult) {
@@ -102,17 +129,36 @@ class WorldpayOrderStatusResponseTest {
     }
 
     @Test
-    void get_expiry_date_should_return_empty_optional_when_expiry_date_fields_are_absent() throws Exception {
+    void get_expiry_date_should_return_empty_optional_but_no_log_when_expiry_date_fields_are_absent_from_failed_response() throws Exception {
         String response = load(WORLDPAY_AUTHORISATION_FAILED_RESPONSE);
         WorldpayOrderStatusResponse worldpayOrderStatusResponse = XMLUnmarshaller.unmarshall(response, WorldpayOrderStatusResponse.class);
         assertThat(worldpayOrderStatusResponse.getCardExpiryDate().isPresent(), is(false));
+        ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
     }
-    
+
     @Test
-    void get_expiry_date_should_return_empty_optional_when_expiry_date_year_is_invalid() throws Exception {
+    void get_expiry_date_should_return_empty_optional_and_log_when_expiry_date_fields_are_absent_from_success_response() throws Exception {
+        String response = load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE_WITH_MISSING_EXPIRY_DATE);
+        WorldpayOrderStatusResponse worldpayOrderStatusResponse = XMLUnmarshaller.unmarshall(response, WorldpayOrderStatusResponse.class);
+        assertThat(worldpayOrderStatusResponse.getCardExpiryDate().isPresent(), is(false));
+        verifyLogging(1, "Expiry date is not included in Worldpay wallet payment authorisation success response.");
+    }
+
+    @Test
+    void get_expiry_date_should_return_empty_optional_and_log_when_expiry_date_is_invalid() throws Exception {
         String response = load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE_WITH_INVALID_EXPIRY_YEAR);
         WorldpayOrderStatusResponse worldpayOrderStatusResponse = XMLUnmarshaller.unmarshall(response, WorldpayOrderStatusResponse.class);
         assertThat(worldpayOrderStatusResponse.getCardExpiryDate().isPresent(), is(false));
+        verifyLogging(1, "Expiry date in Worldpay wallet payment authorisation response is in an unexpected format; month has 2 digits, year has 3 digits.");
     }
+
+    private void verifyLogging(int invocations, String logMessage) {
+        ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(mockAppender, times(invocations)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.stream().anyMatch(le -> le.getFormattedMessage().contains(logMessage)), is(true));
+    }
+
 
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -11,6 +11,7 @@ public class TestTemplateResourceLoader {
 
     public static final String WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-success-response.xml";
     public static final String WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE_WITH_INVALID_EXPIRY_YEAR = WORLDPAY_BASE_NAME + "/authorisation-success-response-with-invalid-expiry-year.xml";
+    public static final String WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE_WITH_MISSING_EXPIRY_DATE = WORLDPAY_BASE_NAME + "/authorisation-success-response-with-missing-expiry-date.xml";
     public static final String WORLDPAY_EXEMPTION_REQUEST_HONOURED_RESPONSE = WORLDPAY_BASE_NAME + "/exemption-request-honoured-response.xml";
     public static final String WORLDPAY_EXEMPTION_REQUEST_SOFT_DECLINE_RESULT_REJECTED_RESPONSE = WORLDPAY_BASE_NAME + "/exemption-request-soft-decline-result-rejected-response.xml";
     public static final String WORLDPAY_EXEMPTION_REQUEST_SOFT_DECLINE_RESULT_OUT_OF_SCOPE_RESPONSE = WORLDPAY_BASE_NAME + "/exemption-request-soft-decline-result-out-of-scope-response.xml";

--- a/src/test/resources/templates/worldpay/authorisation-success-response-with-missing-expiry-date.xml
+++ b/src/test/resources/templates/worldpay/authorisation-success-response-with-missing-expiry-date.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <reply>
+        <orderStatus orderCode="transaction-id">
+            <payment>
+                <paymentMethod>VISA-SSL</paymentMethod>
+                <paymentMethodDetail>
+                    <card number="4444********1111" type="creditcard">
+                    </card>
+                </paymentMethodDetail>
+                <amount value="500" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+                <lastEvent>AUTHORISED</lastEvent>
+                <AuthorisationId id="666"/>
+                <CVCResultCode description="NOT SENT TO ACQUIRER"/>
+                <AVSResultCode description="NOT SENT TO ACQUIRER"/>
+                <cardHolderName>
+                    <![CDATA[Coucou]]>
+                </cardHolderName>
+                <issuerCountryCode>N/A</issuerCountryCode>
+                <balance accountType="IN_PROCESS_AUTHORISED">
+                    <amount value="500" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+                </balance>
+                <riskScore value="51"/>
+            </payment>
+        </orderStatus>
+    </reply>
+</paymentService>


### PR DESCRIPTION
Context: Currently, a Sentry alert is triggered for missing expiry dates in Worldpay responses to wallet authorisations.
This is overly sensitive as the expiry date is not expected in decline or error responses, only in some success responses.

- Correct conditional statements so that:
  - log at info level when expiry date is missing from a Worldpay wallet authorisation success response
  - log at error level when expiry date is present but in an unexpected format for any Worldpay wallet authorisation response
- Update/add tests accordingly