### PR TITLE
PP-11393 Implement expandable fields for Stripe responses

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeExpandableField.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeExpandableField.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import java.util.Optional;
+
+public class StripeExpandableField<T extends StripeObjectWithId> {
+    
+    private String id;
+    private T expandedObject;
+
+    public StripeExpandableField(String id, T expandedObject) {
+        this.id = id;
+        this.expandedObject = expandedObject;
+    }
+
+    public boolean isExpanded() {
+        return expandedObject != null;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Optional<T> getExpanded() {
+        return Optional.ofNullable(expandedObject);
+    }
+
+    public void setExpanded(T expandedObject) {
+        this.expandedObject = expandedObject;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeExpandableFieldDeserializer.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeExpandableFieldDeserializer.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+
+import java.io.IOException;
+
+import static java.lang.String.format;
+
+public class StripeExpandableFieldDeserializer extends JsonDeserializer<StripeExpandableField<?>> implements ContextualDeserializer {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private JavaType type;
+    private String name;
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext context, BeanProperty property) {
+        this.type = property.getType().containedType(0);
+        this.name = property.getName();
+        return this;
+    }
+
+    @Override
+    public StripeExpandableField<?> deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException, JacksonException {
+        JsonNode jsonNode = context.readTree(jsonParser);
+        if (jsonNode.isNull()) {
+            return null;
+        }
+        if (jsonNode.isTextual()) {
+            return new StripeExpandableField<>(jsonNode.asText(), null);
+        } else if (jsonNode.isObject()) {
+            if (!jsonNode.has("id")) {
+                throw JsonMappingException.from(jsonParser, format("Expected field [id] to exist on nested object [%s]", name));
+            }
+            String id = jsonNode.get("id").asText();
+            return new StripeExpandableField<>(id, objectMapper.treeToValue(jsonNode, type));
+        }
+
+        throw JsonMappingException.from(jsonParser, format("Field [%s] is a non-object, non-textual type.", name));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeObjectWithId.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeObjectWithId.java
@@ -1,0 +1,5 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+public interface StripeObjectWithId {
+    public String getId();
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentIntentResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentIntentResponse.java
@@ -2,8 +2,12 @@ package uk.gov.pay.connector.gateway.stripe.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.stripe.json.StripeExpandableField;
 import uk.gov.pay.connector.gateway.stripe.json.StripeCharge;
+import uk.gov.pay.connector.gateway.stripe.json.StripeExpandableFieldDeserializer;
 import uk.gov.pay.connector.gateway.stripe.json.StripePaymentIntent;
 import uk.gov.pay.connector.gateway.stripe.model.StripeChargeStatus;
 import uk.gov.pay.connector.gateway.stripe.util.PaymentIntentStringifier;
@@ -34,7 +38,7 @@ public class StripePaymentIntentResponse {
     private String customerId;
     
     @JsonProperty("payment_method")
-    private StripePaymentMethodResponse paymentMethod;
+    private StripeExpandableField<StripePaymentMethodResponse> paymentMethod;
 
     public String getId() {
         return id;
@@ -48,7 +52,8 @@ public class StripePaymentIntentResponse {
         return customerId;
     }
 
-    public StripePaymentMethodResponse getPaymentMethod() {
+    @JsonDeserialize(using = StripeExpandableFieldDeserializer.class)
+    public StripeExpandableField<StripePaymentMethodResponse> getPaymentMethod() {
         return paymentMethod;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentMethodResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentMethodResponse.java
@@ -2,11 +2,12 @@ package uk.gov.pay.connector.gateway.stripe.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.connector.gateway.stripe.json.StripeObjectWithId;
 
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class StripePaymentMethodResponse {
+public class StripePaymentMethodResponse implements StripeObjectWithId {
     @JsonProperty("id")
     private String id;
     

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/json/StripeExpandableFieldDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/json/StripeExpandableFieldDeserializerTest.java
@@ -1,0 +1,97 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class StripeExpandableFieldDeserializerTest {
+
+    @Test
+    void shouldDeserializeFieldWithTextualValue() throws Exception {
+        String json = "{\"stripe_object\": \"an-id\"}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        TestModel testModel = objectMapper.readValue(json, TestModel.class);
+        
+        assertThat(testModel.getStripeObject(), not(nullValue()));
+        assertThat(testModel.getStripeObject().getId(), is("an-id"));
+        assertThat(testModel.getStripeObject().isExpanded(), is(false));
+        assertThat(testModel.getStripeObject().getExpanded(), is(Optional.empty()));
+    }
+
+    @Test
+    void shouldDeserializeFieldWithExpandedValue() throws Exception {
+        String json = "{\"stripe_object\": {\"id\": \"an-id\", \"foo\": \"bar\"}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        TestModel testModel = objectMapper.readValue(json, TestModel.class);
+
+        assertThat(testModel.getStripeObject(), not(nullValue()));
+        assertThat(testModel.getStripeObject().getId(), is("an-id"));
+        assertThat(testModel.getStripeObject().isExpanded(), is(true));
+        assertThat(testModel.getStripeObject().getExpanded().isPresent(), is(true));
+        assertThat(testModel.getStripeObject().getExpanded().get().foo, is("bar"));
+    }
+
+    @Test
+    void shouldThrowExceptionIfNestedObjectDoesNotHaveId() {
+        String json = "{\"stripe_object\": {\"foo\": \"bar\"}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonMappingException exception = assertThrows(JsonMappingException.class, () -> objectMapper.readValue(json, TestModel.class));
+        assertThat(exception.getMessage(), startsWith("Expected field [id] to exist on nested object [stripe_object]"));
+    }
+
+    @Test
+    void shouldDeserializeNullValueAsNull() throws Exception {
+        String json = "{\"stripe_object\": null}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        TestModel testModel = objectMapper.readValue(json, TestModel.class);
+        
+        assertThat(testModel.getStripeObject(), is(nullValue()));
+    }
+    
+    @Test
+    void shouldThrowExceptionIfFieldHasUnexpectedType() {
+        String json = "{\"stripe_object\": 1}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonMappingException exception = assertThrows(JsonMappingException.class, () -> objectMapper.readValue(json, TestModel.class));
+        assertThat(exception.getMessage(), startsWith("Field [stripe_object] is a non-object, non-textual type."));
+    }
+
+    private static class TestModel {
+        @JsonProperty("stripe_object")
+        @JsonDeserialize(using = StripeExpandableFieldDeserializer.class)
+        private StripeExpandableField<TestStripeObject> stripeObject;
+
+        public StripeExpandableField<TestStripeObject> getStripeObject() {
+            return stripeObject;
+        }
+    }
+    
+    private static class TestStripeObject implements StripeObjectWithId {
+        @JsonProperty("id")
+        private String id;
+        
+        @JsonProperty("foo")
+        private String foo;
+
+        @Override
+        public String getId() {
+            return id;
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/json/StripeExpandableFieldTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/json/StripeExpandableFieldTest.java
@@ -1,0 +1,67 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class StripeExpandableFieldTest {
+
+    public static final String ID = "an-id";
+
+    @Test
+    void shouldReturnFalseIfNotExpanded() {
+        StripeExpandableField<TestStripeObject> expandableField = new StripeExpandableField<>(ID, null);
+        assertThat(expandableField.isExpanded(), is(false));
+    }
+
+    @Test
+    void shouldReturnEmptyOptionalIfNotExpanded() {
+        StripeExpandableField<TestStripeObject> expandableField = new StripeExpandableField<>(ID, null);
+        assertThat(expandableField.getExpanded(), is(Optional.empty()));
+    }
+
+    @Test
+    void shouldReturnIdIfNotExpanded() {
+        StripeExpandableField<TestStripeObject> expandableField = new StripeExpandableField<>(ID, null);
+        assertThat(expandableField.getId(), is(ID));
+    }
+
+    @Test
+    void shouldReturnTrueIfExpanded() {
+        TestStripeObject object = new TestStripeObject(ID);
+        StripeExpandableField<TestStripeObject> expandableField = new StripeExpandableField<>(ID, object);
+        assertThat(expandableField.isExpanded(), is(true));
+    }
+
+    @Test
+    void shouldReturnExpandedObject() {
+        TestStripeObject object = new TestStripeObject(ID);
+        StripeExpandableField<TestStripeObject> expandableField = new StripeExpandableField<>(ID, object);
+        assertThat(expandableField.getExpanded().isPresent(), is(true));
+        assertThat(expandableField.getExpanded().get().getId(), is(ID));
+    }
+
+    @Test
+    void shouldReturnIdIfExpanded() {
+        TestStripeObject object = new TestStripeObject(ID);
+        StripeExpandableField<TestStripeObject> expandableField = new StripeExpandableField<>(ID, object);
+        assertThat(expandableField.getId(), is(ID));
+    }
+
+    private static class TestStripeObject implements StripeObjectWithId {
+
+        private final String id;
+        
+        public TestStripeObject(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public String getId() {
+            return id;
+        }
+    }
+}


### PR DESCRIPTION
When making a request to Stripe, it is possible to specify fields to be "expanded" in the response. If these fields are not expanded, Stripe will return the ID for the resource the field refers to. If they are expanded, the resource will be embedded in the response.

Implement a method to handle the response containing either the expanded object or the ID by first trying to deserialize the response in the getter for the expandable field, and if this throws an exception assuming the value is an ID and returning this.

For now, just use this for getting the payment method from a payment intent response.