### PR TITLE
PP-11393 Fix status code for auth errors

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -331,7 +331,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java",
         "hashed_secret": "423e3dd3782e3527b4f9af75dd9faf9ebbb7889c",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 104
       }
     ],
     "src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2023-09-25T18:23:48Z"
+  "generated_at": "2023-09-28T12:50:46Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseAuthoriseResponse.java
@@ -34,6 +34,7 @@ public interface BaseAuthoriseResponse extends BaseResponse {
     default Optional<CardExpiryDate> getCardExpiryDate() { return Optional.empty(); }
     
     enum AuthoriseStatus {
+        // SUBMITTED only applies to ePDQ and can be removed when ePDQ code is deleted
         SUBMITTED(ChargeStatus.AUTHORISATION_SUBMITTED),
         AUTHORISED(ChargeStatus.AUTHORISATION_SUCCESS),
         REJECTED(ChargeStatus.AUTHORISATION_REJECTED),

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.paymentprocessor.resource;
 
-import com.google.common.collect.ImmutableMap;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -187,26 +186,20 @@ public class CardResource {
         AuthorisationResponse response = cardAuthoriseService.doAuthoriseWeb(chargeId, authCardDetails);
 
         return response.getGatewayError().map(this::handleError)
-                .orElseGet(() -> response.getAuthoriseStatus().map(status -> handleAuthResponse(chargeId, status))
+                .orElseGet(() -> response.getAuthoriseStatus().map(this::handleAuthResponse)
                         .orElseGet(() -> ResponseUtil.serviceErrorResponse("InterpretedStatus not found for Gateway response")));
     }
 
-    private Response handleAuthResponse(String chargeId, AuthoriseStatus authoriseStatus) {
-        // TODO The following if statement can be deleted as it covers a uniquely epdq case. See PP-1494:
-        // "A charge at AUTHORISATION SUBMITTED should appear externally to be an error. i.e. payment can not be continued. 
-        // This is because ePDQ can defer authorisation for instance during a planned system outage. However we require 
-        // authorisation to be immediate so we should not support this. ePDQ have assured us it happens extremely rarely 
-        // so it is acceptable to treat this as an error."
-        if (authoriseStatus.equals(AuthoriseStatus.SUBMITTED)) {
-            logger.info("Charge {}: authorisation was deferred.", chargeId);
-            return badRequestResponse("This transaction was deferred.");
+    private Response handleAuthResponse(AuthoriseStatus authoriseStatus) {
+        switch (authoriseStatus) {
+            case REJECTED:
+                return badRequestResponse("This transaction was declined.");
+            case ERROR:
+            case EXCEPTION:
+                return gatewayErrorResponse("There was an error authorising the transaction.");
+            default:
+                return ResponseUtil.successResponseWithEntity(Map.of("status", authoriseStatus.getMappedChargeStatus().toString()));
         }
-
-        if (isAuthorisationDeclined(authoriseStatus)) {
-            return badRequestResponse("This transaction was declined.");
-        }
-
-        return ResponseUtil.successResponseWithEntity(ImmutableMap.of("status", authoriseStatus.getMappedChargeStatus().toString()));
     }
 
     @POST
@@ -390,10 +383,5 @@ public class CardResource {
         } else {
             return ResponseUtil.serviceErrorResponse("InterpretedStatus not found for Gateway response");
         }
-    }
-
-    private static boolean isAuthorisationDeclined(AuthoriseStatus authoriseStatus) {
-        return authoriseStatus.equals(AuthoriseStatus.REJECTED) ||
-                authoriseStatus.equals(AuthoriseStatus.ERROR);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -22,6 +22,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_GET_PA
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CANCEL_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CUSTOMER;
@@ -61,6 +62,11 @@ public class StripeMockClient {
     
     public void mockCreatePaymentIntentAuthorisationRejected() {
         String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_RESPONSE);
+        setupResponse(payload, "/v1/payment_intents", 402);
+    }
+
+    public void mockCreatePaymentIntentAuthorisationError() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_ERROR_RESPONSE);
         setupResponse(payload, "/v1/payment_intents", 402);
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -141,6 +141,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CUSTOMER = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response_with_customer.json";
     public static final String STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_requires_3ds_response.json";
     public static final String STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_authorisation_rejected_response.json";
+    public static final String STRIPE_PAYMENT_INTENT_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_error_response.json";
     public static final String STRIPE_PAYMENT_INTENT_CANCEL_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/payment_intent_cancel_response.json";
     public static final String STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/get_payment_intent_with_3ds_authorised_success_response.json";
     public static final String STRIPE_GET_PAYMENT_INTENT_WITH_MULTIPLE_CHARGES = TEMPLATE_BASE_NAME + "/stripe/get_payment_intent_with_multiple_charges.json";

--- a/src/test/resources/templates/stripe/create_payment_intent_error_response.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_error_response.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "message": "Error while communicating with one of our backends.  Sorry about that!  We have been notified of the problem.  If you have any questions, we can help at https://support.stripe.com/.",
+    "request_log_url": "https://dashboard.stripe.com/logs/req_abc123",
+    "type": "api_error"
+  }
+}


### PR DESCRIPTION
When the Stripe API returns an error, the GatewayResponse returned by the authorise service does not have a GatewayError set, but the BaseAuthoriseResponse has an AuthoriseStatus of Error.

We were treating this the same as a decline and returning a 400 response code. PP-8693 made some changes so that authorisation errors return a 402 response rather than a 500 response. It makes sense that all authorisation errors return a 402 rather than a 400. The frontend code for wallet payments also now expects a 400 response to always be a decline.

Remove handling for AuthoriseStatus.SUBMITTED, as this was only possible for ePDQ which has now been retired.