### PR TITLE
PP-12302 Refactor ServiceArchivedEventIT to use JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>au.com.dius</groupId>
+            <artifactId>pact-jvm-consumer-junit5</artifactId>
+            <version>4.0.10</version>
+        </dependency>
+        <dependency>
             <groupId>org.exparity</groupId>
             <artifactId>hamcrest-date</artifactId>
             <version>2.0.8</version>

--- a/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
+++ b/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
@@ -261,4 +261,8 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
 //        return sqsClient.getQueueUrl("event-queue").getQueueUrl();
         return SqsTestDocker.getQueueUrl("event-queue");
     }
+    
+    public String getTasksQueueUrl() {
+        return SqsTestDocker.getQueueUrl("tasks-queue");
+    }
 }


### PR DESCRIPTION
## WHAT YOU DID
Refactor ServiceArchivedEventIT to use JUnit5 with RegisterExtension
Use pact-jvm-consumer-junit5 to run Pact tests with JUnit5

## How to test
Run integration tests