### PR TITLE
PP-11601 Improved rejected authorisation error handling

### DIFF
--- a/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
+++ b/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
@@ -20,6 +20,7 @@ import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.status;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.AUTHORISATION_REJECTED;
 
 public class ResponseUtil {
     
@@ -53,6 +54,10 @@ public class ResponseUtil {
 
     public static Response badRequestResponse(String message) {
         return buildErrorResponse(BAD_REQUEST, message);
+    }
+
+    public static Response authorisationRejectedResponse(String message) {
+        return buildErrorResponse(BAD_REQUEST, AUTHORISATION_REJECTED, message);
     }
 
     public static Response badRequestResponse(List<String> messages) {
@@ -98,6 +103,10 @@ public class ResponseUtil {
         return responseWithEntity(status, errorResponse);
     }
 
+    public static Response buildErrorResponse(Status status, ErrorIdentifier errorIdentifier, String message) {
+        ErrorResponse errorResponse = new ErrorResponse(errorIdentifier, message);
+        return responseWithEntity(status, errorResponse);
+    }
     public static Response buildErrorResponse(Status status, ErrorIdentifier errorIdentifier, List<String> messages) {
         ErrorResponse errorResponse = new ErrorResponse(errorIdentifier, messages);
         return responseWithEntity(status, errorResponse);

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
@@ -11,9 +11,8 @@ import javax.inject.Inject;
 import javax.ws.rs.core.Response;
 import java.util.Map;
 
-import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.authorisationRejectedResponse;
 import static uk.gov.pay.connector.util.ResponseUtil.gatewayErrorResponse;
-
 public class WalletService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WalletService.class);
@@ -40,7 +39,7 @@ public class WalletService {
     private Response handleAuthorisationResponse(BaseAuthoriseResponse baseAuthoriseResponse) {
         switch (baseAuthoriseResponse.authoriseStatus()) {
             case REJECTED:
-                return badRequestResponse("This transaction was declined.");
+                return authorisationRejectedResponse("This transaction was declined.");
             case ERROR:
             case EXCEPTION:
                 return gatewayErrorResponse("There was an error authorising the transaction.");

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureIT.java
@@ -136,5 +136,4 @@ public class CardResourceCaptureIT extends ChargingITestBase {
                 .body("message", contains(message))
                 .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
-
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
@@ -132,7 +132,6 @@ public class ChargeCancelFrontendResourceIT extends ChargingITestBase {
 
     @Test
     public void respondWith204With3DSRequiredState_whenCancellationBeforeAuth() {
-
         String chargeId = addCharge(AUTHORISATION_3DS_REQUIRED, "ref", Instant.now().minus(1, HOURS), "irrelvant");
         userCancelChargeAndCheckApiStatus(chargeId, USER_CANCELLED, 204);
         List<String> events = databaseTestHelper.getInternalEvents(chargeId);

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -109,7 +110,7 @@ public class WorldpayAuthoriseGooglePayIT extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
                 .body("message", contains("This transaction was declined."))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.AUTHORISATION_REJECTED.toString()));
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_REJECTED.getValue());
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -24,8 +24,8 @@ import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
 import static javax.ws.rs.core.HttpHeaders.COOKIE;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.PAYMENT_REQUIRED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -170,7 +170,7 @@ public class WorldpayCardResourceIT extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
                 .body("message", contains("This transaction was declined."))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.AUTHORISATION_REJECTED.toString()));
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_REJECTED.getValue());
     }


### PR DESCRIPTION
## WHAT YOU DID
Improved rejected authorisation error handling

## How to test

- How should it be reviewed? 
Software engineer with experience of connector integration and error handling
- What feedback do you need? 
That changes works and will not break current frontend payment authorisation logic and error handling

### Documentation
 https://payments-platform.atlassian.net/browse/PP-11601