### PR TITLE
PP-11279: Connector-adminusers messaging pact test

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -46,6 +46,16 @@ jobs:
           -DPACT_BROKER_PASSWORD=${{ secrets.pact_broker_password }} -DPACT_CONSUMER_TAG=master \
           -DPACT_CONSUMER_VERSION=${{ github.sha }}
 
+  adminusers-provider-contract-tests:
+    needs: publish-connector-consumer-contract-tests
+    uses: alphagov/pay-adminusers/.github/workflows/_run-pact-provider-tests.yml@master
+    with:
+      consumer: connector
+      consumer_tag: master
+    secrets:
+      pact_broker_username: ${{ secrets.pact_broker_username }}
+      pact_broker_password: ${{ secrets.pact_broker_password }}
+
   ledger-provider-contract-tests:
     needs: publish-connector-consumer-contract-tests
     uses: alphagov/pay-ledger/.github/workflows/_run-pact-provider-tests.yml@master

--- a/src/test/java/uk/gov/pay/connector/junit/DropwizardTestApplications.java
+++ b/src/test/java/uk/gov/pay/connector/junit/DropwizardTestApplications.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.junit;
 
+import com.amazonaws.services.sqs.AmazonSQS;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.google.common.collect.Sets;
 import io.dropwizard.Application;
@@ -77,11 +78,12 @@ final class DropwizardTestApplications {
         }
     }
 
