### PR TITLE
PP-11058: Add migration to drop GIN indexes

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1999,4 +1999,9 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="drop gin indexes" author="">
+        <dropIndex indexName="idx_lower_charges_cardholder_name_gin_idx" tableName="charges"/>
+        <dropIndex indexName="idx_lower_charges_email_gin_idx" tableName="charges"/>
+        <dropIndex indexName="idx_lower_charges_reference_gin_idx" tableName="charges"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
Add DB migration to drop GIN indexes in anticipation of deleting the pg_trgm extension

## How to test
Launch pay local and check the indexes are gone :) 

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [x] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
