### PR TITLE
PP-11641-Undo_separation_of_Google_Pay_auth_endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,63 +155,63 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 2334
+        "line_number": 2383
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 2378
+        "line_number": 2427
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 2845
+        "line_number": 2894
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3225
+        "line_number": 3274
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3261
+        "line_number": 3310
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3288
+        "line_number": 3337
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 3928
+        "line_number": 3989
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4396
+        "line_number": 4457
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4407
+        "line_number": 4468
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -331,7 +331,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java",
         "hashed_secret": "423e3dd3782e3527b4f9af75dd9faf9ebbb7889c",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 105
       }
     ],
     "src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java": [
@@ -358,7 +358,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayEncryptedPaymentData.java",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 26
+        "line_number": 27
       }
     ],
     "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeCreatedTest.java": [
@@ -1071,5 +1071,5 @@
       }
     ]
   },
-  "generated_at": "2023-10-18T14:50:40Z"
+  "generated_at": "2023-10-24T12:24:32Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1802,6 +1802,55 @@ paths:
       summary: Authorise Apple Pay payment
       tags:
       - Charge operations
+  /v1/frontend/charges/{chargeId}/wallets/google:
+    post:
+      operationId: authoriseChargeGooglePay
+      parameters:
+      - description: Charge external ID
+        example: b02b63b370fd35418ad66b0101
+        in: path
+        name: chargeId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenericGooglePayAuthRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+        "202":
+          description: Accepted - payment has been submitted for authorisation and
+            awaiting response from payment service provider
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request - invalid payload or the payment has been declined
+        "402":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Gateway error
+        "404":
+          description: Not found
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unprocessable Entity - Invalid payload or missing mandatory
+            attributes
+        "500":
+          description: Internal server error
+      summary: Authorise Google Pay payment
+      tags:
+      - Charge operations
   /v1/frontend/charges/{chargeId}/wallets/google/stripe:
     post:
       operationId: authoriseChargeGooglePayStripe
@@ -3916,8 +3965,20 @@ components:
         rawGatewayResponse:
           type: string
           example: Worldpay response ()
+    GenericGooglePayAuthRequest:
+      type: object
+      properties:
+        encrypted_payment_data:
+          $ref: '#/components/schemas/GooglePayEncryptedPaymentData'
+        payment_info:
+          $ref: '#/components/schemas/GooglePayPaymentInfo'
+        token_id:
+          type: string
+          description: only required for Stripe payments
+          writeOnly: true
     GooglePayEncryptedPaymentData:
       type: object
+      description: only required for Worldpay and Sandbox payments
       properties:
         protocol_version:
           type: string

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -32,6 +32,7 @@ import uk.gov.pay.connector.util.MDCUtils;
 import uk.gov.pay.connector.util.ResponseUtil;
 import uk.gov.pay.connector.wallets.WalletService;
 import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
+import uk.gov.pay.connector.wallets.googlepay.api.GenericGooglePayAuthRequest;
 import uk.gov.pay.connector.wallets.googlepay.api.StripeGooglePayAuthRequest;
 import uk.gov.pay.connector.wallets.googlepay.api.WorldpayGooglePayAuthRequest;
 
@@ -108,6 +109,33 @@ public class CardResource {
         return walletService.authorise(chargeId, applePayAuthRequest);
     }
 
