### PR TITLE
PP 11594 Allow enabling Apple Pay and Google Pay for Sandbox gateway accounts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -712,7 +712,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java",
         "hashed_secret": "e9b6cb662f24d2346839fb0b797ad778c290994e",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 129
       }
     ],
     "src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java": [
@@ -1071,5 +1071,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-02T17:08:49Z"
+  "generated_at": "2023-11-03T19:38:40Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -5,7 +5,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
-import uk.gov.pay.connector.gatewayaccount.exception.DigitalWalletNotSupportedGatewayException;
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountWithoutAnActiveCredentialException;
 import uk.gov.pay.connector.gatewayaccount.exception.MissingWorldpay3dsFlexCredentialsEntityException;
 import uk.gov.pay.connector.gatewayaccount.exception.NotSupportedGatewayAccountException;
@@ -29,7 +28,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Map.entry;
 import static net.logstash.logback.argument.StructuredArguments.kv;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_APPLE_PAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_AUTHORISATION_API;
@@ -124,14 +122,12 @@ public class GatewayAccountService {
             entry(
                     FIELD_ALLOW_GOOGLE_PAY,
                     (gatewayAccountRequest, gatewayAccountEntity) -> {
-                        throwIfNotDigitalWalletSupportedGateway(gatewayAccountEntity);
                         gatewayAccountEntity.setAllowGooglePay(Boolean.parseBoolean(gatewayAccountRequest.valueAsString()));
                     }
             ),
             entry(
                     FIELD_ALLOW_APPLE_PAY,
                     (gatewayAccountRequest, gatewayAccountEntity) -> {
-                        throwIfNotDigitalWalletSupportedGateway(gatewayAccountEntity);
                         gatewayAccountEntity.setAllowApplePay(Boolean.parseBoolean(gatewayAccountRequest.valueAsString()));
                     }
             ),
@@ -238,12 +234,6 @@ public class GatewayAccountService {
     private void throwIfNoActiveCredentialExist(GatewayAccountEntity gatewayAccountEntity) {
         if (!gatewayAccountCredentialsService.hasActiveCredentials(gatewayAccountEntity.getId())) {
             throw new GatewayAccountWithoutAnActiveCredentialException(gatewayAccountEntity.getId());
-        }
-    }
-
-    private void throwIfNotDigitalWalletSupportedGateway(GatewayAccountEntity gatewayAccountEntity) {
-        if (!(WORLDPAY.getName().equals(gatewayAccountEntity.getGatewayName()) || STRIPE.getName().equals(gatewayAccountEntity.getGatewayName()))) {
-            throw new DigitalWalletNotSupportedGatewayException(gatewayAccountEntity.getGatewayName());
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
@@ -102,24 +102,6 @@ public class ChargesApiResourceAllowWebPaymentsIT {
                 .body("gateway_account.allow_google_pay", is(isGooglePayAllowed));
     }
 
-    @Test
-    public void assertBadRequestResponseIfPatchingDigitalWalletWithNonSupportedGateway() throws JsonProcessingException {
-        assertAppleAndGooglePayAreDisabledByDefault();
-
-        String accountIdWithNotDigitalWalletSupportedGateway = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "epdq"));
-        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
-                "path", "allow_apple_pay",
-                "value", true));
-        given().port(testContext.getPort()).contentType(JSON)
-                .body(payload)
-                .patch("/v1/api/accounts/" + accountIdWithNotDigitalWalletSupportedGateway)
-                .then()
-                .body("message", contains("Gateway epdq does not support digital wallets."))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()))
-                .and()
-                .statusCode(HttpStatus.SC_BAD_REQUEST);
-    }
-
     private void assertAppleAndGooglePayAreDisabledByDefault() {
         given().port(testContext.getPort()).contentType(JSON)
                 .get("/v1/frontend/charges/" + chargeId)

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -11,7 +11,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
-import uk.gov.pay.connector.gatewayaccount.exception.DigitalWalletNotSupportedGatewayException;
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountWithoutAnActiveCredentialException;
 import uk.gov.pay.connector.gatewayaccount.exception.MissingWorldpay3dsFlexCredentialsEntityException;
 import uk.gov.pay.connector.gatewayaccount.exception.NotSupportedGatewayAccountException;
@@ -204,7 +203,7 @@ class GatewayAccountServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"worldpay", "stripe"})
+    @ValueSource(strings = {"worldpay", "stripe", "sandbox"})
     void shouldUpdateAllowApplePay(String provider) {
         JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
@@ -221,7 +220,7 @@ class GatewayAccountServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"worldpay", "stripe"})
+    @ValueSource(strings = {"worldpay", "stripe", "sandbox"})
     void shouldUpdateAllowGooglePay(String provider) {
         JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
@@ -235,20 +234,6 @@ class GatewayAccountServiceTest {
         assertThat(optionalGatewayAccount.isPresent(), is(true));
         verify(mockGatewayAccountEntity).setAllowGooglePay(true);
         verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"allow_apple_pay", "allow_google_pay"})
-    void shouldNotAllowDigitalWalletForUnsupportedGateways(String path) {
-        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
-                "op", "replace",
-                "path", path,
-                "value", "true")));
-
-        when(mockGatewayAccountEntity.getGatewayName()).thenReturn("epdq");
-        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
-        assertThrows(DigitalWalletNotSupportedGatewayException.class,
-                () -> gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
Allow making a PATCH request to /v1/api/accounts/{accountId} with path allow_apple_pay and allow_google_pay for an account with any payment provider, rather than restricting by payment provider.

- Remove throwIfNotDigitalWalletSupportedGateway method and associated unit test as payment provider restriction lifted
- Extend existing 'isDigitalWalletSupported' test with check for 'sandbox' payment provider and new feature flag environment variable (ALLOW_ENABLING_DIGITAL_WALLETS_FOR_SANDBOX_ACCOUNT). Update associated unit test.

## How to test

- Unit tests and Pact tests should cover new and removed code
- Manually test by altering Digital Wallet settings in the admin tool

### Documentation

[https://payments-platform.atlassian.net/browse/PP-11594](https://payments-platform.atlassian.net/browse/PP-11594)
