### PR TITLE
PP-11641 Throw UnsupportedOperationException for unknown pp

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
@@ -51,7 +51,7 @@ public class WalletService {
             case STRIPE: 
                 return authorise(chargeId, genericGooglePayAuthRequest.toStripeGooglePayAuthRequest());
             default: 
-                throw new RuntimeException("payment provider not supported");
+                throw new UnsupportedOperationException("Payment provider not supported");
         }
     }
 


### PR DESCRIPTION
Currently a RuntimeException is thrown if wallet authorisation is requested for a payment provider other than Stripe or Worldpay. This causes a 500 response when it should be 400. This was identified in frontend consumer PACT test.

- Throw UnsupportedOperationException instead; this maps to a 400 response.
