### PR TITLE
PP-11279: Persistence tests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -126,7 +126,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @Enumerated(EnumType.STRING)
     private EmailCollectionMode emailCollectionMode = EmailCollectionMode.MANDATORY;
 
-    @OneToOne(mappedBy = "accountEntity", cascade = CascadeType.PERSIST)
+    @OneToOne(mappedBy = "accountEntity", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private NotificationCredentials notificationCredentials;
 
     @OneToOne(mappedBy = "gatewayAccountEntity", cascade = CascadeType.PERSIST)

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayMerchantCodeCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayMerchantCodeCredentials.java
@@ -14,6 +14,8 @@ import java.util.Objects;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorldpayMerchantCodeCredentials {
 
+    public static final String DELETED = "<DELETED>";
+    
     @JsonView({GatewayCredentials.Views.Api.class})
     private String merchantCode;
     @JsonView({GatewayCredentials.Views.Api.class})
@@ -29,6 +31,11 @@ public class WorldpayMerchantCodeCredentials {
         this.merchantCode = merchantCode;
         this.username = username;
         this.password = password;
+    }
+    
+    public void redactSensitiveInformation() {
+        username = DELETED;
+        password = DELETED;
     }
 
     public String getMerchantCode() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -180,7 +180,8 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     }
 
     public void setCredentials(GatewayCredentials credentials) {
-        this.credentials = objectMapper.convertValue(credentials, new TypeReference<Map<String, Object>>() {});
+        this.credentials = objectMapper.convertValue(credentials, new TypeReference<>() {
+        });
     }
 
     public void setState(GatewayAccountCredentialState state) {

--- a/src/test/java/uk/gov/pay/connector/it/dao/DaoITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DaoITestBase.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.it.dao;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.persist.jpa.JpaPersistModule;
 import com.spotify.docker.client.exceptions.DockerException;
 import liquibase.Liquibase;
@@ -23,6 +24,7 @@ abstract public class DaoITestBase {
 
     protected static DatabaseTestHelper databaseTestHelper;
     protected static GuicedTestEnvironment env;
+    protected static ObjectMapper objectMapper = new ObjectMapper();
     
     private static String CHANGE_LOG_FILE = "it-migrations.xml";
 


### PR DESCRIPTION
As per the acceptance criteria of this story, when a service is archived, for it's related gateway accounts, we want to verify we can:
- Disable the gateway account(s)
- Remove notification credentials from a gateway account(s)
- Redact sensitive gateway account(s) credentials information

This PR doesn't include removing rows from the `gateway_account_credentials_history` table.