### PR TITLE
PP-11613: Make refund status for EPDQ always be unavailable

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -109,7 +109,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
 
     @Override
     public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundList) {
-        throw new UnsupportedOperationException();
+        return ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE;
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqChargeApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqChargeApiResourceIT.java
@@ -8,7 +8,7 @@ import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
 import static org.hamcrest.core.Is.is;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
@@ -18,15 +18,11 @@ public class EpdqChargeApiResourceIT extends ChargingITestBase {
     }
 
     @Test
-    public void shouldSuccessfully_authorise3ds() {
-        String externalChargeId = createNewChargeWithNoTransactionId(AUTHORISATION_3DS_REQUIRED);
-        String chargeId = externalChargeId.replace("charge-", "");
-        String expectedHtml = "someHtml";
-        databaseTestHelper.updateCharge3dsDetails(Long.valueOf(chargeId), null, null, expectedHtml, null);
+    public void getChargeRefundStatusShouldBeUnavailable() {
+        String externalChargeId = createNewChargeWith(CAPTURED, "a-gateway-tx-id");
 
-        connectorRestApiClient.withChargeId(externalChargeId).getFrontendCharge()
+        connectorRestApiClient.withChargeId(externalChargeId).getCharge()
                 .statusCode(200)
-                .body("status", is(AUTHORISATION_3DS_REQUIRED.toString()))
-                .body("auth_3ds_data.htmlOut", is(expectedHtml));
+                .body("refund_summary.status", is("unavailable"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
@@ -187,7 +187,6 @@ public class WorldpayRefundsResourceIT extends ChargingITestBase {
 
         Long firstRefundAmount = 80L;
         Long secondRefundAmount = 20L;
-        Long chargeId = defaultTestCharge.getChargeId();
         String externalChargeId = defaultTestCharge.getExternalChargeId();
 
         worldpayMockClient.mockRefundSuccess();


### PR DESCRIPTION
This is because we don't support EPDQ anymore.
