### PR TITLE
PP-11591 Do not set 3ds flex in connector

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
@@ -14,7 +14,7 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class GatewayAccountObjectConverter {
 
-    private static final int DEFAULT_INTEGRATION_VERSION_3_DS = 2;
+    private static final int DEFAULT_INTEGRATION_VERSION_3_DS = 1;
 
     public static GatewayAccountEntity createEntityFrom(GatewayAccountRequest gatewayAccountRequest) {
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderService.java
@@ -71,8 +71,6 @@ public class GatewayAccountSwitchPaymentProviderService {
         activeCredentialEntity.setActiveEndDate(Instant.now());
 
         gatewayAccountEntity.setProviderSwitchEnabled(false);
-        gatewayAccountEntity
-                .setIntegrationVersion3ds(2);
 
         gatewayAccountCredentialsDao.merge(switchToCredentialsEntity);
         gatewayAccountCredentialsDao.merge(activeCredentialEntity);


### PR DESCRIPTION
Context: 3DS integration version is already set to 2 in self-service when flex credentials are entered

- Don't set 3DS integration version in connector when creating gateway accounts or switching to Worldpay.