### PR TITLE
PP-11567 Delay retrying failed emails as per config

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/NotifyConfiguration.java
@@ -12,6 +12,8 @@ public class NotifyConfiguration extends Configuration {
     private String notificationBaseURL;
     private boolean emailNotifyEnabled;
 
+    private long retryFailedEmailAfterSeconds;
+
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     public String getEmailTemplateId() {
@@ -32,5 +34,9 @@ public class NotifyConfiguration extends Configuration {
 
     public String getRefundIssuedEmailTemplateId() {
         return refundIssuedEmailTemplateId;
+    }
+
+    public long getRetryFailedEmailAfterSeconds() {
+        return retryFailedEmailAfterSeconds;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/RetryPaymentOrRefundEmailTaskHandler.java
@@ -1,51 +1,80 @@
 package uk.gov.pay.connector.queue.tasks.handlers;
 
 import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.queue.tasks.model.RetryPaymentOrRefundEmailTaskData;
 import uk.gov.pay.connector.refund.exception.RefundNotFoundRuntimeException;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
+import java.time.Clock;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.PAYMENT_CONFIRMED;
 import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.REFUND_ISSUED;
+import static uk.gov.service.payments.logging.LoggingKeys.RESOURCE_EXTERNAL_ID;
 
 public class RetryPaymentOrRefundEmailTaskHandler {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetryPaymentOrRefundEmailTaskHandler.class);
     private final ChargeService chargeService;
     private final RefundService refundService;
     private final GatewayAccountService gatewayAccountService;
     private final UserNotificationService userNotificationService;
+    private final TaskQueueService taskQueueService;
+    private final long retryFailedEmailAfterSeconds;
+    private final Clock clock;
 
     @Inject
     public RetryPaymentOrRefundEmailTaskHandler(ChargeService chargeService,
                                                 RefundService refundService,
                                                 GatewayAccountService gatewayAccountService,
-                                                UserNotificationService userNotificationService) {
+                                                UserNotificationService userNotificationService,
+                                                TaskQueueService taskQueueService,
+                                                ConnectorConfiguration connectorConfiguration,
+                                                Clock clock) {
         this.chargeService = chargeService;
         this.refundService = refundService;
         this.gatewayAccountService = gatewayAccountService;
         this.userNotificationService = userNotificationService;
+        this.taskQueueService = taskQueueService;
+        retryFailedEmailAfterSeconds = connectorConfiguration.getNotifyConfiguration().getRetryFailedEmailAfterSeconds();
+        this.clock = clock;
     }
 
     public void process(RetryPaymentOrRefundEmailTaskData retryPaymentOrRefundEmailTaskData) {
-        if (retryPaymentOrRefundEmailTaskData.getEmailNotificationType() == PAYMENT_CONFIRMED) {
-            Charge charge = getCharge(retryPaymentOrRefundEmailTaskData.getResourceExternalId());
-            GatewayAccountEntity gatewayAccountEntity = getGatewayAccountEntity(charge.getGatewayAccountId());
+        long timeElapsedInSeconds = clock.instant().getEpochSecond() -
+                retryPaymentOrRefundEmailTaskData.getFailedAttemptTime().getEpochSecond();
 
-            userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, gatewayAccountEntity, false);
-        } else if (retryPaymentOrRefundEmailTaskData.getEmailNotificationType() == REFUND_ISSUED) {
-            RefundEntity refundEntity = getRefund(retryPaymentOrRefundEmailTaskData.getResourceExternalId());
-            Charge charge = getCharge(refundEntity.getChargeExternalId());
-            GatewayAccountEntity gatewayAccountEntity = getGatewayAccountEntity(charge.getGatewayAccountId());
+        if (timeElapsedInSeconds >= retryFailedEmailAfterSeconds) {
+            if (retryPaymentOrRefundEmailTaskData.getEmailNotificationType() == PAYMENT_CONFIRMED) {
+                Charge charge = getCharge(retryPaymentOrRefundEmailTaskData.getResourceExternalId());
+                GatewayAccountEntity gatewayAccountEntity = getGatewayAccountEntity(charge.getGatewayAccountId());
 
-            userNotificationService.sendRefundIssuedEmailSynchronously(charge, gatewayAccountEntity, refundEntity, false);
+                userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, gatewayAccountEntity, false);
+            } else if (retryPaymentOrRefundEmailTaskData.getEmailNotificationType() == REFUND_ISSUED) {
+                RefundEntity refundEntity = getRefund(retryPaymentOrRefundEmailTaskData.getResourceExternalId());
+                Charge charge = getCharge(refundEntity.getChargeExternalId());
+                GatewayAccountEntity gatewayAccountEntity = getGatewayAccountEntity(charge.getGatewayAccountId());
+
+                userNotificationService.sendRefundIssuedEmailSynchronously(charge, gatewayAccountEntity, refundEntity, false);
+            }
+        } else {
+            taskQueueService.addRetryFailedPaymentOrRefundEmailTask(retryPaymentOrRefundEmailTaskData);
+            LOGGER.info("Added retry failed payment or refund email task message back to task queue",
+                    kv("time_elapsed_since_failure", timeElapsedInSeconds),
+                    kv(RESOURCE_EXTERNAL_ID, retryPaymentOrRefundEmailTaskData.getResourceExternalId()),
+                    kv("email_notification_type", retryPaymentOrRefundEmailTaskData.getEmailNotificationType()));
         }
     }
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -216,6 +216,7 @@ notifyConfig:
   refundIssuedEmailTemplateId: ${NOTIFY_REFUND_ISSUED_EMAIL_TEMPLATE_ID}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://api.notifications.service.gov.uk}
   emailNotifyEnabled: ${NOTIFY_EMAIL_ENABLED:-false}
+  retryFailedEmailAfterSeconds: ${NOTIFY_RETRY_FAILED_EMAIL_AFTER_SECONDS:-3600}
 
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -160,6 +160,7 @@ notifyConfig:
   apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false
+  retryFailedEmailAfterSeconds: 3600
 
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -150,6 +150,7 @@ notifyConfig:
   apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false
+  retryFailedEmailAfterSeconds: 3600
 
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -158,6 +158,7 @@ notifyConfig:
   apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false
+  retryFailedEmailAfterSeconds: 3600
 
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -155,6 +155,7 @@ notifyConfig:
   apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false
+  retryFailedEmailAfterSeconds: 3600
 
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}


### PR DESCRIPTION
## WHAT YOU DID
 - Adds RetryPaymentOrRefundEmail task to SQS queue if the time elapsed since failure is less than the config.
      Message is added back to SQS queue with maximum delivery delay allowed (15 mins) for SQS queue.
- Always delays message delivery by max_delivery_delay and doesn't calculate time left which can be done separately if required.
