### PR TITLE
PP-11595 apple pay sandbox implementation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -739,7 +739,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java",
         "hashed_secret": "aa4f63822a427d27308ddef0e735bc21f8f2f7f7",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 146
       }
     ],
     "src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java": [
@@ -1071,5 +1071,5 @@
       }
     ]
   },
-  "generated_at": "2023-09-29T13:43:40Z"
+  "generated_at": "2023-10-11T15:50:07Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxGatewayResponseGenerator.java
@@ -6,7 +6,9 @@ import uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.sandbox.wallets.SandboxWalletMagicValues;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
 
+import java.time.YearMonth;
 import java.util.Map;
 import java.util.Optional;
 
@@ -38,10 +40,11 @@ public class SandboxGatewayResponseGenerator {
                         .build();
             }
             if (magicValue == DECLINED || magicValue == REFUSED) {
-                return getSandboxGatewayResponse(false);
+                return getSandboxGatewayResponse(false, true);
             }
         }
-        return getSandboxGatewayResponse(true);
+        
+        return getSandboxGatewayResponse(true, true);
     }
 
 
@@ -63,8 +66,12 @@ public class SandboxGatewayResponseGenerator {
                 .withGatewayError(new GatewayError("Unsupported card details.", GENERIC_GATEWAY_ERROR))
                 .build();
     }
