### PR TITLE
PP-12354 using service id instead of gateway

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -132,63 +132,63 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 2192
+        "line_number": 2261
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 2236
+        "line_number": 2305
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 2703
+        "line_number": 2772
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3083
+        "line_number": 3152
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3119
+        "line_number": 3188
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3146
+        "line_number": 3215
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 3798
+        "line_number": 3867
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4258
+        "line_number": 4327
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4269
+        "line_number": 4338
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java": [
@@ -299,7 +299,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 78
       }
     ],
     "src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java": [

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1264,6 +1264,38 @@ paths:
       summary: Handle Worldpay notifications
       tags:
       - Notifications
+  /v1/api/service/{serviceId}/{accountType}/account:
+    get:
+      description: "Get gateway account by service external ID and account type (test|live).\
+        \ Returns notifications credentials, gateway account credentials (without\
+        \ password). Doesn't include card_types or gateway_merchant_id"
+      operationId: getGatewayAccountByServiceIdAndAccountType
+      parameters:
+      - in: path
+        name: serviceId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: accountType
+        required: true
+        schema:
+          type: string
+          enum:
+          - test
+          - live
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GatewayAccountWithCredentialsResponse'
+          description: OK
+        "404":
+          description: Not found
+      summary: Find gateway account by service external ID and account type (test|live)
+      tags:
+      - Gateway accounts
   /v1/frontend/accounts/external-id/{externalId}:
     get:
       description: "Get gateway account by external ID. Also returns notifications\
@@ -1788,6 +1820,43 @@ paths:
       summary: Get Worldpay 3DS Flex DDC JWT
       tags:
       - Charges - Frontend
+  /v1/frontend/service/{serviceId}/{accountType}/card-types:
+    get:
+      operationId: getAcceptedCardTypesByServiceIdAndAccountType
+      parameters:
+      - in: path
+        name: serviceId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: accountType
+        required: true
+        schema:
+          type: string
+          enum:
+          - test
+          - live
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+                example:
+                  card_types:
+                  - id: ab8a3abd-bcfd-4fa6-8905-321ce913e7f5
+                    brand: visa
+                    label: Visa
+                    type: DEBIT
+                    requires3ds: false
+          description: OK
+        "404":
+          description: Not found
+      summary: Get card types for gateway account by service external ID and account
+        type
+      tags:
+      - Gateway accounts
   /v1/frontend/tokens/{chargeTokenId}:
     delete:
       operationId: deleteToken

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
@@ -5,6 +5,7 @@ import com.google.inject.persist.Transactional;
 import uk.gov.pay.connector.common.dao.JpaDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -66,6 +67,17 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
         return entityManager.get()
                 .createQuery(query, GatewayAccountEntity.class)
                 .setParameter("externalId", externalId)
+                .getResultList().stream().findFirst();
+    }
+
+    public Optional<GatewayAccountEntity> findByServiceIdAndAccountType(String serviceId, GatewayAccountType accountType) {
+        // TODO: review this query, decide what to do about multiple records
+        String query = "SELECT g FROM GatewayAccountEntity g where g.serviceId = :serviceId and g.type = :accountType order by g.id DESC";
+
+        return entityManager.get()
+                .createQuery(query, GatewayAccountEntity.class)
+                .setParameter("serviceId", serviceId)
+                .setParameter("accountType", accountType)
                 .getResultList().stream().findFirst();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -253,7 +253,7 @@ public class GatewayAccountResource {
         logger.info("Getting accepted card types for service id {}, account type {}", serviceId, accountType.toString());
         System.out.println("Account type: " + accountType);
         return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
-                .map(gatewayAccount -> successResponseWithEntity(ImmutableMap.of(CARD_TYPES_FIELD_NAME, gatewayAccount.getCardTypes())))
+                .map(gatewayAccount -> successResponseWithEntity(Map.of(CARD_TYPES_FIELD_NAME, gatewayAccount.getCardTypes())))
                 .orElseGet(() -> notFoundResponse(format("Gateway account for service external id %s and account type %s not found.", serviceId, accountType)));
     }
     

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
@@ -132,6 +133,10 @@ public class GatewayAccountService {
 
     public Optional<GatewayAccountEntity> getGatewayAccountByExternal(String gatewayAccountExternalId) {
         return gatewayAccountDao.findByExternalId(gatewayAccountExternalId);
+    }
+
+    public Optional<GatewayAccountEntity> getGatewayAccountByServiceIdAndAccountType(String serviceId, GatewayAccountType accountType) {
+        return gatewayAccountDao.findByServiceIdAndAccountType(serviceId, accountType);
     }
 
     public boolean isATelephonePaymentNotificationAccount(String merchantCode) {

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -359,8 +359,8 @@ public class DatabaseFixtures {
         private boolean motoMaskCardNumberInput;
         private boolean motoMaskCardSecurityCodeInput;
         private boolean allowTelephonePaymentNotifications;
-
         private boolean recurringEnabled;
+        private boolean requires3ds;
         private final Map<String, Object> defaultCredentials = Map.of(
                 CREDENTIALS_MERCHANT_ID, "merchant-id",
                 CREDENTIALS_USERNAME, "username",
@@ -422,6 +422,8 @@ public class DatabaseFixtures {
         public boolean isAllowTelephonePaymentNotifications() {
             return allowTelephonePaymentNotifications;
         }
+        public boolean isRequires3ds() { return requires3ds; }
+        public void setRequires3ds(boolean requires3ds) { this.requires3ds = requires3ds; }
 
         public boolean isRecurringEnabled() {
             return recurringEnabled;
@@ -541,6 +543,11 @@ public class DatabaseFixtures {
             return this;
         }
 
+        public TestAccount withRequires3ds(boolean requires3ds) {
+            this.requires3ds = requires3ds;
+            return this;
+        }
+        
         public TestAccount withRecurringEnabled(boolean recurringEnabled) {
             this.recurringEnabled = recurringEnabled;
             return this;
@@ -581,6 +588,7 @@ public class DatabaseFixtures {
                     .withMotoMaskCardSecurityCodeInput(motoMaskCardSecurityCodeInput)
                     .withAllowTelephonePaymentNotifications(allowTelephonePaymentNotifications)
                     .withServiceId(serviceId)
+                    .withRequires3ds(requires3ds)
                     .withRecurringEnabled(recurringEnabled)
                     .build());
             for (TestCardType cardType : cardTypes) {

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.usernotification.model.domain.NotificationCredentials;
@@ -641,6 +642,23 @@ public class GatewayAccountDaoIT {
                 .withExternalId(externalId)
                 .insert();
         Optional<GatewayAccountEntity> gatewayAccountOptional = gatewayAccountDao.findByExternalId(externalId);
+        assertThat(gatewayAccountOptional.isPresent(), is(true));
+        assertThat(gatewayAccountOptional.get().getId(), is(id));
+        assertThat(gatewayAccountOptional.get().getExternalId(), is(externalId));
+    }
+
+    @Test
+    void findByServiceIdAndAccountType_shouldFindGatewayAccount() {
+        Long id = nextLong();
+        String externalId = randomUuid();
+        String serviceExternalId = randomUuid();
+        databaseFixtures
+                .aTestAccount()
+                .withAccountId(id)
+                .withExternalId(externalId)
+                .withServiceId(serviceExternalId)
+                .insert();
+        Optional<GatewayAccountEntity> gatewayAccountOptional = gatewayAccountDao.findByServiceIdAndAccountType(serviceExternalId, TEST);
         assertThat(gatewayAccountOptional.isPresent(), is(true));
         assertThat(gatewayAccountOptional.get().getId(), is(id));
         assertThat(gatewayAccountOptional.get().getExternalId(), is(externalId));

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -648,20 +648,31 @@ public class GatewayAccountDaoIT {
     }
 
     @Test
-    void findByServiceIdAndAccountType_shouldFindGatewayAccount() {
-        Long id = nextLong();
-        String externalId = randomUuid();
+    void findByServiceIdAndAccountType_shouldReturnMostRecentlyAddedAccount_whenMultipleAccountsExist() {
+        // TODO: update this test when decision has been made about multiple accounts
+        Long firstAccountId = nextLong();
+        String firstExternalId = randomUuid();
         String serviceExternalId = randomUuid();
         databaseFixtures
                 .aTestAccount()
-                .withAccountId(id)
-                .withExternalId(externalId)
+                .withAccountId(firstAccountId)
+                .withExternalId(firstExternalId)
                 .withServiceId(serviceExternalId)
                 .insert();
+
+        Long secondAccountId = firstAccountId + 1;
+        String secondExternalId = randomUuid();
+        databaseFixtures
+                .aTestAccount()
+                .withAccountId(secondAccountId)
+                .withExternalId(secondExternalId)
+                .withServiceId(serviceExternalId)
+                .insert();
+        
         Optional<GatewayAccountEntity> gatewayAccountOptional = gatewayAccountDao.findByServiceIdAndAccountType(serviceExternalId, TEST);
         assertThat(gatewayAccountOptional.isPresent(), is(true));
-        assertThat(gatewayAccountOptional.get().getId(), is(id));
-        assertThat(gatewayAccountOptional.get().getExternalId(), is(externalId));
+        assertThat(gatewayAccountOptional.get().getId(), is(secondAccountId));
+        assertThat(gatewayAccountOptional.get().getExternalId(), is(secondExternalId));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.http.ContentType;
 import org.apache.commons.lang.math.RandomUtils;
 import org.hamcrest.core.Is;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
@@ -45,6 +45,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator.FIELD_GATEWAY_MERCHANT_ID;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_SERVICE_ID_URL;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_FRONTEND_URL;
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
@@ -55,14 +56,191 @@ public class GatewayAccountResourceIT {
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions("sandbox", app.getLocalPort());
     private static final ObjectMapper objectMapper = new ObjectMapper();
-
     private DatabaseFixtures.TestAccount defaultTestAccount;
 
-    @AfterEach
-    public void tearDown() {
-        app.getDatabaseTestHelper().truncateAllData();
+
+    @Test
+    void shouldReturn404IfServiceIdIsUnknown_whenGetByServiceIdAndAccountType() {
+        String unknownServiceId = "unknown-service-id";
+        String url = ACCOUNTS_API_SERVICE_ID_URL.replace("{serviceId}", unknownServiceId).replace("{accountType}", GatewayAccountType.TEST.name());
+        app.givenSetup()
+                .get(url)
+                .then()
+                .statusCode(404);
     }
 
+    @Test
+    void shouldReturn404IfNoLiveAccountExists_whenGetByServiceIdAndAccountType() {
+        defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                .aTestAccount()
+                .insert();
+        String url = ACCOUNTS_API_SERVICE_ID_URL.replace("{serviceId}", "valid-external-service-id").replace("{accountType}", GatewayAccountType.LIVE.name());
+        app.givenSetup()
+                .get(url)
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void shouldReturnAccountInformation_withWorldpayCredentials_whenGetByServiceIdAndAccountType() {
+        long accountId = RandomUtils.nextInt();
+        AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
+                .withPaymentProvider(WORLDPAY.getName())
+                .withGatewayAccountId(accountId)
+                .withState(ACTIVE)
+                .withCredentials(Map.of(
+                        CREDENTIALS_MERCHANT_ID, "legacy-merchant-code",
+                        CREDENTIALS_USERNAME, "legacy-username",
+                        CREDENTIALS_PASSWORD, "legacy-password",
+                        FIELD_GATEWAY_MERCHANT_ID, "google-pay-merchant-id",
+                        ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, "one-off-merchant-code",
+                                CREDENTIALS_USERNAME, "one-off-username",
+                                CREDENTIALS_PASSWORD, "one-off-password"),
+                        RECURRING_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, "cit-merchant-code",
+                                CREDENTIALS_USERNAME, "cit-username",
+                                CREDENTIALS_PASSWORD, "cit-password"),
+                        RECURRING_MERCHANT_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, "mit-merchant-code",
+                                CREDENTIALS_USERNAME, "mit-username",
+                                CREDENTIALS_PASSWORD, "mit-password")))
+                .build();
+
+        defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                .aTestAccount()
+                .withAccountId(accountId)
+                .withAllowTelephonePaymentNotifications(true)
+                .withAllowMoto(true)
+                .withCorporateCreditCardSurchargeAmount(250)
+                .withCorporateDebitCardSurchargeAmount(50)
+                .withAllowAuthApi(true)
+                .withRecurringEnabled(true)
+                .withPaymentProvider(WORLDPAY.getName())
+                .withDefaultCredentials()
+                .withGatewayAccountCredentials(List.of(credentialsParams))
+                .withRequires3ds(true)
+                .insert();
+
+        app.getDatabaseTestHelper().allowApplePay(accountId);
+        app.getDatabaseTestHelper().allowZeroAmount(accountId);
+        app.getDatabaseTestHelper().blockPrepaidCards(accountId);
+        app.getDatabaseTestHelper().enableProviderSwitch(accountId);
+        app.getDatabaseTestHelper().setDisabled(accountId);
+        app.getDatabaseTestHelper().setDisabledReason(accountId, "Disabled because reasons");
+        app.getDatabaseTestHelper().insertWorldpay3dsFlexCredential(accountId, "macKey", "issuer", "org_unit_id", 2L);
+
+        int accountIdAsInt = Math.toIntExact(accountId);
+        String url = ACCOUNTS_API_SERVICE_ID_URL.replace("{serviceId}", "valid-external-service-id").replace("{accountType}", GatewayAccountType.TEST.name());
+        app.givenSetup()
+                .get(url)
+                .then()
+                .statusCode(200)
+                .body("payment_provider", is("worldpay"))
+                .body("gateway_account_id", is(Math.toIntExact(defaultTestAccount.getAccountId())))
+                .body("external_id", is(defaultTestAccount.getExternalId()))
+                .body("type", is(TEST.toString()))
+                .body("description", is("a description"))
+                .body("analytics_id", is("an analytics id"))
+                .body("email_collection_mode", is("OPTIONAL"))
+                .body("email_notifications.PAYMENT_CONFIRMED.template_body", is("Lorem ipsum dolor sit amet, consectetur adipiscing elit."))
+                .body("email_notifications.PAYMENT_CONFIRMED.enabled", is(true))
+                .body("email_notifications.REFUND_ISSUED.template_body", is("Lorem ipsum dolor sit amet, consectetur adipiscing elit."))
+                .body("email_notifications.REFUND_ISSUED.enabled", is(true))
+                .body("service_name", is("service_name"))
+                .body("corporate_credit_card_surcharge_amount", is(250))
+                .body("corporate_debit_card_surcharge_amount", is(50))
+                .body("allow_google_pay", is(false))
+                .body("allow_apple_pay", is(true))
+                .body("send_payer_ip_address_to_gateway", is(false))
+                .body("send_payer_email_to_gateway", is(false))
+                .body("allow_zero_amount", is(true))
+                .body("integration_version_3ds", is(2))
+                .body("allow_telephone_payment_notifications", is(true))
+                .body("provider_switch_enabled", is(true))
+                .body("service_id", is("valid-external-service-id"))
+                .body("send_reference_to_gateway", is(false))
+                .body("allow_authorisation_api", is(true))
+                .body("recurring_enabled", is(true))
+                .body("requires3ds", is(true))
+                .body("block_prepaid_cards", is(true))
+                .body("disabled", is(true))
+                .body("disabled_reason", is("Disabled because reasons"))
+                .body("gateway_account_credentials.size()", is(1))
+                .body("gateway_account_credentials[0].payment_provider", is("worldpay"))
+                .body("gateway_account_credentials[0].state", is("ACTIVE"))
+                .body("gateway_account_credentials[0].gateway_account_id", is(accountIdAsInt))
+                .body("gateway_account_credentials[0].credentials", hasEntry("gateway_merchant_id", "google-pay-merchant-id"))
+                .body("gateway_account_credentials[0].credentials", hasKey("one_off_customer_initiated"))
+                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", hasEntry("merchant_code", "one-off-merchant-code"))
+                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", hasEntry("username", "one-off-username"))
+                .body("gateway_account_credentials[0].credentials.one_off_customer_initiated", not(hasKey("password")))
+                .body("gateway_account_credentials[0].credentials", hasKey("recurring_customer_initiated"))
+                .body("gateway_account_credentials[0].credentials.recurring_customer_initiated", hasEntry("merchant_code", "cit-merchant-code"))
+                .body("gateway_account_credentials[0].credentials.recurring_customer_initiated", hasEntry("username", "cit-username"))
+                .body("gateway_account_credentials[0].credentials.recurring_customer_initiated", not(hasKey("password")))
+                .body("gateway_account_credentials[0].credentials", hasKey("recurring_merchant_initiated"))
+                .body("gateway_account_credentials[0].credentials.recurring_merchant_initiated", hasEntry("merchant_code", "mit-merchant-code"))
+                .body("gateway_account_credentials[0].credentials.recurring_merchant_initiated", hasEntry("username", "mit-username"))
+                .body("gateway_account_credentials[0].credentials.recurring_merchant_initiated", not(hasKey("password")))
+                .body("$", hasKey("worldpay_3ds_flex"))
+                .body("worldpay_3ds_flex.issuer", is("issuer"))
+                .body("worldpay_3ds_flex.organisational_unit_id", is("org_unit_id"))
+                .body("worldpay_3ds_flex", not(hasKey("jwt_mac_key")))
+                .body("worldpay_3ds_flex", not(hasKey("version")))
+                .body("worldpay_3ds_flex", not(hasKey("gateway_account_id")))
+                .body("worldpay_3ds_flex.exemption_engine_enabled", is(false));
+    }
+
+    @Test
+    void shouldReturnAccountInformation_withStripeCredentials_whenGetByServiceIdAndAccountType() {
+        long accountId = RandomUtils.nextInt();
+        AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
+                .withPaymentProvider(STRIPE.getName())
+                .withGatewayAccountId(accountId)
+                .withState(ACTIVE)
+                .withCredentials(Map.of(CREDENTIALS_STRIPE_ACCOUNT_ID, "a-stripe-account-id"))
+                .build();
+
+        defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                .aTestAccount()
+                .withAccountId(accountId)
+                .withPaymentProvider(STRIPE.getName())
+                .withGatewayAccountCredentials(List.of(credentialsParams))
+                .insert();
+
+        int accountIdAsInt = Math.toIntExact(accountId);
+        String url = ACCOUNTS_API_SERVICE_ID_URL.replace("{serviceId}", "valid-external-service-id").replace("{accountType}", GatewayAccountType.TEST.name());
+        app.givenSetup()
+                .get(url)
+                .then()
+                .statusCode(200)
+                .body("payment_provider", is("stripe"))
+                .body("gateway_account_credentials.size()", is(1))
+                .body("gateway_account_credentials[0].payment_provider", is("stripe"))
+                .body("gateway_account_credentials[0].state", is("ACTIVE"))
+                .body("gateway_account_credentials[0].gateway_account_id", is(accountIdAsInt))
+                .body("gateway_account_credentials[0].credentials", hasEntry("stripe_account_id", "a-stripe-account-id"));
+    }
+
+    @Test
+    void shouldNotReturn3dsFlexCredentials_whenGatewayIsNotAWorldpayAccount_whenGetByServiceIdAndAccountType() {
+        defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                .aTestAccount()
+                .withPaymentProvider(STRIPE.getName())
+                .insert();
+        String url = ACCOUNTS_API_SERVICE_ID_URL.replace("{serviceId}", "valid-external-service-id").replace("{accountType}", GatewayAccountType.TEST.name());
+        app.givenSetup()
+                .get(url)
+                .then()
+                .statusCode(200)
+                .body("worldpay_3ds_flex", nullValue());
+    }
+    
     @Test
     void getAccountShouldReturn404IfAccountIdIsUnknown() {
         String unknownAccountId = "92348739";
@@ -70,26 +248,6 @@ public class GatewayAccountResourceIT {
                 .get(ACCOUNTS_API_URL + unknownAccountId)
                 .then()
                 .statusCode(404);
-    }
-
-    @Test
-    void getAccountShouldNotReturnCredentials() {
-        String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay");
-        app.givenSetup()
-                .get(ACCOUNTS_API_URL + gatewayAccountId)
-                .then()
-                .statusCode(200)
-                .body("credentials", is(nullValue()));
-    }
-
-    @Test
-    void getAccountShouldNotReturnCardTypes() {
-        String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay");
-        app.givenSetup()
-                .get(ACCOUNTS_API_URL + gatewayAccountId)
-                .then()
-                .statusCode(200)
-                .body("card_types", is(nullValue()));
     }
 
     @Test
@@ -125,6 +283,7 @@ public class GatewayAccountResourceIT {
                 .body("description", is("desc"));
     }
 
+
     @Test
     void getAccountShouldReturn3dsSetting() {
         String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("stripe", "desc", "id", "true", "test");
@@ -139,7 +298,7 @@ public class GatewayAccountResourceIT {
     void getAccountShouldReturnCorporateCreditCardSurchargeAmountAndCorporateDebitCardSurchargeAmount() {
         int corporateCreditCardSurchargeAmount = 250;
         int corporateDebitCardSurchargeAmount = 50;
-        this.defaultTestAccount = DatabaseFixtures
+        defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aTestAccount()
                 .withCorporateCreditCardSurchargeAmount(corporateCreditCardSurchargeAmount)
@@ -157,7 +316,7 @@ public class GatewayAccountResourceIT {
     @Test
     void getAccountShouldReturnCorporatePrepaidDebitCardSurchargeAmount() {
         int corporatePrepaidDebitCardSurchargeAmount = 50;
-        this.defaultTestAccount = DatabaseFixtures
+        defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aTestAccount()
                 .withCorporatePrepaidDebitCardSurchargeAmount(corporatePrepaidDebitCardSurchargeAmount)
@@ -196,7 +355,7 @@ public class GatewayAccountResourceIT {
                                 CREDENTIALS_PASSWORD, "mit-password")))
                 .build();
 
-        this.defaultTestAccount = DatabaseFixtures
+        defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aTestAccount()
                 .withAccountId(accountId)
@@ -281,7 +440,7 @@ public class GatewayAccountResourceIT {
                 .withCredentials(Map.of(CREDENTIALS_STRIPE_ACCOUNT_ID, "a-stripe-account-id"))
                 .build();
 
-        this.defaultTestAccount = DatabaseFixtures
+        defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aTestAccount()
                 .withAccountId(accountId)
@@ -316,7 +475,7 @@ public class GatewayAccountResourceIT {
                         CREDENTIALS_SHA_OUT_PASSPHRASE, "a-sha-out-passphrase"))
                 .build();
 
-        this.defaultTestAccount = DatabaseFixtures
+        defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aTestAccount()
                 .withAccountId(accountId)
@@ -350,6 +509,7 @@ public class GatewayAccountResourceIT {
                 .statusCode(200)
                 .body("worldpay_3ds_flex", nullValue());
     }
+
 
     @Test
     void shouldReturnEmptyCollectionOfAccountsWhenNoneFound() {
@@ -401,7 +561,7 @@ public class GatewayAccountResourceIT {
                                 CREDENTIALS_PASSWORD, "one-off-password")))
                 .build();
 
-        this.defaultTestAccount = DatabaseFixtures
+        defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aTestAccount()
                 .withAccountId(accountId)
@@ -434,7 +594,7 @@ public class GatewayAccountResourceIT {
                                 CREDENTIALS_PASSWORD, "recurring-password")))
                 .build();
 
-        this.defaultTestAccount = DatabaseFixtures
+        defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aTestAccount()
                 .withAccountId(accountId)
@@ -752,6 +912,25 @@ public class GatewayAccountResourceIT {
     }
 
     @Test
+    void shouldReturn3dsFlexCredentials_whenGatewayAccountHasCreds_byServiceIdAndAccountType() {
+        String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
+        app.getDatabaseTestHelper().updateServiceIdFor(Long.parseLong(gatewayAccountId), "a-valid-service-id");
+        app.getDatabaseTestHelper().insertWorldpay3dsFlexCredential(Long.valueOf(gatewayAccountId), "macKey", "issuer", "org_unit_id", 2L);
+        String url = ACCOUNTS_API_SERVICE_ID_URL.replace("{serviceId}", "a-valid-service-id").replace("{accountType}", GatewayAccountType.TEST.name());
+        app.givenSetup()
+                .get(url)
+                .then()
+                .statusCode(200)
+                .body("$", hasKey("worldpay_3ds_flex"))
+                .body("worldpay_3ds_flex.issuer", is("issuer"))
+                .body("worldpay_3ds_flex.organisational_unit_id", is("org_unit_id"))
+                .body("worldpay_3ds_flex", not(hasKey("jwt_mac_key")))
+                .body("worldpay_3ds_flex", not(hasKey("version")))
+                .body("worldpay_3ds_flex", not(hasKey("gateway_account_id")))
+                .body("worldpay_3ds_flex.exemption_engine_enabled", is(false));
+    }
+
+    @Test
     void shouldNotReturn3dsFlexCredentials_whenGatewayIsNotAWorldpayAccount() {
         String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("stripe", "a-description", "analytics-id");
         app.givenSetup()
@@ -799,7 +978,7 @@ public class GatewayAccountResourceIT {
                 .then()
                 .statusCode(CONFLICT.getStatusCode());
     }
-
+    
     @Test
     void whenNotificationCredentialsInvalidKeys_shouldReturn400() {
         String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("stripe");

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITBaseExtensions.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITBaseExtensions.java
@@ -27,8 +27,8 @@ public class GatewayAccountResourceITBaseExtensions {
     }
 
     public static final String ACCOUNTS_API_URL = "/v1/api/accounts/";
+    public static final String ACCOUNTS_API_SERVICE_ID_URL = "/v1/api/service/{serviceId}/{accountType}/account";
     public static final String ACCOUNTS_FRONTEND_URL = "/v1/frontend/accounts/";
-    public static final String ACCOUNTS_EXTERNAL_ID_URL = ACCOUNTS_API_URL + "external-id/";
     public static final String ACCOUNT_FRONTEND_EXTERNAL_ID_URL = "/v1/frontend/accounts/external-id/";
 
     protected String createAGatewayAccountFor(String provider) {

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
@@ -96,6 +97,16 @@ class GatewayAccountServiceTest {
         when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
 
         Optional<GatewayAccountEntity> gatewayAccountEntity = gatewayAccountService.getGatewayAccount(GATEWAY_ACCOUNT_ID);
+
+        assertThat(gatewayAccountEntity.get(), is(this.mockGatewayAccountEntity));
+    }
+
+    @Test
+    void shouldGetGatewayAccountByServiceIdAndAccountType() {
+        String serviceId = "a-service-id";
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(serviceId, GatewayAccountType.TEST)).thenReturn(Optional.of(mockGatewayAccountEntity));
+
+        Optional<GatewayAccountEntity> gatewayAccountEntity = gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, GatewayAccountType.TEST);
 
         assertThat(gatewayAccountEntity.get(), is(this.mockGatewayAccountEntity));
     }


### PR DESCRIPTION
- Add v1/frontend endpoint to get card types for a gateway account by serviceId and accountType (test|live)
- Add v1/api endpoint to get gateway account by serviceId and accountType
- Add unit tests
- Add integration tests and removed some redundant integration tests

NB: where multiple test gateway accounts exist for a service, the one most recently added to the database will be returned. This logic will need refinement in a future story.