+
+    @POST
+    @Path("/v1/frontend/charges/{chargeId}/wallets/google")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @Operation(
+            summary = "Authorise Google Pay payment",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "202", description = "Accepted - payment has been submitted for authorisation and awaiting response from payment service provider"),
+                    @ApiResponse(responseCode = "400", description = "Bad request - invalid payload or the payment has been declined",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "402", description = "Gateway error",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "422", description = "Unprocessable Entity - Invalid payload or missing mandatory attributes",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error"),
+            }
+    )
+    public Response authoriseChargeGooglePay(@Parameter(example = "b02b63b370fd35418ad66b0101", description = "Charge external ID")
+                                                     @PathParam("chargeId") String chargeId,
+                                                     @NotNull @Valid GenericGooglePayAuthRequest genericGooglePayAuthRequest) {
+        logger.info("Received wallet payment info \n{} \nfor charge with id {}", genericGooglePayAuthRequest.getPaymentInfo().toString(), chargeId);
+        return walletService.convertAndAuthorise(chargeId, genericGooglePayAuthRequest);
+    }
+    
     @POST
     @Path("/v1/frontend/charges/{chargeId}/wallets/google/worldpay")
     @Consumes(APPLICATION_JSON)

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GenericGooglePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GenericGooglePayAuthRequest.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.connector.wallets.googlepay.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.connector.wallets.WalletType;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class GenericGooglePayAuthRequest {
+    
+    @Schema(hidden = true)
+    @NotNull
+    @Valid
+    private final GooglePayPaymentInfo paymentInfo;
+    
+    @Valid
+    @Schema(hidden = true)
+    private final GooglePayEncryptedPaymentData encryptedPaymentData;
+    
+    @Valid
+    @JsonProperty("token_id")
+    private final String tokenId;
+
+    public GenericGooglePayAuthRequest(@JsonProperty("payment_info") GooglePayPaymentInfo paymentInfo,
+                                       @JsonProperty("encrypted_payment_data") GooglePayEncryptedPaymentData encryptedPaymentData,
+                                       @JsonProperty("token_id") String tokenId) {
+        this.paymentInfo = paymentInfo;
+        this.encryptedPaymentData = encryptedPaymentData;
+        this.tokenId = tokenId;
+    }
+    
+    public GooglePayPaymentInfo getPaymentInfo() {
+        return paymentInfo;
+    }
+
+    @Schema(description = "only required for Stripe payments", writeOnly = true)
+    public String getTokenId() { return tokenId; }
+    
+    public GooglePayEncryptedPaymentData getEncryptedPaymentData() {
+        return encryptedPaymentData;
+    }
+    
+    @Schema(hidden = true)
+    public WalletType getWalletType() {
+        return WalletType.GOOGLE_PAY;
+    }
+    
+    public WorldpayGooglePayAuthRequest toWorldpayGooglePayAuthRequest() {
+        return new WorldpayGooglePayAuthRequest(paymentInfo, encryptedPaymentData);
+    }
+    
+    public StripeGooglePayAuthRequest toStripeGooglePayAuthRequest() {
+        return new StripeGooglePayAuthRequest(paymentInfo, tokenId);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayEncryptedPaymentData.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayEncryptedPaymentData.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotEmpty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "only required for Worldpay and Sandbox payments")
 public class GooglePayEncryptedPaymentData {
     @NotEmpty(message= "Field [signed_message] must not be empty")
     @Schema(hidden = true)

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -337,6 +337,11 @@ public class ChargingITestBase {
     public static String authoriseChargeUrlForGooglePayWorldpay(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/wallets/google/worldpay".replace("{chargeId}", chargeId);
     }
+    
+    public static String authoriseChargeUrlForGooglePay(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/wallets/google".replace("{chargeId}", chargeId);
+    }
+    
 
     public static String authoriseChargeUrlFor(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeId);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceTest.java
@@ -411,7 +411,7 @@ class CardResourceTest {
     }
     
     @Test
-    void authoriseGooglePayWorldpayShouldReturn422IfCardholderNameIsTooLong() throws JsonProcessingException {
+    void authoriseGooglePayWorldpayShouldReturn422IfCardholderNameIsTooLong_WorldpaySpecificEndpoint() throws JsonProcessingException {
         String payloadStr = fixture("googlepay/example-auth-request.json").replace("Example Name", "A".repeat(256));
         JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
 
@@ -423,7 +423,7 @@ class CardResourceTest {
     }
 
     @Test
-    void authoriseGooglePayWorldpayShouldReturn422IfEmailIsTooLong() throws JsonProcessingException {
+    void authoriseGooglePayWorldpayShouldReturn422IfEmailIsTooLong_WorldpaySpecificEndpoint() throws JsonProcessingException {
         String payloadStr = fixture("googlepay/example-auth-request.json").replace("example@test.example","A".repeat(250) + "@" + "email.com");;
         JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
 
@@ -435,7 +435,7 @@ class CardResourceTest {
     }
 
     @Test
-    void authoriseGooglePayWorldpayShouldReturn422IfSignedMessageIsEmpty() throws JsonProcessingException {
+    void authoriseGooglePayWorldpayShouldReturn422IfSignedMessageIsEmpty_WorldpaySpecificEndpoint() throws JsonProcessingException {
         String payloadStr = fixture("googlepay/example-auth-request.json").replace("aSignedMessage", "");
         JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
 
@@ -447,7 +447,7 @@ class CardResourceTest {
     }
 
     @Test
-    void authoriseGooglePayWorldpayShouldReturn422IfSignatureIsEmpty() throws JsonProcessingException {
+    void authoriseGooglePayWorldpayShouldReturn422IfSignatureIsEmpty_WorldpaySpecificEndpoint() throws JsonProcessingException {
         String payloadStr = fixture("googlepay/example-auth-request.json").replace("MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl", "");
         JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
 
@@ -459,7 +459,7 @@ class CardResourceTest {
     }
 
     @Test
-    void authoriseGooglePayStripeShouldReturn422IfCardholderNameIsTooLong() throws JsonProcessingException {
+    void authoriseGooglePayStripeShouldReturn422IfCardholderNameIsTooLong_StripeSpecificEndpoint() throws JsonProcessingException {
         String payloadStr = fixture("googlepay/example-auth-request-stripe.json").replace("Example Name", "A".repeat(256));
         JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
 
@@ -471,11 +471,83 @@ class CardResourceTest {
     }
 
     @Test
-    void authoriseGooglePayStripeShouldReturn422IfEmailIsTooLong() throws JsonProcessingException {
+    void authoriseGooglePayStripeShouldReturn422IfEmailIsTooLong_StripeSpecificEndpoint() throws JsonProcessingException {
         String payloadStr = fixture("googlepay/example-auth-request-stripe.json").replace("example@test.example","A".repeat(250) + "@" + "email.com");;
         JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
 
         Response response = resources.target("/v1/frontend/charges/a-valid-chargeId/wallets/google/stripe")
+                .request().post(Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+
+        verify422AndErrorMessage(response, "Email must be a maximum of 254 chars");
+        verifyReceiptOfPayloadNotLogged(response, "Received wallet payment info");
+    }
+
+    @Test
+    void authoriseGooglePayWorldpayShouldReturn422IfCardholderNameIsTooLong() throws JsonProcessingException {
+        String payloadStr = fixture("googlepay/example-auth-request.json").replace("Example Name", "A".repeat(256));
+        JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
+
+        Response response = resources.target("/v1/frontend/charges/a-valid-chargeId/wallets/google")
+                .request().post(Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+
+        verify422AndErrorMessage(response, "Card holder name must be a maximum of 255 chars");
+        verifyReceiptOfPayloadNotLogged(response, "Received encrypted payload for charge with id");
+    }
+
+    @Test
+    void authoriseGooglePayWorldpayShouldReturn422IfEmailIsTooLong() throws JsonProcessingException {
+        String payloadStr = fixture("googlepay/example-auth-request.json").replace("example@test.example","A".repeat(250) + "@" + "email.com");;
+        JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
+
+        Response response = resources.target("/v1/frontend/charges/a-valid-chargeId/wallets/google")
+                .request().post(Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+
+        verify422AndErrorMessage(response, "Email must be a maximum of 254 chars");
+        verifyReceiptOfPayloadNotLogged(response, "Received encrypted payload for charge with id");
+    }
+
+    @Test
+    void authoriseGooglePayWorldpayShouldReturn422IfSignedMessageIsEmpty() throws JsonProcessingException {
+        String payloadStr = fixture("googlepay/example-auth-request.json").replace("aSignedMessage", "");
+        JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
+
+        Response response = resources.target("/v1/frontend/charges/a-valid-chargeId/wallets/google")
+                .request().post(Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+
+        verify422AndErrorMessage(response, "Field [signed_message] must not be empty");
+        verifyReceiptOfPayloadNotLogged(response, "Received encrypted payload for charge with id");
+    }
+
+    @Test
+    void authoriseGooglePayWorldpayShouldReturn422IfSignatureIsEmpty() throws JsonProcessingException {
+        String payloadStr = fixture("googlepay/example-auth-request.json").replace("MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl", "");
+        JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
+
+        Response response = resources.target("/v1/frontend/charges/a-valid-chargeId/wallets/google")
+                .request().post(Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+
+        verify422AndErrorMessage(response, "Field [signature] must not be empty");
+        verifyReceiptOfPayloadNotLogged(response, "Received encrypted payload for charge with id");
+    }
+
+    @Test
+    void authoriseGooglePayStripeShouldReturn422IfCardholderNameIsTooLong() throws JsonProcessingException {
+        String payloadStr = fixture("googlepay/example-auth-request-stripe.json").replace("Example Name", "A".repeat(256));
+        JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
+
+        Response response = resources.target("/v1/frontend/charges/a-valid-chargeId/wallets/google")
+                .request().post(Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+
+        verify422AndErrorMessage(response, "Card holder name must be a maximum of 255 chars");
+        verifyReceiptOfPayloadNotLogged(response, "Received wallet payment info");
+    }
+
+    @Test
+    void authoriseGooglePayStripeShouldReturn422IfEmailIsTooLong() throws JsonProcessingException {
+        String payloadStr = fixture("googlepay/example-auth-request-stripe.json").replace("example@test.example","A".repeat(250) + "@" + "email.com");;
+        JsonNode payload = Jackson.getObjectMapper().readTree(payloadStr);
+
+        Response response = resources.target("/v1/frontend/charges/a-valid-chargeId/wallets/google")
                 .request().post(Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
 
         verify422AndErrorMessage(response, "Email must be a maximum of 254 chars");

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gateway.model.ErrorType;
 import uk.gov.pay.connector.gateway.model.GatewayError;
@@ -40,6 +41,9 @@ public class WalletServiceTest {
 
     @Mock
     private WalletAuthoriseService mockWalletAuthoriseService;
+    
+    @Mock
+    private ChargeService mockChargeService;
 
     @Mock
     private WorldpayOrderStatusResponse worldpayResponse;
@@ -48,7 +52,7 @@ public class WalletServiceTest {
 
     @BeforeEach
     void setUp() {
-        walletService = new WalletService(mockWalletAuthoriseService);
+        walletService = new WalletService(mockWalletAuthoriseService, mockChargeService);
     }
 
     @Test


### PR DESCRIPTION
Context: In preparation for implementing support for sandbox, have a single endpoint for Google Pay authorisations

- Add wallets/google endpoint with generic request class
- Add method to convert from generic request to payment provider-specific request
- Update openapi spec
- Duplicate tests for new endpoint

Subsequent PRs will point frontend to this new endpoint and remove outdated endpoints and tests.