### PR TITLE
PP-12242 Search by merchant code in recurring payment credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
@@ -222,7 +222,9 @@ public class GatewayAccountSearchParams {
                     "    select gateway_account_id " +
                     "    from gateway_account_credentials gac " +
                     "    where gac.gateway_account_id = ga.id and gac.credentials->>'stripe_account_id' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD +
-                    "    or gac.credentials->'one_off_customer_initiated'->>'merchant_code' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD + ") a" +
+                    "    or gac.credentials->'one_off_customer_initiated'->>'merchant_code' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD +
+                    "    or gac.credentials->'recurring_customer_initiated'->>'merchant_code' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD +
+                    "    or gac.credentials->'recurring_merchant_initiated'->>'merchant_code' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD + ") a" +
                     ")");
         }
         if (StringUtils.isNotEmpty(providerSwitchEnabled)) {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
@@ -54,7 +54,9 @@ import static org.hamcrest.collection.IsMapWithSize.anEmptyMap;
                 " ga.id in (   select gateway_account_id   from " +
                         "(     select gateway_account_id     from gateway_account_credentials gac     " +
                         "where gac.gateway_account_id = ga.id and gac.credentials->>'stripe_account_id' = #paymentProviderAccountId" +
-                        "    or gac.credentials->'one_off_customer_initiated'->>'merchant_code' = #paymentProviderAccountId) a)")
+                        "    or gac.credentials->'one_off_customer_initiated'->>'merchant_code' = #paymentProviderAccountId" +
+                        "    or gac.credentials->'recurring_customer_initiated'->>'merchant_code' = #paymentProviderAccountId" +
+                        "    or gac.credentials->'recurring_merchant_initiated'->>'merchant_code' = #paymentProviderAccountId) a)")
         );
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -557,12 +557,29 @@ public class GatewayAccountDaoIT extends DaoITestBase {
     }    
     
     @Test
