### PR TITLE
PP-11567 Add method to add new task to queue with max delay

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
@@ -6,8 +6,9 @@ public enum TaskType {
     COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT("collect_fee_for_stripe_failed_payment"),
     HANDLE_STRIPE_WEBHOOK_NOTIFICATION("handle_stripe_webhook_notification"),
     AUTHORISE_WITH_USER_NOT_PRESENT("authorise_with_user_not_present"),
-    DELETE_STORED_PAYMENT_DETAILS("delete_stored_payment_details");
-    
+    DELETE_STORED_PAYMENT_DETAILS("delete_stored_payment_details"),
+    RETRY_FAILED_PAYMENT_OR_REFUND_EMAIL("retry_failed_payment_or_refund_email");
+
     TaskType(String name) {
         this.name = name;
     }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/model/RetryPaymentOrRefundEmailTaskData.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/model/RetryPaymentOrRefundEmailTaskData.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.connector.queue.tasks.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
+
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RetryPaymentOrRefundEmailTaskData {
+    @JsonProperty("resource_external_id")
+    private String resourceExternalId;
+    @JsonProperty("email_notification_type")
+    private EmailNotificationType emailNotificationType;
+
+    public RetryPaymentOrRefundEmailTaskData() {
+        // empty
+    }
+
+    public RetryPaymentOrRefundEmailTaskData(String paymentOrRefundExternalId, EmailNotificationType emailNotificationType) {
+        this.resourceExternalId = paymentOrRefundExternalId;
+        this.emailNotificationType = emailNotificationType;
+    }
+
+    public static RetryPaymentOrRefundEmailTaskData of(String paymentOrRefundExternalId, EmailNotificationType emailNotificationType) {
+        return new RetryPaymentOrRefundEmailTaskData(paymentOrRefundExternalId, emailNotificationType);
+    }
+
+    public String getResourceExternalId() {
+        return resourceExternalId;
+    }
+
+    public EmailNotificationType getEmailNotificationType() {
+        return emailNotificationType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RetryPaymentOrRefundEmailTaskData that = (RetryPaymentOrRefundEmailTaskData) o;
+        return Objects.equals(resourceExternalId, that.resourceExternalId) && emailNotificationType == that.emailNotificationType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceExternalId, emailNotificationType);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueTest.java
@@ -19,10 +19,10 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.SqsConfig;
 import uk.gov.pay.connector.app.config.TaskQueueConfig;
+import uk.gov.pay.connector.queue.tasks.model.Task;
 import uk.gov.service.payments.commons.queue.exception.QueueException;
 import uk.gov.service.payments.commons.queue.model.QueueMessage;
 import uk.gov.service.payments.commons.queue.sqs.SqsQueueService;
-import uk.gov.pay.connector.queue.tasks.model.Task;
 
 import java.util.List;
 
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class TaskQueueTest {
+class TaskQueueTest {
 
     @Mock
     SqsQueueService sqsQueueService;
@@ -69,7 +69,7 @@ public class TaskQueueTest {
     }
 
     @Test
-    public void shouldParseChargeIdReceivedFromQueueGivenWellFormattedJSON() throws QueueException {
+    void shouldParseChargeIdReceivedFromQueueGivenWellFormattedJSON() throws QueueException {
         String validJsonMessage = "{ \"data\": \"payload data\",\"task\":\"collect_fee_for_stripe_failed_payment\"}";
         SendMessageResult messageResult = mock(SendMessageResult.class);
         List<QueueMessage> messages = List.of(QueueMessage.of(messageResult, validJsonMessage));
@@ -83,7 +83,7 @@ public class TaskQueueTest {
     }
 
     @Test
-    public void shouldParseChargeIdReceivedFromQueueGivenWellFormattedJSON_OldFormat() throws QueueException {
+    void shouldParseChargeIdReceivedFromQueueGivenWellFormattedJSON_OldFormat() throws QueueException {
         String validJsonMessage = "{ \"payment_external_id\": \"external-id-123\",\"task\":\"collect_fee_for_stripe_failed_payment\"}";
         SendMessageResult messageResult = mock(SendMessageResult.class);
         List<QueueMessage> messages = List.of(QueueMessage.of(messageResult, validJsonMessage));
@@ -95,9 +95,9 @@ public class TaskQueueTest {
         assertEquals("external-id-123", taskMessages.get(0).getTask().getPaymentExternalId());
         assertEquals(TaskType.COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT, taskMessages.get(0).getTask().getTaskType());
     }
-    
+
     @Test
-    public void shouldLogErrorWhenTaskTypeDoesntExist() throws QueueException {
+    void shouldLogErrorWhenTaskTypeDoesntExist() throws QueueException {
         String invalidJsonMessage = "{ \"data\": \"payload data\",\"task\":\"foo\"}";
         String validJsonMessage = "{ \"data\": \"payload data\",\"task\":\"collect_fee_for_stripe_failed_payment\"}";
         SendMessageResult messageResult = mock(SendMessageResult.class);
@@ -105,11 +105,11 @@ public class TaskQueueTest {
         when(sqsQueueService.receiveMessages(anyString(), anyString())).thenReturn(messages);
         TaskQueue queue = new TaskQueue(sqsQueueService, connectorConfiguration, objectMapper);
         List<TaskMessage> taskMessages = queue.retrieveTaskQueueMessages();
-        
+
         assertThat(taskMessages, hasSize(1));
         assertEquals("payload data", taskMessages.get(0).getTask().getData());
         assertEquals(TaskType.COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT, taskMessages.get(0).getTask().getTaskType());
-        
+
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
         LoggingEvent loggingEvent = loggingEventArgumentCaptor.getValue();
         assertThat(loggingEvent.getLevel(), is(Level.ERROR));
@@ -117,7 +117,7 @@ public class TaskQueueTest {
     }
 
     @Test
-    public void shouldSendValidSerialisedChargeToQueue() throws QueueException, JsonProcessingException {
+    void shouldSendValidSerialisedChargeToQueue() throws QueueException, JsonProcessingException {
         when(sqsQueueService.sendMessage(anyString(), anyString(), anyInt())).thenReturn(mock(QueueMessage.class));
 
         TaskQueue queue = new TaskQueue(sqsQueueService, connectorConfiguration, objectMapper);
@@ -126,5 +126,17 @@ public class TaskQueueTest {
 
         verify(sqsQueueService).sendMessage(connectorConfiguration.getSqsConfig().getTaskQueueUrl(),
                 "{\"data\":\"payload data\",\"task\":\"collect_fee_for_stripe_failed_payment\"}", 2);
+    }
+
+    @Test
+    void addTaskToQueueWithDelay_shouldSendValidSerialisedDataToQueueWithSpecifiedDelay() throws QueueException, JsonProcessingException {
+        when(sqsQueueService.sendMessage(anyString(), anyString(), anyInt())).thenReturn(mock(QueueMessage.class));
+
+        TaskQueue queue = new TaskQueue(sqsQueueService, connectorConfiguration, objectMapper);
+        Task task = new Task("payload data", TaskType.RETRY_FAILED_PAYMENT_OR_REFUND_EMAIL);
+        queue.addTaskToQueue(task, 100);
+
+        verify(sqsQueueService).sendMessage(connectorConfiguration.getSqsConfig().getTaskQueueUrl(),
+                "{\"data\":\"payload data\",\"task\":\"retry_failed_payment_or_refund_email\"}", 100);
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Added method to TaskService to add `RETRY_FAILED_PAYMENT_OR_REFUND_EMAIL` task message to the task queue
- Specifies the delay to 900 seconds (15 minutes), the maximum delivery delay allowed for the SQS queue. To add this to the config separately.

