### PR TITLE
PP 11594 Allow enabling Apple Pay and Google Pay for Sandbox gateway accounts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -712,7 +708,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java",
         "hashed_secret": "e9b6cb662f24d2346839fb0b797ad778c290994e",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 129
       }
     ],
     "src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java": [
@@ -1071,5 +1067,5 @@
       }
     ]
   },
-  "generated_at": "2023-10-13T09:35:14Z"
+  "generated_at": "2023-10-17T15:12:57Z"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine@sha256:77f7c2509dba2f346bf042e424d395b16b0c432ee1eabf0cbcc17922dc900c73
+FROM eclipse-temurin:11-jre-alpine@sha256:aea6ff5a31148a9dc80c65fad592d5681c61f73dab8ad2f5b8fb08de256899dc
 
 RUN ["apk", "--no-cache", "upgrade"]
 

--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre@sha256:e12585f95f18fba9841aa3c12e6e4261f74b608cbc27b0fab61ac267b57de8f6
+FROM eclipse-temurin:11-jre@sha256:df64521dab52dd2d362ccc34dc7bf50c1bf28cd9fbac944ea5e4037be5154850
 
 ARG DNS_TTL=15
 

--- a/pom.xml
+++ b/pom.xml
@@ -576,7 +576,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>analyze</id>

--- a/pom.xml
+++ b/pom.xml
@@ -641,7 +641,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.1</version>
                 <configuration>
                     <outputFile>target/${project.artifactId}-${project.version}-allinone.jar</outputFile>
                     <filters>

--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
-            <version>1.12.521</version>
+            <version>1.12.566</version>
         </dependency>
         <dependency>
             <groupId>org.dhatim</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <liquibase.version>4.21.1</liquibase.version>
         <dropwizard.version>2.1.6</dropwizard.version>
         <wiremock.version>2.35.1</wiremock.version>
-        <eclipselink.version>2.7.11</eclipselink.version>
+        <eclipselink.version>2.7.13</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.15.2</jackson.version>
         <pay-java-commons.version>1.0.20230913114417</pay-java-commons.version>

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -5,7 +5,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
-import uk.gov.pay.connector.gatewayaccount.exception.DigitalWalletNotSupportedGatewayException;
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountWithoutAnActiveCredentialException;
 import uk.gov.pay.connector.gatewayaccount.exception.MissingWorldpay3dsFlexCredentialsEntityException;
 import uk.gov.pay.connector.gatewayaccount.exception.NotSupportedGatewayAccountException;
@@ -29,7 +28,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Map.entry;
 import static net.logstash.logback.argument.StructuredArguments.kv;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_APPLE_PAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_AUTHORISATION_API;
