### PR TITLE
PP-11567 Add retry payment/refund email task to the task queue

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -226,7 +226,7 @@ public class ChargesApiResource {
                 .orElseThrow(() -> new GatewayAccountNotFoundException(accountId));
 
         return chargeService.findCharge(chargeId, accountId)
-                            .map(charge -> userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, account)
+                            .map(charge -> userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, account, true)
                             .map((reference) -> noContentResponse())
                             .orElseGet(() -> buildErrorResponse(Response.Status.PAYMENT_REQUIRED, "Failed to send email")))
                 .orElseGet(() -> responseWithChargeNotFound(chargeId));

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandler.java
@@ -39,13 +39,13 @@ public class RetryPaymentOrRefundEmailTaskHandler {
             Charge charge = getCharge(retryPaymentOrRefundEmailTaskData.getResourceExternalId());
             GatewayAccountEntity gatewayAccountEntity = getGatewayAccountEntity(charge.getGatewayAccountId());
 
-            userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, gatewayAccountEntity);
+            userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, gatewayAccountEntity, false);
         } else if (retryPaymentOrRefundEmailTaskData.getEmailNotificationType() == REFUND_ISSUED) {
             RefundEntity refundEntity = getRefund(retryPaymentOrRefundEmailTaskData.getResourceExternalId());
             Charge charge = getCharge(refundEntity.getChargeExternalId());
             GatewayAccountEntity gatewayAccountEntity = getGatewayAccountEntity(charge.getGatewayAccountId());
 
-            userNotificationService.sendRefundIssuedEmailSynchronously(charge, gatewayAccountEntity, refundEntity);
+            userNotificationService.sendRefundIssuedEmailSynchronously(charge, gatewayAccountEntity, refundEntity, false);
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceTest.java
@@ -151,7 +151,7 @@ public class ChargesApiResourceTest {
 
         when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(account));
         when(chargeService.findCharge(chargeId, accountId)).thenReturn(Optional.of(charge));
-        when(userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, account))
+        when(userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, account, true))
                 .thenReturn(Optional.empty());
 
         Response response = resources
@@ -171,7 +171,7 @@ public class ChargesApiResourceTest {
 
         when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(account));
         when(chargeService.findCharge(chargeId, accountId)).thenReturn(Optional.of(charge));
-        when(userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, account))
+        when(userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, account, true))
                 .thenReturn(Optional.of("Email sent"));
 
         Response response = resources

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandlerTest.java
@@ -99,7 +99,7 @@ class RetryPaymentOrRefundEmailTaskHandlerTest {
 
             retryPaymentOrRefundEmailTaskHandler.process(data);
 
-            verify(mockUserNotificationService).sendPaymentConfirmedEmailSynchronously(charge, gatewayAccountEntity);
+            verify(mockUserNotificationService).sendPaymentConfirmedEmailSynchronously(charge, gatewayAccountEntity, false);
         }
     }
 
@@ -174,7 +174,7 @@ class RetryPaymentOrRefundEmailTaskHandlerTest {
 
             retryPaymentOrRefundEmailTaskHandler.process(data);
 
-            verify(mockUserNotificationService).sendRefundIssuedEmailSynchronously(charge, gatewayAccountEntity, refund);
+            verify(mockUserNotificationService).sendRefundIssuedEmailSynchronously(charge, gatewayAccountEntity, refund, false);
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceEmailCollectionModeTest.java
+++ b/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceEmailCollectionModeTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.ExecutorServiceConfig;
 import uk.gov.pay.connector.app.NotifyConfiguration;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
+import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.SendEmailResponse;
@@ -56,6 +57,8 @@ class UserNotificationServiceEmailCollectionModeTest {
 
     @Mock
     private NotifyConfiguration notifyConfiguration;
+    @Mock
+    private TaskQueueService mockTaskQueueService;
     
     private UserNotificationService userNotificationService;
     
@@ -71,8 +74,7 @@ class UserNotificationServiceEmailCollectionModeTest {
 
         when(environment.metrics()).thenReturn(metricRegistry);
 
-        userNotificationService = new UserNotificationService(notifyClientFactory, connectorConfig, environment);
-
+        userNotificationService = new UserNotificationService(notifyClientFactory, connectorConfig, environment, mockTaskQueueService);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## WHAT YOU DID
- When a payment/refund email fails, adds a message to the task queue for retrying (doesn't send failures metric)
- Doesn't retry sending email, if the task handler attempts emails. Instead sends a failure metric and logs an error.

