### PR TITLE
PP-11393 Add additional Stripe Google Pay tests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
@@ -65,7 +65,8 @@ public class StripeErrorResponse {
         }
         
         public Optional<CardExpiryDate> getCardExpiryDate() {
-            return stripePaymentIntent.getCardExpiryDate();
+            return Optional.ofNullable(stripePaymentIntent)
+                    .flatMap(StripePaymentIntent::getCardExpiryDate);
         }
 
         @Override


### PR DESCRIPTION
Add some unit and integration tests to test the case when there is an authorisation error, or 3DS is requested when authorising a Stripe Google Pay payment.