### PR TITLE
PP-11470 Return 402 for all authorisation errors

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
@@ -53,7 +53,7 @@ public class WalletService {
                 return gatewayErrorResponse(error.getMessage());
             default:
                 LOGGER.info("Charge {}: error {}", chargeId, error.getMessage());
-                return badRequestResponse(error.getMessage());
+                return gatewayErrorResponse(error.getMessage());
         }
     }
 


### PR DESCRIPTION
Frontend expected connector to return 402 for an authorisation error, and 400 if the authorisation is rejected. For one type of error we were returning 402 rather than 400, which looks like a mistake.

Make it so that we return a 402 for all authorisation errors.