### PR TITLE
PP-11393 Stripe requests for Google Pay

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -197,21 +197,21 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 4279
+        "line_number": 4272
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4307
+        "line_number": 4300
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4318
+        "line_number": 4311
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2023-09-12T09:52:04Z"
+  "generated_at": "2023-09-20T09:31:05Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1817,7 +1817,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GooglePayAuthRequest'
+              $ref: '#/components/schemas/WorldpayGooglePayAuthRequest'
         required: true
       responses:
         "200":
@@ -3841,13 +3841,6 @@ components:
         rawGatewayResponse:
           type: string
           example: Worldpay response ()
-    GooglePayAuthRequest:
-      type: object
-      properties:
-        encrypted_payment_data:
-          $ref: '#/components/schemas/EncryptedPaymentData'
-        payment_info:
-          $ref: '#/components/schemas/WalletPaymentInfo'
     JsonNode:
       type: object
     LastDigitsCardNumber:
@@ -4329,6 +4322,13 @@ components:
           $ref: '#/components/schemas/WorldpayMerchantCodeCredentials'
         recurring_merchant_initiated:
           $ref: '#/components/schemas/WorldpayMerchantCodeCredentials'
+    WorldpayGooglePayAuthRequest:
+      type: object
+      properties:
+        encrypted_payment_data:
+          $ref: '#/components/schemas/EncryptedPaymentData'
+        payment_info:
+          $ref: '#/components/schemas/WalletPaymentInfo'
     WorldpayMerchantCodeCredentials:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -52,7 +52,6 @@ import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
