### PR TITLE
PP-11385 Authorise Stripe Apple Pay payment

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTokenRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTokenRequest.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
+import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
+import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
+
+import java.util.Map;
+
+public class StripeTokenRequest extends StripePostRequest {
+
+    private final String paymentData;
+    private String displayName;
+    private String network;
+    private String transactionIdentifier;
+
+    private StripeTokenRequest(GatewayAccountEntity gatewayAccount, StripeGatewayConfig stripeGatewayConfig, GatewayCredentials credentials, ApplePayAuthRequest applePayAuthRequest) {
+        super(gatewayAccount, null, stripeGatewayConfig, credentials);
+        this.paymentData = applePayAuthRequest.getPaymentData();
+        this.displayName = applePayAuthRequest.getPaymentInfo().getDisplayName();
+        this.network = applePayAuthRequest.getPaymentInfo().getNetwork();
+        this.transactionIdentifier = applePayAuthRequest.getPaymentInfo().getTransactionIdentifier();
+    }
+
+    public static StripeTokenRequest of(WalletAuthorisationGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeTokenRequest(request.getGatewayAccount(), stripeGatewayConfig, request.getGatewayCredentials(), (ApplePayAuthRequest) request.getWalletAuthorisationRequest());
+    }
+
+    @Override
+    protected Map<String, String> params() {
+        return Map.of("pk_token", paymentData,
+                "pk_token_instrument_name", displayName,
+                "pk_token_payment_network", network,
+                "pk_token_transaction_id", transactionIdentifier);
+    }
+
+    @Override
+    protected String urlPath() {
+        return "/v1/tokens";
+    }
+
+    @Override
+    protected OrderRequestType orderRequestType() {
+        return OrderRequestType.AUTHORISE;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeTokenResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeTokenResponse.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.gateway.stripe.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripeTokenResponse {
+    @JsonProperty("id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
@@ -162,6 +162,9 @@ public class JsonRequestHelper {
         paymentInfo.addProperty("card_type", "DEBIT");
         paymentInfo.addProperty("cardholder_name", cardHolderName);
         paymentInfo.addProperty("email", email);
+        paymentInfo.addProperty("display_name", "Visa 4242");
+        paymentInfo.addProperty("transaction_identifier", "abc123");
+        paymentInfo.addProperty("network", "Visa");
 
         JsonObject payload = new JsonObject();
         payload.add("payment_info", paymentInfo);

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -478,7 +478,7 @@ public class ChargingITestBase {
     protected ChargeUtils.ExternalChargeId addChargeForSetUpAgreement(ChargeStatus status, String agreementExternalId) {
         return addChargeForSetUpAgreement(status, agreementExternalId, null);
     }
-    
+
     protected ChargeUtils.ExternalChargeId addChargeForSetUpAgreement(ChargeStatus status, String agreementExternalId, Long paymentInstrumentId) {
         long chargeId = RandomUtils.nextInt();
         ChargeUtils.ExternalChargeId externalChargeId = ChargeUtils.ExternalChargeId.fromChargeId(chargeId);
@@ -507,7 +507,7 @@ public class ChargingITestBase {
         databaseTestHelper.addAgreement(agreementParams);
         return agreementExternalId;
     }
-    
+
     protected Long addPaymentInstrument(String agreementExternalId, PaymentInstrumentStatus status) {
         Long paymentInstrumentId = nextLong();
         AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -19,6 +19,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHOR
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CUSTOMER_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CANCEL_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE;
@@ -27,6 +28,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMEN
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_REFUND_FULL_CHARGE_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_SEARCH_PAYMENT_INTENTS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_TOKEN_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_TRANSFER_RESPONSE;
 
 public class StripeMockClient {
@@ -52,9 +54,14 @@ public class StripeMockClient {
         setupResponse(payload, "/v1/refunds", 402);
     }
 
-    public void mockAuthorisationFailedWithPaymentIntents() {
+    public void mockCreatePaymentMethodAuthorisationRejected() {
         String payload = TestTemplateResourceLoader.load(STRIPE_AUTHORISATION_FAILED_RESPONSE);
         setupResponse(payload, "/v1/payment_methods", 400);
+    }
+    
+    public void mockCreatePaymentIntentAuthorisationRejected() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_RESPONSE);
+        setupResponse(payload, "/v1/payment_intents", 402);
     }
 
     public void mockAuthorisationFailedPaymentIntentAndRetriableForUserNotPresentPayment() {
@@ -129,6 +136,11 @@ public class StripeMockClient {
     public void mockCreateCustomer() {
         String payload = TestTemplateResourceLoader.load(STRIPE_CUSTOMER_SUCCESS_RESPONSE);
         setupResponse(payload, "/v1/customers", 200);
+    }
+    
+    public void mockCreateToken() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_TOKEN_SUCCESS_RESPONSE);
+        setupResponse(payload, "/v1/tokens", 200);
     }
 
     public void mockCreatePaymentIntentDelayedResponse() {

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -140,12 +140,14 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CHARGE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response_with_charge.json";
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CUSTOMER = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response_with_customer.json";
     public static final String STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_requires_3ds_response.json";
+    public static final String STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_authorisation_rejected_response.json";
     public static final String STRIPE_PAYMENT_INTENT_CANCEL_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/payment_intent_cancel_response.json";
     public static final String STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/get_payment_intent_with_3ds_authorised_success_response.json";
     public static final String STRIPE_GET_PAYMENT_INTENT_WITH_MULTIPLE_CHARGES = TEMPLATE_BASE_NAME + "/stripe/get_payment_intent_with_multiple_charges.json";
     public static final String STRIPE_PAYMENT_INTENT_WITHOUT_BALANCE_TRANSACTION_EXPANDED = TEMPLATE_BASE_NAME + "/stripe/payment_intent_without_balance_transaction_expanded.json";
     public static final String STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_method_success_response.json";
     public static final String STRIPE_CUSTOMER_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_customer_success_response.json";
+    public static final String STRIPE_TOKEN_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_token_success_response.json";
     public static final String STRIPE_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/error_response.json";
     public static final String STRIPE_REFUND_FULL_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_full_charge.json";
     public static final String STRIPE_TRANSFER_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/transfer_success_response.json";

--- a/src/test/resources/templates/stripe/create_payment_intent_authorisation_rejected_response.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_authorisation_rejected_response.json
@@ -1,0 +1,32 @@
+{
+  "error": {
+    "charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+    "code": "card_declined",
+    "decline_code": "generic_decline",
+    "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+    "message": "Your card was declined.",
+    "payment_intent": {
+      "id": "pi_3N6AIYHj08j2jFuB1IozJAVc",
+      "object": "payment_intent",
+      "amount": 1000,
+      "payment_method": {
+        "id": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+        "card": {
+          "exp_month": 8,
+          "exp_year": 2024
+        }
+      },
+      "last_payment_error": {
+        "charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+        "code": "card_declined",
+        "decline_code": "generic_decline",
+        "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+        "message": "Your card was declined.",
+        "type": "card_error"
+      },
+      "latest_charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+      "livemode": false
+    },
+    "type": "card_error"
+  }
+}

--- a/src/test/resources/templates/stripe/create_token_success_response.json
+++ b/src/test/resources/templates/stripe/create_token_success_response.json
@@ -1,0 +1,3 @@
+{
+  "id": "tok_1NrjK3Hj08j2jFuBm3LGVHYe"
+}


### PR DESCRIPTION
Authorise Apple Pay payment by:

- Making a POST request to /v1/tokens on Stripe with the data from Apple Pay to create a token.
- Making a POST request to /v1/payment_intents to create a Payment intent and authorise the payment by providing the token ID.
    
When an authorisation is rejected, we should be able to extract the card expiry date from the create payment intent response. This will be done in a follow-up PR.