### PR TITLE
PP-11279: Service layer for dealing with an archived service

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -73,8 +73,8 @@ public class GatewayAccountService {
     private final GatewayAccountDao gatewayAccountDao;
     private final CardTypeDao cardTypeDao;
     private final GatewayAccountCredentialsService gatewayAccountCredentialsService;
-    private GatewayAccountCredentialsHistoryDao gatewayAccountCredentialsHistoryDao;
-    private GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
+    private final GatewayAccountCredentialsHistoryDao gatewayAccountCredentialsHistoryDao;
+    private final GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
 
     @Inject
     public GatewayAccountService(GatewayAccountDao gatewayAccountDao, CardTypeDao cardTypeDao,

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -16,6 +16,10 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.CreateGatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
+import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
+import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsHistoryDao;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchRequest;
 
@@ -54,24 +58,32 @@ import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequest
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_REFERENCE_TO_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_TYPE;
 import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER;
+import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 
 public class GatewayAccountService {
 
-    private static final Logger logger = LoggerFactory.getLogger(GatewayAccountService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GatewayAccountService.class);
 
     private final GatewayAccountDao gatewayAccountDao;
     private final CardTypeDao cardTypeDao;
     private final GatewayAccountCredentialsService gatewayAccountCredentialsService;
+    private GatewayAccountCredentialsHistoryDao gatewayAccountCredentialsHistoryDao;
+    private GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
 
     @Inject
     public GatewayAccountService(GatewayAccountDao gatewayAccountDao, CardTypeDao cardTypeDao,
-                                 GatewayAccountCredentialsService gatewayAccountCredentialsService) {
+                                 GatewayAccountCredentialsService gatewayAccountCredentialsService, 
+                                 GatewayAccountCredentialsHistoryDao gatewayAccountCredentialsHistoryDao, 
+                                 GatewayAccountCredentialsDao gatewayAccountCredentialsDao) {
         this.gatewayAccountDao = gatewayAccountDao;
         this.cardTypeDao = cardTypeDao;
         this.gatewayAccountCredentialsService = gatewayAccountCredentialsService;
+        this.gatewayAccountCredentialsHistoryDao = gatewayAccountCredentialsHistoryDao;
+        this.gatewayAccountCredentialsDao = gatewayAccountCredentialsDao;
     }
 
     public Optional<GatewayAccountEntity> getGatewayAccount(long gatewayAccountId) {
@@ -100,7 +112,7 @@ public class GatewayAccountService {
 
         GatewayAccountEntity gatewayAccountEntity = GatewayAccountObjectConverter.createEntityFrom(gatewayAccountRequest);
 
-        logger.info("Setting the new account to accept all card types by default");
+        LOGGER.info("Setting the new account to accept all card types by default");
 
         gatewayAccountEntity.setCardTypes(cardTypeDao.findAllNon3ds());
 
@@ -211,7 +223,7 @@ public class GatewayAccountService {
                         gatewayAccountEntity.setProviderSwitchEnabled(gatewayAccountRequest.valueAsBoolean());
 
                         if (gatewayAccountRequest.valueAsBoolean()) {
-                            logger.info("Enabled switching payment provider for gateway account [id={}]",
+                            LOGGER.info("Enabled switching payment provider for gateway account [id={}]",
                                     gatewayAccountEntity.getId(),
                                     kv(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId()),
                                     kv(GATEWAY_ACCOUNT_TYPE, gatewayAccountEntity.getType()),
@@ -229,7 +241,7 @@ public class GatewayAccountService {
                 if (!disable) {
                     gatewayAccountEntity.setDisabledReason(null);
                 }
-                logger.info("Gateway account {}", disable ? "disabled" : "re-enabled");
+                LOGGER.info("Gateway account {}", disable ? "disabled" : "re-enabled");
             }),
             entry(FIELD_DISABLED_REASON, (gatewayAccountRequest, gatewayAccountEntity) ->
                     gatewayAccountEntity.setDisabledReason(gatewayAccountRequest.valueAsString()))
@@ -251,5 +263,31 @@ public class GatewayAccountService {
         if (!WORLDPAY.getName().equals(gatewayAccountEntity.getGatewayName())) {
             throw new NotSupportedGatewayAccountException(gatewayAccountEntity.getId(), WORLDPAY.getName(), path);
         }
+    }
+
+    public void onServiceArchive(String serviceId) {
+        gatewayAccountDao.findByServiceId(serviceId).forEach(ga -> {
+            ga.setDisabled(true);
+            ga.setNotificationCredentials(null);
+            gatewayAccountDao.merge(ga);
+            ga.getGatewayAccountCredentials().forEach(creds -> {
+                creds.setState(RETIRED);
+                switch (creds.getPaymentProvider()) {
+                    case "worldpay":
+                        WorldpayCredentials worldpayCredentials = (WorldpayCredentials) creds.getCredentialsObject();
+                        worldpayCredentials.getRecurringCustomerInitiatedCredentials().ifPresent(WorldpayMerchantCodeCredentials::redactSensitiveInformation);
+                        worldpayCredentials.getOneOffCustomerInitiatedCredentials().ifPresent(WorldpayMerchantCodeCredentials::redactSensitiveInformation);
+                        worldpayCredentials.getRecurringMerchantInitiatedCredentials().ifPresent(WorldpayMerchantCodeCredentials::redactSensitiveInformation);
+                        creds.setCredentials(worldpayCredentials);
+                        gatewayAccountCredentialsDao.merge(creds);
+                    default:
+                        LOGGER.info("No credentials to redact.",
+                                kv(SERVICE_EXTERNAL_ID, serviceId),
+                                kv(GATEWAY_ACCOUNT_ID, ga.getExternalId()),
+                                kv(PROVIDER, creds.getPaymentProvider()));
+                }
+            });
+        });
+        gatewayAccountCredentialsHistoryDao.delete(serviceId);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -267,6 +267,7 @@ public class GatewayAccountService {
         }
     }
 
+    @Transactional
     public void disableAccountsAndRedactOrDeleteCredentials(String serviceId) {
         gatewayAccountDao.findByServiceId(serviceId).forEach(ga -> {
             ga.setDisabled(true);

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -267,7 +267,7 @@ public class GatewayAccountService {
         }
     }
 
-    public void onServiceArchive(String serviceId) {
+    public void disableAccountsAndRedactOrDeleteCredentials(String serviceId) {
         gatewayAccountDao.findByServiceId(serviceId).forEach(ga -> {
             ga.setDisabled(true);
             ga.setNotificationCredentials(null);

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -10,13 +10,13 @@ import uk.gov.pay.connector.gatewayaccount.exception.DigitalWalletNotSupportedGa
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountWithoutAnActiveCredentialException;
 import uk.gov.pay.connector.gatewayaccount.exception.MissingWorldpay3dsFlexCredentialsEntityException;
 import uk.gov.pay.connector.gatewayaccount.exception.NotSupportedGatewayAccountException;
+import uk.gov.pay.connector.gatewayaccount.model.CreateGatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.EpdqCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
-import uk.gov.pay.connector.gatewayaccount.model.CreateGatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
@@ -282,12 +282,14 @@ public class GatewayAccountService {
                         worldpayCredentials.getRecurringMerchantInitiatedCredentials().ifPresent(WorldpayMerchantCodeCredentials::redactSensitiveInformation);
                         creds.setCredentials(worldpayCredentials);
                         gatewayAccountCredentialsDao.merge(creds);
+                        break;
                     case EPDQ:
                         EpdqCredentials epdqCredentials = (EpdqCredentials) creds.getCredentialsObject();
                         epdqCredentials.setUsername("<DELETED>");
                         epdqCredentials.setPassword("<DELETED>");
                         creds.setCredentials(epdqCredentials);
                         gatewayAccountCredentialsDao.merge(creds);
+                        break;
                     default:
                         LOGGER.info("No credentials to redact.",
                                 kv(SERVICE_EXTERNAL_ID, serviceId),

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDao.java
@@ -5,8 +5,6 @@ import com.google.inject.persist.Transactional;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Transactional
 public class GatewayAccountCredentialsHistoryDao {

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
@@ -15,7 +15,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.stripe.response.StripeNotification;
 import uk.gov.pay.connector.queue.tasks.handlers.AuthoriseWithUserNotPresentHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.CollectFeesForFailedPaymentsTaskHandler;

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceDisableGatewayAccountTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceDisableGatewayAccountTest.java
@@ -52,7 +52,7 @@ import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccoun
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 @ExtendWith(MockitoExtension.class)
-public class OnServiceArchiveTest {
+public class GatewayAccountServiceDisableGatewayAccountTest {
 
     private GatewayAccountService gatewayAccountService;
 
@@ -98,7 +98,7 @@ public class OnServiceArchiveTest {
 
         when(mockGatewayAccountCredentialsHistoryDao.delete(serviceId)).thenReturn(1);
 
-        gatewayAccountService.onServiceArchive(serviceId);
+        gatewayAccountService.disableAccountsAndRedactOrDeleteCredentials(serviceId);
 
         verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
         assertThat(loggingEventArgumentCaptor.getValue().getFormattedMessage(), containsString("No credentials to redact."));
@@ -116,7 +116,7 @@ public class OnServiceArchiveTest {
         
         when(mockGatewayAccountCredentialsHistoryDao.delete(serviceId)).thenReturn(1);
         
-        gatewayAccountService.onServiceArchive(serviceId);
+        gatewayAccountService.disableAccountsAndRedactOrDeleteCredentials(serviceId);
         
         verify(mockGatewayAccountDao).findByServiceId(serviceId);
 
@@ -144,7 +144,7 @@ public class OnServiceArchiveTest {
 
         when(mockGatewayAccountCredentialsHistoryDao.delete(serviceId)).thenReturn(1);
 
-        gatewayAccountService.onServiceArchive(serviceId);
+        gatewayAccountService.disableAccountsAndRedactOrDeleteCredentials(serviceId);
 
         verify(mockGatewayAccountDao).findByServiceId(serviceId);
 

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -22,6 +22,8 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
+import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsHistoryDao;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchRequest;
 
@@ -37,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -81,7 +84,7 @@ class GatewayAccountServiceTest {
     @BeforeEach
     void setUp() {
         gatewayAccountService = new GatewayAccountService(mockGatewayAccountDao, mockCardTypeDao,
-                mockGatewayAccountCredentialsService);
+                mockGatewayAccountCredentialsService, mock(GatewayAccountCredentialsHistoryDao.class), mock(GatewayAccountCredentialsDao.class));
         lenient().when(mockGatewayAccountEntity.getType()).thenReturn("test");
         lenient().when(getMockGatewayAccountEntity1.getType()).thenReturn("test");
         lenient().when(getMockGatewayAccountEntity1.getServiceName()).thenReturn("service one");

--- a/src/test/java/uk/gov/pay/connector/service/OnServiceArchiveTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/OnServiceArchiveTest.java
@@ -1,5 +1,10 @@
 package uk.gov.pay.connector.service;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -7,13 +12,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsHistoryDao;
-import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.usernotification.model.domain.NotificationCredentials;
@@ -21,14 +26,17 @@ import uk.gov.pay.connector.usernotification.model.domain.NotificationCredential
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
@@ -36,7 +44,9 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.StripeCredentials.STRIPE_ACCOUNT_ID_KEY;
 import static uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials.DELETED;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
@@ -59,6 +69,12 @@ public class OnServiceArchiveTest {
     
     @Captor
     private ArgumentCaptor<GatewayAccountCredentialsEntity> updatedGatewayAccountCredentialsEntity;
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
     
     @BeforeEach
     void setUp() {
@@ -66,10 +82,28 @@ public class OnServiceArchiveTest {
                 mock(GatewayAccountCredentialsService.class), mockGatewayAccountCredentialsHistoryDao, 
                 mockGatewayAccountCredentialsDao);
     }
-    
+
     @Test
-    void shouldLogIfServiceDoesNotExist() {
-        
+    void shouldLogIfNotWorldpayOrEpdqCredentials() {
+        Logger root = (Logger) LoggerFactory.getLogger(GatewayAccountService.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
+
+        String serviceId = "service-to-be-archived";
+
+        GatewayAccountEntity account1 = new GatewayAccountEntity(TEST);
+        account1.setExternalId(randomUuid());
+        account1.setDisabled(false);
+        account1.setGatewayAccountCredentials(List.of(
+                new GatewayAccountCredentialsEntity(account1, STRIPE.getName(), Map.of(STRIPE_ACCOUNT_ID_KEY, "acct_123"), ACTIVE)));
+        when(mockGatewayAccountDao.findByServiceId(serviceId)).thenReturn(List.of(account1));
+
+        when(mockGatewayAccountCredentialsHistoryDao.delete(serviceId)).thenReturn(1);
+
+        gatewayAccountService.onServiceArchive(serviceId);
+
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        assertThat(loggingEventArgumentCaptor.getValue().getFormattedMessage(), containsString("No credentials to redact."));
     }
     
     @Test
@@ -84,7 +118,7 @@ public class OnServiceArchiveTest {
         account1.setDisabled(false);
         account1.setNotificationCredentials(new NotificationCredentials(account1));
         account1.setGatewayAccountCredentials(List.of(
-                new GatewayAccountCredentialsEntity(account1, WORLDPAY.getName(), worldpayCreds, GatewayAccountCredentialState.ACTIVE)));
+                new GatewayAccountCredentialsEntity(account1, WORLDPAY.getName(), worldpayCreds, ACTIVE)));
         when(mockGatewayAccountDao.findByServiceId(serviceId)).thenReturn(List.of(account1));
         
         when(mockGatewayAccountCredentialsHistoryDao.delete(serviceId)).thenReturn(1);
@@ -124,7 +158,7 @@ public class OnServiceArchiveTest {
                 "sha_in_passphrase", "123456",
                 "sha_out_passphrase", "123456");
         account1.setGatewayAccountCredentials(List.of(
-                new GatewayAccountCredentialsEntity(account1, EPDQ.getName(), epdqCreds, GatewayAccountCredentialState.ACTIVE)));
+                new GatewayAccountCredentialsEntity(account1, EPDQ.getName(), epdqCreds, ACTIVE)));
         when(mockGatewayAccountDao.findByServiceId(serviceId)).thenReturn(List.of(account1));
 
         when(mockGatewayAccountCredentialsHistoryDao.delete(serviceId)).thenReturn(1);

--- a/src/test/java/uk/gov/pay/connector/service/OnServiceArchiveTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/OnServiceArchiveTest.java
@@ -1,0 +1,116 @@
+package uk.gov.pay.connector.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
+import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsHistoryDao;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+import uk.gov.pay.connector.usernotification.model.domain.NotificationCredentials;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials.DELETED;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
+import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
+
+@ExtendWith(MockitoExtension.class)
+public class OnServiceArchiveTest {
+
+    private GatewayAccountService gatewayAccountService;
+
+    @Mock
+    private GatewayAccountDao mockGatewayAccountDao;
+    
+    @Mock
+    private GatewayAccountCredentialsHistoryDao mockGatewayAccountCredentialsHistoryDao;
+    
+    @Mock
+    private GatewayAccountCredentialsDao mockGatewayAccountCredentialsDao;
+
+    @Captor
+    private ArgumentCaptor<GatewayAccountEntity> updatedGatewayAccountEntity;
+    
+    @Captor
+    private ArgumentCaptor<GatewayAccountCredentialsEntity> updatedGatewayAccountCredentialsEntity;
+    
+    @BeforeEach
+    void setUp() {
+        gatewayAccountService = new GatewayAccountService(mockGatewayAccountDao, mock(CardTypeDao.class),
+                mock(GatewayAccountCredentialsService.class), mockGatewayAccountCredentialsHistoryDao, 
+                mockGatewayAccountCredentialsDao);
+    }
+    
+    @Test
+    void shouldLogIfServiceDoesNotExist() {
+        
+    }
+    
+    @Test
+    void shouldDisableWorldpayAccount_redactCredentials_deleteCredentialsHistory() {
+        String serviceId = "service-to-be-archived";
+        Map<String, Object> worldpayCreds = Map.of(
+                ONE_OFF_CUSTOMER_INITIATED, Map.of(CREDENTIALS_MERCHANT_CODE, "a-merchant-code-1", CREDENTIALS_USERNAME, "a-merchant-code-1", CREDENTIALS_PASSWORD, "passw0rd1"),
+                RECURRING_MERCHANT_INITIATED, Map.of(CREDENTIALS_MERCHANT_CODE, "a-merchant-code-3", CREDENTIALS_USERNAME, "a-merchant-code-3", CREDENTIALS_PASSWORD, "passw0rd1"));
+        
+        GatewayAccountEntity account1 = new GatewayAccountEntity(TEST);
+        account1.setExternalId(randomUuid());
+        account1.setDisabled(false);
+        account1.setNotificationCredentials(new NotificationCredentials(account1));
+        account1.setGatewayAccountCredentials(List.of(
+                new GatewayAccountCredentialsEntity(account1, WORLDPAY.getName(), worldpayCreds, GatewayAccountCredentialState.ACTIVE)));
+        when(mockGatewayAccountDao.findByServiceId(serviceId)).thenReturn(List.of(account1));
+        
+        when(mockGatewayAccountCredentialsHistoryDao.delete(serviceId)).thenReturn(1);
+        
+        gatewayAccountService.onServiceArchive(serviceId);
+        
+        verify(mockGatewayAccountDao).findByServiceId(serviceId);
+        
+        verify(mockGatewayAccountDao).merge(updatedGatewayAccountEntity.capture());
+        var capturedGatewayAccountEntity = updatedGatewayAccountEntity.getValue();
+        assertTrue(capturedGatewayAccountEntity.isDisabled());
+        assertNull(capturedGatewayAccountEntity.getNotificationCredentials());
+        
+        verify(mockGatewayAccountCredentialsDao).merge(updatedGatewayAccountCredentialsEntity.capture());
+        var capturedGatewayAccountCredentialsEntity = updatedGatewayAccountCredentialsEntity.getValue();
+        assertThat(capturedGatewayAccountCredentialsEntity.getState(), is(RETIRED));
+        Map<String, Object> expectedCredentials = Map.of(
+                ONE_OFF_CUSTOMER_INITIATED, Map.of(CREDENTIALS_MERCHANT_CODE, "a-merchant-code-1", CREDENTIALS_USERNAME, DELETED, CREDENTIALS_PASSWORD, DELETED),
+                RECURRING_MERCHANT_INITIATED, Map.of(CREDENTIALS_MERCHANT_CODE, "a-merchant-code-3", CREDENTIALS_USERNAME, DELETED, CREDENTIALS_PASSWORD, DELETED)
+        );
+        assertThat(capturedGatewayAccountCredentialsEntity.getCredentials(), is(expectedCredentials));
+
+        verify(mockGatewayAccountCredentialsHistoryDao).delete(serviceId);
+    }
+
+    @Test
+    void shouldDisableEpdqAccount_redactCredentials_deleteCredentialsHistory() {
+        
+    }
+}


### PR DESCRIPTION
Service layer to make the following happen when a service is archived:
- Disable associated gateway account(s)
- Set `username` and `password` for the credentials to be `<DELETED` for gateway accounts with Worldpay and Epdq payment providers
- Remove notification creds
- Remove gateway account credentials history record

Logging (which I think will be more appropriate at the message handler level) and metrics will be in a future PR.