### PR TITLE
PP-12302 refactor connector part 1

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -712,7 +712,16 @@
         "filename": "src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java",
         "hashed_secret": "e9b6cb662f24d2346839fb0b797ad778c290994e",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 96
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsParameterizedIT.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsParameterizedIT.java",
+        "hashed_secret": "e9b6cb662f24d2346839fb0b797ad778c290994e",
+        "is_verified": false,
+        "line_number": 120
       }
     ],
     "src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java": [
@@ -1071,5 +1080,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-04T10:07:47Z"
+  "generated_at": "2024-03-05T16:32:21Z"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+            <version>1.19.3</version>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-jdbi3</artifactId>
             <version>${dropwizard.version}</version>

--- a/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceIT.java
@@ -4,17 +4,13 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
-import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
-import uk.gov.pay.connector.junit.DropwizardTestContext;
-import uk.gov.pay.connector.junit.TestContext;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.pay.connector.rules.AppWithPostgresAndSqsRule;
 import uk.gov.pay.connector.rules.LedgerStub;
 import uk.gov.pay.connector.rules.WorldpayMockClient;
 import uk.gov.pay.connector.util.AddAgreementParams;
@@ -26,37 +22,34 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.apache.http.HttpStatus.SC_CREATED;
 import static java.lang.String.format;
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
 import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
 import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class AgreementsApiResourceIT {
+    @ClassRule
+    public static AppWithPostgresAndSqsRule connectorApp = new AppWithPostgresAndSqsRule();
+
     private static final String REFERENCE_ID = "1234";
     private static final String DESCRIPTION = "a valid description";
     private static final String USER_IDENTIFIER = "a-valid-user-identifier";
     private static final String REFERENCE_ID_TOO_LONG = new String(new char[260]).replace('\0', '1');
     private static final String REFERENCE_ID_EMPTY = "";
-    private DatabaseFixtures.TestAccount testAccount;
-
     private static final String CREATE_AGREEMENT_URL = "/v1/api/accounts/%s/agreements";
     private static final String CANCEL_AGREEMENT_URL = "/v1/api/accounts/%s/agreements/%s/cancel";
-
-    @DropwizardTestContext
-    private TestContext testContext;
+    private DatabaseFixtures.TestAccount testAccount;
 
     private DatabaseTestHelper databaseTestHelper;
     private WireMockServer wireMockServer;
@@ -73,8 +66,8 @@ public class AgreementsApiResourceIT {
     
     @Before
     public void setUp() {
-        databaseTestHelper = testContext.getDatabaseTestHelper();
-        wireMockServer = testContext.getWireMockServer();
+        databaseTestHelper = connectorApp.getDatabaseTestHelper();
+        wireMockServer = connectorApp.getWireMockServer();
         worldpayMockClient = new WorldpayMockClient(wireMockServer);
         ledgerStub = new LedgerStub(wireMockServer);
         databaseFixtures = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper);
@@ -88,7 +81,7 @@ public class AgreementsApiResourceIT {
     }
 
     protected RequestSpecification givenSetup() {
-        return given().port(testContext.getPort()).contentType(JSON);
+        return given().port(connectorApp.getLocalPort()).contentType(JSON);
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
@@ -8,6 +8,8 @@ import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
+import uk.gov.pay.connector.it.resources.NewGatewayAccountResourceTestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.junit.DropwizardTestContext;
@@ -28,21 +30,10 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargesFrontendResourceWorldpayJwtIT {
+public class ChargesFrontendResourceWorldpayJwtIT extends NewChargingITestBase {
 
-    @DropwizardTestContext
-    private TestContext testContext;
-
-    private DatabaseTestHelper databaseTestHelper;
-    private RestAssuredClient connectorRestApi;
-
-    
-    @Before
-    public void setUp() {
-        databaseTestHelper = testContext.getDatabaseTestHelper();
-        connectorRestApi = new RestAssuredClient(testContext.getPort());
+    public ChargesFrontendResourceWorldpayJwtIT() {
+        super("worldpay");
     }
 
     @After
@@ -61,7 +52,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
         );
         setUpChargeAndAccount(gatewayAccountId, WORLDPAY, validCredentials, nextLong(), chargeExternalId, ChargeStatus.CREATED);
 
-        connectorRestApi
+        connectorRestApiClient
                 .withChargeId(chargeExternalId)
                 .getWorldpay3dsFlexDdcJwt()
                 .statusCode(HttpStatus.SC_OK)
@@ -75,7 +66,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
         setUpChargeAndAccount(gatewayAccountId, WORLDPAY, null, nextLong(), chargeExternalId,
                 ChargeStatus.CREATED);
 
-        connectorRestApi
+        connectorRestApiClient
                 .withChargeId(chargeExternalId)
                 .getWorldpay3dsFlexDdcJwt()
                 .statusCode(HttpStatus.SC_CONFLICT)
@@ -94,7 +85,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
         setUpChargeAndAccount(gatewayAccountId, STRIPE, validCredentials, nextLong(), chargeExternalId,
                 ChargeStatus.CREATED);
 
-        connectorRestApi
+        connectorRestApiClient
                 .withChargeId(chargeExternalId)
                 .getWorldpay3dsFlexDdcJwt()
                 .statusCode(HttpStatus.SC_CONFLICT)
@@ -120,7 +111,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
                 "a-payload", 
                 "2.1.0");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(gatewayAccountId)
                 .withChargeId(chargeExternalId)
                 .getFrontendCharge()
@@ -148,7 +139,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
                 "a-payload",
                 "2.1.0");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(gatewayAccountId)
                 .withChargeId(chargeExternalId)
                 .getFrontendCharge()

--- a/src/test/java/uk/gov/pay/connector/it/base/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/IntegrationTest.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.connector.it.base;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.restassured.specification.RequestSpecification;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import uk.gov.pay.connector.rules.AppWithPostgresAndSqsRule;
+import uk.gov.pay.connector.rules.CardidStub;
+import uk.gov.pay.connector.rules.LedgerStub;
+import uk.gov.pay.connector.rules.StripeMockClient;
+import uk.gov.pay.connector.rules.WorldpayMockClient;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+
+public class IntegrationTest {
+
+    @ClassRule
+    public static final AppWithPostgresAndSqsRule connectorApp = new AppWithPostgresAndSqsRule();
+
+    protected static WorldpayMockClient worldpayMockClient;
+    protected static StripeMockClient stripeMockClient;
+    protected static LedgerStub ledgerStub;
+    protected static DatabaseTestHelper databaseTestHelper;
+    protected static WireMockServer wireMockServer;
+    protected static Injector injector = Guice.createInjector();
+    protected static CardidStub cardidStub;
+    protected static ObjectMapper mapper;
+
+    @BeforeClass
+    public static void setUpIntegrationTest() {
+        wireMockServer = connectorApp.getWireMockServer();
+        worldpayMockClient = new WorldpayMockClient(wireMockServer);
+        stripeMockClient = new StripeMockClient(wireMockServer);
+        ledgerStub = new LedgerStub(wireMockServer);
+        cardidStub = new CardidStub(wireMockServer);
+        databaseTestHelper = connectorApp.getDatabaseTestHelper();
+        mapper = new ObjectMapper();
+    }
+
+    RequestSpecification givenSetup() {
+        return given().port(connectorApp.getLocalPort())
+                .contentType(JSON);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/base/NewChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/NewChargingITestBase.java
@@ -1,0 +1,558 @@
+package uk.gov.pay.connector.it.base;
+
+import com.google.gson.JsonObject;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.apache.commons.lang.math.RandomUtils;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.After;
+import org.junit.Before;
+import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
+import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.ServicePaymentReference;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.it.util.ChargeUtils;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.pay.connector.util.AddAgreementParams;
+import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
+import uk.gov.pay.connector.util.AddPaymentInstrumentParams;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+import uk.gov.pay.connector.util.RestAssuredClient;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.apache.commons.lang.math.RandomUtils.nextInt;
+import static org.apache.commons.lang.math.RandomUtils.nextLong;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_STRIPE_ACCOUNT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_CUSTOMER_INITIATED;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
+import static uk.gov.pay.connector.it.util.ChargeUtils.createNewChargeWithAccountId;
+import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
+import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
+import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
+import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
+import static uk.gov.pay.connector.util.JsonEncoder.toJson;
+import static uk.gov.pay.connector.util.TransactionId.randomId;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
+
+public class NewChargingITestBase extends IntegrationTest{
+    protected static final String ADDRESS_LINE_1 = "The Money Pool";
+    protected static final String ADDRESS_CITY = "London";
+    protected static final String ADDRESS_POSTCODE = "DO11 4RS";
+    protected static final String ADDRESS_COUNTRY_GB = "GB";
+    protected static final String CVC = "123";
+
+    protected static final String RETURN_URL = "http://service.local/success-page/";
+    protected static final String EMAIL = randomAlphabetic(242) + "@example.com";
+    protected static final long AMOUNT = 6234L;
+    protected static final String JSON_REFERENCE_VALUE = "Test reference";
+    protected static final String JSON_DESCRIPTION_VALUE = "Test description";
+
+    protected static final String SERVICE_ID = "external-service-id";
+    protected static final String JSON_PROVIDER_KEY = "payment_provider";
+    protected static final String JSON_CREDENTIAL_ID_KEY = "credential_id";
+    protected static final String PROVIDER_NAME = "sandbox";
+    protected static final String JSON_CHARGE_KEY = "charge_id";
+    protected static final String JSON_MESSAGE_KEY = "message";
+    protected static final String JSON_AMOUNT_KEY = "amount";
+    protected static final String JSON_REFERENCE_KEY = "reference";
+    protected static final String JSON_DESCRIPTION_KEY = "description";
+    protected static final String JSON_RETURN_URL_KEY = "return_url";
+    protected static final String JSON_LANGUAGE_KEY = "language";
+    protected static final String JSON_EMAIL_KEY = "email";
+    protected static final String JSON_MOTO_KEY = "moto";
+    protected static final String JSON_METADATA_KEY = "metadata";
+    protected static final String JSON_AUTH_MODE_KEY = "authorisation_mode";
+    protected static final String JSON_AUTH_MODE_MOTO_API = "moto_api";
+    protected static final String JSON_DELAYED_CAPTURE_KEY = "delayed_capture";
+    protected static final String JSON_SOURCE_KEY = "source";
+
+    private String paymentProvider;
+    protected RestAssuredClient connectorRestApiClient;
+    protected String accountId = String.valueOf(RandomUtils.nextInt());
+    protected int gatewayAccountCredentialsId  = RandomUtils.nextInt();
+    protected Map<String, Object> credentials;
+    protected DatabaseFixtures.TestAccount testAccount;
+
+    protected static AddGatewayAccountCredentialsParams credentialParams;
+
+    public NewChargingITestBase(String paymentProvider) {
+        this.paymentProvider = paymentProvider;
+    }
+
+    @Before
+    public void setUpBase() {
+        if (paymentProvider.equals(STRIPE.getName())) {
+            credentials = Map.of(CREDENTIALS_STRIPE_ACCOUNT_ID, "stripe-account-id");
+        } else if (paymentProvider.equals(WORLDPAY.getName())) {
+            credentials = Map.of(
+                    ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                            CREDENTIALS_MERCHANT_CODE, "merchant-id",
+                            CREDENTIALS_USERNAME, "test-user",
+                            CREDENTIALS_PASSWORD, "test-password"),
+                    RECURRING_CUSTOMER_INITIATED, Map.of(
+                            CREDENTIALS_MERCHANT_CODE, "cit-merchant-id",
+                            CREDENTIALS_USERNAME, "cit-user",
+                            CREDENTIALS_PASSWORD, "cit-password"),
+                    RECURRING_MERCHANT_INITIATED, Map.of(
+                            CREDENTIALS_MERCHANT_CODE, "mit-merchant-id",
+                            CREDENTIALS_USERNAME, "mit-user",
+                            CREDENTIALS_PASSWORD, "mit-password")
+            );
+        } else {
+            credentials = Map.of(
+                    CREDENTIALS_MERCHANT_ID, "merchant-id",
+                    CREDENTIALS_USERNAME, "test-user",
+                    CREDENTIALS_PASSWORD, "test-password",
+                    CREDENTIALS_SHA_IN_PASSPHRASE, "test-sha-in-passphrase",
+                    CREDENTIALS_SHA_OUT_PASSPHRASE, "test-sha-out-passphrase"
+            );
+        }
+        ledgerStub.acceptPostEvent();
+
+        credentialParams = anAddGatewayAccountCredentialsParams()
+                .withId(gatewayAccountCredentialsId)
+                .withPaymentProvider(paymentProvider)
+                .withGatewayAccountId(Long.parseLong(accountId))
+                .withState(ACTIVE)
+                .withCredentials(credentials)
+                .build();
+
+        CardTypeEntity visaCreditCard = databaseTestHelper.getVisaCreditCard();
+        testAccount = withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .withAccountId(Long.parseLong(accountId))
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayAccountCredentials(List.of(credentialParams))
+                .withServiceId(SERVICE_ID)
+                .withAllowAuthApi(true)
+                .withCardTypeEntities(List.of(visaCreditCard))
+                .insert();
+
+        connectorRestApiClient = new RestAssuredClient(connectorApp.getLocalPort(), accountId);
+    }
+
+    @After
+    public void tearDown() {
+        databaseTestHelper.truncateAllData();
+    }
+
+    public Map<String, Object> getCredentials() {
+        return credentials;
+    }
+
+    protected static String authorisationDetailsWithMinimalAddress(String cardNumber, String cardBrand, String cardType) {
+        JsonObject addressObject = new JsonObject();
+
+        addressObject.addProperty("line1", ADDRESS_LINE_1);
+        addressObject.addProperty("city", ADDRESS_CITY);
+        addressObject.addProperty("postcode", ADDRESS_POSTCODE);
+        addressObject.addProperty("country", ADDRESS_COUNTRY_GB);
+
+        JsonObject authorisationDetails = new JsonObject();
+        authorisationDetails.addProperty("card_number", cardNumber);
+        authorisationDetails.addProperty("cvc", CVC);
+        authorisationDetails.addProperty("expiry_date", "12/21");
+        authorisationDetails.addProperty("cardholder_name", "Mr. Payment");
+        authorisationDetails.addProperty("card_brand", cardBrand);
+        authorisationDetails.addProperty("card_type", cardType);
+        authorisationDetails.add("address", addressObject);
+        authorisationDetails.addProperty("accept_header", "text/html");
+        authorisationDetails.addProperty("user_agent_header", "Mozilla/5.0");
+        return toJson(authorisationDetails);
+    }
+
+    protected static String buildJsonWithPaResponse() {
+        JsonObject auth3dsDetails = new JsonObject();
+        auth3dsDetails.addProperty("pa_response", "this-is-a-test-pa-response");
+
+        return auth3dsDetails.toString();
+    }
+
+    protected ValidatableResponse getCharge(String chargeId) {
+        return connectorRestApiClient
+                .withChargeId(chargeId)
+                .getCharge();
+    }
+
+    protected void assertFrontendChargeStatusIs(String chargeId, String status) {
+        connectorRestApiClient
+                .withChargeId(chargeId)
+                .getFrontendCharge()
+                .body("status", is(status));
+    }
+
+    protected void assertFrontendChargeCorporateSurchargeAmount(String chargeId, String status, Long corporateSurcharge) {
+        connectorRestApiClient
+                .withChargeId(chargeId)
+                .getFrontendCharge()
+                .body("status", is(status))
+                .body("corporate_card_surcharge", is(corporateSurcharge.intValue()));
+    }
+
+    protected void assertFrontendChargeStatusAndTransactionId(String chargeId, String status) {
+        connectorRestApiClient
+                .withChargeId(chargeId)
+                .getFrontendCharge()
+                .body("status", is(status))
+                .body("gateway_transaction_id", is(notNullValue()));
+    }
+
+    protected void assertRefundStatus(String chargeId, String refundId, String status, Integer amount) {
+        connectorRestApiClient.withChargeId(chargeId)
+                .withRefundId(refundId)
+                .getRefund()
+                .body("status", is(status))
+                .body("amount", is(amount));
+    }
+
+    protected void assertApiStateIs(String chargeId, String stateString) {
+        getCharge(chargeId).body("state.status", is(stateString));
+    }
+
+    protected String authoriseNewCharge() {
+        String externalChargeId = createNewChargeWithNoTransactionId(AUTHORISATION_SUCCESS);
+        databaseTestHelper.updateChargeCardDetails(
+                Long.parseLong(externalChargeId.replace("charge-", "")),
+                AuthCardDetailsFixture.anAuthCardDetails().build());
+        return externalChargeId;
+    }
+
+    protected String createNewCharge() {
+        return createNewChargeWith(CREATED, "");
+    }
+
+    protected String createNewChargeWithNoGatewayTransactionIdOrEmailAddress(ChargeStatus status) {
+        return createNewChargeWithAccountId(status, null, accountId, databaseTestHelper, null, paymentProvider).toString();
+    }
+
+    protected String createNewChargeWithDescriptionAndNoGatewayTransactionIdOrEmailAddress(ChargeStatus status, String description) {
+        return createNewChargeWithAccountId(status, null, accountId, databaseTestHelper, null, paymentProvider, description).toString();
+    }
+
+    protected String createNewChargeWithNoTransactionId(ChargeStatus status) {
+        return createNewChargeWith(status, null);
+    }
+
+    protected String createNewCharge(ChargeStatus status) {
+        return createNewChargeWith(status, randomId());
+    }
+
+    protected String createNewChargeWith(ChargeStatus status, String gatewayTransactionId) {
+        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId, databaseTestHelper, paymentProvider, credentialParams.getId()).toString();
+    }
+
+    protected RequestSpecification givenSetup() {
+        return given().port(connectorApp.getLocalPort())
+                .contentType(JSON);
+    }
+
+    public <T> T getInstanceFromGuiceContainer(Class<T> clazz) {
+        return injector.getInstance(clazz);
+    }
+
+    protected void shouldReturnErrorForAuthorisationDetailsWithMessage(String authorisationDetails, String errorMessage, String status) {
+
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+
+        givenSetup()
+                .body(authorisationDetails)
+                .post(authoriseChargeUrlFor(chargeId))
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .contentType(JSON)
+                .body("message", contains(errorMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+
+        assertFrontendChargeStatusIs(chargeId, status);
+    }
+
+    public static String authoriseChargeUrlForApplePay(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/wallets/apple".replace("{chargeId}", chargeId);
+    }
+    public static String authoriseChargeUrlForGooglePayStripe(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/wallets/google/stripe".replace("{chargeId}", chargeId);
+    }
+
+    public static String authoriseChargeUrlForGooglePayWorldpay(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/wallets/google/worldpay".replace("{chargeId}", chargeId);
+    }
+    
+    public static String authoriseChargeUrlForGooglePay(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/wallets/google".replace("{chargeId}", chargeId);
+    }
+    
+
+    public static String authoriseChargeUrlFor(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeId);
+    }
+
+    protected static String authorise3dsChargeUrlFor(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/3ds".replace("{chargeId}", chargeId);
+    }
+
+    protected static String captureChargeUrlFor(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/capture".replace("{chargeId}", chargeId);
+    }
+
+    protected static String captureUrlForAwaitingCaptureCharge(String accountId, String chargeId) {
+        return "/v1/api/accounts/{accountId}/charges/{chargeId}/capture"
+                .replace("{accountId}", accountId)
+                .replace("{chargeId}", chargeId);
+    }
+
+    public static String cancelChargeUrlFor(String accountId, String chargeId) {
+        return "/v1/api/accounts/{accountId}/charges/{chargeId}/cancel".replace("{accountId}", accountId).replace("{chargeId}", chargeId);
+    }
+
+    protected Matcher<? super List<Map<String, Object>>> hasEvent(ChargeStatus chargeStatus) {
+        return new TypeSafeMatcher<>() {
+            @Override
+            protected boolean matchesSafely(List<Map<String, Object>> chargeEvents) {
+                return chargeEvents.stream()
+                        .anyMatch(chargeEvent ->
+                                chargeStatus.getValue().equals(chargeEvent.get("status"))
+                        );
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(format("no matching charge event with status [%s]", chargeStatus.getValue()));
+            }
+        };
+    }
+
+    protected String cancelChargeAndCheckApiStatus(String chargeId, ChargeStatus targetState, int targetHttpStatus) {
+
+        connectorRestApiClient
+                .withChargeId(chargeId)
+                .postChargeCancellation()
+                .statusCode(targetHttpStatus); //assertion
+
+        connectorRestApiClient
+                .withChargeId(chargeId)
+                .getCharge()
+                .body("state.status", is("cancelled"))
+                .body("state.message", is("Payment was cancelled by the service"))
+                .body("state.code", is("P0040"));
+
+        connectorRestApiClient
+                .withChargeId(chargeId)
+                .getFrontendCharge()
+                .body("status", is(targetState.getValue()))
+                .body("state.status", is("cancelled"))
+                .body("state.finished", is(true))
+                .body("state.message", is("Payment was cancelled by the service"))
+                .body("state.code", is("P0040"));
+
+        connectorRestApiClient
+                .withChargeId(chargeId)
+                .getCharge()
+                .body("status", emptyOrNullString())
+                .body("state.status", is("cancelled"))
+                .body("state.finished", is(true))
+                .body("state.message", is("Payment was cancelled by the service"))
+                .body("state.code", is("P0040"));
+
+        return chargeId;
+    }
+
+    protected String addChargeAndCardDetails(ChargeStatus status, ServicePaymentReference reference, Instant fromDate) {
+        return addChargeAndCardDetails(status, reference, fromDate, "");
+
+    }
+
+    protected String addChargeAndCardDetails(ChargeStatus status, ServicePaymentReference reference, Instant fromDate, String cardBrand) {
+        return addChargeAndCardDetails(nextLong(), status, reference, fromDate, cardBrand);
+    }
+
+    protected String addCharge(ChargeStatus status) {
+        return addCharge(status, "ref", Instant.now(), RandomIdGenerator.newId());
+    }
+
+    protected String addCharge(ChargeStatus status, String reference, Instant createdDate, String transactionId) {
+        return addCharge(status, reference, createdDate, transactionId, "tokenId", WEB);
+    }
+
+    protected String addCharge(ChargeStatus status, String reference, Instant createdDate, String transactionId, String tokenId, AuthorisationMode authorisationMode) {
+        long chargeId = RandomUtils.nextInt();
+        String externalChargeId = "charge" + chargeId;
+        ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
+        addCharge(chargeId, externalChargeId, status, ServicePaymentReference.of(reference), createdDate, transactionId, paymentProvider, authorisationMode);
+        databaseTestHelper.addToken(chargeId, tokenId);
+        databaseTestHelper.addEvent(chargeId, chargeStatus.getValue());
+        databaseTestHelper.updateChargeCardDetails(
+                chargeId,
+                AuthCardDetailsFixture.anAuthCardDetails().build());
+        return externalChargeId;
+    }
+
+    private void addCharge(long chargeId, String externalChargeId, ChargeStatus chargeStatus,
+                           ServicePaymentReference reference, Instant createdDate, String transactionId,
+                           String paymentProvider, AuthorisationMode authorisationMode) {
+        databaseTestHelper.addCharge(anAddChargeParams()
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withGatewayAccountId(accountId)
+                .withServiceId(SERVICE_ID)
+                .withAmount(AMOUNT)
+                .withPaymentProvider(paymentProvider)
+                .withStatus(chargeStatus)
+                .withTransactionId(transactionId)
+                .withReference(reference)
+                .withCreatedDate(createdDate)
+                .withVersion(1)
+                .withLanguage(SupportedLanguage.ENGLISH)
+                .withDelayedCapture(false)
+                .withEmail(EMAIL)
+                .withGatewayCredentialId(credentialParams.getId())
+                .withAuthorisationMode(authorisationMode)
+                .build());
+    }
+
+    protected String addChargeAndCardDetails(Long chargeId, ChargeStatus status, ServicePaymentReference reference, Instant fromDate, String cardBrand) {
+        String externalChargeId = "charge" + chargeId;
+        ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
+        addCharge(chargeId, externalChargeId, chargeStatus, reference, fromDate, null, paymentProvider, WEB);
+        databaseTestHelper.addToken(chargeId, "tokenId");
+        databaseTestHelper.addEvent(chargeId, chargeStatus.getValue());
+        databaseTestHelper.updateChargeCardDetails(chargeId, cardBrand, "1234", "123456", "Mr. McPayment",
+                CardExpiryDate.valueOf("03/18"), null, "line1", null, "postcode", "city", null, "country");
+
+        return externalChargeId;
+    }
+
+    protected ChargeUtils.ExternalChargeId addChargeForSetUpAgreement(ChargeStatus status) {
+        String agreementExternalId = addAgreement();
+        return addChargeForSetUpAgreement(status, agreementExternalId);
+    }
+
+    protected ChargeUtils.ExternalChargeId addChargeForSetUpAgreement(ChargeStatus status, String agreementExternalId) {
+        return addChargeForSetUpAgreement(status, agreementExternalId, null);
+    }
+
+    protected ChargeUtils.ExternalChargeId addChargeForSetUpAgreement(ChargeStatus status, String agreementExternalId, Long paymentInstrumentId) {
+        long chargeId = RandomUtils.nextInt();
+        ChargeUtils.ExternalChargeId externalChargeId = ChargeUtils.ExternalChargeId.fromChargeId(chargeId);
+        databaseTestHelper.addCharge(anAddChargeParams()
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId.toString())
+                .withGatewayAccountId(accountId)
+                .withPaymentProvider(getPaymentProvider())
+                .withAmount(6234L)
+                .withStatus(status)
+                .withEmail("email@fake.test")
+                .withSavePaymentInstrumentToAgreement(true)
+                .withAgreementExternalId(agreementExternalId)
+                .withGatewayCredentialId((long) gatewayAccountCredentialsId)
+                .withPaymentInstrumentId(paymentInstrumentId)
+                .build());
+        return externalChargeId;
+    }
+
+    protected String addAgreement() {
+        String agreementExternalId = String.valueOf(nextLong());
+        AddAgreementParams agreementParams = anAddAgreementParams()
+                .withGatewayAccountId(accountId)
+                .withExternalAgreementId(agreementExternalId)
+                .build();
+        databaseTestHelper.addAgreement(agreementParams);
+        return agreementExternalId;
+    }
+
+    protected Long addPaymentInstrument(String agreementExternalId, PaymentInstrumentStatus status) {
+        Long paymentInstrumentId = nextLong();
+        AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
+                .withPaymentInstrumentId(paymentInstrumentId)
+                .withAgreementExternalId(agreementExternalId)
+                .withPaymentInstrumentStatus(status)
+                .build();
+        databaseTestHelper.addPaymentInstrument(paymentInstrumentParams);
+        return paymentInstrumentId;
+    }
+
+    protected ChargeUtils.ExternalChargeId addChargeWithAuthorisationModeAgreement(Map<String, String> recurringAuthToken) {
+        return addChargeWithAuthorisationModeAgreement(null, null, recurringAuthToken);
+    }
+
+    protected ChargeUtils.ExternalChargeId addChargeWithAuthorisationModeAgreement(
+            FirstDigitsCardNumber first6DigitsCardNumber,
+            LastDigitsCardNumber last4DigitsCardNumber,
+            Map<String, String> recurringAuthToken
+    ) {
+        String agreementExternalId = addAgreement();
+
+        long paymentInstrumentId = nextInt();
+        AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder paymentInstrumentParamsBuilder = anAddPaymentInstrumentParams()
+                .withPaymentInstrumentId(paymentInstrumentId)
+                .withExternalPaymentInstrumentId(String.valueOf(nextInt()))
+                .withRecurringAuthToken(recurringAuthToken)
+                .withAgreementExternalId(agreementExternalId);
+
+        Optional.ofNullable(first6DigitsCardNumber).ifPresent(paymentInstrumentParamsBuilder::withFirstDigitsCardNumber);
+        Optional.ofNullable(last4DigitsCardNumber).ifPresent(paymentInstrumentParamsBuilder::withLastDigitsCardNumber);
+
+        databaseTestHelper.addPaymentInstrument(paymentInstrumentParamsBuilder.build());
+        databaseTestHelper.updateAgreementPaymentInstrumentId(agreementExternalId, paymentInstrumentId);
+
+        long chargeId = RandomUtils.nextInt();
+        ChargeUtils.ExternalChargeId externalChargeId = ChargeUtils.ExternalChargeId.fromChargeId(chargeId);
+        var chargeParams = anAddChargeParams()
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId.toString())
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayAccountId(accountId)
+                .withGatewayCredentialId((long) gatewayAccountCredentialsId)
+                .withAgreementExternalId(agreementExternalId)
+                .withAmount(10000)
+                .withStatus(ChargeStatus.CREATED)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withPaymentInstrumentId(paymentInstrumentId);
+        databaseTestHelper.addCharge(chargeParams.build());
+
+        return externalChargeId;
+    }
+
+    protected String getPaymentProvider() {
+        return paymentProvider;
+    }
+
+    protected DatabaseFixtures.TestAccount getTestAccount() {
+        return testAccount;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayIT.java
@@ -10,14 +10,10 @@ import org.apache.commons.lang3.tuple.Triple;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.pay.connector.paymentprocessor.resource.CardResource;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
@@ -38,9 +34,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonApplePayAuthorisationDetails;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class CardResourceAuthoriseApplePayIT extends ChargingITestBase {
+public class CardResourceAuthoriseApplePayIT extends NewChargingITestBase {
 
     private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
@@ -49,10 +43,9 @@ public class CardResourceAuthoriseApplePayIT extends ChargingITestBase {
         super("sandbox");
     }
 
-    @Override
     @Before
     public void setUp() {
-        super.setUp();
+        super.setUpIntegrationTest();
         Logger root = (Logger) LoggerFactory.getLogger(CardResource.class);
         root.setLevel(Level.INFO);
         root.addAppender(mockAppender);

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
@@ -5,13 +5,9 @@ import io.restassured.specification.RequestSpecification;
 import org.apache.commons.lang.math.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.pay.connector.it.util.ChargeUtils;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
@@ -63,9 +59,7 @@ import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGa
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.TransactionId.randomId;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class CardResourceAuthoriseIT extends ChargingITestBase {
+public class CardResourceAuthoriseIT extends NewChargingITestBase {
 
     public CardResourceAuthoriseIT() {
         super("sandbox");

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
@@ -2,13 +2,9 @@ package uk.gov.pay.connector.it.resources;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.service.payments.commons.model.ErrorIdentifier;
-import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.time.Instant;
 import java.util.List;
@@ -42,9 +38,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCELL
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_READY;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargeCancelFrontendResourceIT extends ChargingITestBase {
+public class ChargeCancelFrontendResourceIT extends NewChargingITestBase {
 
     private static final List<ChargeStatus> NON_USER_CANCELLABLE_STATUSES = ImmutableList.of(
             AUTHORISATION_REJECTED,

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResource204ResponseParameterizedIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResource204ResponseParameterizedIT.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.it.resources;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static java.time.temporal.ChronoUnit.HOURS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(Parameterized.class)
+public class ChargeCancelResource204ResponseParameterizedIT extends NewChargingITestBase {
+
+    @Parameterized.Parameter()
+    public ChargeStatus status;
+
+    public ChargeCancelResource204ResponseParameterizedIT() {
+        super("worldpay");
+    }
+
+    @Parameterized.Parameters()
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                { ChargeStatus.CREATED }, { ChargeStatus.ENTERING_CARD_DETAILS }
+        });
+    }
+
+    @Test
+    public void shouldRespond204WithNoLockingEvent_IfCancelledBeforeAuth() {
+        String chargeId = addCharge(status, "ref", Instant.now().minus(1, HOURS), "irrelevant");
+        cancelChargeAndCheckApiStatus(chargeId, ChargeStatus.SYSTEM_CANCELLED, 204);
+
+        List<String> events = databaseTestHelper.getInternalEvents(chargeId);
+        assertThat(events.size(), is(2));
+        assertThat(events, hasItems(status.getValue(), ChargeStatus.SYSTEM_CANCELLED.getValue()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResource400ResponseParameterizedIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResource400ResponseParameterizedIT.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.connector.it.resources;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static io.restassured.http.ContentType.JSON;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(Parameterized.class)
+public class ChargeCancelResource400ResponseParameterizedIT extends NewChargingITestBase {
+
+    @Parameterized.Parameter()
+    public ChargeStatus notCancellableState;
+
+    public ChargeCancelResource400ResponseParameterizedIT() {
+        super("worldpay");
+    }
+
+    @Parameterized.Parameters()
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {ChargeStatus.AUTHORISATION_REJECTED},
+                {ChargeStatus.AUTHORISATION_ERROR},
+                {ChargeStatus.CAPTURE_READY},
+                {ChargeStatus.CAPTURED},
+                {ChargeStatus.CAPTURE_SUBMITTED},
+                {ChargeStatus.CAPTURE_ERROR},
+                {ChargeStatus.EXPIRED},
+                {ChargeStatus.EXPIRE_CANCEL_FAILED},
+                {ChargeStatus.SYSTEM_CANCEL_ERROR},
+                {ChargeStatus.SYSTEM_CANCELLED},
+                {ChargeStatus.USER_CANCEL_READY},
+                {ChargeStatus.USER_CANCELLED},
+                {ChargeStatus.USER_CANCEL_ERROR}
+        });
+    }
+
+    @Test
+    public void respondWith400_whenNotCancellableState() {
+        String chargeId = createNewInPastChargeWithStatus(notCancellableState);
+        String expectedMessage = "Charge not in correct state to be processed, " + chargeId;
+        connectorRestApiClient
+                .withChargeId(chargeId)
+                .postChargeCancellation()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .and()
+                .contentType(JSON)
+                .body("message", contains(expectedMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+    }
+
+    private String createNewInPastChargeWithStatus(ChargeStatus status) {
+        return addCharge(status, "ref", Instant.now().minus(1, HOURS), "irrelavant");
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceIT.java
@@ -2,11 +2,7 @@ package uk.gov.pay.connector.it.resources;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.time.Instant;
@@ -35,10 +31,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCE
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCEL_READY;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargeExpiryResourceIT extends ChargingITestBase {
-
+public class ChargeExpiryResourceIT extends NewChargingITestBase {
     private static final String JSON_CHARGE_KEY = "charge_id";
     private static final String JSON_STATE_KEY = "state.status";
     private static final String PROVIDER_NAME = "worldpay";

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateLanguageIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateLanguageIT.java
@@ -2,11 +2,7 @@ package uk.gov.pay.connector.it.resources;
 
 import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -16,9 +12,7 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargesApiResourceCreateLanguageIT extends ChargingITestBase {
+public class ChargesApiResourceCreateLanguageIT extends NewChargingITestBase {
 
     public ChargesApiResourceCreateLanguageIT() {
         super(PROVIDER_NAME);

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateMetadataIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateMetadataIT.java
@@ -2,13 +2,9 @@ package uk.gov.pay.connector.it.resources;
 
 import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.postgresql.util.PGobject;
-import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.util.ExternalMetadataConverter;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -30,9 +26,7 @@ import static org.junit.Assert.assertNull;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.JsonEncoder.toJsonWithNulls;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargesApiResourceCreateMetadataIT extends ChargingITestBase {
+public class ChargesApiResourceCreateMetadataIT extends NewChargingITestBase {
 
     public ChargesApiResourceCreateMetadataIT() {
         super(PROVIDER_NAME);

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateMotoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateMotoIT.java
@@ -1,11 +1,7 @@
 package uk.gov.pay.connector.it.resources;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.util.Map;
@@ -15,9 +11,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargesApiResourceCreateMotoIT extends ChargingITestBase {
+public class ChargesApiResourceCreateMotoIT extends NewChargingITestBase {
 
     public ChargesApiResourceCreateMotoIT() {
         super(PROVIDER_NAME);

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreatePrefilledCardholderDetailsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreatePrefilledCardholderDetailsIT.java
@@ -1,11 +1,7 @@
 package uk.gov.pay.connector.it.resources;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -18,9 +14,7 @@ import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargesApiResourceCreatePrefilledCardholderDetailsIT extends ChargingITestBase {
+public class ChargesApiResourceCreatePrefilledCardholderDetailsIT extends NewChargingITestBase {
 
     private static final String JSON_PREFILLED_CARDHOLDER_DETAILS_KEY = "prefilled_cardholder_details";
     private static final String JSON_BILLING_ADDRESS_KEY = "billing_address";

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateProviderCredentialsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateProviderCredentialsIT.java
@@ -1,14 +1,9 @@
 package uk.gov.pay.connector.it.resources;
 
 import org.apache.commons.lang3.RandomUtils;
-import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.pay.connector.util.AddGatewayAccountParams;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
@@ -26,9 +21,7 @@ import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGa
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargesApiResourceCreateProviderCredentialsIT extends ChargingITestBase {
+public class ChargesApiResourceCreateProviderCredentialsIT extends NewChargingITestBase {
 
     public ChargesApiResourceCreateProviderCredentialsIT() {
         super(PROVIDER_NAME);

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateReturnUrlIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateReturnUrlIT.java
@@ -1,11 +1,7 @@
 package uk.gov.pay.connector.it.resources;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.util.Map;
@@ -15,9 +11,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargesApiResourceCreateReturnUrlIT extends ChargingITestBase {
+public class ChargesApiResourceCreateReturnUrlIT extends NewChargingITestBase {
 
     public ChargesApiResourceCreateReturnUrlIT() {
         super(PROVIDER_NAME);

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateSourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateSourceIT.java
@@ -2,11 +2,7 @@ package uk.gov.pay.connector.it.resources;
 
 import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -19,9 +15,7 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.JsonEncoder.toJsonWithNulls;
 import static uk.gov.service.payments.commons.model.Source.CARD_API;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargesApiResourceCreateSourceIT extends ChargingITestBase {
+public class ChargesApiResourceCreateSourceIT extends NewChargingITestBase {
 
     private static final String JSON_SOURCE_KEY = "source";
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateZeroAmountIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateZeroAmountIT.java
@@ -1,11 +1,7 @@
 package uk.gov.pay.connector.it.resources;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.util.Map;
@@ -15,9 +11,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargesApiResourceCreateZeroAmountIT extends ChargingITestBase {
+public class ChargesApiResourceCreateZeroAmountIT extends NewChargingITestBase {
 
     public ChargesApiResourceCreateZeroAmountIT() {
         super(PROVIDER_NAME);

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
@@ -5,11 +5,7 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
 import java.util.HashMap;
@@ -29,12 +25,7 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 import static uk.gov.service.payments.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(
-        app = ConnectorApp.class,
-        config = "config/test-it-config.yaml"
-)
-public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
+public class ChargesApiResourceTelephonePaymentsIT extends NewChargingITestBase {
 
     private static final String PROVIDER_NAME = "sandbox";
     private static final HashMap<String, Object> postBody = new HashMap<>();
@@ -48,9 +39,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
     }
 
     @Before
-    @Override
     public void setUp() {
-        super.setUp();
         postBody.put("amount", 12000);
         postBody.put("reference", "MRPC12345");
         postBody.put("description", "New passport application");
@@ -138,7 +127,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
                 .body("state.status", is("success"))
                 .body("state.finished", is(true));
 
-        DatabaseTestHelper testHelper = testContext.getDatabaseTestHelper();
+        DatabaseTestHelper testHelper = connectorApp.getDatabaseTestHelper();
         Map<String, Object> chargeDetails = testHelper.getChargeByGatewayTransactionId(providerId).get(0);
         Long chargeId = Long.parseLong(chargeDetails.get("id").toString());
         assertThat(chargeDetails.get("language"), is("en"));
@@ -329,7 +318,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
                 .statusCode(201)
                 .contentType(JSON);
 
-        DatabaseTestHelper testHelper = testContext.getDatabaseTestHelper();
+        DatabaseTestHelper testHelper = connectorApp.getDatabaseTestHelper();
         Map<String, Object> chargeDetails = testHelper.getChargeByGatewayTransactionId(providerId).get(0);
 
         assertThat(chargeDetails.get("source"), is(CARD_EXTERNAL_TELEPHONE.toString()));
@@ -365,7 +354,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
                 .body("state.status", is("success"))
                 .body("state.finished", is(true));
 
-        DatabaseTestHelper testHelper = testContext.getDatabaseTestHelper();
+        DatabaseTestHelper testHelper = connectorApp.getDatabaseTestHelper();
         List<Map<String, Object>> chargesByGatewayTransactionId = testHelper.getChargeByGatewayTransactionId(providerId);
 
         assertThat(chargesByGatewayTransactionId.size(), is(1));

--- a/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceIT.java
@@ -3,13 +3,9 @@ package uk.gov.pay.connector.it.resources;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.time.Instant;
@@ -37,9 +33,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTH
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CANCEL_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class DiscrepancyResourceIT extends ChargingITestBase {
+public class DiscrepancyResourceIT extends NewChargingITestBase {
     public DiscrepancyResourceIT() {
         super("worldpay");
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
@@ -2,14 +2,10 @@ package uk.gov.pay.connector.it.resources;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.service.payments.commons.model.ErrorIdentifier;
-import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.usernotification.resource.EmailNotificationResource;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,9 +17,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class EmailNotificationResourceIT extends GatewayAccountResourceTestBase {
+public class EmailNotificationResourceIT extends NewGatewayAccountResourceTestBase {
 
     @Test
     public void patchEmailNotification_shouldNotUpdateIfMissingField() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
@@ -46,9 +46,20 @@ public class GatewayAccountResourceCreateIT extends GatewayAccountResourceTestBa
     }
 
     @Test
-    @Parameters({"sandbox", "worldpay", "epdq"})
-    public void createAGatewayAccount(String provider) {
-        ValidatableResponse response = createAGatewayAccountFor(testContext.getPort(), provider, "my test service", "analytics");
+    public void createASandboxGatewayAccount() {
+        ValidatableResponse response = createAGatewayAccountFor(testContext.getPort(), "sandbox", "my test service", "analytics");
+        assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
+    }
+
+    @Test
+    public void createAWorldpaySandboxGatewayAccount() {
+        ValidatableResponse response = createAGatewayAccountFor(testContext.getPort(), "worldpay", "my test service", "analytics");
+        assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
+    }
+
+    @Test
+    public void createAWorldpayStripeGatewayAccount() {
+        ValidatableResponse response = createAGatewayAccountFor(testContext.getPort(), "stripe", "my test service", "analytics");
         assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -6,11 +6,7 @@ import io.restassured.http.ContentType;
 import org.apache.commons.lang.math.RandomUtils;
 import org.hamcrest.core.Is;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
@@ -49,9 +45,7 @@ import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAcc
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
+public class GatewayAccountResourceIT extends NewGatewayAccountResourceTestBase {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
@@ -3,10 +3,6 @@ package uk.gov.pay.connector.it.resources;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 
 import java.util.List;
@@ -21,9 +17,7 @@ import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccoun
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class GatewayAccountResourceSwitchPspIT extends GatewayAccountResourceTestBase {
+public class GatewayAccountResourceSwitchPspIT extends NewGatewayAccountResourceTestBase {
 
     private static ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
@@ -2,11 +2,7 @@ package uk.gov.pay.connector.it.resources;
 
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 
 import java.util.List;
 
@@ -23,15 +19,12 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
 import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class GatewayCleanupResourceIT extends ChargingITestBase {
+public class GatewayCleanupResourceIT extends NewChargingITestBase {
 
     private static final String PROVIDER_NAME = "worldpay";
 
@@ -71,7 +64,7 @@ public class GatewayCleanupResourceIT extends ChargingITestBase {
         worldpayMockClient.mockCancelSuccess();
         worldpayMockClient.mockAuthorisationQuerySuccess();
 
-        given().port(testContext.getPort())
+        given().port(connectorApp.getLocalPort())
                 .post("/v1/tasks/gateway-cleanup-sweep?limit=10")
                 .then()
                 .statusCode(OK.getStatusCode())
@@ -109,7 +102,7 @@ public class GatewayCleanupResourceIT extends ChargingITestBase {
         worldpayMockClient.mockCancelSuccess();
         worldpayMockClient.mockAuthorisationQuerySuccess();
 
-        given().port(testContext.getPort())
+        given().port(connectorApp.getLocalPort())
                 .post("/v1/tasks/gateway-cleanup-sweep?limit=2")
                 .then()
                 .statusCode(OK.getStatusCode())
@@ -120,7 +113,7 @@ public class GatewayCleanupResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422WhenLimitQueryParamMissing() {
-        given().port(testContext.getPort())
+        given().port(connectorApp.getLocalPort())
                 .post("/v1/tasks/gateway-cleanup-sweep")
                 .then()
                 .statusCode(422)

--- a/src/test/java/uk/gov/pay/connector/it/resources/NewGatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/NewGatewayAccountResourceTestBase.java
@@ -1,0 +1,225 @@
+package uk.gov.pay.connector.it.resources;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.rules.AppWithPostgresAndSqsRule;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static uk.gov.pay.connector.util.JsonEncoder.toJson;
+
+public class NewGatewayAccountResourceTestBase {
+
+    public static final String ACCOUNTS_API_URL = "/v1/api/accounts/";
+    public static final String ACCOUNTS_FRONTEND_URL = "/v1/frontend/accounts/";
+    public static final String ACCOUNTS_EXTERNAL_ID_URL = ACCOUNTS_API_URL + "external-id/";
+    public static final String ACCOUNT_FRONTEND_EXTERNAL_ID_URL = "/v1/frontend/accounts/external-id/";
+
+    @ClassRule
+    public static final AppWithPostgresAndSqsRule connectorApp = new AppWithPostgresAndSqsRule();
+
+    protected DatabaseTestHelper databaseTestHelper;
+    protected DatabaseFixtures databaseFixtures;
+
+    @Before
+    public void setUp() {
+        databaseTestHelper = connectorApp.getDatabaseTestHelper();
+        databaseFixtures = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper);
+    }
+
+    @After
+    public void tearDown() {
+        databaseTestHelper.truncateAllData();
+    }
+
+    protected RequestSpecification givenSetup() {
+        return given().port(connectorApp.getLocalPort())
+                .contentType(JSON);
+    }
+
+    protected String createAGatewayAccountFor(String provider) {
+        return extractGatewayAccountId(createAGatewayAccountFor(connectorApp.getLocalPort(), provider));
+    }
+
+    protected String createAGatewayAccountFor(String provider, String desc, String analyticsId) {
+        return extractGatewayAccountId(createAGatewayAccountFor(connectorApp.getLocalPort(), provider, desc, analyticsId));
+    }
+
+    protected String createAGatewayAccountFor(String provider, String description, String analyticsId, String requires3ds, String type) {
+        return extractGatewayAccountId(createAGatewayAccountFor(connectorApp.getLocalPort(), provider, description, analyticsId, requires3ds, type, null));
+    }
+
+    public static String extractGatewayAccountId(ValidatableResponse validatableResponse) {
+        return validatableResponse.extract().path("gateway_account_id");
+    }
+
+    public static ValidatableResponse createAGatewayAccountFor(int port, String testProvider) {
+        return createAGatewayAccountFor(port, testProvider, null, null);
+    }
+
+    public static ValidatableResponse createAGatewayAccountFor(int port, String testProvider, String description, String analyticsId) {
+        return createAGatewayAccountFor(port, testProvider, description, analyticsId, null, "test", null);
+    }
+
+    protected String createAGatewayAccountWithServiceId(String serviceId) {
+        return extractGatewayAccountId(createAGatewayAccountFor(connectorApp.getLocalPort(), "sandbox", "description", "analytics-id", "", "test", serviceId));
+    }
+
+    public static ValidatableResponse createAGatewayAccountFor(int port, String testProvider, String description, String analyticsId, String requires3ds, String type, String serviceId) {
+        Map<String, String> payload = Maps.newHashMap();
+        payload.put("payment_provider", testProvider);
+        if (description != null) {
+            payload.put("description", description);
+        }
+        if (analyticsId != null) {
+            payload.put("analytics_id", analyticsId);
+        }
+        if (requires3ds != null) {
+            payload.put("requires_3ds", requires3ds);
+        }
+        if (type != null) {
+            payload.put("type", type);
+        }
+        if (serviceId != null) {
+            payload.put("service_id", serviceId);
+        }
+        return given().port(port)
+                .contentType(JSON)
+                .body(toJson(payload))
+                .post(ACCOUNTS_API_URL)
+                .then()
+                .statusCode(201)
+                .contentType(JSON);
+    }
+
+    void updateGatewayAccount(String gatewayAccountId, String path, Object value) {
+        given()
+                .port(connectorApp.getLocalPort())
+                .contentType(JSON)
+                .body(Map.of("path", path,
+                        "op", "replace",
+                        "value", value))
+                .patch(ACCOUNTS_API_URL + gatewayAccountId)
+                .then()
+                .statusCode(200);
+    }
+
+    public static void assertGettingAccountReturnsProviderName(int port, ValidatableResponse response, String providerName, GatewayAccountType providerUrlType) {
+        given().port(port)
+                .contentType(JSON)
+                .get(response.extract().header("Location").replace("https", "http")) //Scheme on links back are forced to be https
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("payment_provider", is(providerName))
+                .body("gateway_account_id", is(notNullValue()))
+                .body("type", is(providerUrlType.toString()));
+    }
+
+    public static void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountType type, String description, String analyticsId, String name) {
+        String accountId = response.extract().path("gateway_account_id");
+        String urlSlug = "api/accounts/" + accountId;
+
+        response.header("Location", containsString(urlSlug))
+                .body("gateway_account_id", containsString(accountId))
+                .body("external_id", is(notNullValue()))
+                .body("type", is(type.toString()))
+                .body("description", is(description))
+                .body("service_name", is(name))
+                .body("analytics_id", is(analyticsId))
+                .body("corporate_credit_card_surcharge_amount", is(nullValue()))
+                .body("corporate_debit_card_surcharge_amount", is(nullValue()))
+                .body("links[0].href", containsString(urlSlug))
+                .body("links[0].rel", is("self"))
+                .body("links[0].method", is("GET"));
+    }
+
+    public static class GatewayAccountPayload {
+        String userName;
+        String password;
+        String merchantId;
+        String serviceName;
+
+        static GatewayAccountPayload createDefault() {
+            return new GatewayAccountPayload()
+                    .withUsername("a-username")
+                    .withPassword("a-password")
+                    .withMerchantId("a-merchant-id")
+                    .withServiceName("a-service-name");
+        }
+
+        public GatewayAccountPayload withServiceName(String serviceName) {
+            this.serviceName = serviceName;
+            return this;
+        }
+
+        public GatewayAccountPayload withUsername(String userName) {
+            this.userName = userName;
+            return this;
+        }
+
+        public GatewayAccountPayload withPassword(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public GatewayAccountPayload withMerchantId(String merchantId) {
+            this.merchantId = merchantId;
+            return this;
+        }
+
+        public Map<String, Object> getCredentials() {
+            HashMap<String, Object> credentials = new HashMap<>();
+
+            if (this.userName != null) {
+                credentials.put("username", userName);
+            }
+
+            if (this.password != null) {
+                credentials.put("password", password);
+            }
+
+            if (this.merchantId != null) {
+                credentials.put("merchant_id", merchantId);
+            }
+
+            return credentials;
+        }
+
+        Map buildServiceNamePayload() {
+            return ImmutableMap.of("service_name", serviceName);
+        }
+
+        String getServiceName() {
+            return serviceName;
+        }
+
+        String getPassword() {
+            return password;
+        }
+
+        String getUserName() {
+            return userName;
+        }
+
+        String getMerchantId() {
+            return merchantId;
+        }
+
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqChargeApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqChargeApiResourceIT.java
@@ -1,18 +1,12 @@
 package uk.gov.pay.connector.it.resources.epdq;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class EpdqChargeApiResourceIT extends ChargingITestBase {
+public class EpdqChargeApiResourceIT extends NewChargingITestBase {
     public EpdqChargeApiResourceIT() {
         super("epdq");
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxNotificationResourceIT.java
@@ -1,18 +1,12 @@
 package uk.gov.pay.connector.it.resources.sandbox;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 
 import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class SandboxNotificationResourceIT extends ChargingITestBase {
+public class SandboxNotificationResourceIT extends NewChargingITestBase {
     private static final String SANDBOX_IP_ADDRESS = "1.1.1.1, 3.3.3.3";
     private static final String UNEXPECTED_IP_ADDRESS = "3.4.3.1, 1.1.1.1";
     private static final String NOTIFICATION_PATH = "/v1/api/notifications/sandbox";
@@ -23,7 +17,7 @@ public class SandboxNotificationResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn200ForSandboxNotificationsFromValidIPAddress() {
-        given().port(testContext.getPort())
+        given().port(connectorApp.getLocalPort())
                 .header("X-Forwarded-For", SANDBOX_IP_ADDRESS)
                 .body("sandbox-notification")
                 .contentType(APPLICATION_JSON)
@@ -34,7 +28,7 @@ public class SandboxNotificationResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn200ForSandboxNotificationsWithValidAuthToken() {
-        given().port(testContext.getPort())
+        given().port(connectorApp.getLocalPort())
                 .header("X-Forwarded-For", UNEXPECTED_IP_ADDRESS)
                 .header("Authorization", "let-me-in")
                 .body("sandbox-notification")
@@ -46,7 +40,7 @@ public class SandboxNotificationResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldReturnForbiddenIfRequestComesFromUnexpectedIpAddress() {
-        given().port(testContext.getPort())
+        given().port(connectorApp.getLocalPort())
                 .header("X-Forwarded-For", UNEXPECTED_IP_ADDRESS)
                 .body("sandbox-notification")
                 .contentType(APPLICATION_JSON)

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
@@ -5,15 +5,11 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.ChargeResponse;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
@@ -30,7 +26,6 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static org.eclipse.jetty.http.HttpStatus.FORBIDDEN_403;
-import static org.eclipse.jetty.http.HttpStatus.UNPROCESSABLE_ENTITY_422;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -47,9 +42,7 @@ import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidL
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class SandboxRefundsResourceIT extends ChargingITestBase {
+public class SandboxRefundsResourceIT extends NewChargingITestBase {
 
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private DatabaseFixtures.TestCharge defaultTestCharge;
@@ -60,7 +53,6 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
 
     @Before
     public void setUp() {
-        super.setUp();
         defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
@@ -450,7 +442,7 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
                 .body("created_date", isWithin(10, SECONDS));
 
         String paymentUrl = format("https://localhost:%s/v1/api/accounts/%s/charges/%s",
-                testContext.getPort(), defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId());
+                connectorApp.getLocalPort(), defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId());
 
         String refundId = response.extract().path("refund_id");
         response.body("_links.self.href", is(paymentUrl + "/refunds/" + refundId))

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
@@ -6,12 +6,8 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.rules.StripeMockClient;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
@@ -33,9 +29,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class StripeRefundsResourceIT extends ChargingITestBase {
+public class StripeRefundsResourceIT extends NewChargingITestBase {
     private String stripeAccountId = "stripe_account_id";
     private String accountId = String.valueOf(nextLong());
 
@@ -49,7 +43,6 @@ public class StripeRefundsResourceIT extends ChargingITestBase {
 
     @Before
     public void setUp() {
-        super.setUp();
         stripeMockClient = new StripeMockClient(wireMockServer);
         defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
@@ -91,7 +84,7 @@ public class StripeRefundsResourceIT extends ChargingITestBase {
 
         ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", testChargeCreatedWithStripeChargeAPI.getAmount());
         String refundPayload = new Gson().toJson(refundData);
-        ValidatableResponse response = given().port(testContext.getPort())
+        ValidatableResponse response = given().port(connectorApp.getLocalPort())
                 .body(refundPayload)
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
@@ -130,7 +123,7 @@ public class StripeRefundsResourceIT extends ChargingITestBase {
 
         ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
         String refundPayload = new Gson().toJson(refundData);
-        ValidatableResponse response = given().port(testContext.getPort())
+        ValidatableResponse response = given().port(connectorApp.getLocalPort())
                 .body(refundPayload)
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
@@ -165,7 +158,7 @@ public class StripeRefundsResourceIT extends ChargingITestBase {
 
         ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
         String refundPayload = new Gson().toJson(refundData);
-        given().port(testContext.getPort())
+        given().port(connectorApp.getLocalPort())
                 .body(refundPayload)
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
@@ -191,7 +184,7 @@ public class StripeRefundsResourceIT extends ChargingITestBase {
         ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
         String refundPayload = new Gson().toJson(refundData);
 
-        given().port(testContext.getPort())
+        given().port(connectorApp.getLocalPort())
                 .body(refundPayload)
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
@@ -9,13 +9,9 @@ import com.amazonaws.util.json.Jackson;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.pay.connector.paymentprocessor.resource.CardResource;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
@@ -34,9 +30,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class WorldpayAuthoriseGooglePayIT extends ChargingITestBase {
+public class WorldpayAuthoriseGooglePayIT extends NewChargingITestBase {
 
     private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
@@ -45,10 +39,8 @@ public class WorldpayAuthoriseGooglePayIT extends ChargingITestBase {
         super("worldpay");
     }
 
-    @Override
     @Before
     public void setUp() {
-        super.setUp();
         Logger root = (Logger) LoggerFactory.getLogger(CardResource.class);
         root.setLevel(Level.INFO);
         root.addAppender(mockAppender);

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayChargeCancelResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayChargeCancelResourceIT.java
@@ -2,12 +2,8 @@ package uk.gov.pay.connector.it.resources.worldpay;
 
 import io.restassured.http.ContentType;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -17,9 +13,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static uk.gov.pay.connector.rules.WorldpayMockClient.WORLDPAY_URL;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CANCEL_WORLDPAY_REQUEST;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class WorldpayChargeCancelResourceIT extends ChargingITestBase {
+public class WorldpayChargeCancelResourceIT extends NewChargingITestBase {
 
     public WorldpayChargeCancelResourceIT() {
         super("worldpay");

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
@@ -7,12 +7,8 @@ import io.restassured.response.ValidatableResponse;
 import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.base.NewChargingITestBase;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.junit.DropwizardConfig;
-import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
@@ -60,9 +56,7 @@ import static uk.gov.pay.connector.rules.WorldpayMockClient.WORLDPAY_URL;
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST;
 
-@RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class WorldpayRefundsResourceIT extends ChargingITestBase {
+public class WorldpayRefundsResourceIT extends NewChargingITestBase {
 
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private DatabaseFixtures.TestCharge defaultTestCharge;
@@ -73,7 +67,6 @@ public class WorldpayRefundsResourceIT extends ChargingITestBase {
 
     @Before
     public void setUp() {
-        super.setUp();
         defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
@@ -394,7 +387,7 @@ public class WorldpayRefundsResourceIT extends ChargingITestBase {
                 .insert();
 
         String paymentUrl = format("https://localhost:%s/v1/api/accounts/%s/charges/%s",
-                testContext.getPort(), defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId());
+                connectorApp.getLocalPort(), defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId());
 
         getRefundsFor(defaultTestAccount.getAccountId(),
                 defaultTestCharge.getExternalChargeId())
@@ -518,7 +511,7 @@ public class WorldpayRefundsResourceIT extends ChargingITestBase {
                 .body("created_date", is(notNullValue()));
 
         String paymentUrl = format("https://localhost:%s/v1/api/accounts/%s/charges/%s",
-                testContext.getPort(), defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId());
+                connectorApp.getLocalPort(), defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId());
 
         String refundId = response.extract().path("refund_id");
         response.body("_links.self.href", is(paymentUrl + "/refunds/" + refundId))
@@ -526,5 +519,4 @@ public class WorldpayRefundsResourceIT extends ChargingITestBase {
 
         return refundId;
     }
-
 }

--- a/src/test/java/uk/gov/pay/connector/rules/AppWithPostgresAndSqsRule.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AppWithPostgresAndSqsRule.java
@@ -1,0 +1,175 @@
+package uk.gov.pay.connector.rules;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.google.inject.persist.jpa.JpaPersistModule;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import liquibase.Liquibase;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LiquibaseException;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.apache.commons.lang3.ArrayUtils;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+import uk.gov.service.payments.commons.testing.db.PostgresDockerRule;
+import uk.gov.service.payments.commons.testing.db.PostgresTestHelper;
+import uk.gov.service.payments.commons.testing.port.PortFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.google.common.collect.Lists.newArrayList;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+
+public class AppWithPostgresAndSqsRule implements TestRule {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppWithPostgresAndSqsRule.class);
+    private static final String JPA_UNIT = "ConnectorUnit";
+
+    private final String configFilePath;
+    private final PostgresDockerRule postgres;
+    private final AmazonSQS sqsClient;
+    private final DropwizardAppRule<ConnectorConfiguration> app;
+    private final RuleChain rules;
+    private DatabaseTestHelper databaseTestHelper;
+    private final WireMockServer wireMockServer;
+    private final int wireMockPort = PortFactory.findFreePort();
+
+    public AppWithPostgresAndSqsRule(ConfigOverride... configOverrides) {
+        this("config/test-it-config.yaml", configOverrides);
+    }
+
+    public AppWithPostgresAndSqsRule(String configPath, ConfigOverride... configOverrides) {
+        configFilePath = resourceFilePath(configPath);
+        postgres = new PostgresDockerRule("15.2");
+
+        sqsClient = SqsTestDocker.initialise(List.of("capture-queue", "event-queue", "tasks-queue"));
+
+        ConfigOverride[] newConfigOverrides = List.of(
+                        config("database.url", postgres.getConnectionUrl()),
+                        config("database.user", postgres.getUsername()),
+                        config("database.password", postgres.getPassword()))
+                .toArray(new ConfigOverride[0]);
+        newConfigOverrides = overrideSqsConfig(newConfigOverrides);
+        newConfigOverrides = overrideUrlsConfig(newConfigOverrides);
+
+        createJpaModule(postgres);
+
+        app = new DropwizardAppRule<>(
+                ConnectorApp.class,
+                configFilePath,
+                ArrayUtils.addAll(newConfigOverrides, configOverrides)
+        );
+        wireMockServer = new WireMockServer(wireMockConfig().port(wireMockPort));
+        wireMockServer.start();
+        rules = RuleChain.outerRule(postgres).around(app);
+        registerShutdownHook();
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return rules.apply(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                LOGGER.info("Clearing database.");
+                app.getApplication().run("db", "drop-all", "--confirm-delete-everything", configFilePath);
+                doSecondaryDatabaseMigration();
+                restoreDropwizardsLogging();
+
+                DataSourceFactory dataSourceFactory = app.getConfiguration().getDataSourceFactory();
+                databaseTestHelper = new DatabaseTestHelper(Jdbi.create(dataSourceFactory.getUrl(), dataSourceFactory.getUser(), dataSourceFactory.getPassword()));
+
+                base.evaluate();
+            }
+        }, description);
+    }
+
+    private void doSecondaryDatabaseMigration() throws SQLException, LiquibaseException {
+        try (Connection connection = DriverManager.getConnection(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword())) {
+            Liquibase migrator = new Liquibase("it-migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
+            migrator.update("");
+        }
+    }
+
+    public int getLocalPort() {
+        return app.getLocalPort();
+    }
+
+    public DatabaseTestHelper getDatabaseTestHelper() {
+        return databaseTestHelper;
+    }
+
+    public AmazonSQS getSqsClient() {
+        return sqsClient;
+    }
+
+    public int getWireMockPort() {
+        return wireMockPort;
+    }
+
+    public WireMockServer getWireMockServer() {
+        return wireMockServer;
+    }
+
+    private void registerShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(new Thread(PostgresTestHelper::stop));
+    }
+
+    private JpaPersistModule createJpaModule(final PostgresDockerRule postgres) {
+        final Properties properties = new Properties();
+        properties.put("javax.persistence.jdbc.driver", postgres.getDriverClass());
+        properties.put("javax.persistence.jdbc.url", postgres.getConnectionUrl());
+        properties.put("javax.persistence.jdbc.user", postgres.getUsername());
+        properties.put("javax.persistence.jdbc.password", postgres.getPassword());
+
+        final JpaPersistModule jpaModule = new JpaPersistModule(JPA_UNIT);
+        jpaModule.properties(properties);
+
+        return jpaModule;
+    }
+
+    private void restoreDropwizardsLogging() {
+        app.getConfiguration().getLoggingFactory().configure(app.getEnvironment().metrics(),
+                app.getApplication().getName());
+    }
+
+    private ConfigOverride[] overrideDBConfig(ConfigOverride[] configOverrides) {
+        List<ConfigOverride> newConfigOverride = newArrayList(configOverrides);
+        newConfigOverride.add(config("database.url", postgres.getConnectionUrl()));
+        newConfigOverride.add(config("database.user", postgres.getUsername()));
+        newConfigOverride.add(config("database.password", postgres.getPassword()));
+        return newConfigOverride.toArray(new ConfigOverride[0]);
+    }
+
+    private ConfigOverride[] overrideSqsConfig(ConfigOverride[] configOverrides) {
+        List<ConfigOverride> newConfigOverride = newArrayList(configOverrides);
+        newConfigOverride.add(config("sqsConfig.captureQueueUrl", sqsClient.getQueueUrl("capture-queue").getQueueUrl()));
+        newConfigOverride.add(config("sqsConfig.eventQueueUrl", sqsClient.getQueueUrl("event-queue").getQueueUrl()));
+        newConfigOverride.add(config("sqsConfig.taskQueueUrl", sqsClient.getQueueUrl("tasks-queue").getQueueUrl()));
+        return newConfigOverride.toArray(new ConfigOverride[0]);
+    }
+
+    private ConfigOverride[] overrideUrlsConfig(ConfigOverride[] configOverrides) {
+        List<ConfigOverride> newConfigOverride = newArrayList(configOverrides);
+        newConfigOverride.add(config("worldpay.urls.test", "http://localhost:" + wireMockPort + "/jsp/merchant/xml/paymentService.jsp"));
+        newConfigOverride.add(config("worldpay.threeDsFlexDdcUrls.test", "http://localhost:" + wireMockPort + "/shopper/3ds/ddc.html"));
+        newConfigOverride.add(config("stripe.url", "http://localhost:" + wireMockPort));
+        newConfigOverride.add(config("ledgerBaseURL", "http://localhost:" + wireMockPort));
+        newConfigOverride.add(config("cardidBaseURL", "http://localhost:" + wireMockPort));
+        return newConfigOverride.toArray(new ConfigOverride[0]);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/rules/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/connector/rules/SqsTestDocker.java
@@ -1,0 +1,70 @@
+package uk.gov.pay.connector.rules;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.util.List;
+
+public class SqsTestDocker {
+    private static final Logger logger = LoggerFactory.getLogger(SqsTestDocker.class);
+
+    private static GenericContainer sqsContainer;
+
+    public static AmazonSQS initialise(List<String> queueNames) {
+        try {
+            createContainer();
+            return createQueues(queueNames);
+        } catch (Exception e) {
+            logger.error("Exception initialising SQS Container - {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void createContainer() {
+        if (sqsContainer == null) {
+            logger.info("Creating SQS Container");
+
+            sqsContainer = new GenericContainer("softwaremill/elasticmq-native:1.4.2")
+                    .withExposedPorts(9324)
+                    .waitingFor(Wait.forLogMessage(".*ElasticMQ server.*.*started.*", 1));
+            sqsContainer.start();
+        }
+    }
+
+    private static AmazonSQS createQueues(List<String> queueNames) {
+        AmazonSQS amazonSQS = getSqsClient();
+        queueNames.forEach(amazonSQS::createQueue);
+
+        return amazonSQS;
+    }
+
+    public static String getQueueUrl(String queueName) {
+        return getEndpoint() + "/queue/" + queueName;
+    }
+
+    public static String getEndpoint() {
+        return "http://localhost:" + sqsContainer.getMappedPort(9324);
+    }
+
+    private static AmazonSQS getSqsClient() {
+        // random credentials required by AWS SDK to build SQS client
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials("x", "x");
+
+        return AmazonSQSClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .withEndpointConfiguration(
+                        new AwsClientBuilder.EndpointConfiguration(
+                                getEndpoint(),
+                                "region-1"
+                        ))
+                .withRequestHandlers()
+                .build();
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID

The first iteration of removing our reliance on the `junitparams` framework, and paving the road to use `Junit5`.

This iteration addresses the simple cases and replaces the `@RunWith` annotation based execution of integration tests with inherited `@ClassRule` one.

Introduced `NewChargingITestBase` and `NewGatewayAccountResourceTestBase` classes. These shall be renamed without the New prefix once we refactored all of the integration tests.

This branch runs 6 more tests, the difference is due to changing some parameterised tests