### PR TITLE
PP-12349 Calculate amounts for DISPUTE_LOST event

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -385,7 +385,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeLostTest.java",
         "hashed_secret": "0f95fda055818f350f3daf93e80654be7ea2ec8f",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 34
       }
     ],
     "src/test/java/uk/gov/pay/connector/events/model/dispute/DisputeWonTest.java": [
@@ -1020,6 +1020,15 @@
         "line_number": 3
       }
     ],
+    "src/test/resources/templates/stripe/charge_dispute_lost_with_multiple_balance_transactions.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/templates/stripe/charge_dispute_lost_with_multiple_balance_transactions.json",
+        "hashed_secret": "14affa13a78b01acd95006c95c6e2a647609077c",
+        "is_verified": false,
+        "line_number": 59
+      }
+    ],
     "src/test/resources/templates/stripe/create_payment_intent_requires_3ds_response.json": [
       {
         "type": "Secret Keyword",
@@ -1080,5 +1089,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-05T16:32:21Z"
+  "generated_at": "2024-03-07T16:43:25Z"
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeLost.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/dispute/DisputeLost.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.events.model.dispute;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.dispute.DisputeLostEventDetails;
 import uk.gov.pay.connector.gateway.stripe.json.StripeDisputeData;
-import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 
 import java.time.Instant;
 
@@ -14,18 +13,14 @@ public class DisputeLost extends DisputeEvent {
     }
 
     public static DisputeLost from(String disputeExternalId, StripeDisputeData stripeDisputeData, Instant eventDate,
-                                   LedgerTransaction transaction, boolean rechargedToService) {
-        if (stripeDisputeData.getBalanceTransactionList().size() > 1) {
-            throw new RuntimeException("Dispute data has too many balance_transactions");
-        }
-        BalanceTransaction balanceTransaction = stripeDisputeData.getBalanceTransactionList().get(0);
+                                   LedgerTransaction transaction, boolean rechargedToService, long netAmount, long fee) {
         DisputeLostEventDetails eventDetails;
         if (rechargedToService) {
             eventDetails = new DisputeLostEventDetails(
                     transaction.getGatewayAccountId(),
                     stripeDisputeData.getAmount(),
-                    balanceTransaction.getNetAmount(),
-                    Math.abs(balanceTransaction.getFee()));
+                    netAmount,
+                    fee);
         } else {
             eventDetails = new DisputeLostEventDetails(
                     transaction.getGatewayAccountId(),

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/util/StripeDisputeCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/util/StripeDisputeCalculator.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.connector.queue.tasks.util;
+
+import uk.gov.pay.connector.gateway.stripe.json.StripeDisputeData;
+import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
+
+public class StripeDisputeCalculator {
+    private StripeDisputeCalculator() {
+    }
+
+    public static long getNetAmountForLostDispute(StripeDisputeData stripeDisputeData) {
+        long totalNet = stripeDisputeData.getBalanceTransactionList().stream().mapToLong(BalanceTransaction::getNetAmount).sum();
+        if (totalNet > 0) {
+            throw new RuntimeException("Expected total net amount for a lost dispute to be negative, but was positive");
+        }
+        return totalNet;
+    }
+
+    public static long getFeeForLostDispute(StripeDisputeData stripeDisputeData) {
+        long totalFee = stripeDisputeData.getBalanceTransactionList().stream().mapToLong(BalanceTransaction::getFee).sum();
+        if (totalFee < 0) {
+            throw new RuntimeException("Expected total fee for a lost dispute to be positive, but was negative");
+        }
+        return totalFee;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/util/StripeDisputeCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/util/StripeDisputeCalculatorTest.java
@@ -1,0 +1,83 @@
+package uk.gov.pay.connector.queue.tasks.util;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.gateway.stripe.json.StripeDisputeData;
+import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
+import uk.gov.pay.connector.queue.tasks.dispute.EvidenceDetails;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+class StripeDisputeCalculatorTest {
+
+    @Test
+    void shouldReturnNetAmountForSingleBalanceTransaction() {
+        BalanceTransaction balanceTransaction = new BalanceTransaction(-6500L, 1500L, -8000L);
+        var balanceTransactionList = List.of(balanceTransaction);
+        StripeDisputeData stripeDisputeData = getStripeDisputeData(balanceTransactionList);
+
+        assertThat(StripeDisputeCalculator.getNetAmountForLostDispute(stripeDisputeData), is(-8000L));
+    }
+    
+    @Test
+    void shouldReturnNetAmountForMultipleBalanceTransactions() {
+        BalanceTransaction balanceTransaction1 = new BalanceTransaction(-6500L, 1500L, -8000L);
+        BalanceTransaction balanceTransaction2 = new BalanceTransaction(-100L, 0L, -100L);
+        BalanceTransaction balanceTransaction3 = new BalanceTransaction(10L, 0L, 10L);
+        var balanceTransactionList = List.of(balanceTransaction1, balanceTransaction2, balanceTransaction3);
+        StripeDisputeData stripeDisputeData = getStripeDisputeData(balanceTransactionList);
+
+        assertThat(StripeDisputeCalculator.getNetAmountForLostDispute(stripeDisputeData), is(-8090L));
+    }
+
+    @Test
+    void shouldThrowWhenNetAmountIsPositive() {
+        BalanceTransaction balanceTransaction = new BalanceTransaction(6500L, 0L, 6500L);
+        var balanceTransactionList = List.of(balanceTransaction);
+        StripeDisputeData stripeDisputeData = getStripeDisputeData(balanceTransactionList);
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> StripeDisputeCalculator.getNetAmountForLostDispute(stripeDisputeData));
+        assertThat(exception.getMessage(), is("Expected total net amount for a lost dispute to be negative, but was positive"));
+    }
+
+    @Test
+    void shouldReturnFeeForSingleBalanceTransaction() {
+        BalanceTransaction balanceTransaction = new BalanceTransaction(-6500L, 1500L, -8000L);
+        var balanceTransactionList = List.of(balanceTransaction);
+        StripeDisputeData stripeDisputeData = getStripeDisputeData(balanceTransactionList);
+
+        assertThat(StripeDisputeCalculator.getFeeForLostDispute(stripeDisputeData), is(1500L));
+    }
+
+    @Test
+    void shouldReturnFeeForMultipleBalanceTransactions() {
+        BalanceTransaction balanceTransaction1 = new BalanceTransaction(-6500L, 1500L, -8000L);
+        BalanceTransaction balanceTransaction2 = new BalanceTransaction(-100L, 1L, -100L);
+        var balanceTransactionList = List.of(balanceTransaction1, balanceTransaction2);
+        StripeDisputeData stripeDisputeData = getStripeDisputeData(balanceTransactionList);
+
+        assertThat(StripeDisputeCalculator.getFeeForLostDispute(stripeDisputeData), is(1501L));
+    }
+
+    @Test
+    void shouldThrowWhenFeeIsNegative() {
+        BalanceTransaction balanceTransaction = new BalanceTransaction(-6500L, -10L, -6500L);
+        var balanceTransactionList = List.of(balanceTransaction);
+        StripeDisputeData stripeDisputeData = getStripeDisputeData(balanceTransactionList);
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> StripeDisputeCalculator.getFeeForLostDispute(stripeDisputeData));
+        assertThat(exception.getMessage(), is("Expected total fee for a lost dispute to be positive, but was negative"));
+    }
+    
+    private static StripeDisputeData getStripeDisputeData(List<BalanceTransaction> balanceTransactionList) {
+        StripeDisputeData stripeDisputeData = new StripeDisputeData("du_1LIaq8Dv3CZEaFO2MNQJK333",
+                "pi_123456789", "needs_response", 6500L, "fraudulent",
+                1642579160L, balanceTransactionList, new EvidenceDetails(1642679160L),
+                null, false);
+        return stripeDisputeData;
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -159,6 +159,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_NOTIFICATION_ACCOUNT_UPDATED = TEMPLATE_BASE_NAME + "/stripe/account_updated.json";
     public static final String STRIPE_NOTIFICATION_CHARGE_REFUND_UPDATED = TEMPLATE_BASE_NAME + "/stripe/charge_refund_updated.json";
     public static final String STRIPE_NOTIFICATION_CHARGE_DISPUTE = TEMPLATE_BASE_NAME + "/stripe/charge_dispute.json";
+    public static final String STRIPE_NOTIFICATION_CHARGE_DISPUTE_LOST_WITH_MULTIPLE_BALANCE_TRANSACTIONS = TEMPLATE_BASE_NAME + "/stripe/charge_dispute_lost_with_multiple_balance_transactions.json";
     public static final String STRIPE_SUBMIT_DISPUTE_EVIDENCE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/dispute_submit_evidence_response.json";
     public static final String STRIPE_SEARCH_TRANSFERS_FOR_CAPTURED_PAYMENT_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/search_transfers_for_captured_payment_response.json";
     public static final String STRIPE_SEARCH_TRANSFERS_EMPTY_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/search_transfers_empty_response.json";

--- a/src/test/resources/templates/stripe/charge_dispute_lost_with_multiple_balance_transactions.json
+++ b/src/test/resources/templates/stripe/charge_dispute_lost_with_multiple_balance_transactions.json
@@ -1,0 +1,111 @@
+{
+  "created": 1326853478,
+  "livemode": true,
+  "id": "evt_00000000000000",
+  "type": "{{type}}",
+  "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2019-05-16",
+  "data": {
+    "object": {
+      "id": "du_1111111111",
+      "object": "dispute",
+      "livemode": true,
+      "payment_intent": "pi_1111111111",
+      "status": "{{status}}",
+      "amount": 6500,
+      "balance_transaction": "txn_1111111111",
+      "balance_transactions": [
+        {
+          "id": "txn_1111111111",
+          "object": "balance_transaction",
+          "amount": -6500,
+          "available_on": 1642579171,
+          "created": 1642579171,
+          "currency": "gbp",
+          "description": "Chargeback withdrawal for ch_1111111111",
+          "exchange_rate": null,
+          "fee": 1500,
+          "fee_details": [
+            {
+              "amount": 1500,
+              "application": null,
+              "currency": "gbp",
+              "description": "Dispute fee",
+              "type": "stripe_fee"
+            }
+          ],
+          "net": -8000,
+          "reporting_category": "dispute",
+          "source": "du_1111111111",
+          "status": "available",
+          "type": "adjustment"
+        },
+        {
+          "id": "txn_1OqqJyDv3CZEaFO2MCTVJwEH",
+          "object": "balance_transaction",
+          "amount": 50,
+          "available_on": 1709615626,
+          "created": 1709615626,
+          "currency": "gbp",
+          "description": "Adjustment of lost dispute for ch_3Odw2xDv3CZEaFO21RgRK9VJ",
+          "exchange_rate": null,
+          "fee": 1,
+          "fee_details": [
+          ],
+          "net": 50,
+          "reporting_category": "dispute_reversal",
+          "source": "du_1Oh2iyDv3CZEaFO2AzqXPVwh",
+          "status": "available",
+          "type": "adjustment"
+        }
+      ],
+      "charge": "ch_1111111111",
+      "created": 1642579160,
+      "currency": "gbp",
+      "evidence": {
+        "access_activity_log": null,
+        "billing_address": "THE WHITE CHAPEL BUILDING\n10 WHITECHAPEL HIGH STREET\nLONDON, E1 8QS, GB",
+        "cancellation_policy": null,
+        "cancellation_policy_disclosure": null,
+        "cancellation_rebuttal": null,
+        "customer_communication": null,
+        "customer_email_address": null,
+        "customer_name": "JOHN DOE",
+        "customer_purchase_ip": null,
+        "customer_signature": null,
+        "duplicate_charge_documentation": null,
+        "duplicate_charge_explanation": null,
+        "duplicate_charge_id": null,
+        "product_description": null,
+        "receipt": null,
+        "refund_policy": null,
+        "refund_policy_disclosure": null,
+        "refund_refusal_explanation": null,
+        "service_date": null,
+        "service_documentation": null,
+        "shipping_address": null,
+        "shipping_carrier": null,
+        "shipping_date": null,
+        "shipping_documentation": null,
+        "shipping_tracking_number": null,
+        "uncategorized_file": null,
+        "uncategorized_text": "losing_evidence"
+      },
+      "evidence_details": {
+        "due_by": 1644883199,
+        "has_evidence": false,
+        "past_due": false,
+        "submission_count": 0
+      },
+      "is_charge_refundable": false,
+      "metadata": {
+      },
+      "reason": "general"
+    }
+  }
+}
+
+
+


### PR DESCRIPTION
Handle the case where a dispute lost Stripe event has multiple balance_transactions associated with it for calculating the net amount and fee fields to send in the DISPUTE_LOST event.

Move calculating the total net amount and fee for a dispute lost  event to a new StripeDisputeCalculator, which is called from  StripeWebhookTaskHandler in order to calculate the total net amount once to be used for both transferring the money in Stripe and creating the DISPUTE_LOST event to send to ledger.