### PR TITLE
PP-11563 Overhaul the Worldpay request builder

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -533,7 +533,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java",
         "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
         "is_verified": false,
-        "line_number": 78
+        "line_number": 70
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java": [
@@ -1071,5 +1071,5 @@
       }
     ]
   },
-  "generated_at": "2023-09-25T18:23:48Z"
+  "generated_at": "2023-09-27T16:48:35Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/OrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/OrderRequestBuilder.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway;
 
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
-import uk.gov.pay.connector.gateway.templates.PayloadBuilder;
+import uk.gov.pay.connector.gateway.templates.TemplateBuilder;
 
 import javax.ws.rs.core.MediaType;
 
@@ -87,10 +87,10 @@ public abstract class OrderRequestBuilder {
 
     private final TemplateData templateData;
 
-    private PayloadBuilder payloadBuilder;
+    private TemplateBuilder payloadBuilder;
     private OrderRequestType orderRequestType;
 
-    public OrderRequestBuilder(TemplateData templateData, PayloadBuilder payloadBuilder, OrderRequestType orderRequestType) {
+    public OrderRequestBuilder(TemplateData templateData, TemplateBuilder payloadBuilder, OrderRequestType orderRequestType) {
         this.templateData = templateData;
         this.payloadBuilder = payloadBuilder;
         this.orderRequestType = orderRequestType;

--- a/src/main/java/uk/gov/pay/connector/gateway/templates/PayloadBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/templates/PayloadBuilder.java
@@ -1,8 +1,0 @@
-package uk.gov.pay.connector.gateway.templates;
-
-import static uk.gov.pay.connector.gateway.OrderRequestBuilder.TemplateData;
-
-public interface PayloadBuilder {
-
-    String buildWith(TemplateData templateData);
-}

--- a/src/main/java/uk/gov/pay/connector/gateway/templates/TemplateBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/templates/TemplateBuilder.java
@@ -13,14 +13,14 @@ import java.util.Locale;
 
 import static freemarker.template.Configuration.VERSION_2_3_20;
 
-public class TemplateBuilder implements PayloadBuilder {
+public class TemplateBuilder {
     private Template template;
 
     public TemplateBuilder(String templatePath) {
         templateSetup("/templates", templatePath);
     }
 
-    public String buildWith(TemplateData templateData) {
+    public String buildWith(Object templateData) {
         Writer responseWriter = new StringWriter();
         try {
             template.process(templateData, responseWriter);

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
@@ -82,11 +83,13 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
         logMissingDdcResultFor3dsFlexIntegration(request);
 
         try {
+            GatewayOrder gatewayOrder = WorldpayAuthoriseOrderRequest.createAuthoriseOrderRequest(request, acceptLanguageHeaderParser, withExemptionEngine)
+                    .buildGatewayOrder();
             GatewayClient.Response response = authoriseClient.postRequestFor(
                     gatewayUrlMap.get(request.getGatewayAccount().getType()),
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
-                    WorldpayOrderBuilder.buildAuthoriseOrderWithExemptionEngine(request, withExemptionEngine, acceptLanguageHeaderParser),
+                    gatewayOrder,
                     getWorldpayAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()));
 
             if (response.getEntity().contains("request3DSecure")) {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseOrderRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseOrderRequest.java
@@ -1,0 +1,288 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import org.checkerframework.checker.units.qual.N;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.templates.TemplateBuilder;
+import uk.gov.pay.connector.gateway.util.AuthUtil;
+import uk.gov.pay.connector.northamericaregion.NorthAmericaRegion;
+import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
+import uk.gov.pay.connector.util.AcceptLanguageHeaderParser;
+
+import java.util.Optional;
+
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayAuthoriseOrderRequest.WorldpayAuthoriseOrderRequestBuilder.aWorldpayAuthoriseOrderRequest;
+
+public class WorldpayAuthoriseOrderRequest extends WorldpayOrderRequest {
+    private static final TemplateBuilder templateBuilder = new TemplateBuilder("/worldpay/WorldpayAuthoriseOrderTemplate.xml");
+    private static final NorthAmericanRegionMapper northAmericanRegionMapper = new NorthAmericanRegionMapper();
+    private String description;
+    private AuthCardDetails authCardDetails;
+    private String amount;
+    private String paymentPlatformReference;
+    private String state;
+    private boolean savePaymentInstrumentToAgreement;
+    private boolean requires3ds;
+    private String sessionId;
+    private String payerIpAddress;
+    private String payerEmail;
+    private String agreementId;
+    private String browserLanguage;
+    private int integrationVersion3ds;
+    private boolean exemptionEngineEnabled;
+
+    private WorldpayAuthoriseOrderRequest(String transactionId,
+                                          String merchantCode,
+                                          String description,
+                                          AuthCardDetails authCardDetails,
+                                          String amount,
+                                          String paymentPlatformReference,
+                                          String state,
+                                          boolean savePaymentInstrumentToAgreement,
+                                          boolean requires3ds,
+                                          String sessionId,
+                                          String payerIpAddress,
+                                          String payerEmail,
+                                          String agreementId,
+                                          String browserLanguage,
+                                          int integrationVersion3ds,
+                                          boolean exemptionEngineEnabled) {
+        super(transactionId, merchantCode);
+        this.description = description;
+        this.authCardDetails = authCardDetails;
+        this.amount = amount;
+        this.paymentPlatformReference = paymentPlatformReference;
+        this.state = state;
+        this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
+        this.requires3ds = requires3ds;
+        this.sessionId = sessionId;
+        this.payerIpAddress = payerIpAddress;
+        this.payerEmail = payerEmail;
+        this.agreementId = agreementId;
+        this.browserLanguage = browserLanguage;
+        this.integrationVersion3ds = integrationVersion3ds;
+        this.exemptionEngineEnabled = exemptionEngineEnabled;
+    }
+
+    public static WorldpayAuthoriseOrderRequest createAuthoriseOrderRequest(
+            CardAuthorisationGatewayRequest request,
+            AcceptLanguageHeaderParser acceptLanguageHeaderParser,
+            boolean exemptionEngineEnabled) {
+
+        WorldpayAuthoriseOrderRequestBuilder builder = aWorldpayAuthoriseOrderRequest();
+        if (request.getGatewayAccount().isSendPayerIpAddressToGateway()) {
+            request.getAuthCardDetails().getIpAddress().ifPresent(builder::withPayerIpAddress);
+        }
+
+        if (request.getGatewayAccount().isSendPayerEmailToGateway()) {
+            Optional.ofNullable(request.getEmail()).ifPresent(builder::withPayerEmail);
+        }
+
+        if (request.getGatewayAccount().isSendReferenceToGateway()) {
+            builder.withDescription(request.getReference().toString());
+        } else {
+            builder.withDescription(request.getDescription());
+        }
+
+        request.getAuthCardDetails().getAddress()
+                .flatMap(northAmericanRegionMapper::getNorthAmericanRegionForCountry)
+                .map(NorthAmericaRegion::getAbbreviation)
+                .ifPresent(builder::withState);
+
+        boolean is3dsRequired = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
+                request.getGatewayAccount().isRequires3ds();
+
+        return builder
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getGovUkPayPaymentId()).toString())
+                .withRequires3ds(is3dsRequired)
+                .withSavePaymentInstrumentToAgreement(request.isSavePaymentInstrumentToAgreement())
+                .withAgreementId(request.getAgreement().map(AgreementEntity::getExternalId).orElse(null))
+                .withTransactionId(request.getTransactionId().orElse(""))
+                .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()))
+                .withAmount(request.getAmount())
+                .withAuthCardDetails(request.getAuthCardDetails())
+                .withIntegrationVersion3ds(request.getGatewayAccount().getIntegrationVersion3ds())
+                .withPaymentPlatformReference(request.getGovUkPayPaymentId())
+                .withBrowserLanguage(acceptLanguageHeaderParser.getPreferredLanguageFromAcceptLanguageHeader(request.getAuthCardDetails().getAcceptLanguageHeader()))
+                .withExemptionEngineEnabled(exemptionEngineEnabled)
+                .build();
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public AuthCardDetails getAuthCardDetails() {
+        return authCardDetails;
+    }
+
+    public String getAmount() {
+        return amount;
+    }
+
+    public String getPaymentPlatformReference() {
+        return paymentPlatformReference;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public boolean isSavePaymentInstrumentToAgreement() {
+        return savePaymentInstrumentToAgreement;
+    }
+
+    public boolean isRequires3ds() {
+        return requires3ds;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public String getPayerIpAddress() {
+        return payerIpAddress;
+    }
+
+    public String getPayerEmail() {
+        return payerEmail;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    public String getBrowserLanguage() {
+        return browserLanguage;
+    }
+
+    public int getIntegrationVersion3ds() {
+        return integrationVersion3ds;
+    }
+
+    public boolean isExemptionEngineEnabled() {
+        return exemptionEngineEnabled;
+    }
+
+    @Override
+    public OrderRequestType getOrderRequestType() {
+        return OrderRequestType.AUTHORISE;
+    }
+
+    @Override
+    protected TemplateBuilder getTemplateBuilder() {
+        return templateBuilder;
+    }
+
+    static final class WorldpayAuthoriseOrderRequestBuilder {
+        private String description;
+        private AuthCardDetails authCardDetails;
+        private String amount;
+        private String paymentPlatformReference;
+        private String state;
+        private boolean savePaymentInstrumentToAgreement;
+        private boolean requires3ds;
+        private String sessionId;
+        private String payerIpAddress;
+        private String payerEmail;
+        private String agreementId;
+        private String browserLanguage;
+        private int integrationVersion3ds;
+        private boolean exemptionEngineEnabled;
+        private String transactionId;
+        private String merchantCode;
+
+        private WorldpayAuthoriseOrderRequestBuilder() {
+        }
+
+        public static WorldpayAuthoriseOrderRequestBuilder aWorldpayAuthoriseOrderRequest() {
+            return new WorldpayAuthoriseOrderRequestBuilder();
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withAuthCardDetails(AuthCardDetails authCardDetails) {
+            this.authCardDetails = authCardDetails;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withAmount(String amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withPaymentPlatformReference(String paymentPlatformReference) {
+            this.paymentPlatformReference = paymentPlatformReference;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withState(String state) {
+            this.state = state;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withSavePaymentInstrumentToAgreement(boolean savePaymentInstrumentToAgreement) {
+            this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withRequires3ds(boolean requires3ds) {
+            this.requires3ds = requires3ds;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withSessionId(String sessionId) {
+            this.sessionId = sessionId;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withPayerIpAddress(String payerIpAddress) {
+            this.payerIpAddress = payerIpAddress;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withPayerEmail(String payerEmail) {
+            this.payerEmail = payerEmail;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withAgreementId(String agreementId) {
+            this.agreementId = agreementId;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withBrowserLanguage(String browserLanguage) {
+            this.browserLanguage = browserLanguage;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withIntegrationVersion3ds(int integrationVersion3ds) {
+            this.integrationVersion3ds = integrationVersion3ds;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withExemptionEngineEnabled(boolean exemptionEngineEnabled) {
+            this.exemptionEngineEnabled = exemptionEngineEnabled;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withTransactionId(String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequestBuilder withMerchantCode(String merchantCode) {
+            this.merchantCode = merchantCode;
+            return this;
+        }
+
+        public WorldpayAuthoriseOrderRequest build() {
+            return new WorldpayAuthoriseOrderRequest(transactionId, merchantCode, description, authCardDetails, amount, paymentPlatformReference, state, savePaymentInstrumentToAgreement, requires3ds, sessionId, payerIpAddress, payerEmail, agreementId, browserLanguage, integrationVersion3ds, exemptionEngineEnabled);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -1,70 +1,16 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
-import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.gateway.GatewayOrder;
-import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.util.AuthUtil;
-import uk.gov.pay.connector.util.AcceptLanguageHeaderParser;
 
 import java.util.Optional;
 
-import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseRecurringOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY;
 
 public interface WorldpayOrderBuilder {
-
-    static WorldpayOrderRequestBuilder buildAuthoriseOrderWithExemptionEngine(WorldpayOrderRequestBuilder builder,
-                                                                              CardAuthorisationGatewayRequest request,
-                                                                              AcceptLanguageHeaderParser acceptLanguageHeaderParser) {
-
-        return buildAuthoriseOrderWithoutExemptionEngine(builder, request, acceptLanguageHeaderParser).withExemptionEngine(true);
-    }
-
-    static WorldpayOrderRequestBuilder buildAuthoriseOrderWithoutExemptionEngine(WorldpayOrderRequestBuilder builder,
-                                                                                 CardAuthorisationGatewayRequest request,
-                                                                                 AcceptLanguageHeaderParser acceptLanguageHeaderParser) {
-
-        if (request.getGatewayAccount().isSendPayerIpAddressToGateway()) {
-            request.getAuthCardDetails().getIpAddress().ifPresent(builder::withPayerIpAddress);
-        }
-
-        if (request.getGatewayAccount().isSendPayerEmailToGateway()) {
-            Optional.ofNullable(request.getEmail()).ifPresent(builder::withPayerEmail);
-        }
-
-        if (request.getGatewayAccount().isSendReferenceToGateway()) {
-            builder.withDescription(request.getReference().toString());
-        } else {
-            builder.withDescription(request.getDescription());
-        }
-
-        boolean is3dsRequired = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
-                request.getGatewayAccount().isRequires3ds();
-
-        return (WorldpayOrderRequestBuilder) builder
-                .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getGovUkPayPaymentId()))
-                .with3dsRequired(is3dsRequired)
-                .withSavePaymentInstrumentToAgreement(request.isSavePaymentInstrumentToAgreement())
-                .withAgreementId(request.getAgreement().map(AgreementEntity::getExternalId).orElse(null))
-                .withTransactionId(request.getTransactionId().orElse(""))
-                .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()))
-                .withAmount(request.getAmount())
-                .withAuthorisationDetails(request.getAuthCardDetails())
-                .withIntegrationVersion3ds(request.getGatewayAccount().getIntegrationVersion3ds())
-                .withPaymentPlatformReference(request.getGovUkPayPaymentId())
-                .withBrowserLanguage(acceptLanguageHeaderParser.getPreferredLanguageFromAcceptLanguageHeader(request.getAuthCardDetails().getAcceptLanguageHeader()));
-    }
-
-    static GatewayOrder buildAuthoriseOrderWithExemptionEngine(CardAuthorisationGatewayRequest request, boolean withExemptionEngine, AcceptLanguageHeaderParser acceptLanguageHeaderParser) {
-        if (withExemptionEngine) {
-            return buildAuthoriseOrderWithExemptionEngine(aWorldpayAuthoriseOrderRequestBuilder(), request, acceptLanguageHeaderParser).build();
-        } else {
-            return buildAuthoriseOrderWithoutExemptionEngine(aWorldpayAuthoriseOrderRequestBuilder(), request, acceptLanguageHeaderParser).build();
-        }
-    }
 
     static GatewayOrder buildAuthoriseRecurringOrder(RecurringPaymentAuthorisationGatewayRequest request) {
         var paymentInstrument = request.getPaymentInstrument().orElseThrow(() -> new IllegalArgumentException("Expected request to have payment instrument but it does not"));

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequest.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.templates.TemplateBuilder;
+
+import javax.ws.rs.core.MediaType;
+
+public abstract class WorldpayOrderRequest {
+    private String transactionId;
+    private String merchantCode;
+
+    public WorldpayOrderRequest(String transactionId, String merchantCode) {
+        this.transactionId = transactionId;
+        this.merchantCode = merchantCode;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public String getMerchantCode() {
+        return merchantCode;
+    }
+
+    public abstract OrderRequestType getOrderRequestType();
+    
+    protected abstract TemplateBuilder getTemplateBuilder();
+    
+//    protected abstract String buildOrderRequest();
+    
+    public GatewayOrder buildGatewayOrder() {
+        String payload = getTemplateBuilder().buildWith(this);
+        return new GatewayOrder(getOrderRequestType(), payload, MediaType.APPLICATION_XML_TYPE);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.OrderRequestBuilder;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
-import uk.gov.pay.connector.gateway.templates.PayloadBuilder;
 import uk.gov.pay.connector.gateway.templates.TemplateBuilder;
 import uk.gov.pay.connector.northamericaregion.NorthAmericaRegion;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
@@ -213,10 +212,6 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     private final WorldpayTemplateData worldpayTemplateData;
     private final NorthAmericanRegionMapper northAmericanRegionMapper;
 
-    public static WorldpayOrderRequestBuilder aWorldpayAuthoriseOrderRequestBuilder() {
-        return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), AUTHORISE_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE);
-    }
-
     public static WorldpayOrderRequestBuilder aWorldpayAuthoriseRecurringOrderRequestBuilder() {
         return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), AUTHORISE_RECURRING_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE);
     }
@@ -254,7 +249,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     }
 
 
-    private WorldpayOrderRequestBuilder(WorldpayTemplateData worldpayTemplateData, PayloadBuilder payloadBuilder, OrderRequestType orderRequestType) {
+    private WorldpayOrderRequestBuilder(WorldpayTemplateData worldpayTemplateData, TemplateBuilder payloadBuilder, OrderRequestType orderRequestType) {
         super(worldpayTemplateData, payloadBuilder, orderRequestType);
         this.northAmericanRegionMapper = new NorthAmericanRegionMapper();
         this.worldpayTemplateData = worldpayTemplateData;

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpay3dsResponseAuthOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseApplePayOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseGooglePayOrderRequestBuilder;
-import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseRecurringOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCancelOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCaptureOrderRequestBuilder;
@@ -29,22 +28,15 @@ import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayRefundOrderRequestBuilder;
 import static uk.gov.pay.connector.model.domain.applepay.ApplePayDecryptedPaymentDataFixture.anApplePayDecryptedPaymentData;
 import static uk.gov.pay.connector.model.domain.applepay.WalletPaymentInfoFixture.aWalletPaymentInfo;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_SPECIAL_CHAR_VALID_CAPTURE_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CANCEL_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CAPTURE_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_DELETE_TOKEN_REQUEST;
@@ -79,28 +71,6 @@ class WorldpayOrderRequestBuilderTest {
     );
 
     @Test
-    void shouldGenerateValidAuthoriseOrderRequestForAddressWithMinimumFields() throws Exception {
-
-        Address minAddress = new Address("123 My Street", null, "SW8URR", "London", null, "GB");
-
-        AuthCardDetails authCardDetails = getValidTestCard(minAddress);
-
-        GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
-                .withAcceptHeader("text/html")
-                .withUserAgentHeader("Mozilla/5.0")
-                .withTransactionId("MyUniqueTransactionId!")
-                .withMerchantCode("MERCHANTCODE")
-                .withDescription("This is the description")
-                .withAmount("500")
-                .withAuthorisationDetails(authCardDetails)
-                .build();
-
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS), actualRequest.getPayload());
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
-    }
-
-    @Test
     void shouldGenerateValidAuthoriseRecurringOrderRequestWithSchemeIdentifier() throws Exception {
         GatewayOrder actualRequest = aWorldpayAuthoriseRecurringOrderRequestBuilder()
                 .withPaymentTokenId("test-payment-token-123456")
@@ -128,137 +98,6 @@ class WorldpayOrderRequestBuilderTest {
                 .build();
 
         assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER), actualRequest.getPayload());
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
-    }
-
-    @Test
-    void shouldGenerateValidAuthoriseOrderRequestForAddressWithMinimumFieldsWhen3dsEnabled() throws Exception {
-
-        Address minAddress = new Address("123 My Street", null, "SW8URR", "London", null, "GB");
-
-        AuthCardDetails authCardDetails = getValidTestCard(minAddress);
-
-        GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
-                .with3dsRequired(true)
-                .withAcceptHeader("text/html")
-                .withUserAgentHeader("Mozilla/5.0")
-                .withTransactionId("MyUniqueTransactionId!")
-                .withMerchantCode("MERCHANTCODE")
-                .withDescription("This is the description")
-                .withAmount("500")
-                .withAuthorisationDetails(authCardDetails)
-                .build();
-
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS), actualRequest.getPayload());
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
-    }
-
-    @Test
-    void shouldGenerateValidAuthoriseOrderRequestForAddressWithState() throws Exception {
-
-        Address usAddress = new Address("10 WCB", null, "20500", "Washington D.C.", null, "US");
-
-        AuthCardDetails authCardDetails = getValidTestCard(usAddress);
-
-        GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
-                .withAcceptHeader("text/html")
-                .withUserAgentHeader("Mozilla/5.0")
-                .withTransactionId("MyUniqueTransactionId!")
-                .withMerchantCode("MERCHANTCODE")
-                .withDescription("This is the description")
-                .withAmount("500")
-                .withAuthorisationDetails(authCardDetails)
-                .build();
-
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE), actualRequest.getPayload());
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
-    }
-
-    @Test
-    void shouldGenerateValidAuthoriseOrderRequestForAddressWithStateWhen3dsEnabled() throws Exception {
-
-        Address usAddress = new Address("10 WCB", null, "20500", "Washington D.C.", null, "US");
-
-        AuthCardDetails authCardDetails = getValidTestCard(usAddress);
-
-        GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
-                .with3dsRequired(true)
-                .withAcceptHeader("text/html")
-                .withUserAgentHeader("Mozilla/5.0")
-                .withTransactionId("MyUniqueTransactionId!")
-                .withMerchantCode("MERCHANTCODE")
-                .withDescription("This is the description")
-                .withAmount("500")
-                .withAuthorisationDetails(authCardDetails)
-                .build();
-
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE), actualRequest.getPayload());
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
-    }
-
-    @Test
-    void shouldGenerateValidAuthoriseOrderRequestForAddressWithAllFields() throws Exception {
-
-        Address fullAddress = new Address("123 My Street", "This road", "SW8URR", "London", "London county", "GB");
-
-        AuthCardDetails authCardDetails = getValidTestCard(fullAddress);
-
-        GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
-                .withAcceptHeader("text/html")
-                .withUserAgentHeader("Mozilla/5.0")
-                .withTransactionId("MyUniqueTransactionId!")
-                .withMerchantCode("MERCHANTCODE")
-                .withDescription("This is the description")
-                .withAmount("500")
-                .withAuthorisationDetails(authCardDetails)
-                .build();
-
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS), actualRequest.getPayload());
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
-    }
-
-    @Test
-    void shouldGenerateValidAuthoriseOrderRequestWhenSpecialCharactersInUserInput() throws Exception {
-
-        Address address = new Address("123 & My Street", "This road -->", "SW8 > URR", "London !>", null, "GB");
-
-        AuthCardDetails authCardDetails = getValidTestCard(address);
-
-        GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
-                .withAcceptHeader("text/html")
-                .withUserAgentHeader("Mozilla/5.0")
-                .withTransactionId("MyUniqueTransactionId!")
-                .withMerchantCode("MERCHANTCODE")
-                .withDescription("This is the description with <!-- ")
-                .withAmount("500")
-                .withAuthorisationDetails(authCardDetails)
-                .build();
-
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS), actualRequest.getPayload());
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
-    }
-
-    @Test
-    void shouldGenerateValidAuthoriseOrderRequestWhenAddressIsMissing() throws Exception {
-        AuthCardDetails authCardDetails = getValidTestCard(null);
-
-        GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
-                .withAcceptHeader("text/html")
-                .withUserAgentHeader("Mozilla/5.0")
-                .withTransactionId("MyUniqueTransactionId!")
-                .withMerchantCode("MERCHANTCODE")
-                .withDescription("This is the description")
-                .withAmount("500")
-                .withAuthorisationDetails(authCardDetails)
-                .build();
-
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS), actualRequest.getPayload());
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/request/WorldpayAuthoriseOrderRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/request/WorldpayAuthoriseOrderRequestTest.java
@@ -1,0 +1,180 @@
+package uk.gov.pay.connector.gateway.worldpay.request;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthoriseOrderRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
+import uk.gov.pay.connector.util.AcceptLanguageHeaderParser;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
+
+import java.util.List;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS;
+
+class WorldpayAuthoriseOrderRequestTest {
+
+    private GatewayAccountCredentialsEntity credentialsEntity;
+    private AcceptLanguageHeaderParser acceptLanguageHeaderParser = new AcceptLanguageHeaderParser();
+
+    @BeforeEach
+    void setUp() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
+        worldpayCredentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials("MERCHANTCODE", "foo", "bar"));
+        credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(WORLDPAY.getName())
+                .withCredentialsObject(worldpayCredentials)
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build();
+    }
+
+    @Test
+    void shouldGenerateValidAuthoriseOrderRequestForAddressWithMinimumFieldsWhen3dsEnabled() throws Exception {
+
+        Address minAddress = new Address("123 My Street", null, "SW8URR", "London", null, "GB");
+
+        AuthCardDetails authCardDetails = getValidTestCard(minAddress);
+
+        GatewayOrder actualRequest = buildGatewayOrder(authCardDetails, true);
+
+        String expectedPayload = TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS);
+        assertXMLEqual(expectedPayload, actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+    
+    @Test
+    void shouldGenerateValidAuthoriseOrderRequestForAddressWithState() throws Exception {
+
+        Address usAddress = new Address("10 WCB", null, "20500", "Washington D.C.", null, "US");
+
+        AuthCardDetails authCardDetails = getValidTestCard(usAddress);
+
+        GatewayOrder actualRequest = buildGatewayOrder(authCardDetails, false);
+
+        String expectedPayload = TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE);
+        assertXMLEqual(expectedPayload, actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    void shouldGenerateValidAuthoriseOrderRequestForAddressWithStateWhen3dsEnabled() throws Exception {
+
+        Address usAddress = new Address("10 WCB", null, "20500", "Washington D.C.", null, "US");
+
+        AuthCardDetails authCardDetails = getValidTestCard(usAddress);
+
+        GatewayOrder actualRequest = buildGatewayOrder(authCardDetails, true);
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    void shouldGenerateValidAuthoriseOrderRequestForAddressWithAllFields() throws Exception {
+
+        Address fullAddress = new Address("123 My Street", "This road", "SW8URR", "London", "London county", "GB");
+
+        AuthCardDetails authCardDetails = getValidTestCard(fullAddress);
+
+        GatewayOrder actualRequest = buildGatewayOrder(authCardDetails, false);
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    void shouldGenerateValidAuthoriseOrderRequestWhenSpecialCharactersInUserInput() throws Exception {
+
+        Address address = new Address("123 & My Street", "This road -->", "SW8 > URR", "London !>", null, "GB");
+
+        AuthCardDetails authCardDetails = getValidTestCard(address);
+
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                .withRequires3ds(false)
+                .withGatewayAccountCredentials(List.of(credentialsEntity))
+                .build();
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(gatewayAccountEntity)
+                .withGatewayAccountCredentialsEntity(credentialsEntity)
+                .withExternalId("uniqueSessionId")
+                .withGatewayTransactionId("MyUniqueTransactionId!")
+                .withDescription("This is the description with <!-- ")
+                .withAmount(500l)
+                .build();
+
+        GatewayOrder actualRequest = buildGatewayOrder(authCardDetails, chargeEntity);
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    void shouldGenerateValidAuthoriseOrderRequestWhenAddressIsMissing() throws Exception {
+        AuthCardDetails authCardDetails = getValidTestCard(null);
+
+        GatewayOrder actualRequest = buildGatewayOrder(authCardDetails, false);
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    private GatewayOrder buildGatewayOrder(AuthCardDetails authCardDetails, boolean requires3ds) {
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                .withRequires3ds(requires3ds)
+                .withGatewayAccountCredentials(List.of(credentialsEntity))
+                .build();
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(gatewayAccountEntity)
+                .withGatewayAccountCredentialsEntity(credentialsEntity)
+                .withExternalId("uniqueSessionId")
+                .withGatewayTransactionId("MyUniqueTransactionId!")
+                .withDescription("This is the description")
+                .withAmount(500l)
+                .build();
+
+        return buildGatewayOrder(authCardDetails, chargeEntity);
+    }
+
+    private GatewayOrder buildGatewayOrder(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
+        var cardAuthorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, authCardDetails);
+        var worldpayAuthoriseOrderRequest =  WorldpayAuthoriseOrderRequest.createAuthoriseOrderRequest(
+                cardAuthorisationGatewayRequest, acceptLanguageHeaderParser, false);
+        return worldpayAuthoriseOrderRequest.buildGatewayOrder();
+    }
+
+
+    private AuthCardDetails getValidTestCard(Address address) {
+        return AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("Mr. Payment")
+                .withCardNo("4111111111111111")
+                .withCvc("123")
+                .withEndDate(CardExpiryDate.valueOf("12/15"))
+                .withCardBrand("visa")
+                .withAddress(address)
+                .withAcceptHeader("text/html")
+                .withUserAgentHeader("Mozilla/5.0")
+                .build();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityFixture.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gatewayaccountcredentials.model;
 
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 
 import java.time.Instant;
 import java.util.Map;
@@ -13,7 +14,8 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 public final class GatewayAccountCredentialsEntityFixture {
     private Instant activeStartDate = Instant.now();
     private String paymentProvider = WORLDPAY.getName();
-    private Map<String, Object> credentials = Map.of();
+    private Map<String, Object> credentialsMap = Map.of();
+    private GatewayCredentials gatewayCredentials;
     private GatewayAccountCredentialState state = ACTIVE;
     private GatewayAccountEntity gatewayAccountEntity;
     private String externalId = randomUuid();
@@ -42,12 +44,17 @@ public final class GatewayAccountCredentialsEntityFixture {
     }
 
     public GatewayAccountCredentialsEntityFixture withCredentials(Map<String, Object> credentials) {
-        this.credentials = credentials;
+        this.credentialsMap = credentials;
+        return this;
+    }
+    
+    public GatewayAccountCredentialsEntityFixture withCredentialsObject(GatewayCredentials gatewayCredentials) {
+        this.gatewayCredentials = gatewayCredentials;
         return this;
     }
     
     public GatewayAccountCredentialsEntityFixture withStripeCredentials() {
-        this.credentials = Map.of(CREDENTIALS_STRIPE_ACCOUNT_ID, "acct_abc123");
+        this.credentialsMap = Map.of(CREDENTIALS_STRIPE_ACCOUNT_ID, "acct_abc123");
         return this;
     }
 
@@ -67,10 +74,13 @@ public final class GatewayAccountCredentialsEntityFixture {
     }
 
     public GatewayAccountCredentialsEntity build() {
-        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = new GatewayAccountCredentialsEntity(gatewayAccountEntity, paymentProvider, credentials, state);
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = new GatewayAccountCredentialsEntity(gatewayAccountEntity, paymentProvider, credentialsMap, state);
         gatewayAccountCredentialsEntity.setCreatedDate(createdDate);
         gatewayAccountCredentialsEntity.setActiveStartDate(activeStartDate);
         gatewayAccountCredentialsEntity.setExternalId(externalId);
+        if (gatewayCredentials != null) {
+         gatewayAccountCredentialsEntity.setCredentials(gatewayCredentials);   
+        }
         return gatewayAccountCredentialsEntity;
     }
 }


### PR DESCRIPTION
Add interface WorldpayOrderRequest to replace most of the existing classes used to build Worldpay order request. This encapsulates all the logic for building a GatewayOrder and should make it easier to follow the code. This more closely mirrors how we build Stripe requests.

Will have subclasses per request type which will only contain the data required to build the order for that request. This commit adds WorldpayAuthoriseOrderRequest for building authorisation requests and uses that instead of WorldpayOrderRequestBuilder.

Re-create the tests from WorldpayOrderRequestBuilderTest for building the authorise request in WorldpayAuthoriseOrderRequestTest.