### PR TITLE
PP-12211 Correct CodeQL config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "master" ]
     paths:
       - 'src/**'
+  push:
+    branches: [ "master" ]
   schedule:
     # Weekly schedule
     - cron: '43 7 * * 1'
@@ -30,6 +32,9 @@ jobs:
         with:
           # CodeQL options: [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
           languages: 'java-kotlin'
+          config: |
+            paths:
+              - 'src/**'
 
       - name: Set up JDK 11
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93


### PR DESCRIPTION
Changes the CodeQL config file to:

- enable scans on push to master branch (this was overlooked previously)
- only scan files in the /src/** folder. Note that this is separate to the trigger for the workflow ("only run the workflow if a file in /src/** is changed" versus "when the workflow is run, scan stuff in /src/**")