### PR TITLE
PP-12374 Clarify logs with charge status for Wallet payment requests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -109,7 +109,7 @@ public class WalletAuthoriseService {
                     operationResponse.getBaseResponse().flatMap(BaseAuthoriseResponse::extractAuth3dsRequiredDetails);
             CardExpiryDate cardExpiryDate = operationResponse.getBaseResponse().flatMap(BaseAuthoriseResponse::getCardExpiryDate).orElse(null);
 
-            logMetrics(charge, operationResponse, requestStatus, walletAuthorisationRequest.getWalletType());
+            logMetrics(charge, operationResponse, requestStatus, chargeStatus, walletAuthorisationRequest.getWalletType());
 
             processGatewayAuthorisationResponse(
                     charge.getExternalId(),
@@ -136,10 +136,11 @@ public class WalletAuthoriseService {
     private void logMetrics(ChargeEntity chargeEntity,
                             GatewayResponse<BaseAuthoriseResponse> operationResponse,
                             String successOrFailure,
+                            ChargeStatus chargeStatus,
                             WalletType walletType) {
 
-        LOGGER.info("{} authorisation {} - charge_external_id={}, payment provider response={}",
-                walletType.toString(), successOrFailure, chargeEntity.getExternalId(), operationResponse.toString());
+        LOGGER.info("{} authorisation - charge status={}, request status={}, charge_external_id={}, payment provider response={}",
+                walletType.toString(), chargeStatus, successOrFailure, chargeEntity.getExternalId(), operationResponse.toString());
         metricRegistry.counter(format("gateway-operations.%s.%s.authorise.%s.result.%s",
                 chargeEntity.getPaymentProvider(),
                 chargeEntity.getGatewayAccount().getType(),

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -232,7 +232,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
         verify(mockAppender, times(4)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
         assertThat(loggingEvents.stream().anyMatch(le -> le.getFormattedMessage().contains(
-                format("APPLE_PAY authorisation success - charge_external_id=%s, payment provider response=%s", charge.getExternalId(), gatewayResponse.toString()))
+                format("APPLE_PAY authorisation - charge status=AUTHORISATION SUCCESS, request status=success, charge_external_id=%s, payment provider response=%s", charge.getExternalId(), gatewayResponse.toString()))
         ), is(true));
     }
 


### PR DESCRIPTION
With this change, we are updating the Wallet Authorise Service in order to log
the "charge status" alongside and more prominently than the "request status"
for Apple and Google payments.

This is needed, because the current log message implies that the "success"
status logged is related to the payment itself, e.g. with "APPLE_PAY
authorisation success".

However that "success" word is for the request_status, showing that Connector
managed to connect to the Apple Pay Gateway successfully.

To make the log clearer, avoiding confusion, this commit changes the text
logged, by indicating the charge status first, and then also showing the
request status but in brackets and clearly indicated as such.

This would mean that for the example above, the log will now show:
"APPLE_PAY authorisation - charge status=AUTHORISATION REJECTED, request status=success"

Note that we have verified that the log message being changed is **not used** by the charts displayed in the
[Wallet Payments dashboard](https://gds.splunkcloud.com/en-GB/app/gds-004-pay/googlepay_payments) in Splunk.

Note that by adding the charge status to the parameters passed to the log,
instead of replacing it, we are keeping the metricRegistry and the
walletPaymentAuthorisationSuccessCounter unchanged.

**Further changes will be needed to correct them: we have agreed to coordinate
them around a follow up PR.**

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-12374

## Examples of failed Apple Pay events logged as success

https://gds.splunkcloud.com/en-GB/app/gds-004-pay/report?s=%2FservicesNS%2Fnobody%2Fgds-004-pay%2Fsaved%2Fsearches%2FFailed%2520Apple%2520Pay%2520payments%2520logged%2520as%2520success&sid=_bWFyY28udHJhbmNoaW5vQGRpZ2l0YWwuY2FiaW5ldC1vZmZpY2UuZ292LnVr_bWFyY28udHJhbmNoaW5vQGRpZ2l0YWwuY2FiaW5ldC1vZmZpY2UuZ292LnVr_Z2RzLTAwNC1wYXk__RMD50c086d415149575d_at_1714139132_85155&display.page.search.mode=smart&dispatch.sample_ratio=1&earliest=-24h%40h&latest=now

## Feedback request

**QUESTION 1**
**Are we happy with the formatting changes within the log and the wording as follows?**

**From:**
- APPLE_PAY authorisation success

**To:**
- APPLE_PAY charge status=AUTHORISATION REJECTED (request status=success)

**QUESTION 2**
**Are we happy to fix just the log (as per Jira PP-12374) ?**
We could add a new ticket to investigate whether metricRegistry and walletPaymentAuthorisationSuccessCounter need changing too.

## How to test

- Manually, locally
- Searching in Splunk after deployment

## Code review checklist

### ~~Logging~~

- [ ] ~~only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.~~

### ~~Documentation~~

- [ ] ~~Updated README.md for any of the following ?~~

* ~~Introduced any new environment variables / removed existing environment variable~~
* ~~Added new API / updated existing API definition~~
