### PR TITLE
PP-11221: Run CodeQL on all master branch PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,6 @@ name: CodeQL
 on:
   pull_request:
     branches: [ "master" ]
-    paths:
-      - 'src/**'
   push:
     branches: [ "master" ]
   schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,9 @@ name: CodeQL
 on:
   pull_request:
     branches: [ "master" ]
+    paths:
+      # Temporarily add back in
+      - 'src/**'
   push:
     branches: [ "master" ]
   schedule:

--- a/src/delete-me
+++ b/src/delete-me
@@ -1,0 +1,1 @@
+Adding a temporary file to see if something in the src/** folder triggers a CodeQL workflow.


### PR DESCRIPTION
## WHAT YOU DID
It's unclear why CodeQL isn't running on pull requests for Java apps (when the same config runs fine for Node apps).

This PR removes the path restrictions on the workflow trigger, so the CodeQL scan should run on this PR. Let's see if it works.