### PR TITLE
PP-11567 Refactor RetryPaymentOrRefundEmailTaskData

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -846,7 +846,7 @@
         "filename": "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 123
       }
     ],
     "src/test/resources/config/client-factory-test-config.yaml": [
@@ -876,7 +876,7 @@
         "filename": "src/test/resources/config/client-factory-test-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 112
+        "line_number": 113
       }
     ],
     "src/test/resources/config/test-config.yaml": [
@@ -906,7 +906,7 @@
         "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 122
       }
     ],
     "src/test/resources/config/test-it-config.yaml": [
@@ -936,7 +936,7 @@
         "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 118
       }
     ],
     "src/test/resources/googlepay/auth-request-with-empty-last-digits-card-number.json": [
@@ -1071,5 +1071,5 @@
       }
     ]
   },
-  "generated_at": "2023-10-13T09:35:14Z"
+  "generated_at": "2023-10-18T14:50:40Z"
 }

--- a/src/main/java/uk/gov/pay/connector/app/SqsConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/SqsConfig.java
@@ -26,7 +26,7 @@ public class SqsConfig extends Configuration {
     private int messageMaximumBatchSize;
 
     @Max(900)
-    private int maxAllowedDeliveryDelay;
+    private int maxAllowedDeliveryDelayInSeconds;
 
     private String eventQueueUrl;
 
@@ -64,8 +64,8 @@ public class SqsConfig extends Configuration {
         return messageMaximumBatchSize;
     }
 
-    public int getMaxAllowedDeliveryDelay() {
-        return maxAllowedDeliveryDelay;
+    public int getMaxAllowedDeliveryDelayInSeconds() {
+        return maxAllowedDeliveryDelayInSeconds;
     }
 
     public String getEventQueueUrl() {

--- a/src/main/java/uk/gov/pay/connector/app/SqsConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/SqsConfig.java
@@ -24,6 +24,10 @@ public class SqsConfig extends Configuration {
     private int messageMaximumWaitTimeInSeconds;
     @Max(10)
     private int messageMaximumBatchSize;
+
+    @Max(900)
+    private int maxAllowedDeliveryDelay;
+
     private String eventQueueUrl;
 
     private String taskQueueUrl;
@@ -58,6 +62,10 @@ public class SqsConfig extends Configuration {
 
     public int getMessageMaximumBatchSize() {
         return messageMaximumBatchSize;
+    }
+
+    public int getMaxAllowedDeliveryDelay() {
+        return maxAllowedDeliveryDelay;
     }
 
     public String getEventQueueUrl() {

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueService.java
@@ -42,7 +42,7 @@ public class TaskQueueService {
                             ConnectorConfiguration connectorConfiguration) {
         this.taskQueue = taskQueue;
         this.objectMapper = objectMapper;
-        maxAllowedDeliveryDelay = connectorConfiguration.getSqsConfig().getMaxAllowedDeliveryDelay();
+        maxAllowedDeliveryDelay = connectorConfiguration.getSqsConfig().getMaxAllowedDeliveryDelayInSeconds();
     }
 
     public void offerTasksOnStateTransition(ChargeEntity chargeEntity) {

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/model/RetryPaymentOrRefundEmailTaskData.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/model/RetryPaymentOrRefundEmailTaskData.java
@@ -2,8 +2,11 @@ package uk.gov.pay.connector.queue.tasks.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
+import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
 
+import java.time.Instant;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -13,21 +16,30 @@ public class RetryPaymentOrRefundEmailTaskData {
     @JsonProperty("email_notification_type")
     private EmailNotificationType emailNotificationType;
 
+    @JsonProperty("failed_attempt_time")
+    @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    private Instant failedAttemptTime;
+
     public RetryPaymentOrRefundEmailTaskData() {
         // empty
     }
 
-    public RetryPaymentOrRefundEmailTaskData(String paymentOrRefundExternalId, EmailNotificationType emailNotificationType) {
+    public RetryPaymentOrRefundEmailTaskData(String paymentOrRefundExternalId, EmailNotificationType emailNotificationType, Instant failedAttemptTime) {
         this.resourceExternalId = paymentOrRefundExternalId;
         this.emailNotificationType = emailNotificationType;
+        this.failedAttemptTime = failedAttemptTime;
     }
 
-    public static RetryPaymentOrRefundEmailTaskData of(String paymentOrRefundExternalId, EmailNotificationType emailNotificationType) {
-        return new RetryPaymentOrRefundEmailTaskData(paymentOrRefundExternalId, emailNotificationType);
+    public static RetryPaymentOrRefundEmailTaskData of(String paymentOrRefundExternalId, EmailNotificationType emailNotificationType, Instant failedAttemptTime) {
+        return new RetryPaymentOrRefundEmailTaskData(paymentOrRefundExternalId, emailNotificationType, failedAttemptTime);
     }
 
     public String getResourceExternalId() {
         return resourceExternalId;
+    }
+
+    public Instant getFailedAttemptTime() {
+        return failedAttemptTime;
     }
 
     public EmailNotificationType getEmailNotificationType() {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -121,6 +121,7 @@ sqsConfig:
   taskQueueUrl: ${AWS_SQS_CONNECTOR_TASKS_QUEUE_URL}
   messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-20}
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
+  maxAllowedDeliveryDelay: ${AWS_SQS_MESSAGE_MAXIMUM_ALLOWED_DELIVERY_DELAY:-900}
 
 eventQueue:
   eventQueueEnabled: ${EVENT_QUEUE_ENABLED:-true}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -121,7 +121,7 @@ sqsConfig:
   taskQueueUrl: ${AWS_SQS_CONNECTOR_TASKS_QUEUE_URL}
   messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-20}
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
-  maxAllowedDeliveryDelay: ${AWS_SQS_MESSAGE_MAXIMUM_ALLOWED_DELIVERY_DELAY:-900}
+  maxAllowedDeliveryDelayInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_ALLOWED_DELIVERY_DELAY_SECONDS:-900}
 
 eventQueue:
   eventQueueEnabled: ${EVENT_QUEUE_ENABLED:-true}

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueServiceTest.java
@@ -77,7 +77,7 @@ class TaskQueueServiceTest {
     void setUp() {
         SqsConfig mockSqsConfig = mock(SqsConfig.class);
         when(mockConnectorConfiguration.getSqsConfig()).thenReturn(mockSqsConfig);
-        when(mockSqsConfig.getMaxAllowedDeliveryDelay()).thenReturn(100);
+        when(mockSqsConfig.getMaxAllowedDeliveryDelayInSeconds()).thenReturn(100);
         taskQueueService = new TaskQueueService(mockTaskQueue, objectMapper, mockConnectorConfiguration);
         Logger logger = (Logger) LoggerFactory.getLogger(TaskQueueService.class);
         logger.setLevel(Level.INFO);

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandlerTest.java
@@ -17,6 +17,9 @@ import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -59,7 +62,7 @@ class RetryPaymentOrRefundEmailTaskHandlerTest {
 
         @Test
         void shouldThrowExceptionIfChargeIsNotFound() {
-            var data = of(paymentExternalId, PAYMENT_CONFIRMED);
+            var data = of(paymentExternalId, PAYMENT_CONFIRMED, Instant.parse("2020-01-01T09:10:10.100Z"));
 
             when(mockChargeService.findCharge(paymentExternalId))
                     .thenThrow(new ChargeNotFoundRuntimeException(paymentExternalId));
@@ -71,7 +74,7 @@ class RetryPaymentOrRefundEmailTaskHandlerTest {
 
         @Test
         void shouldThrowExceptionIfGatewayAccountIsNotFound() {
-            var data = of(paymentExternalId, PAYMENT_CONFIRMED);
+            var data = of(paymentExternalId, PAYMENT_CONFIRMED, Instant.parse("2020-01-01T09:10:10.100Z"));
 
             GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withId(1L).build();
             Charge charge = Charge.from(aValidChargeEntity()
@@ -87,7 +90,7 @@ class RetryPaymentOrRefundEmailTaskHandlerTest {
 
         @Test
         void shouldSendEmailForPaymentConfirmedNotificationType() {
-            var data = of(paymentExternalId, PAYMENT_CONFIRMED);
+            var data = of(paymentExternalId, PAYMENT_CONFIRMED, Instant.parse("2020-01-01T09:10:10.100Z"));
 
             GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withId(1L).build();
             Charge charge = Charge.from(aValidChargeEntity()
@@ -116,7 +119,7 @@ class RetryPaymentOrRefundEmailTaskHandlerTest {
 
         @Test
         void shouldThrowExceptionIfChargeIsNotFound() {
-            var data = of(refundExternalId, REFUND_ISSUED);
+            var data = of(refundExternalId, REFUND_ISSUED, Instant.parse("2020-01-01T09:10:10.100Z"));
 
 
             when(mockChargeService.findCharge(paymentExternalId))
@@ -129,7 +132,7 @@ class RetryPaymentOrRefundEmailTaskHandlerTest {
 
         @Test
         void shouldThrowExceptionIfGatewayAccountIsNotFound() {
-            var data = of(refundExternalId, REFUND_ISSUED);
+            var data = of(refundExternalId, REFUND_ISSUED, Instant.parse("2020-01-01T09:10:10.100Z"));
 
             GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withId(1L).build();
             Charge charge = Charge.from(aValidChargeEntity()
@@ -145,7 +148,7 @@ class RetryPaymentOrRefundEmailTaskHandlerTest {
 
         @Test
         void shouldThrowExceptionIfRefundIsNotFound() {
-            var data = of(refundExternalId, REFUND_ISSUED);
+            var data = of(refundExternalId, REFUND_ISSUED, Instant.parse("2020-01-01T09:10:10.100Z"));
 
             when(mockRefundService.findRefundByExternalId(refundExternalId))
                     .thenThrow(new RefundNotFoundRuntimeException(refundExternalId));
@@ -157,7 +160,7 @@ class RetryPaymentOrRefundEmailTaskHandlerTest {
 
         @Test
         void shouldSendEmailForRefundConfirmedNotificationType() {
-            var data = of(refundExternalId, REFUND_ISSUED);
+            var data = of(refundExternalId, REFUND_ISSUED, Instant.parse("2020-01-01T09:10:10.100Z"));
 
             GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withId(1L).build();
             Charge charge = Charge.from(aValidChargeEntity()

--- a/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceEmailCollectionModeTest.java
+++ b/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceEmailCollectionModeTest.java
@@ -18,6 +18,7 @@ import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.SendEmailResponse;
 
+import java.time.Clock;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -74,7 +75,7 @@ class UserNotificationServiceEmailCollectionModeTest {
 
         when(environment.metrics()).thenReturn(metricRegistry);
 
-        userNotificationService = new UserNotificationService(notifyClientFactory, connectorConfig, environment, mockTaskQueueService);
+        userNotificationService = new UserNotificationService(notifyClientFactory, connectorConfig, environment, mockTaskQueueService, Clock.systemUTC());
     }
 
     @ParameterizedTest

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -99,7 +99,7 @@ sqsConfig:
   taskQueueUrl: ${AWS_SQS_CONNECTOR_TASKS_QUEUE_URL}
   messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-20}
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
-  maxAllowedDeliveryDelay: 900
+  maxAllowedDeliveryDelayInSeconds: 900
 
 eventQueue:
   eventQueueEnabled: ${EVENT_QUEUE_ENABLED:-false}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -99,6 +99,7 @@ sqsConfig:
   taskQueueUrl: ${AWS_SQS_CONNECTOR_TASKS_QUEUE_URL}
   messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-20}
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
+  maxAllowedDeliveryDelay: 900
 
 eventQueue:
   eventQueueEnabled: ${EVENT_QUEUE_ENABLED:-false}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -89,7 +89,7 @@ sqsConfig:
   taskQueueUrl: ${AWS_SQS_CONNECTOR_TASKS_QUEUE_URL}
   messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-20}
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
-  maxAllowedDeliveryDelay: 900
+  maxAllowedDeliveryDelayInSeconds: 900
 
 eventQueue:
   eventQueueEnabled: ${EVENT_QUEUE_ENABLED:-false}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -89,6 +89,7 @@ sqsConfig:
   taskQueueUrl: ${AWS_SQS_CONNECTOR_TASKS_QUEUE_URL}
   messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-20}
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
+  maxAllowedDeliveryDelay: 900
 
 eventQueue:
   eventQueueEnabled: ${EVENT_QUEUE_ENABLED:-false}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -80,6 +80,7 @@ sqsConfig:
   taskQueueUrl: ${AWS_SQS_CONNECTOR_TASKS_QUEUE_URL}
   messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-20}
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
+  maxAllowedDeliveryDelay: 900
 
 eventQueue:
   eventQueueEnabled: ${EVENT_QUEUE_ENABLED:-false}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -80,7 +80,7 @@ sqsConfig:
   taskQueueUrl: ${AWS_SQS_CONNECTOR_TASKS_QUEUE_URL}
   messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-20}
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
-  maxAllowedDeliveryDelay: 900
+  maxAllowedDeliveryDelayInSeconds: 900
 
 eventQueue:
   eventQueueEnabled: ${EVENT_QUEUE_ENABLED:-false}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -94,7 +94,7 @@ sqsConfig:
   accessKey: ${AWS_ACCESS_KEY:-access-key}
   messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-20}
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
-  maxAllowedDeliveryDelay: 900
+  maxAllowedDeliveryDelayInSeconds: 900
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -94,6 +94,7 @@ sqsConfig:
   accessKey: ${AWS_ACCESS_KEY:-access-key}
   messageMaximumWaitTimeInSeconds: ${AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS:-20}
   messageMaximumBatchSize: ${AWS_SQS_MESSAGE_MAXIMUM_BATCH_SIZE:-10}
+  maxAllowedDeliveryDelay: 900
 
 jerseyClient:
   timeout: 500ms


### PR DESCRIPTION
## WHAT YOU DID
- Refactored `RetryPaymentOrRefundEmailTaskData` class to add a failed timestamp. Failed timestamp will be used (https://github.com/alphagov/pay-connector/pull/4775) to delay retrying failed emails for the required duration (1 hour or as per config). SQS only allows a maximum delivery delay of 15 minutes so we have to use failed_timestamp to defer (add message back to SQS queue) retrying if longer than 15 mins.
- Uses the system clock in UserNotificaitonService so fixed dates can be used for testing
- Also added maximum delivery delay to config
