### PR TITLE
PP-11393 Save card expiry date for auth rejected

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
@@ -60,7 +60,7 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
                 stripePaymentIntent.stringify(),
                 stripePaymentIntent.getCustomerId(),
                 stripePaymentIntent.getPaymentMethod().getId(),
-                extractCardExpiryDate(stripePaymentIntent).orElse(null)
+                stripePaymentIntent.getCardExpiryDate().orElse(null)
         );
     }
 
@@ -106,23 +106,5 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
     @Override
     public Optional<CardExpiryDate> getCardExpiryDate() {
         return Optional.of(cardExpiryDate);
-    }
-
-    private static Optional<CardExpiryDate> extractCardExpiryDate(StripePaymentIntent stripePaymentIntent) {
-        return stripePaymentIntent.getPaymentMethod().getExpanded()
-                .flatMap(StripePaymentMethodResponse::getCard)
-                .map(card -> {
-                    if (card.getCardExpiryYear() == null || card.getCardExpiryMonth() == null) {
-                        LOGGER.info("Missing card expiry date on payment method");
-                        return null;
-                    }
-                    try {
-                        YearMonth yearMonth = YearMonth.of(card.getCardExpiryYear(), card.getCardExpiryMonth());
-                        return CardExpiryDate.valueOf(yearMonth);
-                    } catch (DateTimeException | IllegalArgumentException e) {
-                        LOGGER.error(String.format("Invalid card expiry date in response from Stripe: %s", e.getMessage()));
-                        return null;
-                    }
-                });
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason;
 import uk.gov.pay.connector.gateway.model.StripeAuthorisationRejectedCodeMapper;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -72,6 +73,11 @@ public class StripeAuthorisationFailedResponse implements BaseAuthoriseResponse 
     @Override
     public Optional<? extends Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<CardExpiryDate> getCardExpiryDate() {
+        return errorResponse.getError().getCardExpiryDate();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.gateway.stripe.util.PaymentIntentStringifier;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -21,7 +22,7 @@ import java.util.StringJoiner;
  **/
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StripeErrorResponse {
-
+    
     @JsonProperty("error")
     private Error error;
 
@@ -61,6 +62,10 @@ public class StripeErrorResponse {
 
         public Optional<StripePaymentIntent> getStripePaymentIntent() {
             return Optional.ofNullable(stripePaymentIntent);
+        }
+        
+        public Optional<CardExpiryDate> getCardExpiryDate() {
+            return stripePaymentIntent.getCardExpiryDate();
         }
 
         @Override

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
@@ -321,7 +321,7 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.last_digits_card_number", is("4242"))
                 .body("card_details.card_type", is("debit"))
                 .body("card_details.card_brand", is("Visa"))
-                .body("card_details.expiry_date", is(nullValue()));;
+                .body("card_details.expiry_date", is("08/24"));;
     }
 
     @Test
@@ -376,7 +376,7 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.last_digits_card_number", is("4242"))
                 .body("card_details.card_type", is("debit"))
                 .body("card_details.card_brand", is("Visa"))
-                .body("card_details.expiry_date", is(nullValue()));;
+                .body("card_details.expiry_date", is("08/24"));;
     }
 
     @Test


### PR DESCRIPTION
When Stripe returns a response indicating the authorisation was rejected when creating the payment_intent for a wallet payment, extract the card expiry date from the response and save it on the charge.