### PR TITLE
PP-11591 Set integration_version_3ds to 2 by default

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
@@ -14,7 +14,7 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class GatewayAccountObjectConverter {
 
-    private static final int DEFAULT_INTEGRATION_VERSION_3_DS = 1;
+    private static final int DEFAULT_INTEGRATION_VERSION_3_DS = 2;
 
     public static GatewayAccountEntity createEntityFrom(GatewayAccountRequest gatewayAccountRequest) {
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderService.java
@@ -72,8 +72,7 @@ public class GatewayAccountSwitchPaymentProviderService {
 
         gatewayAccountEntity.setProviderSwitchEnabled(false);
         gatewayAccountEntity
-                .setIntegrationVersion3ds(switchToCredentialsEntity.getPaymentProvider().
-                        equalsIgnoreCase("worldpay") ? 1 : 2);
+                .setIntegrationVersion3ds(2);
 
         gatewayAccountCredentialsDao.merge(switchToCredentialsEntity);
         gatewayAccountCredentialsDao.merge(activeCredentialEntity);


### PR DESCRIPTION
Set integration_version_3ds to 2 for new Worldpay accounts and when switching PSP.