### PR TITLE
PP-11711 upgrade notify client 3.19.1 -> 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>uk.gov.service.notify</groupId>
             <artifactId>notifications-java-client</artifactId>
-            <version>3.19.1-RELEASE</version>
+            <version>4.1.0-RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## WHAT YOU DID

Upgrade notify client 3.19.1 -> 4.1.0

Noteworthy changes in this version:

- Joda-Time has been removed and replaced with java.time
  - The client now uses [ZonedDateTime instead of DateTime](https://blog.joda.org/2014/11/converting-from-joda-time-to-javatime.html)