### PR TITLE
PP-12173 stop dependabot from upgrading dropwizard-module to v4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@
         # Dropwizard 4.x only works with Jakarta EE and not Java EE
         versions:
           - ">= 4"
+      - dependency-name: "io.dropwizard.modules:dropwizard-testing-junit4"
+        # Dropwizard 4.x only works with Jakarta EE and not Java EE
+        versions:
+          - ">= 4"
       - dependency-name: "org.dhatim:dropwizard-sentry"
         # We essentially forked Dropwizard Sentry because it did not support
         # Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports


### PR DESCRIPTION
## WHAT YOU DID

Dropwizard 4.x only works with Jakarta EE and not Java EE