-
+    
     public GatewayResponse getSandboxGatewayResponse(boolean isAuthorised) {
+        return getSandboxGatewayResponse(isAuthorised, false);
+    }
+
+    public GatewayResponse getSandboxGatewayResponse(boolean isAuthorised, boolean mockExpiry) {
         GatewayResponse.GatewayResponseBuilder<BaseAuthoriseResponse> gatewayResponseBuilder = responseBuilder();
         return gatewayResponseBuilder.withResponse(new BaseAuthoriseResponse() {
 
@@ -93,6 +100,11 @@ public class SandboxGatewayResponseGenerator {
             @Override
             public Optional<Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
                 return Optional.empty();
+            }
+            
+            @Override
+            public Optional<CardExpiryDate> getCardExpiryDate() { 
+                return Optional.ofNullable(mockExpiry ? CardExpiryDate.valueOf(YearMonth.of(2050, 12)) : null); 
             }
 
             @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletAuthorisationHandler.java
@@ -16,7 +16,7 @@ public class SandboxWalletAuthorisationHandler {
     }
     
     public GatewayResponse<BaseAuthoriseResponse> authoriseApplePay(ApplePayAuthorisationGatewayRequest request) {
-        return authoriseWallet(request.getApplePayAuthRequest().getPaymentInfo());
+        return sandboxGatewayResponseGenerator.getSandboxGatewayWalletResponse(request.getDescription());
     }
 
     public GatewayResponse<BaseAuthoriseResponse> authoriseGooglePay(GooglePayAuthorisationGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletMagicValues.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletMagicValues.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.connector.gateway.sandbox.wallets;
+
+public enum SandboxWalletMagicValues {
+    REFUSED(""),
+    DECLINED(""),
+    ERROR("This transaction could be not be processed.");
+
+    public final String errorMessage;
+
+    SandboxWalletMagicValues(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public static SandboxWalletMagicValues magicValueFromString(String str) {
+        for (SandboxWalletMagicValues value : SandboxWalletMagicValues.values()) {
+            if (value.name().equalsIgnoreCase(str)) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -29,16 +29,13 @@ import uk.gov.pay.connector.wallets.googlepay.GooglePayAuthorisationGatewayReque
 import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
-import java.time.YearMonth;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 
 public class WalletAuthoriseService {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(WalletAuthoriseService.class);
-    
     private final AuthorisationService authorisationService;
     private final ChargeService chargeService;
     private final PaymentProviders paymentProviders;
@@ -73,7 +70,6 @@ public class WalletAuthoriseService {
             GatewayResponse<BaseAuthoriseResponse> operationResponse;
             ChargeStatus chargeStatus = null;
             String requestStatus = "failure";
-            PaymentGatewayName paymentProvider = charge.getPaymentGatewayName();
 
             try {
 
@@ -114,11 +110,6 @@ public class WalletAuthoriseService {
                     operationResponse.getBaseResponse().flatMap(BaseAuthoriseResponse::extractAuth3dsRequiredDetails);
             CardExpiryDate cardExpiryDate = operationResponse.getBaseResponse().flatMap(BaseAuthoriseResponse::getCardExpiryDate).orElse(null);
 
-            // if sandbox, generate fake expiry date
-            if (paymentProvider == SANDBOX && cardExpiryDate == null) {
-                cardExpiryDate = CardExpiryDate.valueOf(YearMonth.of(2050, 12));
-            }
-            
             logMetrics(charge, operationResponse, requestStatus, walletAuthorisationRequest.getWalletType());
 
             processGatewayAuthorisationResponse(

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletAuthorisationHandlerTest.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.gateway.sandbox.wallets;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
@@ -23,26 +25,22 @@ class SandboxWalletAuthorisationHandlerTest {
 
     private SandboxWalletAuthorisationHandler sandboxWalletAuthorisationHandler;
 
-    private static final String AUTH_SUCCESS_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "4242";
-    private static final String AUTH_REJECTED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0002";
-    private static final String AUTH_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0119";
-
     @BeforeEach
     public void setup() {
         sandboxWalletAuthorisationHandler = new SandboxWalletAuthorisationHandler(new SandboxGatewayResponseGenerator(new SandboxLast4DigitsCardNumbers()));
     }
 
     @Test
-    void authorise_shouldBeAuthorisedWhenLastDigitsCardNumbersAreExpectedToSucceedForAuthorisation_forApplePay() {
+    void authorise_shouldBeAuthorisedWhenChargeDescriptionIsNotMagicValue_forApplePay() {
         ApplePayAuthRequest applePayAuthRequest =
                 anApplePayAuthRequest()
                         .withApplePaymentInfo(
                                 anApplePayPaymentInfo()
-                                        .withLastDigitsCardNumber(AUTH_SUCCESS_APPLE_PAY_LAST_DIGITS_CARD_NUMBER)
+                                        .withLastDigitsCardNumber("1234")
                                         .build())
                         .build();
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseApplePay(
-                new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePayAuthRequest));
+                new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription("whatever").build(), applePayAuthRequest));
 
         assertThat(gatewayResponse.isSuccessful(), is(true));
         assertThat(gatewayResponse.isFailed(), is(false));
@@ -57,17 +55,18 @@ class SandboxWalletAuthorisationHandlerTest {
         assertThat(authoriseResponse.getErrorMessage(), is(nullValue()));
     }
 
-    @Test
-    void authorise_shouldNotBeAuthorisedWhenLastDigitsCardNumbersAreExpectedToBeRejectedForAuthorisation_forApplePay() {
+    @ParameterizedTest
+    @EnumSource(value = SandboxWalletMagicValues.class, names = {"DECLINED", "REFUSED"})
+    void authorise_shouldNotBeAuthorisedWithAnyLastDigitsCardNumbersWhenMagicValuesArePresent_forApplePay(SandboxWalletMagicValues magicValue) {
         ApplePayAuthRequest applePayAuthRequest =
                 anApplePayAuthRequest()
                         .withApplePaymentInfo(
                                 anApplePayPaymentInfo()
-                                        .withLastDigitsCardNumber(AUTH_REJECTED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER)
+                                        .withLastDigitsCardNumber("5678")
                                         .build())
                         .build();
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseApplePay(
-                new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePayAuthRequest));
+                new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription(magicValue.name()).build(), applePayAuthRequest));
 
         assertThat(gatewayResponse.isSuccessful(), is(true));
         assertThat(gatewayResponse.isFailed(), is(false));
@@ -83,16 +82,16 @@ class SandboxWalletAuthorisationHandlerTest {
     }
 
     @Test
-    void authorise_shouldGetGatewayErrorWhenLastDigitsCardNumbersAreExpectedToFailForAuthorisation_forApplePay() {
+    void authorise_shouldGetGatewayErrorWithAnyLastDigitsCardNumbersWhenMagicValueIsPresent_forApplePay() {
         ApplePayAuthRequest applePayAuthRequest =
                 anApplePayAuthRequest()
                         .withApplePaymentInfo(
                                 anApplePayPaymentInfo()
-                                        .withLastDigitsCardNumber(AUTH_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER)
+                                        .withLastDigitsCardNumber("9999")
                                         .build())
                         .build();
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseApplePay(
-                new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePayAuthRequest));
+                new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription(SandboxWalletMagicValues.ERROR.name()).build(), applePayAuthRequest));
 
         assertThat(gatewayResponse.isSuccessful(), is(false));
         assertThat(gatewayResponse.isFailed(), is(true));

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletAuthorisationHandlerTest.java
@@ -12,6 +12,9 @@ import uk.gov.pay.connector.gateway.sandbox.SandboxGatewayResponseGenerator;
 import uk.gov.pay.connector.gateway.sandbox.SandboxLast4DigitsCardNumbers;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
+
+import java.time.YearMonth;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -53,6 +56,8 @@ class SandboxWalletAuthorisationHandlerTest {
         assertThat(authoriseResponse.getTransactionId(), is(notNullValue()));
         assertThat(authoriseResponse.getErrorCode(), is(nullValue()));
         assertThat(authoriseResponse.getErrorMessage(), is(nullValue()));
+        assertThat(authoriseResponse.getCardExpiryDate().isPresent(), is(true));
+        assertThat(authoriseResponse.getCardExpiryDate().get(), is(CardExpiryDate.valueOf(YearMonth.of(2050, 12))));
     }
 
     @ParameterizedTest
@@ -79,6 +84,8 @@ class SandboxWalletAuthorisationHandlerTest {
         assertThat(authoriseResponse.getTransactionId(), is(notNullValue()));
         assertThat(authoriseResponse.getErrorCode(), is(nullValue()));
         assertThat(authoriseResponse.getErrorMessage(), is(nullValue()));
+        assertThat(authoriseResponse.getCardExpiryDate().isPresent(), is(true));
+        assertThat(authoriseResponse.getCardExpiryDate().get(), is(CardExpiryDate.valueOf(YearMonth.of(2050, 12))));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -286,8 +286,12 @@ public class ChargingITestBase {
         return createNewChargeWith(CREATED, "");
     }
 
-    protected String createNewChargeWithNoTransactionIdOrEmailAddress(ChargeStatus status) {
+    protected String createNewChargeWithNoGatewayTransactionIdOrEmailAddress(ChargeStatus status) {
         return createNewChargeWithAccountId(status, null, accountId, databaseTestHelper, null, paymentProvider).toString();
+    }
+
+    protected String createNewChargeWithDescriptionAndNoGatewayTransactionIdOrEmailAddress(ChargeStatus status, String description) {
+        return createNewChargeWithAccountId(status, null, accountId, databaseTestHelper, null, paymentProvider, description).toString();
     }
 
     protected String createNewChargeWithNoTransactionId(ChargeStatus status) {

--- a/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.it.util;
 
 import java.util.Map;
+
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.math.RandomUtils;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
@@ -40,8 +41,18 @@ public class ChargeUtils {
                 "delayed_capture", true));
     }
 
+    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId, 
+                                                                DatabaseTestHelper databaseTestHelper, String paymentProvider) {
+        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId, databaseTestHelper, "email@fake.test", paymentProvider);
+    }
+
     public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId,
                                                                 DatabaseTestHelper databaseTestHelper, String emailAddress, String paymentProvider) {
+        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId, databaseTestHelper, emailAddress, paymentProvider, "Test description");
+    }
+
+    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId,
+                                                                DatabaseTestHelper databaseTestHelper, String emailAddress, String paymentProvider, String description) {
         long chargeId = RandomUtils.nextInt();
         ExternalChargeId externalChargeId = ExternalChargeId.fromChargeId(chargeId);
         databaseTestHelper.addCharge(anAddChargeParams()
@@ -53,6 +64,7 @@ public class ChargeUtils {
                 .withStatus(status)
                 .withTransactionId(gatewayTransactionId)
                 .withEmail(emailAddress)
+                .withDescription(description)
                 .build());
         return externalChargeId;
     }
@@ -74,13 +86,6 @@ public class ChargeUtils {
                 .withGatewayCredentialId(gatewayCredentialId)
                 .build());
         return externalChargeId;
-    }
-
-    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId,
-                                                                String accountId, DatabaseTestHelper databaseTestHelper,
-                                                                String paymentProvider) {
-        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId,
-                databaseTestHelper, "email@fake.test", paymentProvider);
     }
 
     public static class ExternalChargeId {

--- a/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
@@ -86,6 +86,50 @@ public class FrontendContractTest {
                 .build());
     }
 
+    @State("a sandbox account exists with a charge with id testChargeId and description DECLINED that is in state ENTERING_CARD_DETAILS.")
+    public void aChargeExistsAwaitingAuthorisationWithDescriptionDeclined() {
+        long gatewayAccountId = 666L;
+        setUpGatewayAccount(dbHelper, gatewayAccountId);
+
+        String chargeExternalId = "testChargeId";
+
+        dbHelper.addCharge(anAddChargeParams()
+                .withExternalChargeId(chargeExternalId)
+                .withGatewayAccountId(String.valueOf(gatewayAccountId))
+                .withAmount(100)
+                .withStatus(ChargeStatus.ENTERING_CARD_DETAILS)
+                .withReturnUrl("aReturnUrl")
+                .withTransactionId(chargeExternalId)
+                .withReference(ServicePaymentReference.of("aReference"))
+                .withDescription("DECLINED")
+                .withCreatedDate(Instant.now())
+                .withEmail("test@test.com")
+                .withDelayedCapture(false)
+                .build());
+    }
+
+    @State("a sandbox account exists with a charge with id testChargeId and description ERROR that is in state ENTERING_CARD_DETAILS.")
+    public void aChargeExistsAwaitingAuthorisationWithDescriptionError() {
+        long gatewayAccountId = 666L;
+        setUpGatewayAccount(dbHelper, gatewayAccountId);
+
+        String chargeExternalId = "testChargeId";
+
+        dbHelper.addCharge(anAddChargeParams()
+                .withExternalChargeId(chargeExternalId)
+                .withGatewayAccountId(String.valueOf(gatewayAccountId))
+                .withAmount(100)
+                .withStatus(ChargeStatus.ENTERING_CARD_DETAILS)
+                .withReturnUrl("aReturnUrl")
+                .withTransactionId(chargeExternalId)
+                .withReference(ServicePaymentReference.of("aReference"))
+                .withDescription("ERROR")
+                .withCreatedDate(Instant.now())
+                .withEmail("test@test.com")
+                .withDelayedCapture(false)
+                .build());
+    }
+
     @State("a Worldpay account exists with 3DS flex credentials and a charge with id testChargeId")
     public void aWorldpayChargeExists() {
         long gatewayAccountId = 666L;

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
@@ -54,7 +54,6 @@ public abstract class CardServiceTest {
                 .build();
         entity.setCardDetails(new CardDetailsEntity());
         return entity;
-
     }
 
     protected ChargeEntity createNewChargeWithFees(String provider, Long chargeId, ChargeStatus status, String gatewayTransactionId) {


### PR DESCRIPTION
## WHAT YOU DID

- update `SandboxWalletAuthorisationHandler` to pass charge description to appropriate gateway response generator
- logic to detect presence of magic values when building gateway response for sandbox wallet payments
- add enum type `SandboxWalletMagicValues` set of behaviour modifiers when making sandbox wallet payments
- logic to include mocked expiry date when payment provider is sandbox and wallet type is apple pay
