### PR TITLE
PP-12242 Fix search by worldpay merchant id

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
@@ -222,7 +222,7 @@ public class GatewayAccountSearchParams {
                     "    select gateway_account_id " +
                     "    from gateway_account_credentials gac " +
                     "    where gac.gateway_account_id = ga.id and gac.credentials->>'stripe_account_id' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD +
-                    "    or gac.credentials->'one_off_customer_initiated'->>'merchant_id' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD + ") a" +
+                    "    or gac.credentials->'one_off_customer_initiated'->>'merchant_code' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD + ") a" +
                     ")");
         }
         if (StringUtils.isNotEmpty(providerSwitchEnabled)) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
@@ -222,7 +222,7 @@ public class GatewayAccountSearchParams {
                     "    select gateway_account_id " +
                     "    from gateway_account_credentials gac " +
                     "    where gac.gateway_account_id = ga.id and gac.credentials->>'stripe_account_id' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD +
-                    "    or gac.credentials->>'merchant_id' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD + ") a" +
+                    "    or gac.credentials->'one_off_customer_initiated'->>'merchant_id' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD + ") a" +
                     ")");
         }
         if (StringUtils.isNotEmpty(providerSwitchEnabled)) {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
@@ -54,7 +54,7 @@ import static org.hamcrest.collection.IsMapWithSize.anEmptyMap;
                 " ga.id in (   select gateway_account_id   from " +
                         "(     select gateway_account_id     from gateway_account_credentials gac     " +
                         "where gac.gateway_account_id = ga.id and gac.credentials->>'stripe_account_id' = #paymentProviderAccountId" +
-                        "    or gac.credentials->'one_off_customer_initiated'->>'merchant_id' = #paymentProviderAccountId) a)")
+                        "    or gac.credentials->'one_off_customer_initiated'->>'merchant_code' = #paymentProviderAccountId) a)")
         );
     }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
@@ -54,7 +54,7 @@ import static org.hamcrest.collection.IsMapWithSize.anEmptyMap;
                 " ga.id in (   select gateway_account_id   from " +
                         "(     select gateway_account_id     from gateway_account_credentials gac     " +
                         "where gac.gateway_account_id = ga.id and gac.credentials->>'stripe_account_id' = #paymentProviderAccountId" +
-                        "    or gac.credentials->>'merchant_id' = #paymentProviderAccountId) a)")
+                        "    or gac.credentials->'one_off_customer_initiated'->>'merchant_id' = #paymentProviderAccountId) a)")
         );
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -562,7 +562,7 @@ public class GatewayAccountDaoIT extends DaoITestBase {
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(String.valueOf(gatewayAccountId_1))
                 .withPaymentGateway("worldpay")
-                .withCredentials(Map.of("one_off_customer_initiated", Map.of("merchant_id", "acc123")))
+                .withCredentials(Map.of("one_off_customer_initiated", Map.of("merchant_code", "acc123")))
                 .build());
 
         var params = new GatewayAccountSearchParams();

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -561,8 +561,8 @@ public class GatewayAccountDaoIT extends DaoITestBase {
         long gatewayAccountId_1 = nextLong();
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(String.valueOf(gatewayAccountId_1))
-                .withPaymentGateway("sandbox")
-                .withCredentials(Map.of("merchant_id", "acc123"))
+                .withPaymentGateway("worldpay")
+                .withCredentials(Map.of("one_off_customer_initiated", Map.of("merchant_id", "acc123")))
                 .build());
 
         var params = new GatewayAccountSearchParams();

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -404,7 +404,6 @@ public class GatewayAccountResourceIT extends NewGatewayAccountResourceTestBase 
         givenSetup()
                 .get("/v1/api/accounts?payment_provider_account_id=one-off-merchant-code")
                 .then()
-                .log().all()
                 .statusCode(200)
                 .body("accounts", hasSize(1))
                 .body("accounts[0].gateway_account_id", is(accountIdAsInt))


### PR DESCRIPTION
Context: Searching for a gateway account by Worldpay merchant id doesn't work in toolbox since `merchant_id` was moved inside a nested object in the `credentials` field of the `gateway_account_credentials` table.

- Update GatewayAccountSearchParams to check for the search term within the `one_off_customer_initiated` object in the `credentials` field.
- Add test for this scenario.

Subsequent PRs will check for `merchant_id` within the `recurring_customer_initiated` and `recurring_agent_initiated` objects as well.