### PR TITLE
PP-11641 Stub Payment Provider Responses for PACT

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -739,7 +739,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java",
         "hashed_secret": "aa4f63822a427d27308ddef0e735bc21f8f2f7f7",
         "is_verified": false,
-        "line_number": 146
+        "line_number": 169
       }
     ],
     "src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java": [
@@ -1071,5 +1071,5 @@
       }
     ]
   },
-  "generated_at": "2023-10-24T12:24:32Z"
+  "generated_at": "2023-10-31T12:30:29Z"
 }


### PR DESCRIPTION
Context: Need to update provider states for frontend-connector PACT to correctly reflect interactions for wallet payments

- Add new provider states for Worldpay and Stripe charges
- Stub the interaction with Stripe/Worldpay in these new states

Subsequent PR will point frontend consumer tests to these new states