-    static TestContext getTestContextOf(Class<? extends Application<?>> appClass, String configClasspathLocation, WireMockServer wireMockServer) {
+    static TestContext getTestContextOf(Class<? extends Application<?>> appClass, String configClasspathLocation, 
+                                        WireMockServer wireMockServer, AmazonSQS amazonSQS) {
         Pair<Class<? extends Application>, String> appConfig = Pair.of(appClass, configClasspathLocation);
         DropwizardTestSupport application = apps.get(appConfig);
         return new TestContext(application.getLocalPort(), ((ConnectorConfiguration) application.getConfiguration()),
-                InjectorLookup.getInjector(application.getApplication()).get(), wireMockServer);
+                InjectorLookup.getInjector(application.getApplication()).get(), wireMockServer, amazonSQS);
     }
 
     static void removeConfigOverridesFromSystemProperties() {

--- a/src/test/java/uk/gov/pay/connector/junit/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/connector/junit/SqsTestDocker.java
@@ -14,16 +14,16 @@ import org.testcontainers.containers.wait.strategy.Wait;
  * Start a Generic Test container with SQS docker image and creates queues if required.
  * No need to call stop() as container will be stopped after executing the tests
  */
-final class SqsTestDocker {
+public final class SqsTestDocker {
 
     private static final Logger logger = LoggerFactory.getLogger(SqsTestDocker.class);
 
     private static GenericContainer sqsContainer;
 
-    public static void initialise(String... queues) {
+    public static AmazonSQS initialise(String... queues) {
         try {
             createContainer();
-            createQueues(queues);
+            return createQueues(queues);
         } catch (Exception e) {
             logger.error("Exception initialising SQS Container - {}", e.getMessage());
             throw new SqsTestDockerException(e);
@@ -39,13 +39,14 @@ final class SqsTestDocker {
         }
     }
 
-    private static void createQueues(String... queues) {
+    private static AmazonSQS createQueues(String... queues) {
         AmazonSQS amazonSQS = getSqsClient();
         if (queues != null) {
             for (String queue : queues) {
                 amazonSQS.createQueue(queue);
             }
         }
+        return amazonSQS;
     }
 
     public static String getQueueUrl(String queueName) {

--- a/src/test/java/uk/gov/pay/connector/junit/TestContext.java
+++ b/src/test/java/uk/gov/pay/connector/junit/TestContext.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.junit;
 
+import com.amazonaws.services.sqs.AmazonSQS;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.google.inject.Injector;
 import io.dropwizard.db.DataSourceFactory;
@@ -17,13 +18,16 @@ public class TestContext {
     private int port;
     private Injector injector;
     private WireMockServer wireMockServer;
+    private AmazonSQS amazonSQS;
     private String databaseUrl;
     private String databaseUser;
     private String databasePassword;
 
-    TestContext(int port, ConnectorConfiguration connectorConfiguration, Injector injector, WireMockServer wireMockServer) {
+    TestContext(int port, ConnectorConfiguration connectorConfiguration, Injector injector, 
+                WireMockServer wireMockServer, AmazonSQS amazonSQS) {
         this.injector = injector;
         this.wireMockServer = wireMockServer;
+        this.amazonSQS = amazonSQS;
         DataSourceFactory dataSourceFactory = connectorConfiguration.getDataSourceFactory();
         databaseUrl = dataSourceFactory.getUrl();
         databaseUser = dataSourceFactory.getUser();
@@ -68,5 +72,9 @@ public class TestContext {
     
     public String getEventQueueUrl() {
         return connectorConfiguration.getSqsConfig().getEventQueueUrl();
+    }
+
+    public AmazonSQS getAmazonSQS() {
+        return amazonSQS;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/pact/AdminusersQueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/AdminusersQueueMessageContractTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 @Provider("connector")
 @PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker.deploy.payments.service.gov.uk}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
-        consumers = {"adminusers"})
+        consumers = { "adminusers" })
 @IgnoreNoPactsToVerify
 public class AdminusersQueueMessageContractTest extends QueueMessageContractTest {
 }

--- a/src/test/java/uk/gov/pay/connector/pact/event/ServiceArchivedEventIT.java
+++ b/src/test/java/uk/gov/pay/connector/pact/event/ServiceArchivedEventIT.java
@@ -1,0 +1,101 @@
+package uk.gov.pay.connector.pact.event;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.junit.DropwizardTestContext;
+import uk.gov.pay.connector.junit.SqsTestDocker;
+import uk.gov.pay.connector.junit.TestContext;
+import uk.gov.pay.connector.queue.tasks.TaskQueueMessageHandler;
+import uk.gov.pay.connector.queue.tasks.TaskType;
+import uk.gov.pay.connector.queue.tasks.model.ServiceArchivedTaskData;
+import uk.gov.pay.connector.queue.tasks.model.Task;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, withDockerSQS = true, config = "config/test-it-config.yaml")
+public class ServiceArchivedEventIT {
+
+    static ObjectMapper objectMapper = new ObjectMapper();
+    
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @DropwizardTestContext
+    private TestContext testContext;
+
+    private byte[] currentMessage;
+    
+    private String serviceExternalId = "service-external-id";
+
+    @Pact(provider = "adminusers", consumer = "connector")
+    public MessagePact createServiceArchivedEventPact(MessagePactBuilder builder) throws Exception {
+        ServiceArchivedTaskData taskData = new ServiceArchivedTaskData(serviceExternalId);
+        Task event = new Task(objectMapper.writeValueAsString(taskData), TaskType.SERVICE_ARCHIVED);
+
+        return builder
+                .expectsToReceive("a service archived event")
+                .withMetadata(Map.of("contentType", "application/json"))
+                .withContent(getAsPact(event))
+                .toPact();
+    }
+
+    private DslPart getAsPact(Task event) {
+        PactDslJsonBody eventDetails = new PactDslJsonBody();
+        eventDetails.stringType("task", event.getTaskType().getName());
+        eventDetails.stringType("data", event.getData());
+        return eventDetails;
+    }
+
+    @Test
+    @PactVerification({"adminusers"})
+    public void test() throws Exception {
+        var gatewayAccountDao = testContext.getInstanceFromGuiceContainer(GatewayAccountDao.class);
+
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(TEST);
+        gatewayAccount.setDisabled(false);
+        gatewayAccount.setExternalId(randomUuid());
+        gatewayAccount.setServiceId(serviceExternalId);
+        var gatewayAccountCredentials = new GatewayAccountCredentialsEntity(gatewayAccount, WORLDPAY.getName(), Map.of(), ACTIVE);
+        gatewayAccountCredentials.setExternalId(randomUuid());
+        gatewayAccount.setGatewayAccountCredentials(List.of(gatewayAccountCredentials));
+        gatewayAccountDao.persist(gatewayAccount);
+        
+        testContext.getAmazonSQS().sendMessage(SqsTestDocker.getQueueUrl("tasks-queue"), new String(currentMessage));
+
+        testContext.getInstanceFromGuiceContainer(TaskQueueMessageHandler.class).processMessages();
+
+        var updatedGatewayAccount = gatewayAccountDao.findByExternalId(gatewayAccount.getExternalId()).get();
+        assertTrue(updatedGatewayAccount.isDisabled());
+        assertThat(updatedGatewayAccount.getGatewayAccountCredentials().get(0).getState(), is(GatewayAccountCredentialState.RETIRED));
+    }
+
+    public void setMessage(byte[] messageContents) {
+        currentMessage = messageContents;
+    }
+}


### PR DESCRIPTION
A connector (consumer) to adminusers (provider) messaging pact test for a "service_archived" event placed on the connector tasks queue.

The [ConnectorQueueMessageContractTest on the adminusers side](https://github.com/alphagov/pay-adminusers/blob/master/src/test/java/uk/gov/pay/adminusers/pact/ConnectorQueueMessageContractTest.java) can be seen to be passing in the [adminusers-provider-pact-verification](https://pay-cd.deploy.payments.service.gov.uk/builds/97392303) build 🎉 