### PR TITLE
PP-12229 Resolve format string vulnerability

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountNotFoundException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountNotFoundException.java
@@ -11,6 +11,6 @@ public class GatewayAccountNotFoundException extends WebApplicationException {
     }
     
     public GatewayAccountNotFoundException(String message) {
-        super(notFoundResponse(format(message)));
+        super(notFoundResponse(message));
     }
 }


### PR DESCRIPTION
Context: CodeQL [alerted us to a vulnerability](https://github.com/alphagov/pay-connector/security/code-scanning/2) relating to use of an externally-controlled format string, but in the offending line the use of String.format is unnecessary.

- Remove the use of String.format in the offending line to resolve the alert.