### PR TITLE
PP-11385 Extract expiry date from Stripe auth response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
@@ -1,10 +1,15 @@
 package uk.gov.pay.connector.gateway.stripe;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
 import uk.gov.pay.connector.gateway.stripe.response.StripePaymentIntentResponse;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
 
+import java.time.DateTimeException;
+import java.time.YearMonth;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -16,6 +21,8 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
     public static final String STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY = "customerId";
     public static final String STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY = "paymentMethodId";
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(StripeAuthorisationResponse.class);
+
     private final String transactionId;
     private final AuthoriseStatus authoriseStatus;
     private final String redirectUrl;
@@ -23,13 +30,15 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
     private final String stringifiedResponse;
     private final String customerId;
     private final String paymentMethodId;
+    private final CardExpiryDate cardExpiryDate;
 
     private StripeAuthorisationResponse(String transactionId,
                                         AuthoriseStatus authoriseStatus,
                                         String redirectUrl,
                                         String stringifiedResponse,
                                         String customerId,
-                                        String paymentMethodId) {
+                                        String paymentMethodId,
+                                        CardExpiryDate cardExpiryDate) {
         this.customerId = customerId;
         this.paymentMethodId = paymentMethodId;
         if (Objects.isNull(authoriseStatus)) {
@@ -39,6 +48,7 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
         this.authoriseStatus = authoriseStatus;
         this.redirectUrl = redirectUrl;
         this.stringifiedResponse = stringifiedResponse;
+        this.cardExpiryDate = cardExpiryDate;
     }
 
     public static StripeAuthorisationResponse of(StripePaymentIntentResponse stripePaymentIntent) {
@@ -48,8 +58,9 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
                 stripePaymentIntent.getRedirectUrl().orElse(null),
                 stripePaymentIntent.getStringifiedOutcome(),
                 stripePaymentIntent.getCustomerId(),
-                stripePaymentIntent.getPaymentMethodId()
-                );
+                stripePaymentIntent.getPaymentMethod().getId(),
+                extractCardExpiryDate(stripePaymentIntent)
+        );
     }
 
     @Override
@@ -89,5 +100,22 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
                 entry(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY, customerId),
                 entry(STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY, paymentMethodId)
         ));
