### PR TITLE
PP-11279: Add ability to delete from gateway_account_credentials_hist…

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDao.java
@@ -18,11 +18,12 @@ public class GatewayAccountCredentialsHistoryDao {
         this.entityManager = entityManager;
     }
 
-    public int delete(Long gatewayAccountId) {
-        String query = "DELETE FROM gateway_account_credentials_history WHERE gateway_account_id = ?1";
+    public int delete(String serviceId) {
+        String query = "DELETE FROM gateway_account_credentials_history WHERE " +
+                "gateway_account_id IN (SELECT gateway_account_id FROM gateway_accounts WHERE service_id = ?1)";
         
         return entityManager.get().createNativeQuery(query)
-                .setParameter(1, gatewayAccountId)
+                .setParameter(1, serviceId)
                 .executeUpdate();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDao.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.dao;
+
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional
+public class GatewayAccountCredentialsHistoryDao {
+
+    protected final Provider<EntityManager> entityManager;
+
+    @Inject
+    public GatewayAccountCredentialsHistoryDao(Provider<EntityManager> entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public int delete(Long gatewayAccountId) {
+        String query = "DELETE FROM gateway_account_credentials_history WHERE gateway_account_id = ?1";
+        
+        return entityManager.get().createNativeQuery(query)
+                .setParameter(1, gatewayAccountId)
+                .executeUpdate();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDaoIT.java
@@ -40,16 +40,25 @@ public class GatewayAccountCredentialsHistoryDaoIT extends DaoITestBase {
     
     @Test
     public void deleteGatewayAccountCredentialsHistory() {
+        String serviceId = "archived-service-id";
+        var gatewayAccountEntity = createAGatewayAccount(serviceId);
+        persistTwoGatewayAccountCredentialsHistoryRows(gatewayAccountEntity);
+        
+        var anotherGatewayAccountEntity = createAGatewayAccount(serviceId);
+        persistTwoGatewayAccountCredentialsHistoryRows(anotherGatewayAccountEntity);
+
+        assertThat(gatewayAccountCredentialsHistoryDao.delete(serviceId), is(4));
+        assertTrue(databaseTestHelper.getGatewayAccountCredentialsHistoryForAccount(gatewayAccountEntity.getId()).isEmpty());
+        assertTrue(databaseTestHelper.getGatewayAccountCredentialsHistoryForAccount(anotherGatewayAccountEntity.getId()).isEmpty());
+    }
+    
+    private GatewayAccountEntity createAGatewayAccount(String serviceId) {
         long gatewayAccountId = nextLong();
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(String.valueOf(gatewayAccountId))
+                .withServiceId(serviceId)
                 .build());
-        var gatewayAccountEntity = gatewayAccountDao.findById(gatewayAccountId).get();
-
-        persistTwoGatewayAccountCredentialsHistoryRows(gatewayAccountEntity);
-
-        assertThat(gatewayAccountCredentialsHistoryDao.delete(gatewayAccountId), is(2));
-        assertTrue(databaseTestHelper.getGatewayAccountCredentialsHistoryForAccount(gatewayAccountId).isEmpty());
+        return gatewayAccountDao.findById(gatewayAccountId).get();
     }
 
     private void persistTwoGatewayAccountCredentialsHistoryRows(GatewayAccountEntity gatewayAccountEntity) {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDaoIT.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
+import uk.gov.pay.connector.it.dao.DaoITestBase;
+
+import java.util.Map;
+
+import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
+import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
+import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
+
+public class GatewayAccountCredentialsHistoryDaoIT extends DaoITestBase {
+
+    private GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
+    private GatewayAccountCredentialsHistoryDao gatewayAccountCredentialsHistoryDao;
+    private GatewayAccountDao gatewayAccountDao;
+
+    @Before
+    public void setUp() {
+        gatewayAccountCredentialsDao = env.getInstance(GatewayAccountCredentialsDao.class);
+        gatewayAccountDao = env.getInstance(GatewayAccountDao.class);
+        gatewayAccountCredentialsHistoryDao = env.getInstance(GatewayAccountCredentialsHistoryDao.class);
+    }
+    
+    @Test
+    public void deleteGatewayAccountCredentialsHistory() {
+        long gatewayAccountId = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId))
+                .build());
+        var gatewayAccountEntity = gatewayAccountDao.findById(gatewayAccountId).get();
+
+        persistTwoGatewayAccountCredentialsHistoryRows(gatewayAccountEntity);
+
+        assertThat(gatewayAccountCredentialsHistoryDao.delete(gatewayAccountId), is(2));
+        assertTrue(databaseTestHelper.getGatewayAccountCredentialsHistoryForAccount(gatewayAccountId).isEmpty());
+    }
+
+    private void persistTwoGatewayAccountCredentialsHistoryRows(GatewayAccountEntity gatewayAccountEntity) {
+        Map<String, Object> credentials = Map.of(ONE_OFF_CUSTOMER_INITIATED, 
+                Map.of(CREDENTIALS_MERCHANT_CODE, "a-merchant-code-1", CREDENTIALS_USERNAME, "a-merchant-code-1", CREDENTIALS_PASSWORD, "passw0rd1"));
+        String externalCredentialId = randomUuid();
+        var gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+                .withCredentials(credentials)
+                .withGatewayAccountEntity(gatewayAccountEntity)
+                .withPaymentProvider(WORLDPAY.getName())
+                .withState(ACTIVE)
+                .withExternalId(externalCredentialId)
+                .build();
+        gatewayAccountCredentialsDao.persist(gatewayAccountCredentialsEntity);
+
+        gatewayAccountCredentialsEntity.setState(RETIRED);
+        WorldpayCredentials updatedCredentials = new WorldpayCredentials();
+        updatedCredentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials("a-merchant-code-1", "<DELETED>", "<DELETED>"));
+        gatewayAccountCredentialsEntity.setCredentials(updatedCredentials);
+        gatewayAccountCredentialsDao.merge(gatewayAccountCredentialsEntity);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -1108,6 +1108,14 @@ public class DatabaseTestHelper {
                         .list());
     }
 
+    public List<Map<String, Object>> getGatewayAccountCredentialsHistoryForAccount(long accountId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT * FROM gateway_account_credentials_history where gateway_account_id = :accountId")
+                        .bind("accountId", accountId)
+                        .mapToMap()
+                        .list());
+    }
+
     public Map<String, Object> getGatewayAccountCredentialByExternalId(String credentialExternalId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT * FROM gateway_account_credentials where external_id = :externalId")


### PR DESCRIPTION
…ory table

The `GatewayAccountCredentialsHistoryDao.delete` method uses a native SQL query rather than a JPQL one as we do not directly manage entries in the gateway_account_credentials_history table via a Java entity class.

