### PR TITLE
PP-12211: CodeQL config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'src/**'
+  schedule:
+    # Weekly schedule
+    - cron: '43 7 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      # required for CodeQL to raise security issues on the repo
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: '0'
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@379614612a29c9e28f31f39a59013eb8012a51f0
+        with:
+          # CodeQL options: [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
+          languages: 'java-kotlin'
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Compile project
+        run: mvn clean compile
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@379614612a29c9e28f31f39a59013eb8012a51f0
+        with:
+          category: "/language:java-kotlin"


### PR DESCRIPTION
## WHAT YOU DID
Adds CodeQL config file, to exclude non-Java files from scans. 

This will reduce noise on e.g. Docker and pom.xml Dependabot PRs, where CodeQL can't find any Java to scan.

I've used updated SHA pins for v4 of `actions/checkout` and `actions/setup-java`, to remove deprecation warnings. These SHAs have been added to the repo settings.
