### PR TITLE
PP-11513 Accept wallet flags on create gateway account request

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -197,21 +197,21 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 3920
+        "line_number": 3928
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4382
+        "line_number": 4396
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4393
+        "line_number": 4407
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -1071,5 +1071,5 @@
       }
     ]
   },
-  "generated_at": "2023-10-11T15:50:07Z"
+  "generated_at": "2023-10-13T09:35:14Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3330,6 +3330,14 @@ components:
       discriminator:
         propertyName: payment_provider
       properties:
+        allow_apple_pay:
+          type: boolean
+          description: Set to 'true' to enable Apple Pay for this account
+          writeOnly: true
+        allow_google_pay:
+          type: boolean
+          description: Set to 'true' to enable Google Pay for this account
+          writeOnly: true
         analytics_id:
           type: string
           description: Google Analytics (GA) unique ID for the GOV.UK Pay platform
@@ -4187,6 +4195,12 @@ components:
       - $ref: '#/components/schemas/GatewayAccountRequest'
       - type: object
         properties:
+          allow_apple_pay:
+            type: boolean
+            writeOnly: true
+          allow_google_pay:
+            type: boolean
+            writeOnly: true
           analytics_id:
             type: string
             writeOnly: true

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/CreateGatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/CreateGatewayAccountResponse.java
@@ -104,7 +104,6 @@ public class CreateGatewayAccountResponse {
     public static class GatewayAccountResponseBuilder {
 
         private String providerAccountType;
-        private String paymentProvider;
         private String serviceName;
         private String description;
         private String analyticsId;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -46,6 +46,12 @@ public class GatewayAccountRequest {
 
     @JsonIgnore
     private boolean requires3ds;
+    
+    @JsonIgnore
+    private boolean allowApplePay;
+    
+    @JsonIgnore
+    private boolean allowGooglePay;
 
     public GatewayAccountRequest(@JsonProperty("type") @Schema(example = "live", description = "Account type for this provider (test/live)", defaultValue = "test") String providerAccountType,
                                  @JsonProperty("payment_provider") @Schema(example = "stripe", description = "The payment provider for which this account is created", defaultValue = "sandbox")
@@ -55,20 +61,23 @@ public class GatewayAccountRequest {
                                  @JsonProperty("description") @Schema(description = "Some useful non-ambiguous description about the gateway account", example = "account for some gov org") String description,
                                  @JsonProperty("analytics_id") @Schema(description = "Google Analytics (GA) unique ID for the GOV.UK Pay platform", example = "analytics-id")
                                  String analyticsId,
-                                 @JsonProperty("requires_3ds") @Schema(description = "Set to 'true' to enable 3DS for this account") boolean requires3ds
+                                 @JsonProperty("requires_3ds") @Schema(description = "Set to 'true' to enable 3DS for this account") boolean requires3ds,
+                                 @JsonProperty("allow_apple_pay") @Schema(description = "Set to 'true' to enable Apple Pay for this account") boolean allowApplePay,
+                                 @JsonProperty("allow_google_pay") @Schema(description = "Set to 'true' to enable Google Pay for this account") boolean allowGooglePay
     ) {
         this.serviceName = serviceName;
         this.serviceId = serviceId;
         this.description = description;
         this.analyticsId = analyticsId;
         this.requires3ds = requires3ds;
+        this.allowApplePay = allowApplePay;
+        this.allowGooglePay = allowGooglePay;
 
         this.providerAccountType = (providerAccountType == null || providerAccountType.isEmpty()) ?
                 TEST.toString() : providerAccountType;
 
         this.paymentProvider = (paymentProvider == null || paymentProvider.isEmpty()) ?
                 PaymentGatewayName.SANDBOX.getName() : paymentProvider;
-
     }
 
     @ValidationMethod(message = "Unsupported payment provider account type, should be one of (test, live)")
@@ -117,7 +126,15 @@ public class GatewayAccountRequest {
         return newHashMap();
     }
 
-    public boolean getRequires3ds() {
+    public boolean isRequires3ds() {
         return requires3ds;
+    }
+
+    public boolean isAllowApplePay() {
+        return allowApplePay;
+    }
+
+    public boolean isAllowGooglePay() {
+        return allowGooglePay;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeGatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeGatewayAccountRequest.java
@@ -20,10 +20,12 @@ public class StripeGatewayAccountRequest extends GatewayAccountRequest {
                                        @JsonProperty("description") String description,
                                        @JsonProperty("analytics_id") String analyticsId,
                                        @JsonProperty("credentials") StripeCredentials credentials,
-                                       @JsonProperty("requires_3ds") boolean requires3ds
+                                       @JsonProperty("requires_3ds") boolean requires3ds,
+                                       @JsonProperty("allow_apple_pay") boolean allowApplePay,
+                                       @JsonProperty("allow_google_pay") boolean allowGooglePay
     ) {
 
-        super(providerAccountType, paymentProvider, serviceName, serviceId, description, analyticsId, requires3ds);
+        super(providerAccountType, paymentProvider, serviceName, serviceId, description, analyticsId, requires3ds, allowApplePay, allowGooglePay);
         this.credentials = Optional.ofNullable(credentials);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
@@ -27,7 +27,9 @@ public class GatewayAccountObjectConverter {
         gatewayAccountEntity.setServiceId(gatewayAccountRequest.getServiceId());
         gatewayAccountEntity.setDescription(gatewayAccountRequest.getDescription());
         gatewayAccountEntity.setAnalyticsId(gatewayAccountRequest.getAnalyticsId());
-        gatewayAccountEntity.setRequires3ds(gatewayAccountRequest.getRequires3ds());
+        gatewayAccountEntity.setRequires3ds(gatewayAccountRequest.isRequires3ds());
+        gatewayAccountEntity.setAllowApplePay(gatewayAccountRequest.isAllowApplePay());
+        gatewayAccountEntity.setAllowGooglePay(gatewayAccountRequest.isAllowGooglePay());
         gatewayAccountEntity.setIntegrationVersion3ds(DEFAULT_INTEGRATION_VERSION_3_DS);
 
         gatewayAccountEntity.addNotification(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(gatewayAccountEntity));


### PR DESCRIPTION
Accept `allow_apple_pay` and `allow_google_pay` flags on the request to create a gateway account, and use them to set these flags when creating the gateway account.

Do not return the flags in the response, as we only return a sub-set of properties in this response, and it's only worth adding them if we want to consume these values. As this is only consumed by toolbox, for which we don't have pact tests, don't bother doing this for now as it's a bit fiddly due to need to check the gateway account credentials for Worldpay accounts to determine whether Google Pay is enabled.