@@ -124,14 +122,12 @@ public class GatewayAccountService {
             entry(
                     FIELD_ALLOW_GOOGLE_PAY,
                     (gatewayAccountRequest, gatewayAccountEntity) -> {
-                        throwIfNotDigitalWalletSupportedGateway(gatewayAccountEntity);
                         gatewayAccountEntity.setAllowGooglePay(Boolean.parseBoolean(gatewayAccountRequest.valueAsString()));
                     }
             ),
             entry(
                     FIELD_ALLOW_APPLE_PAY,
                     (gatewayAccountRequest, gatewayAccountEntity) -> {
-                        throwIfNotDigitalWalletSupportedGateway(gatewayAccountEntity);
                         gatewayAccountEntity.setAllowApplePay(Boolean.parseBoolean(gatewayAccountRequest.valueAsString()));
                     }
             ),
@@ -238,12 +234,6 @@ public class GatewayAccountService {
     private void throwIfNoActiveCredentialExist(GatewayAccountEntity gatewayAccountEntity) {
         if (!gatewayAccountCredentialsService.hasActiveCredentials(gatewayAccountEntity.getId())) {
             throw new GatewayAccountWithoutAnActiveCredentialException(gatewayAccountEntity.getId());
-        }
-    }
-
-    private void throwIfNotDigitalWalletSupportedGateway(GatewayAccountEntity gatewayAccountEntity) {
-        if (!(WORLDPAY.getName().equals(gatewayAccountEntity.getGatewayName()) || STRIPE.getName().equals(gatewayAccountEntity.getGatewayName()))) {
-            throw new DigitalWalletNotSupportedGatewayException(gatewayAccountEntity.getGatewayName());
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
@@ -6,8 +6,9 @@ public enum TaskType {
     COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT("collect_fee_for_stripe_failed_payment"),
     HANDLE_STRIPE_WEBHOOK_NOTIFICATION("handle_stripe_webhook_notification"),
     AUTHORISE_WITH_USER_NOT_PRESENT("authorise_with_user_not_present"),
-    DELETE_STORED_PAYMENT_DETAILS("delete_stored_payment_details");
-    
+    DELETE_STORED_PAYMENT_DETAILS("delete_stored_payment_details"),
+    RETRY_FAILED_PAYMENT_OR_REFUND_EMAIL("retry_failed_payment_or_refund_email");
+
     TaskType(String name) {
         this.name = name;
     }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandler.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.connector.queue.tasks.handlers;
+
+import com.google.inject.Inject;
+import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.queue.tasks.model.RetryPaymentOrRefundEmailTaskData;
+import uk.gov.pay.connector.refund.exception.RefundNotFoundRuntimeException;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.service.RefundService;
+import uk.gov.pay.connector.usernotification.service.UserNotificationService;
+
+import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.PAYMENT_CONFIRMED;
+import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.REFUND_ISSUED;
+
+public class RetryPaymentOrRefundEmailTaskHandler {
+
+    private final ChargeService chargeService;
+    private final RefundService refundService;
+    private final GatewayAccountService gatewayAccountService;
+    private final UserNotificationService userNotificationService;
+
+    @Inject
+    public RetryPaymentOrRefundEmailTaskHandler(ChargeService chargeService,
+                                                RefundService refundService,
+                                                GatewayAccountService gatewayAccountService,
+                                                UserNotificationService userNotificationService) {
+        this.chargeService = chargeService;
+        this.refundService = refundService;
+        this.gatewayAccountService = gatewayAccountService;
+        this.userNotificationService = userNotificationService;
+    }
+
+    public void process(RetryPaymentOrRefundEmailTaskData retryPaymentOrRefundEmailTaskData) {
+        if (retryPaymentOrRefundEmailTaskData.getEmailNotificationType() == PAYMENT_CONFIRMED) {
+            Charge charge = getCharge(retryPaymentOrRefundEmailTaskData.getResourceExternalId());
+            GatewayAccountEntity gatewayAccountEntity = getGatewayAccountEntity(charge.getGatewayAccountId());
+
+            userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, gatewayAccountEntity);
+        } else if (retryPaymentOrRefundEmailTaskData.getEmailNotificationType() == REFUND_ISSUED) {
+            RefundEntity refundEntity = getRefund(retryPaymentOrRefundEmailTaskData.getResourceExternalId());
+            Charge charge = getCharge(refundEntity.getChargeExternalId());
+            GatewayAccountEntity gatewayAccountEntity = getGatewayAccountEntity(charge.getGatewayAccountId());
+
+            userNotificationService.sendRefundIssuedEmailSynchronously(charge, gatewayAccountEntity, refundEntity);
+        }
+    }
+
+    private GatewayAccountEntity getGatewayAccountEntity(Long gatewayAccountId) {
+        return gatewayAccountService.getGatewayAccount(gatewayAccountId)
+                .orElseThrow(() -> new GatewayAccountNotFoundException(gatewayAccountId));
+    }
+
+    private RefundEntity getRefund(String refundExternalId) {
+        return refundService.findRefundByExternalId(refundExternalId)
+                .orElseThrow(() -> new RefundNotFoundRuntimeException(refundExternalId));
+    }
+
+    private Charge getCharge(String externalId) {
+        return chargeService.findCharge(externalId)
+                .orElseThrow(() -> new ChargeNotFoundRuntimeException(externalId));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/model/RetryPaymentOrRefundEmailTaskData.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/model/RetryPaymentOrRefundEmailTaskData.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.connector.queue.tasks.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
+
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RetryPaymentOrRefundEmailTaskData {
+    @JsonProperty("resource_external_id")
+    private String resourceExternalId;
+    @JsonProperty("email_notification_type")
+    private EmailNotificationType emailNotificationType;
+
+    public RetryPaymentOrRefundEmailTaskData() {
+        // empty
+    }
+
+    public RetryPaymentOrRefundEmailTaskData(String paymentOrRefundExternalId, EmailNotificationType emailNotificationType) {
+        this.resourceExternalId = paymentOrRefundExternalId;
+        this.emailNotificationType = emailNotificationType;
+    }
+
+    public static RetryPaymentOrRefundEmailTaskData of(String paymentOrRefundExternalId, EmailNotificationType emailNotificationType) {
+        return new RetryPaymentOrRefundEmailTaskData(paymentOrRefundExternalId, emailNotificationType);
+    }
+
+    public String getResourceExternalId() {
+        return resourceExternalId;
+    }
+
+    public EmailNotificationType getEmailNotificationType() {
+        return emailNotificationType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RetryPaymentOrRefundEmailTaskData that = (RetryPaymentOrRefundEmailTaskData) o;
+        return Objects.equals(resourceExternalId, that.resourceExternalId) && emailNotificationType == that.emailNotificationType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceExternalId, emailNotificationType);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/refund/exception/RefundNotFoundRuntimeException.java
+++ b/src/main/java/uk/gov/pay/connector/refund/exception/RefundNotFoundRuntimeException.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.refund.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
+
+public class RefundNotFoundRuntimeException extends WebApplicationException {
+    public RefundNotFoundRuntimeException(String refundExternalId) {
+        super(notFoundResponse(format("Refund with id [%s] not found.", refundExternalId)));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
@@ -356,4 +356,8 @@ public class RefundService {
     public void updateRefundParityStatus(String externalId, ParityCheckStatus parityCheckStatus) {
         refundDao.updateParityCheckStatus(externalId, ZonedDateTime.now(ZoneId.of("UTC")), parityCheckStatus);
     }
+
+    public Optional<RefundEntity> findRefundByExternalId(String externalId) {
+        return refundDao.findByExternalId(externalId);
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
@@ -44,7 +44,6 @@ import static uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode.OPTI
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 
-
 public class UserNotificationService {
 
     private static final Pattern LITERAL_DOLLAR_REFERENCE = Pattern.compile(Pattern.quote("$reference"));
@@ -82,6 +81,11 @@ public class UserNotificationService {
     public Optional<String> sendPaymentConfirmedEmailSynchronously(Charge charge, GatewayAccountEntity gatewayAccountEntity) {
         return sendEmailSynchronously(EmailNotificationType.PAYMENT_CONFIRMED, charge, gatewayAccountEntity,
                 buildConfirmationEmailPersonalisationFrom(charge, gatewayAccountEntity));
+    }
+
+    public Optional<String> sendRefundIssuedEmailSynchronously(Charge charge, GatewayAccountEntity gatewayAccountEntity, RefundEntity refundEntity) {
+        return sendEmailSynchronously(EmailNotificationType.REFUND_ISSUED, charge, gatewayAccountEntity,
+                buildRefundEmailPersonalisationFrom(charge, refundEntity, gatewayAccountEntity));
     }
 
     private Future<Optional<String>> sendEmail(EmailNotificationType emailNotificationType, Charge charge, GatewayAccountEntity gatewayAccountEntity, HashMap<String, String> personalisation) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
@@ -102,24 +102,6 @@ public class ChargesApiResourceAllowWebPaymentsIT {
                 .body("gateway_account.allow_google_pay", is(isGooglePayAllowed));
     }
 
-    @Test
-    public void assertBadRequestResponseIfPatchingDigitalWalletWithNonSupportedGateway() throws JsonProcessingException {
-        assertAppleAndGooglePayAreDisabledByDefault();
-
-        String accountIdWithNotDigitalWalletSupportedGateway = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "epdq"));
-        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
-                "path", "allow_apple_pay",
-                "value", true));
-        given().port(testContext.getPort()).contentType(JSON)
-                .body(payload)
-                .patch("/v1/api/accounts/" + accountIdWithNotDigitalWalletSupportedGateway)
-                .then()
-                .body("message", contains("Gateway epdq does not support digital wallets."))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()))
-                .and()
-                .statusCode(HttpStatus.SC_BAD_REQUEST);
-    }
-
     private void assertAppleAndGooglePayAreDisabledByDefault() {
         given().port(testContext.getPort()).contentType(JSON)
                 .get("/v1/frontend/charges/" + chargeId)

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueTest.java
@@ -19,10 +19,10 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.SqsConfig;
 import uk.gov.pay.connector.app.config.TaskQueueConfig;
+import uk.gov.pay.connector.queue.tasks.model.Task;
 import uk.gov.service.payments.commons.queue.exception.QueueException;
 import uk.gov.service.payments.commons.queue.model.QueueMessage;
 import uk.gov.service.payments.commons.queue.sqs.SqsQueueService;
-import uk.gov.pay.connector.queue.tasks.model.Task;
 
 import java.util.List;
 
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class TaskQueueTest {
+class TaskQueueTest {
 
     @Mock
     SqsQueueService sqsQueueService;
@@ -69,7 +69,7 @@ public class TaskQueueTest {
     }
 
     @Test
-    public void shouldParseChargeIdReceivedFromQueueGivenWellFormattedJSON() throws QueueException {
+    void shouldParseChargeIdReceivedFromQueueGivenWellFormattedJSON() throws QueueException {
         String validJsonMessage = "{ \"data\": \"payload data\",\"task\":\"collect_fee_for_stripe_failed_payment\"}";
         SendMessageResult messageResult = mock(SendMessageResult.class);
         List<QueueMessage> messages = List.of(QueueMessage.of(messageResult, validJsonMessage));
@@ -83,7 +83,7 @@ public class TaskQueueTest {
     }
 
     @Test
-    public void shouldParseChargeIdReceivedFromQueueGivenWellFormattedJSON_OldFormat() throws QueueException {
+    void shouldParseChargeIdReceivedFromQueueGivenWellFormattedJSON_OldFormat() throws QueueException {
         String validJsonMessage = "{ \"payment_external_id\": \"external-id-123\",\"task\":\"collect_fee_for_stripe_failed_payment\"}";
         SendMessageResult messageResult = mock(SendMessageResult.class);
         List<QueueMessage> messages = List.of(QueueMessage.of(messageResult, validJsonMessage));
@@ -95,9 +95,9 @@ public class TaskQueueTest {
         assertEquals("external-id-123", taskMessages.get(0).getTask().getPaymentExternalId());
         assertEquals(TaskType.COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT, taskMessages.get(0).getTask().getTaskType());
     }
-    
+
     @Test
-    public void shouldLogErrorWhenTaskTypeDoesntExist() throws QueueException {
+    void shouldLogErrorWhenTaskTypeDoesntExist() throws QueueException {
         String invalidJsonMessage = "{ \"data\": \"payload data\",\"task\":\"foo\"}";
         String validJsonMessage = "{ \"data\": \"payload data\",\"task\":\"collect_fee_for_stripe_failed_payment\"}";
         SendMessageResult messageResult = mock(SendMessageResult.class);
@@ -105,11 +105,11 @@ public class TaskQueueTest {
         when(sqsQueueService.receiveMessages(anyString(), anyString())).thenReturn(messages);
         TaskQueue queue = new TaskQueue(sqsQueueService, connectorConfiguration, objectMapper);
         List<TaskMessage> taskMessages = queue.retrieveTaskQueueMessages();
-        
+
         assertThat(taskMessages, hasSize(1));
         assertEquals("payload data", taskMessages.get(0).getTask().getData());
         assertEquals(TaskType.COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT, taskMessages.get(0).getTask().getTaskType());
-        
+
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
         LoggingEvent loggingEvent = loggingEventArgumentCaptor.getValue();
         assertThat(loggingEvent.getLevel(), is(Level.ERROR));
@@ -117,7 +117,7 @@ public class TaskQueueTest {
     }
 
     @Test
-    public void shouldSendValidSerialisedChargeToQueue() throws QueueException, JsonProcessingException {
+    void shouldSendValidSerialisedChargeToQueue() throws QueueException, JsonProcessingException {
         when(sqsQueueService.sendMessage(anyString(), anyString(), anyInt())).thenReturn(mock(QueueMessage.class));
 
         TaskQueue queue = new TaskQueue(sqsQueueService, connectorConfiguration, objectMapper);
@@ -126,5 +126,17 @@ public class TaskQueueTest {
 
         verify(sqsQueueService).sendMessage(connectorConfiguration.getSqsConfig().getTaskQueueUrl(),
                 "{\"data\":\"payload data\",\"task\":\"collect_fee_for_stripe_failed_payment\"}", 2);
+    }
+
+    @Test
+    void addTaskToQueueWithDelay_shouldSendValidSerialisedDataToQueueWithSpecifiedDelay() throws QueueException, JsonProcessingException {
+        when(sqsQueueService.sendMessage(anyString(), anyString(), anyInt())).thenReturn(mock(QueueMessage.class));
+
+        TaskQueue queue = new TaskQueue(sqsQueueService, connectorConfiguration, objectMapper);
+        Task task = new Task("payload data", TaskType.RETRY_FAILED_PAYMENT_OR_REFUND_EMAIL);
+        queue.addTaskToQueue(task, 100);
+
+        verify(sqsQueueService).sendMessage(connectorConfiguration.getSqsConfig().getTaskQueueUrl(),
+                "{\"data\":\"payload data\",\"task\":\"retry_failed_payment_or_refund_email\"}", 100);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandlerTest.java
@@ -1,0 +1,180 @@
+package uk.gov.pay.connector.queue.tasks.handlers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.refund.exception.RefundNotFoundRuntimeException;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.service.RefundService;
+import uk.gov.pay.connector.usernotification.service.UserNotificationService;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
+import static uk.gov.pay.connector.queue.tasks.model.RetryPaymentOrRefundEmailTaskData.of;
+import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.PAYMENT_CONFIRMED;
+import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.REFUND_ISSUED;
+
+@ExtendWith(MockitoExtension.class)
+class RetryPaymentOrRefundEmailTaskHandlerTest {
+    @Mock
+    private UserNotificationService mockUserNotificationService;
+    @Mock
+    private GatewayAccountService mockGatewayAccountService;
+    @Mock
+    private RefundService mockRefundService;
+    @Mock
+    private ChargeService mockChargeService;
+    private final String paymentExternalId = "payment-external-id";
+    private final String refundExternalId = "refund-external-id";
+
+    private RetryPaymentOrRefundEmailTaskHandler retryPaymentOrRefundEmailTaskHandler;
+
+    @BeforeEach
+    void setup() {
+        retryPaymentOrRefundEmailTaskHandler = new RetryPaymentOrRefundEmailTaskHandler(
+                mockChargeService,
+                mockRefundService,
+                mockGatewayAccountService,
+                mockUserNotificationService
+        );
+    }
+
+    @Nested
+    class TestRetryFailedPaymentEmailTask {
+
+        @Test
+        void shouldThrowExceptionIfChargeIsNotFound() {
+            var data = of(paymentExternalId, PAYMENT_CONFIRMED);
+
+            when(mockChargeService.findCharge(paymentExternalId))
+                    .thenThrow(new ChargeNotFoundRuntimeException(paymentExternalId));
+
+            assertThrows(ChargeNotFoundRuntimeException.class, () -> {
+                retryPaymentOrRefundEmailTaskHandler.process(data);
+            });
+        }
+
+        @Test
+        void shouldThrowExceptionIfGatewayAccountIsNotFound() {
+            var data = of(paymentExternalId, PAYMENT_CONFIRMED);
+
+            GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withId(1L).build();
+            Charge charge = Charge.from(aValidChargeEntity()
+                    .withGatewayAccountEntity(gatewayAccountEntity)
+                    .build());
+            when(mockChargeService.findCharge(paymentExternalId))
+                    .thenReturn(Optional.of(charge));
+
+            assertThrows(GatewayAccountNotFoundException.class, () -> {
+                retryPaymentOrRefundEmailTaskHandler.process(data);
+            });
+        }
+
+        @Test
+        void shouldSendEmailForPaymentConfirmedNotificationType() {
+            var data = of(paymentExternalId, PAYMENT_CONFIRMED);
+
+            GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withId(1L).build();
+            Charge charge = Charge.from(aValidChargeEntity()
+                    .withGatewayAccountEntity(gatewayAccountEntity)
+                    .build());
+            when(mockChargeService.findCharge(paymentExternalId))
+                    .thenReturn(Optional.of(charge));
+            when(mockGatewayAccountService.getGatewayAccount(1L)).thenReturn(Optional.of(gatewayAccountEntity));
+
+            retryPaymentOrRefundEmailTaskHandler.process(data);
+
+            verify(mockUserNotificationService).sendPaymentConfirmedEmailSynchronously(charge, gatewayAccountEntity);
+        }
+    }
+
+    @Nested
+    class TestRetryFailedRefundEmailTask {
+
+        @BeforeEach
+        void setup() {
+            RefundEntity refund = aValidRefundEntity()
+                    .withExternalId(refundExternalId)
+                    .withChargeExternalId(paymentExternalId).build();
+            when(mockRefundService.findRefundByExternalId(refundExternalId)).thenReturn(Optional.of(refund));
+        }
+
+        @Test
+        void shouldThrowExceptionIfChargeIsNotFound() {
+            var data = of(refundExternalId, REFUND_ISSUED);
+
+
+            when(mockChargeService.findCharge(paymentExternalId))
+                    .thenThrow(new ChargeNotFoundRuntimeException(paymentExternalId));
+
+            assertThrows(ChargeNotFoundRuntimeException.class, () -> {
+                retryPaymentOrRefundEmailTaskHandler.process(data);
+            });
+        }
+
+        @Test
+        void shouldThrowExceptionIfGatewayAccountIsNotFound() {
+            var data = of(refundExternalId, REFUND_ISSUED);
+
+            GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withId(1L).build();
+            Charge charge = Charge.from(aValidChargeEntity()
+                    .withGatewayAccountEntity(gatewayAccountEntity)
+                    .build());
+            when(mockChargeService.findCharge(paymentExternalId))
+                    .thenReturn(Optional.of(charge));
+
+            assertThrows(GatewayAccountNotFoundException.class, () -> {
+                retryPaymentOrRefundEmailTaskHandler.process(data);
+            });
+        }
+
+        @Test
+        void shouldThrowExceptionIfRefundIsNotFound() {
+            var data = of(refundExternalId, REFUND_ISSUED);
+
+            when(mockRefundService.findRefundByExternalId(refundExternalId))
+                    .thenThrow(new RefundNotFoundRuntimeException(refundExternalId));
+
+            assertThrows(RefundNotFoundRuntimeException.class, () -> {
+                retryPaymentOrRefundEmailTaskHandler.process(data);
+            });
+        }
+
+        @Test
+        void shouldSendEmailForRefundConfirmedNotificationType() {
+            var data = of(refundExternalId, REFUND_ISSUED);
+
+            GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withId(1L).build();
+            Charge charge = Charge.from(aValidChargeEntity()
+                    .withGatewayAccountEntity(gatewayAccountEntity)
+                    .build());
+            when(mockChargeService.findCharge(paymentExternalId))
+                    .thenReturn(Optional.of(charge));
+            when(mockGatewayAccountService.getGatewayAccount(1L)).thenReturn(Optional.of(gatewayAccountEntity));
+
+            RefundEntity refund = aValidRefundEntity()
+                    .withExternalId(refundExternalId)
+                    .withChargeExternalId(paymentExternalId).build();
+            when(mockRefundService.findRefundByExternalId(refundExternalId)).thenReturn(Optional.of(refund));
+
+            retryPaymentOrRefundEmailTaskHandler.process(data);
+
+            verify(mockUserNotificationService).sendRefundIssuedEmailSynchronously(charge, gatewayAccountEntity, refund);
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -11,7 +11,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
-import uk.gov.pay.connector.gatewayaccount.exception.DigitalWalletNotSupportedGatewayException;
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountWithoutAnActiveCredentialException;
 import uk.gov.pay.connector.gatewayaccount.exception.MissingWorldpay3dsFlexCredentialsEntityException;
 import uk.gov.pay.connector.gatewayaccount.exception.NotSupportedGatewayAccountException;
@@ -204,7 +203,7 @@ class GatewayAccountServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"worldpay", "stripe"})
+    @ValueSource(strings = {"worldpay", "stripe", "sandbox"})
     void shouldUpdateAllowApplePay(String provider) {
         JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
@@ -221,7 +220,7 @@ class GatewayAccountServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"worldpay", "stripe"})
+    @ValueSource(strings = {"worldpay", "stripe", "sandbox"})
     void shouldUpdateAllowGooglePay(String provider) {
         JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
@@ -235,20 +234,6 @@ class GatewayAccountServiceTest {
         assertThat(optionalGatewayAccount.isPresent(), is(true));
         verify(mockGatewayAccountEntity).setAllowGooglePay(true);
         verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"allow_apple_pay", "allow_google_pay"})
-    void shouldNotAllowDigitalWalletForUnsupportedGateways(String path) {
-        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
-                "op", "replace",
-                "path", path,
-                "value", "true")));
-
-        when(mockGatewayAccountEntity.getGatewayName()).thenReturn("epdq");
-        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
-        assertThrows(DigitalWalletNotSupportedGatewayException.class,
-                () -> gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -104,17 +104,17 @@ public class RefundServiceTest {
     private LedgerService mockLedgerService;
     @Mock
     private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
-    
+
     private ChargeEntity chargeEntity;
     private List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntityList = new ArrayList<>();
 
     private final String externalChargeId = "chargeId";
     private final Long accountId = 2L;
     private final GatewayAccountEntity account = aGatewayAccountEntity()
-                .withId(accountId)
-                .withType(TEST)
-                .withGatewayAccountCredentials(gatewayAccountCredentialsEntityList)
-                .build();
+            .withId(accountId)
+            .withType(TEST)
+            .withGatewayAccountCredentials(gatewayAccountCredentialsEntityList)
+            .build();
     private final GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = GatewayAccountCredentialsEntityFixture
             .aGatewayAccountCredentialsEntity()
             .withGatewayAccountEntity(account)
@@ -180,7 +180,7 @@ public class RefundServiceTest {
     @Test
     void shouldRefundSuccessfully_forHistoricPayment() {
         Long refundAmount = 100L;
-        
+
         gatewayAccountCredentialsEntityList.add(gatewayAccountCredentialsEntity);
 
         ChargeResponse.RefundSummary refundSummary = new ChargeResponse.RefundSummary();
@@ -432,7 +432,7 @@ public class RefundServiceTest {
                 .withGatewayAccountCredentials(gatewayAccountCredentialsEntityList)
                 .withDisabled(true)
                 .build();
-        
+
         chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(disabledAccount)
                 .withExternalId(externalChargeId)
@@ -449,7 +449,7 @@ public class RefundServiceTest {
         assertThat(thrown.getMessage(), is("Attempt to create a refund for a disabled gateway account"));
         verify(mockRefundDao, never()).persist(new RefundEntity(chargeEntity.getAmount(), userExternalId, null, null));
     }
-    
+
     @Test
     void shouldFailWhenGatewayAccountCredentialEntityNotFound() {
         chargeEntity = aValidChargeEntity()
@@ -490,7 +490,7 @@ public class RefundServiceTest {
         var thrown = assertThrows(RefundException.class,
                 () -> refundService.doRefund(accountId, charge, new RefundRequest(100L, 0, userExternalId)));
         assertThat(thrown.getMessage(), is("HTTP 400 Bad Request"));
-        assertThat(((ErrorResponse)thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_NOT_AVAILABLE));
+        assertThat(((ErrorResponse) thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_NOT_AVAILABLE));
         verify(mockRefundDao, never()).persist(any());
     }
 
@@ -523,7 +523,7 @@ public class RefundServiceTest {
         var thrown = assertThrows(RefundException.class,
                 () -> refundService.doRefund(accountId, charge, new RefundRequest(100L, 0, userExternalId)));
         assertThat(thrown.getMessage(), is("HTTP 400 Bad Request"));
-        assertThat(((ErrorResponse)thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE));
+        assertThat(((ErrorResponse) thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE));
         verify(mockRefundDao, never()).persist(any());
     }
 
@@ -549,7 +549,7 @@ public class RefundServiceTest {
         var thrown = assertThrows(RefundException.class,
                 () -> refundService.doRefund(accountId, charge, new RefundRequest(amount, amount + 1, userExternalId)));
         assertThat(thrown.getMessage(), is("HTTP 412 Precondition Failed"));
-        assertThat(((ErrorResponse)thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH));
+        assertThat(((ErrorResponse) thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH));
 
         verifyNoMoreInteractions(mockRefundDao);
     }
@@ -578,7 +578,7 @@ public class RefundServiceTest {
         var thrown = assertThrows(RefundException.class,
                 () -> refundService.doRefund(accountId, charge, new RefundRequest(amount, amount, userExternalId)));
         assertThat(thrown.getMessage(), is("HTTP 412 Precondition Failed"));
-        assertThat(((ErrorResponse)thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH));
+        assertThat(((ErrorResponse) thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH));
 
         verifyNoMoreInteractions(mockRefundDao);
     }
@@ -638,7 +638,7 @@ public class RefundServiceTest {
         var thrown = assertThrows(RefundException.class,
                 () -> refundService.doRefund(accountId, charge, new RefundRequest(100L, 800L, userExternalId)));
         assertThat(thrown.getMessage(), is("HTTP 412 Precondition Failed"));
-        assertThat(((ErrorResponse)thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH));
+        assertThat(((ErrorResponse) thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH));
 
         verifyNoMoreInteractions(mockRefundDao);
     }
@@ -667,7 +667,7 @@ public class RefundServiceTest {
         var thrown = assertThrows(RefundException.class,
                 () -> refundService.doRefund(accountId, charge, new RefundRequest(amount, amountAvailableForRefund, userExternalId)));
         assertThat(thrown.getMessage(), is("HTTP 400 Bad Request"));
-        assertThat(((ErrorResponse)thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_NOT_AVAILABLE));
+        assertThat(((ErrorResponse) thrown.getResponse().getEntity()).getIdentifier(), is(ErrorIdentifier.REFUND_NOT_AVAILABLE));
 
         verifyNoMoreInteractions(mockRefundDao);
     }
@@ -675,7 +675,7 @@ public class RefundServiceTest {
     @Test
     void shouldUpdateRefundRecordToFailWhenRefundFails() {
         Long amount = 100L;
-        
+
         gatewayAccountCredentialsEntityList.add(gatewayAccountCredentialsEntity);
         ChargeEntity capturedCharge = aValidChargeEntity()
                 .withGatewayAccountEntity(account)
@@ -863,6 +863,22 @@ public class RefundServiceTest {
 
         Optional<Refund> mayBeRefund = refundService.findHistoricRefundByChargeExternalIdAndGatewayTransactionId(charge, "some-gateway-tx-id");
         assertThat(mayBeRefund.isPresent(), is(false));
+    }
+
+    @Test
+    void findByExternalIdShouldReturnRefundEntityIfFound() {
+        RefundEntity refund = aValidRefundEntity().build();
+        when(mockRefundDao.findByExternalId("refund-external-id")).thenReturn(Optional.of(refund));
+        Optional<RefundEntity> mayBeRefund = refundService.findRefundByExternalId("refund-external-id");
+        assertThat(mayBeRefund.isPresent(), is(true));
+        assertThat(mayBeRefund.get().getExternalId(), is(refund.getExternalId()));
+    }
+
+    @Test
+    void findByExternalIdShouldReturnEmptyOptionalIfRefundEntityIsNotFound() {
+        when(mockRefundDao.findByExternalId("refund-external-id")).thenReturn(Optional.empty());
+        Optional<RefundEntity> refund = refundService.findRefundByExternalId("refund-external-id");
+        assertThat(refund.isPresent(), is(false));
     }
 
     private ArgumentMatcher<RefundEntity> aRefundEntity(long amount, ChargeEntity chargeEntity) {


### PR DESCRIPTION
## WHAT YOU DID
Allow enabling Apple Pay and Google Pay for Sandbox gateway accounts

[https://payments-platform.atlassian.net/browse/PP-11594](https://payments-platform.atlassian.net/browse/PP-11594)

Allow making a PATCH request to /v1/api/accounts/{accountId} with path allow_apple_pay and allow_google_pay for an account with any payment provider, rather than restricting by payment provider.

Remove throwIfNotDigitalWalletSupportedGateway method and associated unit test as payment  provider restriction lifted

## How to test

- Ensure current PACT tests run successfully and create  new tests if required.
- Manually test toggling Apple Pay and Google Pay on and off in the 'Settings / Digital wallet' section of the Pay Admin tool for sandbox accounts 

