### PR TITLE
PP-11613: Return 404 if trying to refund an EPDQ payment

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentGatewayName.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentGatewayName.java
@@ -1,13 +1,17 @@
 package uk.gov.pay.connector.gateway;
 
-import java.util.List;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public enum PaymentGatewayName {
     SANDBOX("sandbox"), SMARTPAY("smartpay"), WORLDPAY("worldpay"), EPDQ("epdq"), STRIPE("stripe");
 
     private final String gatewayName;
     
-    private static List<String> unsupported = List.of(SMARTPAY.gatewayName, EPDQ.gatewayName);
+    private static final Set<String> UNSUPPORTED = Set.of(SMARTPAY.gatewayName, EPDQ.gatewayName);
+
+    private static final Set<String> PAYMENT_GATEWAY_NAMES = EnumSet.allOf(PaymentGatewayName.class).stream().map(x -> x.gatewayName).collect(Collectors.toSet());
 
     PaymentGatewayName(String gatewayName) {
         this.gatewayName = gatewayName;
@@ -18,7 +22,7 @@ public enum PaymentGatewayName {
     }
     
     public static boolean isUnsupported(String gatewayName) {
-        return unsupported.contains(gatewayName);
+        return UNSUPPORTED.contains(gatewayName);
     }
 
     public static class Unsupported extends RuntimeException {
@@ -30,16 +34,14 @@ public enum PaymentGatewayName {
         try {
             valueFrom(name);
             return true;
-        } catch (RuntimeException e){
+        } catch (Unsupported e){
             return false;
         }
     }
 
     public static PaymentGatewayName valueFrom(String gatewayName) {
-        for (PaymentGatewayName paymentGatewayName : values()) {
-            if (paymentGatewayName.getName().equals(gatewayName)) {
-                return paymentGatewayName;
-            }
+        if (PAYMENT_GATEWAY_NAMES.contains(gatewayName)) {
+            return PaymentGatewayName.valueOf(gatewayName.toUpperCase());
         }
         throw new Unsupported("Unsupported Payment Gateway " + gatewayName);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentGatewayName.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentGatewayName.java
@@ -1,9 +1,13 @@
 package uk.gov.pay.connector.gateway;
 
+import java.util.List;
+
 public enum PaymentGatewayName {
     SANDBOX("sandbox"), SMARTPAY("smartpay"), WORLDPAY("worldpay"), EPDQ("epdq"), STRIPE("stripe");
 
     private final String gatewayName;
+    
+    private static List<String> unsupported = List.of(SMARTPAY.gatewayName, EPDQ.gatewayName);
 
     PaymentGatewayName(String gatewayName) {
         this.gatewayName = gatewayName;
@@ -11,6 +15,10 @@ public enum PaymentGatewayName {
 
     public String getName() {
         return gatewayName;
+    }
+    
+    public static boolean isUnsupported(String gatewayName) {
+        return unsupported.contains(gatewayName);
     }
 
     public static class Unsupported extends RuntimeException {

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
@@ -28,6 +28,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -37,7 +38,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.pay.connector.charge.util.RefundCalculator.getTotalAmountAvailableToBeRefunded;
@@ -84,6 +84,10 @@ public class RefundService {
     }
 
     public ChargeRefundResponse doRefund(Long accountId, Charge charge, RefundRequest refundRequest) {
+        if (PaymentGatewayName.isUnsupported(charge.getPaymentGatewayName())) {
+            throw new NotFoundException();
+        }
+        
         GatewayAccountEntity gatewayAccountEntity = gatewayAccountDao.findById(accountId).orElseThrow(
                 () -> new GatewayAccountNotFoundException(accountId));
         if (gatewayAccountEntity.isDisabled()) {

--- a/src/test/java/uk/gov/pay/connector/gateway/PaymentGatewayNameTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/PaymentGatewayNameTest.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.connector.gateway;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PaymentGatewayNameTest {
+    
+    @Test
+    void shouldReturnPaymentGatewayName() {
+        assertEquals(PaymentGatewayName.SANDBOX, PaymentGatewayName.valueFrom("sandbox"));
+        assertEquals(PaymentGatewayName.STRIPE, PaymentGatewayName.valueFrom("stripe"));
+    }
+    
+    @Test
+    void shouldThrowExceptionIfInvalidNameSupplied() {
+        assertThrows(PaymentGatewayName.Unsupported.class, () -> PaymentGatewayName.valueFrom("blah"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/refund/resource/EpdqRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/refund/resource/EpdqRefundsResourceIT.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.connector.refund.resource;
+
+import io.restassured.http.ContentType;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.util.JsonEncoder;
+
+import java.util.Map;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class EpdqRefundsResourceIT extends ChargingITestBase {
+
+    private DatabaseFixtures.TestCharge charge;
+    
+    public EpdqRefundsResourceIT() {
+        super("epdq");
+    }
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        charge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withAmount(100L)
+                .withTransactionId("MyUniqueTransactionId!")
+                .withTestAccount(getTestAccount())
+                .withChargeStatus(CAPTURED)
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayCredentialId(credentialParams.getId())
+                .insert();
+    }
+
+    @Test
+    public void refundAttemptShouldReturn404() {
+        String payload = JsonEncoder.toJson(Map.of(
+                "amount", 100,
+                "refund_amount_available", 100));
+        
+        givenSetup()
+                .body(payload)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .post(format("/v1/api/accounts/%s/charges/%s/refunds", accountId, charge.getExternalChargeId()))
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
The 404 returned  here by connector will be [handled by publicapi](https://github.com/alphagov/pay-publicapi/blob/master/src/main/java/uk/gov/pay/api/service/CreateRefundService.java#L57-L63) which will return a [P0603 API error
message](https://github.com/alphagov/pay-publicapi/blob/master/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java#L35-L37) which fulfills the acceptance criteria of this story.

Also for some java fun, although there aren't enough payment gateways to make any noticeable difference, I amended the `valueFrom` method to use a `Set.contains` (which has O(1) time complexity) rather than iterating through the values (O(n) time complexity).