-import uk.gov.pay.connector.wallets.WalletType;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -165,10 +164,14 @@ public class StripePaymentProvider implements PaymentProvider {
 
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authoriseWallet(WalletAuthorisationGatewayRequest request) throws GatewayException {
-        if (request.getWalletAuthorisationRequest().getWalletType() == WalletType.APPLE_PAY) {
-            return stripeAuthoriseHandler.authoriseApplePay(request); 
+        switch(request.getWalletAuthorisationRequest().getWalletType()) {
+            case APPLE_PAY:
+                return stripeAuthoriseHandler.authoriseApplePay(request);
+            case GOOGLE_PAY:
+                return stripeAuthoriseHandler.authoriseGooglePay(request);
+            default: 
+                throw new UnsupportedOperationException(format("Wallet Type %s is not supported for Stripe", request.getWalletAuthorisationRequest().getWalletType()));
         }
-        throw new UnsupportedOperationException(format("Wallet Type %s is not supported for Stripe", request.getWalletAuthorisationRequest().getWalletType()));
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -8,7 +8,6 @@ import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationG
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -158,6 +157,8 @@ public class StripePaymentIntentRequest extends StripePostRequest {
         return paymentMethodId;
     }
 
+    public String getTokenId() { return tokenId; }
+    
     @Override
     protected String urlPath() {
         return "/v1/payment_intents";
@@ -213,4 +214,6 @@ public class StripePaymentIntentRequest extends StripePostRequest {
     protected List<String> expansionFields() {
         return List.of("payment_method.card");
     }
+    
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
@@ -13,11 +13,10 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthoriseOrderSessionId;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayGatewayResponseGenerator;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.WalletAuthorisationHandler;
-import uk.gov.pay.connector.wallets.WalletType;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
 import uk.gov.pay.connector.wallets.applepay.ApplePayDecrypter;
 import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
-import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
+import uk.gov.pay.connector.wallets.googlepay.api.WorldpayGooglePayAuthRequest;
 import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
 
 import javax.inject.Inject;
@@ -96,7 +95,7 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
             case APPLE_PAY:
                 return decryptApplePaymentData(request.getGovUkPayPaymentId(), (ApplePayAuthRequest) request.getWalletAuthorisationRequest());
             case GOOGLE_PAY:
-                return (GooglePayAuthRequest) request.getWalletAuthorisationRequest();
+                return (WorldpayGooglePayAuthRequest) request.getWalletAuthorisationRequest();
             default:
                 throw new IllegalArgumentException(format("Wallet Type not recognised: {}", request.getWalletAuthorisationRequest().getWalletType()));
         }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -33,7 +33,7 @@ import uk.gov.pay.connector.util.MDCUtils;
 import uk.gov.pay.connector.util.ResponseUtil;
 import uk.gov.pay.connector.wallets.WalletService;
 import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
-import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
+import uk.gov.pay.connector.wallets.googlepay.api.WorldpayGooglePayAuthRequest;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -129,10 +129,10 @@ public class CardResource {
     )
     public Response authoriseChargeGooglePayWorldpay(@Parameter(example = "b02b63b370fd35418ad66b0101", description = "Charge external ID")
                                     @PathParam("chargeId") String chargeId,
-                                    @NotNull @Valid GooglePayAuthRequest googlePayAuthRequest) {
+                                    @NotNull @Valid WorldpayGooglePayAuthRequest worldpayGooglePayAuthRequest) {
         logger.info("Received encrypted payload for charge with id {} ", chargeId);
-        logger.info("Received wallet payment info \n{} \nfor charge with id {}", googlePayAuthRequest.getPaymentInfo().toString(), chargeId);
-        return walletService.authorise(chargeId, googlePayAuthRequest);
+        logger.info("Received wallet payment info \n{} \nfor charge with id {}", worldpayGooglePayAuthRequest.getPaymentInfo().toString(), chargeId);
+        return walletService.authorise(chargeId, worldpayGooglePayAuthRequest);
     }
 
     @POST

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthorisationGatewayRequest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.wallets;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
-import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
 
 public class WalletAuthorisationGatewayRequest extends AuthorisationGatewayRequest {
     private WalletAuthorisationRequest walletAuthorisationRequest;

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/StripeGooglePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/StripeGooglePayAuthRequest.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.connector.wallets.googlepay.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.connector.wallets.WalletAuthorisationRequest;
+import uk.gov.pay.connector.wallets.WalletType;
+import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripeGooglePayAuthRequest implements WalletAuthorisationRequest {
+    
+    @NotNull
+    @Valid
+    private final WalletPaymentInfo paymentInfo;
+
+    @NotNull
+    @Valid
+    private final String tokenId;
+
+    public StripeGooglePayAuthRequest(@JsonProperty("payment_info") WalletPaymentInfo paymentInfo,
+                               @JsonProperty("token_id") String tokenId) {
+        this.paymentInfo = paymentInfo;
+        this.tokenId = tokenId;
+    }
+
+    public WalletPaymentInfo getPaymentInfo() {
+        return paymentInfo;
+    }
+    
+    public String getTokenId() { return tokenId; }
+    
+    @Override
+    @Schema(hidden = true)
+    public WalletType getWalletType() {
+        return WalletType.GOOGLE_PAY;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/WorldpayGooglePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/WorldpayGooglePayAuthRequest.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class GooglePayAuthRequest implements WalletAuthorisationRequest, WalletAuthorisationData {
+public class WorldpayGooglePayAuthRequest implements WalletAuthorisationRequest, WalletAuthorisationData {
 
     @Schema(hidden = true)
     @NotNull
@@ -25,8 +25,8 @@ public class GooglePayAuthRequest implements WalletAuthorisationRequest, WalletA
     @Valid
     private final EncryptedPaymentData encryptedPaymentData;
 
-    GooglePayAuthRequest(@JsonProperty("payment_info") WalletPaymentInfo paymentInfo,
-                         @JsonProperty("encrypted_payment_data") EncryptedPaymentData encryptedPaymentData) {
+    WorldpayGooglePayAuthRequest(@JsonProperty("payment_info") WalletPaymentInfo paymentInfo,
+                                 @JsonProperty("encrypted_payment_data") EncryptedPaymentData encryptedPaymentData) {
         this.paymentInfo = paymentInfo;
         this.encryptedPaymentData = encryptedPaymentData;
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -20,7 +20,7 @@ import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
 import uk.gov.pay.connector.wallets.applepay.ApplePayDecrypter;
 import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
-import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
+import uk.gov.pay.connector.wallets.googlepay.api.WorldpayGooglePayAuthRequest;
 import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
 
 import java.io.IOException;
@@ -330,8 +330,8 @@ class WorldpayWalletAuthorisationHandlerTest {
 
     private WalletAuthorisationGatewayRequest getGooglePayAuthorisationRequest(boolean withPayerEmail) throws IOException {
         String fixturePath = withPayerEmail ? "googlepay/example-auth-request.json" : "googlepay/example-auth-request-without-email.json";
-        GooglePayAuthRequest googlePayAuthRequest = Jackson.getObjectMapper().readValue(fixture(fixturePath), GooglePayAuthRequest.class);
-        return new WalletAuthorisationGatewayRequest(chargeEntity, googlePayAuthRequest);
+        WorldpayGooglePayAuthRequest worldpayGooglePayAuthRequest = Jackson.getObjectMapper().readValue(fixture(fixturePath), WorldpayGooglePayAuthRequest.class);
+        return new WalletAuthorisationGatewayRequest(chargeEntity, worldpayGooglePayAuthRequest);
     }
 
     private WalletAuthorisationGatewayRequest getGooglePay3dsAuthorisationRequest(boolean isRequires3ds, boolean withIpAddress, boolean withPayerEmail,
@@ -340,11 +340,11 @@ class WorldpayWalletAuthorisationHandlerTest {
         String fixturePath = withDDCResult ? "googlepay/example-3ds-auth-request-with-ddc.json" :
                 withPayerEmail ? "googlepay/example-3ds-auth-request.json" :
                         "googlepay/example-3ds-auth-request-without-email.json";
-        GooglePayAuthRequest googlePayAuthRequest = Jackson.getObjectMapper().readValue(fixture(fixturePath), GooglePayAuthRequest.class);
+        WorldpayGooglePayAuthRequest worldpayGooglePayAuthRequest = Jackson.getObjectMapper().readValue(fixture(fixturePath), WorldpayGooglePayAuthRequest.class);
         chargeEntity.getGatewayAccount().setRequires3ds(isRequires3ds);
         chargeEntity.getGatewayAccount().setSendPayerIpAddressToGateway(withIpAddress);
         chargeEntity.setExternalId(GOOGLE_PAY_3DS_WITHOUT_IP_ADDRESS);
-        return new WalletAuthorisationGatewayRequest(chargeEntity, googlePayAuthRequest);
+        return new WalletAuthorisationGatewayRequest(chargeEntity, worldpayGooglePayAuthRequest);
     }
 
     private WalletAuthorisationGatewayRequest getApplePayAuthorisationRequest(boolean withPayerEmail) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.connector.it.resources.stripe;
 
-import com.amazonaws.util.json.Jackson;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.restassured.response.ValidatableResponse;
@@ -27,7 +25,6 @@ import uk.gov.pay.connector.util.RestAssuredClient;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +32,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
@@ -68,7 +64,6 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDe
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithoutAddress;
 import static uk.gov.pay.connector.it.base.ChargingITestBase.authoriseChargeUrlFor;
 import static uk.gov.pay.connector.it.base.ChargingITestBase.authoriseChargeUrlForApplePay;
-import static uk.gov.pay.connector.it.base.ChargingITestBase.authoriseChargeUrlForGooglePayWorldpay;
 import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
@@ -326,25 +321,7 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.card_brand", is("Visa"))
                 .body("card_details.expiry_date", is(nullValue()));;
     }
-
-    @Test
-    public void shouldReturnBadRequestResponseWhenTryingToAuthoriseAGooglePayPayment() throws IOException {
-        addGatewayAccount();
-        JsonNode validPayload = Jackson.getObjectMapper().readTree(
-                fixture("googlepay/example-auth-request.json"));
-
-        String externalChargeId = addCharge();
-
-        given().port(testContext.getPort())
-                .contentType(JSON)
-                .body(validPayload)
-                .post(authoriseChargeUrlForGooglePayWorldpay(externalChargeId))
-                .then()
-                .statusCode(400)
-                .body("message", contains("Wallet Type GOOGLE_PAY is not supported for Stripe"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
-    }
-
+    
     @Test
     public void shouldCaptureCardPayment_IfChargeWasPreviouslyAuthorised() {
 

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
@@ -30,7 +30,7 @@ import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
-import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
+import uk.gov.pay.connector.wallets.googlepay.api.WorldpayGooglePayAuthRequest;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.util.Optional;
@@ -132,7 +132,7 @@ class WalletAuthoriseServiceForGooglePay3dsTest {
         providerRequestsFor3dsAuthorisation(worldpayOrderStatusResponse);
 
         WalletAuthorisationRequest authorisationData =
-                Jackson.getObjectMapper().readValue(fixture("googlepay/example-auth-request.json"), GooglePayAuthRequest.class);
+                Jackson.getObjectMapper().readValue(fixture("googlepay/example-auth-request.json"), WorldpayGooglePayAuthRequest.class);
 
         walletAuthoriseService.doAuthorise(chargeEntity.getExternalId(), authorisationData);
 

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -58,7 +58,7 @@ import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
-import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
+import uk.gov.pay.connector.wallets.googlepay.api.WorldpayGooglePayAuthRequest;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.util.List;
@@ -270,7 +270,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
 
         WalletAuthorisationRequest authorisationData =
-                Jackson.getObjectMapper().readValue(fixture("googlepay/example-auth-request.json"), GooglePayAuthRequest.class);
+                Jackson.getObjectMapper().readValue(fixture("googlepay/example-auth-request.json"), WorldpayGooglePayAuthRequest.class);
 
         GatewayResponse<BaseAuthoriseResponse> response = walletAuthoriseService.doAuthorise(charge.getExternalId(), authorisationData);
 
@@ -303,7 +303,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
 
         WalletAuthorisationRequest authorisationData =
-                Jackson.getObjectMapper().readValue(fixture("googlepay/auth-request-with-empty-last-digits-card-number.json"), GooglePayAuthRequest.class);
+                Jackson.getObjectMapper().readValue(fixture("googlepay/auth-request-with-empty-last-digits-card-number.json"), WorldpayGooglePayAuthRequest.class);
 
         GatewayResponse<BaseAuthoriseResponse> response = walletAuthoriseService.doAuthorise(charge.getExternalId(), authorisationData);
 

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletServiceTest.java
@@ -15,7 +15,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthRequestBuilder;
 import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
-import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
+import uk.gov.pay.connector.wallets.googlepay.api.WorldpayGooglePayAuthRequest;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -89,17 +89,17 @@ public class WalletServiceTest {
     @Test
     void shouldAuthoriseAValidChargeForGooglePay() throws JsonProcessingException {
         String externalChargeId = "external-charge-id";
-        GooglePayAuthRequest googlePayAuthRequest = Jackson.getObjectMapper().readValue(fixture("googlepay/example-auth-request.json"), GooglePayAuthRequest.class);
+        WorldpayGooglePayAuthRequest worldpayGooglePayAuthRequest = Jackson.getObjectMapper().readValue(fixture("googlepay/example-auth-request.json"), WorldpayGooglePayAuthRequest.class);
         GatewayResponse<BaseAuthoriseResponse> gatewayResponse = responseBuilder()
                 .withResponse(worldpayResponse)
                 .withSessionIdentifier(ProviderSessionIdentifier.of("234"))
                 .build();
         when(worldpayResponse.authoriseStatus()).thenReturn(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED);
-        when(mockWalletAuthoriseService.doAuthorise(externalChargeId, googlePayAuthRequest)).thenReturn(gatewayResponse);
+        when(mockWalletAuthoriseService.doAuthorise(externalChargeId, worldpayGooglePayAuthRequest)).thenReturn(gatewayResponse);
 
-        Response authorisationResponse = walletService.authorise(externalChargeId, googlePayAuthRequest);
+        Response authorisationResponse = walletService.authorise(externalChargeId, worldpayGooglePayAuthRequest);
 
-        verify(mockWalletAuthoriseService).doAuthorise(externalChargeId, googlePayAuthRequest);
+        verify(mockWalletAuthoriseService).doAuthorise(externalChargeId, worldpayGooglePayAuthRequest);
         assertThat(authorisationResponse.getStatus(), is(200));
         assertThat(authorisationResponse.getEntity(), is(Map.of("status", "AUTHORISATION SUCCESS")));
     }
@@ -107,7 +107,7 @@ public class WalletServiceTest {
     @Test
     void shouldReturnAuthorise3dsRequiredForAValid3dsChargeForGooglePay() throws JsonProcessingException {
         String externalChargeId = "external-charge-id";
-        GooglePayAuthRequest googlePayAuth3dsRequest = Jackson.getObjectMapper().readValue(fixture("googlepay/example-3ds-auth-request.json"), GooglePayAuthRequest.class);
+        WorldpayGooglePayAuthRequest googlePayAuth3dsRequest = Jackson.getObjectMapper().readValue(fixture("googlepay/example-3ds-auth-request.json"), WorldpayGooglePayAuthRequest.class);
         GatewayResponse<BaseAuthoriseResponse> gatewayResponse = responseBuilder()
                 .withResponse(worldpayResponse)
                 .withSessionIdentifier(ProviderSessionIdentifier.of("234"))
@@ -125,7 +125,7 @@ public class WalletServiceTest {
     @Test
     void shouldReturnInternalServerError_ifGatewayErrorsForGooglePay() throws JsonProcessingException {
         String externalChargeId = "external-charge-id";
-        GooglePayAuthRequest googlePayAuthRequest = Jackson.getObjectMapper().readValue(fixture("googlepay/example-auth-request.json"), GooglePayAuthRequest.class);
+        WorldpayGooglePayAuthRequest worldpayGooglePayAuthRequest = Jackson.getObjectMapper().readValue(fixture("googlepay/example-auth-request.json"), WorldpayGooglePayAuthRequest.class);
         GatewayError gatewayError = mock(GatewayError.class);
         GatewayResponse gatewayResponse = responseBuilder()
                 .withGatewayError(gatewayError)
@@ -133,11 +133,11 @@ public class WalletServiceTest {
                 .build();
         when(gatewayError.getErrorType()).thenReturn(GATEWAY_ERROR);
         when(gatewayError.getMessage()).thenReturn("oops");
-        when(mockWalletAuthoriseService.doAuthorise(externalChargeId, googlePayAuthRequest)).thenReturn(gatewayResponse);
+        when(mockWalletAuthoriseService.doAuthorise(externalChargeId, worldpayGooglePayAuthRequest)).thenReturn(gatewayResponse);
 
-        Response authorisationResponse = walletService.authorise(externalChargeId, googlePayAuthRequest);
+        Response authorisationResponse = walletService.authorise(externalChargeId, worldpayGooglePayAuthRequest);
 
-        verify(mockWalletAuthoriseService).doAuthorise(externalChargeId, googlePayAuthRequest);
+        verify(mockWalletAuthoriseService).doAuthorise(externalChargeId, worldpayGooglePayAuthRequest);
         assertThat(authorisationResponse.getStatus(), is(402));
         ErrorResponse response = (ErrorResponse)authorisationResponse.getEntity();
         assertThat(response.getMessages(), contains("oops"));

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/WorldpayGooglePayAuthRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/WorldpayGooglePayAuthRequestTest.java
@@ -11,14 +11,14 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-class GooglePayAuthRequestTest {
+class WorldpayGooglePayAuthRequestTest {
 
     @Test
     void shouldDeserializeFromJsonCorrectly() throws IOException {
         ObjectMapper objectMapper = Jackson.getObjectMapper();
         JsonNode expected = objectMapper.readTree(fixture("googlepay/example-3ds-auth-request.json"));
-        GooglePayAuthRequest actual = objectMapper.readValue(
-                fixture("googlepay/example-3ds-auth-request.json"), GooglePayAuthRequest.class);
+        WorldpayGooglePayAuthRequest actual = objectMapper.readValue(
+                fixture("googlepay/example-3ds-auth-request.json"), WorldpayGooglePayAuthRequest.class);
 
         JsonNode paymentInfo = expected.get("payment_info");
         assertThat(actual.getPaymentInfo().getCardholderName(), is(paymentInfo.get("cardholder_name").asText()));


### PR DESCRIPTION
- Create specific Google Pay auth request classes for Stripe and Worldpay as the structure is different
- Use token provided by Google Pay via frontend to build the request to Stripe
- Add appropriate unit tests and remove redundant test

The corresponding “Authorise Google Pay via Stripe” endpoint will be added in a subsequent PR
