### PR TITLE
PP-12302 Add localhost bind address to WireMock servers

### DIFF
--- a/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
+++ b/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
@@ -105,11 +105,11 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
         jdbi = Jdbi.create(getConnectionUrl(), getDbUsername(), getDbPassword());
         jdbi.installPlugin(new SqlObjectPlugin());
         
-        wireMockServer = new WireMockServer(wireMockConfig().port(wireMockPort));
+        wireMockServer = new WireMockServer(wireMockConfig().port(wireMockPort).bindAddress("localhost"));
         wireMockServer.start();
-        worldpayWireMockServer = new WireMockServer(wireMockConfig().port(worldpayWireMockPort));
+        worldpayWireMockServer = new WireMockServer(wireMockConfig().port(worldpayWireMockPort).bindAddress("localhost"));
         worldpayWireMockServer.start();
-        stripeWireMockServer = new WireMockServer(wireMockConfig().port(stripeWireMockPort));
+        stripeWireMockServer = new WireMockServer(wireMockConfig().port(stripeWireMockPort).bindAddress("localhost"));
         stripeWireMockServer.start();
         
         databaseTestHelper = new DatabaseTestHelper(jdbi);
@@ -119,7 +119,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
         worldpayMockClient = new WorldpayMockClient(worldpayWireMockServer);
         stripeMockClient = new StripeMockClient(stripeWireMockServer);
 
-        ledgerWireMockServer = new WireMockServer(wireMockConfig().port(ledgerWireMockPort));
+        ledgerWireMockServer = new WireMockServer(wireMockConfig().port(ledgerWireMockPort).bindAddress("localhost"));
         ledgerWireMockServer.start();
         ledgerStub = new LedgerStub(ledgerWireMockServer);
         databaseFixtures = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper);


### PR DESCRIPTION
## WHAT YOU DID
Specify the bind address as `localhost` in WireMock servers used in `AppWithPostgresAndSqsExtension`.
This fixes flaky tests caused by WireMock binding to its default address `0.0.0.0`, which can cause tests to fail where the port is in use on another address. 

## How to test
Run integration tests