### PR TITLE
Correct CodeQL config to run on master not main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: CodeQL
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
     paths:
       - 'src/**'
   schedule:


### PR DESCRIPTION
Correct CodeQL config to run on PRs to 'master' branch not 'main'.