### PR TITLE
PP-11861 enable applepay for sandbox accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static java.util.Map.entry;
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_APPLE_PAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_AUTHORISATION_API;
@@ -116,6 +117,10 @@ public class GatewayAccountService {
         LOGGER.info("Setting the new account to accept all card types by default");
 
         gatewayAccountEntity.setCardTypes(cardTypeDao.findAllNon3ds());
+
+        if (SANDBOX.getName().equalsIgnoreCase(gatewayAccountRequest.getPaymentProvider())) {
+            gatewayAccountEntity.setAllowApplePay(true);
+        }
 
         gatewayAccountDao.persist(gatewayAccountEntity);
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
@@ -75,7 +75,7 @@ public class GatewayAccountResourceCreateIT extends GatewayAccountResourceTestBa
                 .body("gateway_account_id", is(notNullValue()))
                 .body("type", is("test"))
                 .body("requires3ds", is(false))
-                .body("allow_apple_pay", is(false))
+                .body("allow_apple_pay", is(true))
                 .body("allow_google_pay", is(false))
                 .body("corporate_credit_card_surcharge_amount", is(0))
                 .body("corporate_debit_card_surcharge_amount", is(0))

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -382,6 +382,22 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     }
 
     @Test
+    public void shouldSetApplePayEnabledByDefaultForSandboxAccount() {
+        String gatewayAccountId1 = createAGatewayAccountFor("sandbox");
+        String gatewayAccountId2 = createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
+
+        givenSetup()
+                .get("/v1/api/accounts/" + gatewayAccountId1)
+                .then()
+                .body("allow_apple_pay", is(true));
+
+        givenSetup()
+                .get("/v1/api/accounts/" + gatewayAccountId2)
+                .then()
+                .body("allow_apple_pay", is(false));
+    }
+
+    @Test
     public void shouldGetGatewayAccountsByIds() {
         String gatewayAccountId1 = createAGatewayAccountFor("sandbox");
         String gatewayAccountId2 = createAGatewayAccountFor("sandbox");
@@ -454,7 +470,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     public void shouldGetGatewayAccountsByApplePayEnabled() {
         String gatewayAccountId1 = createAGatewayAccountFor("worldpay");
         updateGatewayAccount(gatewayAccountId1, "allow_apple_pay", true);
-        createAGatewayAccountFor("sandbox");
+        createAGatewayAccountFor("stripe");
 
         givenSetup()
                 .get("/v1/api/accounts?apple_pay_enabled=true")


### PR DESCRIPTION
## WHAT YOU DID

Enable Apple Pay by default when a new gateway account is created and the payment provider is sandbox.
