### PR TITLE
PP-12349 Handle multiple balance_transactions for dispute

### DIFF
--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -717,20 +717,19 @@ class StripePaymentProviderTest {
     @Nested
     class TransferDisputeAmount {
         @Test
-        void shouldThrowExceptionWhenMoreThanOneBalanceTransactionPresentForDispute() throws Exception {
-            BalanceTransaction balanceTransaction = new BalanceTransaction(6500L, 1500L, -8000L);
-            BalanceTransaction balanceTransaction2 = new BalanceTransaction(6500L, 1500L, 8000L);
+        void shouldThrowExceptionWhenBalanceTransactionTotalIsPositive() throws Exception {
+            BalanceTransaction balanceTransaction = new BalanceTransaction(6500L, 1500L, 8000L);
             EvidenceDetails evidenceDetails = new EvidenceDetails(1642679160L);
             StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
-                    "pi_123456789", "needs_response", 6500L, "fradulent", 1642579160L, List.of(balanceTransaction,
-                    balanceTransaction2), evidenceDetails, null, true);
+                    "pi_123456789", "needs_response", 6500L, "fraudulent", 
+                    1642579160L, List.of(balanceTransaction), evidenceDetails, null, true);
 
             var gatewayAccountEntity = buildTestGatewayAccountEntity();
             ChargeEntity chargeEntity = buildTestCharge(gatewayAccountEntity);
             Charge charge = Charge.from(chargeEntity);
 
             RuntimeException exception = assertThrows(RuntimeException.class, () -> provider.transferDisputeAmount(stripeDisputeData, charge, gatewayAccountEntity, chargeEntity.getGatewayAccountCredentialsEntity()));
-            assertThat(exception.getMessage(), is("Expected lost dispute to have a single balance_transaction, but has 2"));
+            assertThat(exception.getMessage(), is("Expected total of balance_transactions for a lost dispute to be negative, but was positive"));
         }
 
         @Test
@@ -739,23 +738,10 @@ class StripePaymentProviderTest {
             EvidenceDetails evidenceDetails = new EvidenceDetails(1642679160L);
             String stripeDisputeId = "du_1LIaq8Dv3CZEaFO2MNQJK333";
             String paymentIntentId = "pi_123456789";
-            StripeDisputeData stripeDisputeData = new StripeDisputeData(stripeDisputeId,
-                    paymentIntentId, "needs_response", 6500L, "fradulent",
-                    1642579160L, List.of(balanceTransaction), evidenceDetails, null, false);
+            String stripePlatformAccountId = "platform-account-id";
             String disputeExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeId);
 
-            var gatewayAccountEntity = buildTestGatewayAccountEntity();
-            ChargeEntity chargeEntity = buildTestCharge(gatewayAccountEntity);
-            Charge charge = Charge.from(chargeEntity);
-
-            String stripePlatformAccountId = "platform-account-id";
-            when(gatewayConfig.getPlatformAccountId()).thenReturn(stripePlatformAccountId);
-
-            GatewayClient.Response response = mock(GatewayClient.Response.class);
-            when(response.getEntity()).thenReturn(load(STRIPE_TRANSFER_RESPONSE));
-            when(gatewayClient.postRequestFor(any(StripeTransferInRequest.class))).thenReturn(response);
-
-            provider.transferDisputeAmount(stripeDisputeData, charge, gatewayAccountEntity, chargeEntity.getGatewayAccountCredentialsEntity());
+            Charge charge = transferDisputeAmount(stripeDisputeId, paymentIntentId, evidenceDetails, stripePlatformAccountId, List.of(balanceTransaction));
 
             verify(gatewayClient).postRequestFor(stripeTransferInRequestCaptor.capture());
 
@@ -769,6 +755,54 @@ class StripePaymentProviderTest {
             assertThat(payload, containsString("currency=GBP"));
             assertThat(payload, containsString("metadata%5Bstripe_charge_id%5D=" + paymentIntentId));
             assertThat(payload, containsString("metadata%5Bgovuk_pay_transaction_external_id%5D=" + disputeExternalId));
+        }
+
+        @Test
+        void shouldMakeTransferRequestForLostDispute_whenMultipleBalanceTransactions() throws Exception {
+            BalanceTransaction balanceTransaction1 = new BalanceTransaction(-6500L, 1500L, -8000L);
+            BalanceTransaction balanceTransaction2 = new BalanceTransaction(-100L, 0L, -100L);
+            BalanceTransaction balanceTransaction3 = new BalanceTransaction(10L, 0L, 10L);
+            List<BalanceTransaction> balanceTransactionList = List.of(balanceTransaction1, balanceTransaction2, balanceTransaction3);
+
+            EvidenceDetails evidenceDetails = new EvidenceDetails(1642679160L);
+            String stripeDisputeId = "du_1LIaq8Dv3CZEaFO2MNQJK333";
+            String paymentIntentId = "pi_123456789";
+            String stripePlatformAccountId = "platform-account-id";
+            String disputeExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeId);
+
+            Charge charge = transferDisputeAmount(stripeDisputeId, paymentIntentId, evidenceDetails, stripePlatformAccountId, balanceTransactionList);
+
+            verify(gatewayClient).postRequestFor(stripeTransferInRequestCaptor.capture());
+
+            String payload = stripeTransferInRequestCaptor.getValue().getGatewayOrder().getPayload();
+
+            assertThat(payload, containsString("destination=" + stripePlatformAccountId));
+            assertThat(payload, containsString("amount=8090"));
+            assertThat(payload, containsString("transfer_group=" + charge.getExternalId()));
+            assertThat(payload, containsString("expand%5B%5D=balance_transaction"));
+            assertThat(payload, containsString("expand%5B%5D=destination_payment"));
+            assertThat(payload, containsString("currency=GBP"));
+            assertThat(payload, containsString("metadata%5Bstripe_charge_id%5D=" + paymentIntentId));
+            assertThat(payload, containsString("metadata%5Bgovuk_pay_transaction_external_id%5D=" + disputeExternalId));
+        }
+        
+        private Charge transferDisputeAmount(String stripeDisputeId, String paymentIntentId, EvidenceDetails evidenceDetails, String stripePlatformAccountId, List<BalanceTransaction> balanceTransactionList) throws GatewayException {
+            StripeDisputeData stripeDisputeData = new StripeDisputeData(stripeDisputeId,
+                    paymentIntentId, "needs_response", 6500L, "fraudulent",
+                    1642579160L, balanceTransactionList, evidenceDetails, null, false);
+
+            var gatewayAccountEntity = buildTestGatewayAccountEntity();
+            ChargeEntity chargeEntity = buildTestCharge(gatewayAccountEntity);
+            Charge charge = Charge.from(chargeEntity);
+
+            when(gatewayConfig.getPlatformAccountId()).thenReturn(stripePlatformAccountId);
+
+            GatewayClient.Response response = mock(GatewayClient.Response.class);
+            when(response.getEntity()).thenReturn(load(STRIPE_TRANSFER_RESPONSE));
+            when(gatewayClient.postRequestFor(any(StripeTransferInRequest.class))).thenReturn(response);
+
+            provider.transferDisputeAmount(stripeDisputeData, charge, gatewayAccountEntity, chargeEntity.getGatewayAccountCredentialsEntity());
+            return charge;
         }
     }
 


### PR DESCRIPTION
It is possible for a Stripe dispute to have multiple balance_transactions. This can happen for payments made using an international card, where there might be an an adjustment balance_transaction to account for currency conversion. Handle this by summing the `net` value for all balance_transations on the dispute lost event.

Throw an exception if the sum of the `net` amounts of the balance_transactions is positive, as we expect a negative amount, which represents a deduction from the connect account.