-    public void shouldSearchForAccountsByPaymentProviderMerchantId() {
+    public void shouldSearchForAccountsByWorldpayMerchantCodeInOneOffPaymentCredentials() {
         long gatewayAccountId_1 = nextLong();
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(String.valueOf(gatewayAccountId_1))
                 .withPaymentGateway("worldpay")
                 .withCredentials(Map.of("one_off_customer_initiated", Map.of("merchant_code", "acc123")))
+                .build());
+
+        var params = new GatewayAccountSearchParams();
+        params.setPaymentProviderAccountId("acc123");
+
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+        assertThat(gatewayAccounts, hasSize(1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
+    }
+
+    @Test
+    public void shouldSearchForAccountsByWorldpayMerchantCodeInRecurringPaymentCredentials() {
+        long gatewayAccountId_1 = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_1))
+                .withPaymentGateway("worldpay")
+                .withCredentials(Map.of("recurring_customer_initiated", Map.of("merchant_code", "acc123")))
                 .build());
 
         var params = new GatewayAccountSearchParams();

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -541,9 +541,9 @@ public class GatewayAccountDaoIT extends DaoITestBase {
     
     @Test
     public void shouldSearchForAccountsByPaymentProviderAccountId() {
-        long gatewayAccountId_1 = nextLong();
+        long gatewayAccountId = nextLong();
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
+                .withAccountId(String.valueOf(gatewayAccountId))
                 .withPaymentGateway("sandbox")
                 .withCredentials(Map.of("stripe_account_id", "acc123"))
                 .build());
@@ -553,14 +553,14 @@ public class GatewayAccountDaoIT extends DaoITestBase {
 
         List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
         assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
     }    
     
     @Test
     public void shouldSearchForAccountsByWorldpayMerchantCodeInOneOffPaymentCredentials() {
-        long gatewayAccountId_1 = nextLong();
+        long gatewayAccountId = nextLong();
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
+                .withAccountId(String.valueOf(gatewayAccountId))
                 .withPaymentGateway("worldpay")
                 .withCredentials(Map.of("one_off_customer_initiated", Map.of("merchant_code", "acc123")))
                 .build());
@@ -570,14 +570,14 @@ public class GatewayAccountDaoIT extends DaoITestBase {
 
         List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
         assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
     }
 
     @Test
-    public void shouldSearchForAccountsByWorldpayMerchantCodeInRecurringPaymentCredentials() {
-        long gatewayAccountId_1 = nextLong();
+    public void shouldSearchForAccountsByWorldpayMerchantCodeInRecurringCustomerInitiatedCredentials() {
+        long gatewayAccountId = nextLong();
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
+                .withAccountId(String.valueOf(gatewayAccountId))
                 .withPaymentGateway("worldpay")
                 .withCredentials(Map.of("recurring_customer_initiated", Map.of("merchant_code", "acc123")))
                 .build());
@@ -587,7 +587,24 @@ public class GatewayAccountDaoIT extends DaoITestBase {
 
         List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
         assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
+    }
+
+    @Test
+    public void shouldSearchForAccountsByWorldpayMerchantCodeInRecurringMerchantInitiatedCredentials() {
+        long gatewayAccountId = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId))
+                .withPaymentGateway("worldpay")
+                .withCredentials(Map.of("recurring_merchant_initiated", Map.of("merchant_code", "acc123")))
+                .build());
+
+        var params = new GatewayAccountSearchParams();
+        params.setPaymentProviderAccountId("acc123");
+
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+        assertThat(gatewayAccounts, hasSize(1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -393,12 +393,10 @@ public class GatewayAccountResourceIT extends NewGatewayAccountResourceTestBase 
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
                 .withAccountId(accountId)
-                .withAllowAuthApi(true)
                 .withPaymentProvider(WORLDPAY.getName())
                 .withDefaultCredentials()
                 .withGatewayAccountCredentials(List.of(credentialsParams))
                 .insert();
-        databaseTestHelper.allowApplePay(accountId);
 
         int accountIdAsInt = Math.toIntExact(accountId);
         givenSetup()
@@ -407,12 +405,11 @@ public class GatewayAccountResourceIT extends NewGatewayAccountResourceTestBase 
                 .statusCode(200)
                 .body("accounts", hasSize(1))
                 .body("accounts[0].gateway_account_id", is(accountIdAsInt))
-                .body("accounts[0].payment_provider", is("worldpay"))
-                .body("accounts[0].allow_apple_pay", is(true));
+                .body("accounts[0].payment_provider", is("worldpay"));
     }
 
     @Test
-    public void shouldReturnAccountInformationWhenSearchingByWorldpayMerchantCodeInRecurringPaymentCredentials() {
+    public void shouldReturnAccountInformationWhenSearchingByWorldpayMerchantCodeInRecurringCustomerInitiatedCredentials() {
         long accountId = RandomUtils.nextInt();
         AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                 .withPaymentProvider(WORLDPAY.getName())
@@ -429,12 +426,10 @@ public class GatewayAccountResourceIT extends NewGatewayAccountResourceTestBase 
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
                 .withAccountId(accountId)
-                .withAllowAuthApi(true)
                 .withPaymentProvider(WORLDPAY.getName())
                 .withDefaultCredentials()
                 .withGatewayAccountCredentials(List.of(credentialsParams))
                 .insert();
-        databaseTestHelper.allowApplePay(accountId);
 
         int accountIdAsInt = Math.toIntExact(accountId);
         givenSetup()
@@ -443,10 +438,9 @@ public class GatewayAccountResourceIT extends NewGatewayAccountResourceTestBase 
                 .statusCode(200)
                 .body("accounts", hasSize(1))
                 .body("accounts[0].gateway_account_id", is(accountIdAsInt))
-                .body("accounts[0].payment_provider", is("worldpay"))
-                .body("accounts[0].allow_apple_pay", is(true));
+                .body("accounts[0].payment_provider", is("worldpay"));
     }
-
+    
     @Test
     public void shouldSetApplePayEnabledByDefaultForSandboxAccount() {
         String gatewayAccountId1 = createAGatewayAccountFor("sandbox");

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -376,7 +376,7 @@ public class GatewayAccountResourceIT extends NewGatewayAccountResourceTestBase 
     }
 
     @Test
-    public void shouldReturnAccountInformationWhenSearchingByWorldpayMerchantId() {
+    public void shouldReturnAccountInformationWhenSearchingByWorldpayMerchantCodeInOneOffPaymentCredentials() {
         long accountId = RandomUtils.nextInt();
         AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                 .withPaymentProvider(WORLDPAY.getName())
@@ -403,6 +403,42 @@ public class GatewayAccountResourceIT extends NewGatewayAccountResourceTestBase 
         int accountIdAsInt = Math.toIntExact(accountId);
         givenSetup()
                 .get("/v1/api/accounts?payment_provider_account_id=one-off-merchant-code")
+                .then()
+                .statusCode(200)
+                .body("accounts", hasSize(1))
+                .body("accounts[0].gateway_account_id", is(accountIdAsInt))
+                .body("accounts[0].payment_provider", is("worldpay"))
+                .body("accounts[0].allow_apple_pay", is(true));
+    }
+
+    @Test
+    public void shouldReturnAccountInformationWhenSearchingByWorldpayMerchantCodeInRecurringPaymentCredentials() {
+        long accountId = RandomUtils.nextInt();
+        AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
+                .withPaymentProvider(WORLDPAY.getName())
+                .withGatewayAccountId(accountId)
+                .withState(ACTIVE)
+                .withCredentials(Map.of(
+                        RECURRING_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, "recurring-merchant-code",
+                                CREDENTIALS_USERNAME, "recurring-username",
+                                CREDENTIALS_PASSWORD, "recurring-password")))
+                .build();
+
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .withAccountId(accountId)
+                .withAllowAuthApi(true)
+                .withPaymentProvider(WORLDPAY.getName())
+                .withDefaultCredentials()
+                .withGatewayAccountCredentials(List.of(credentialsParams))
+                .insert();
+        databaseTestHelper.allowApplePay(accountId);
+
+        int accountIdAsInt = Math.toIntExact(accountId);
+        givenSetup()
+                .get("/v1/api/accounts?payment_provider_account_id=recurring-merchant-code")
                 .then()
                 .statusCode(200)
                 .body("accounts", hasSize(1))


### PR DESCRIPTION
A previous PR enabled a search by merchant code within the Worldpay one-off payment credentials

- Search for the merchant code within recurring payment credentials as well.