+    }
+
+    @Override
+    public Optional<CardExpiryDate> getCardExpiryDate() {
+        return Optional.of(cardExpiryDate);
+    }
+
+    private static CardExpiryDate extractCardExpiryDate(StripePaymentIntentResponse stripePaymentIntent) {
+        return stripePaymentIntent.getPaymentMethod().getCard().map(card -> {
+            try {
+                YearMonth yearMonth = YearMonth.of(card.getCardExpiryYear(), card.getCardExpiryMonth());
+                return CardExpiryDate.valueOf(yearMonth);
+            } catch (DateTimeException e) {
+                LOGGER.error(String.format("Invalid card expiry date in response from Stripe: %s", e.getMessage()));
+                return null;
+            }
+        }).orElse(null);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
@@ -109,14 +109,14 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
 
     private static Optional<CardExpiryDate> extractCardExpiryDate(StripePaymentIntentResponse stripePaymentIntent) {
         return stripePaymentIntent.getPaymentMethod().getCard().map(card -> {
+            if (card.getCardExpiryYear() == null || card.getCardExpiryMonth() == null) {
+                LOGGER.info("Missing card expiry date on payment method");
+                return null;
+            }
             try {
-                if (card.getCardExpiryYear() == null || card.getCardExpiryMonth() == null) {
-                    LOGGER.info("Missing card expiry date on payment method");
-                    return null;
-                }
                 YearMonth yearMonth = YearMonth.of(card.getCardExpiryYear(), card.getCardExpiryMonth());
                 return CardExpiryDate.valueOf(yearMonth);
-            } catch (DateTimeException e) {
+            } catch (DateTimeException | IllegalArgumentException e) {
                 LOGGER.error(String.format("Invalid card expiry date in response from Stripe: %s", e.getMessage()));
                 return null;
             }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -7,7 +7,9 @@ import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationG
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Map.entry;
@@ -170,5 +172,10 @@ public class StripePaymentIntentRequest extends StripePostRequest {
     @Override
     protected String idempotencyKeyType() {
         return "payment_intent";
+    }
+
+    @Override
+    protected List<String> expansionFields() {
+        return Collections.singletonList("payment_method.card");
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -176,6 +176,6 @@ public class StripePaymentIntentRequest extends StripePostRequest {
 
     @Override
     protected List<String> expansionFields() {
-        return Collections.singletonList("payment_method.card");
+        return List.of("payment_method.card");
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeCard.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeCard.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.connector.gateway.stripe.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripeCard {
+    
+    @JsonProperty("exp_month")
+    private Integer cardExpiryMonth;
+
+    @JsonProperty("exp_year")
+    private Integer cardExpiryYear;
+
+    public Integer getCardExpiryMonth() {
+        return cardExpiryMonth;
+    }
+
+    public Integer getCardExpiryYear() {
+        return cardExpiryYear;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentIntentResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentIntentResponse.java
@@ -34,7 +34,7 @@ public class StripePaymentIntentResponse {
     private String customerId;
     
     @JsonProperty("payment_method")
-    private String paymentMethodId;
+    private StripePaymentMethodResponse paymentMethod;
 
     public String getId() {
         return id;
@@ -48,8 +48,8 @@ public class StripePaymentIntentResponse {
         return customerId;
     }
 
-    public String getPaymentMethodId() {
-        return paymentMethodId;
+    public StripePaymentMethodResponse getPaymentMethod() {
+        return paymentMethod;
     }
 
     public Optional<String> getRedirectUrl() {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentMethodResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentMethodResponse.java
@@ -3,12 +3,20 @@ package uk.gov.pay.connector.gateway.stripe.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Optional;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StripePaymentMethodResponse {
     @JsonProperty("id")
     private String id;
+    
+    private StripeCard card;
 
     public String getId() {
         return id;
+    }
+
+    public Optional<StripeCard> getCard() {
+        return Optional.ofNullable(card);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -175,6 +175,9 @@ class StripePaymentProviderTest {
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
             assertTrue(response.isSuccessful());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
+            assertThat(response.getBaseResponse().get().getCardExpiryDate().isPresent(), is(true));
+            assertThat(response.getBaseResponse().get().getCardExpiryDate().get().getTwoDigitMonth(), is("08"));
+            assertThat(response.getBaseResponse().get().getCardExpiryDate().get().getTwoDigitYear(), is("24"));
         }
 
         @Test

--- a/src/test/resources/templates/stripe/create_payment_intent_requires_3ds_response.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_requires_3ds_response.json
@@ -36,7 +36,13 @@
     "type": "redirect_to_url"
   },
   "on_behalf_of": "acct_123",
-  "payment_method": "pm_123",
+  "payment_method": {
+    "id": "pm_123",
+    "card": {
+      "exp_month": 8,
+      "exp_year": 2024
+    }
+  },
   "payment_method_options": {
     "card": {
       "request_three_d_secure": "automatic"

--- a/src/test/resources/templates/stripe/create_payment_intent_success_response.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_success_response.json
@@ -30,7 +30,13 @@
   },
   "next_action": null,
   "on_behalf_of": "acct_1EVFduJTPZ7tq2xO",
-  "payment_method": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+  "payment_method": {
+    "id": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+    "card": {
+      "exp_month": 8,
+      "exp_year": 2024
+    }
+  },
   "payment_method_options": {
     "card": {
       "request_three_d_secure": "automatic"

--- a/src/test/resources/templates/stripe/create_payment_intent_success_response_with_charge.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_success_response_with_charge.json
@@ -40,7 +40,13 @@
   },
   "next_action": null,
   "on_behalf_of": "acct_1EVFduJTPZ7tq2xO",
-  "payment_method": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+  "payment_method": {
+    "id": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+    "card": {
+      "exp_month": 8,
+      "exp_year": 2024
+    }
+  },
   "payment_method_options": {
     "card": {
       "request_three_d_secure": "automatic"

--- a/src/test/resources/templates/stripe/create_payment_intent_success_response_with_customer.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_success_response_with_customer.json
@@ -30,7 +30,13 @@
   },
   "next_action": null,
   "on_behalf_of": "acct_1EVFduJTPZ7tq2xO",
-  "payment_method": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+  "payment_method": {
+    "id": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+    "card": {
+      "exp_month": 8,
+      "exp_year": 2024
+    }
+  },
   "payment_method_options": {
     "card": {
       "request_three_d_secure": "automatic"


### PR DESCRIPTION
For Stripe wallet payments, we are not able to obtain the expiry date for the card before authorising. The payment method, included in the payment intent response includes the expiry date. Extract the expiry date from the authorisation response so we can store it on the charge for wallet payments.