### PR TITLE
PP-11791-add-new-CA-bundles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.21_9-jre-alpine@sha256:1017b1b26f9b92921a93a730fa33327d83cdfa0cc2f7fa486b1348ad4eda755c
+FROM eclipse-temurin:11-jre-alpine@sha256:1017b1b26f9b92921a93a730fa33327d83cdfa0cc2f7fa486b1348ad4eda755c
 
 RUN ["apk", "--no-cache", "upgrade"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine@sha256:c033de8d3135b954d230eed6b9bd14dc3dbf32550e448705222f1c907ceebe08
+FROM eclipse-temurin:11.0.21_9-jre-alpine@sha256:1017b1b26f9b92921a93a730fa33327d83cdfa0cc2f7fa486b1348ad4eda755c
 
 RUN ["apk", "--no-cache", "upgrade"]
 
@@ -9,9 +9,8 @@ ENV LANG C.UTF-8
 
 RUN echo networkaddress.cache.ttl=$DNS_TTL >> "$JAVA_HOME/conf/security/java.security"
 
-# Add RDS CA certificates to the default truststore
-RUN wget -qO - https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem       | keytool -importcert -noprompt -cacerts -storepass changeit -alias rds-ca-2019-root \
- && wget -qO - https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem | keytool -importcert -noprompt -cacerts -storepass changeit -alias rds-combined-ca-bundle
+COPY ./import_aws_rds_cert_bundles.sh /
+RUN /import_aws_rds_cert_bundles.sh && rm /import_aws_rds_cert_bundles.sh
 
 RUN ["apk", "add", "--no-cache", "bash", "tini"]
 

--- a/import_aws_rds_cert_bundles.sh
+++ b/import_aws_rds_cert_bundles.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# The cert bundles distributed by AWS are bundles which contain multiple CA cert
+# chains. The keytool command can only import a single cert/chain, and will 
+# silently import the first and ignore the rest. So we need to break the 
+# bundle up into individual certs and then import them individually.
+#
+# This file was heavily based on the AWS example https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html#UsingWithRDS.SSL-certificate-rotation-sample-script
+
+set -euo pipefail
+
+TMPDIR=$(mktemp -d)
+
+for REGION in eu-west-1 eu-central-1; do
+  mkdir "${TMPDIR}/${REGION}"
+
+  wget -q "https://truststore.pki.rds.amazonaws.com/${REGION}/${REGION}-bundle.pem" -O ${TMPDIR}/${REGION}-bundle.pem
+  awk 'BEGIN { n=0 } split_after == 1 {n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1}{print > "'${TMPDIR}/${REGION}'/rds-'"${REGION}"'-ca-" n ".pem"}' < ${TMPDIR}/${REGION}-bundle.pem
+
+  find "${TMPDIR}/${REGION}" -name '*.pem' | while read -r CERT; do
+    echo "Importing $CERT"
+    keytool -importcert -noprompt -cacerts -storepass changeit -alias "${CERT}" -file "${CERT}"
+    rm "$CERT"
+  done
+
+  rm "${TMPDIR}/${REGION}-bundle.pem"
+done
+
+echo "Importing rds-ca-2019-root"
+wget -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -O "${TMPDIR}/rds-ca-2019-root.pem"
+keytool -importcert -noprompt -cacerts -storepass changeit -alias rds-ca-2019-root -file "${TMPDIR}/rds-ca-2019-root.pem"
+echo "Importing rds-combined-ca-bundle"
+wget -q https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -O "${TMPDIR}/rds-combined-ca-bundle.pem"
+keytool -importcert -noprompt -cacerts -storepass changeit -alias rds-combined-ca-bundle -file "${TMPDIR}/rds-combined-ca-bundle.pem"
+
+echo "removing TMPDIR"
+rm -rf "${TMPDIR}"

--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre@sha256:4f82e758d7dfc272cfe04008d722dcf0b020044584ceb9f4326e54cc67844291
+FROM eclipse-temurin:11-jre@sha256:b4f65e8cfe697471f7aa84139df33240e0829025d699a771c4a6a88d8eec07fc
 
 ARG DNS_TTL=15
 
@@ -9,9 +9,9 @@ RUN echo networkaddress.cache.ttl=$DNS_TTL >> "$JAVA_HOME/conf/security/java.sec
 
 RUN apt-get update && apt-get install -y tini wget
 
-# Add RDS CA certificates to the default truststore
-RUN wget -qO - https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem       | keytool -import -cacerts -storepass changeit -noprompt -alias rds-ca-2019-root \
- && wget -qO - https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem | keytool -import -cacerts -storepass changeit -noprompt -alias rds-combined-ca-bundle
+COPY import_aws_rds_cert_bundles.sh /
+RUN /import_aws_rds_cert_bundles.sh
+RUN rm /import_aws_rds_cert_bundles.sh
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081


### PR DESCRIPTION
## WHAT YOU DID

Add to the Docker images the current RDS CA bundle for eu-west-1 and eu-central-1.

I had to bump the base container version as the old one is no longer visible.