### PR TITLE
PP-12374 Pass Wallet Payments authorisation success to metrics and alerts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -31,6 +31,8 @@ import uk.gov.service.payments.commons.model.CardExpiryDate;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 
 public class WalletAuthoriseService {
     
@@ -135,12 +137,14 @@ public class WalletAuthoriseService {
 
     private void logMetrics(ChargeEntity chargeEntity,
                             GatewayResponse<BaseAuthoriseResponse> operationResponse,
-                            String successOrFailure,
+                            String requestStatus,
                             ChargeStatus chargeStatus,
                             WalletType walletType) {
-
+        String successOrFailure = (chargeStatus == AUTHORISATION_SUCCESS || chargeStatus == AUTHORISATION_3DS_REQUIRED)
+                ? "success"
+                : "failure";
         LOGGER.info("{} authorisation - charge status={}, request status={}, charge_external_id={}, payment provider response={}",
-                walletType.toString(), chargeStatus, successOrFailure, chargeEntity.getExternalId(), operationResponse.toString());
+                walletType.toString(), chargeStatus, requestStatus, chargeEntity.getExternalId(), operationResponse.toString());
         metricRegistry.counter(format("gateway-operations.%s.%s.authorise.%s.result.%s",
                 chargeEntity.getPaymentProvider(),
                 chargeEntity.getGatewayAccount().getType(),


### PR DESCRIPTION
With a previous PR[1], we have clarified the logs written by Connector when a
Google Pay or an Apple Pay payment is rejected, by indicating the charge
status more clearly, and then that the connection request had been
successful, despite the payment didn't go through.

With this change, we are now correcting the `successOrFailure` value being
passed on to metrics and alerts.

Previously we were passing success or failure depending on the connection to
the Payment Gateway being successful or not.

With this change, we are now passing `success` only in two cases:
- if the payment has gone through, i.e. only for a charge status of
  `AUTHORISATION SUCCESS`
- if 3D Secure authorisation is required, i.e. for a charge status of
  `AUTHORISATION_3DS_REQUIRED`

The latter happens only in a small proportion of Google Pay payments, and we
have agreed to count these as success(close enough and there will not be many
of them).

For all other charge status values, we will from now on be passing on the
`failure` value.

Further information in JIRA[2].

[1]
https://github.com/alphagov/pay-connector/pull/5176

[2]
https://payments-platform.atlassian.net/browse/PP-12374

## REQUEST FOR FEEDBACK

Are we happy to count success just for AUTHORISATION_SUCCESS ?
In src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeStatus.java we have other options that are not failures, e.g. AUTHORISATION_SUBMITTED or CAPTURE_APPROVED etc.

Would we want to pass something other than success/failure for those cases?


## How to test

Manually, locally
Searching in Splunk after deployment

## Code review checklist

### Logging

- [ ] ~~only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert~~.

### Documentation

- [ ] ~~Updated README.md for any of the following ?~~

* ~~Introduced any new environment variables / removed existing environment variable~~
* ~~Added new API / updated existing API definition~~
