### PR TITLE
test

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -31,6 +31,7 @@ import uk.gov.service.payments.commons.model.CardExpiryDate;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.*;
 
 public class WalletAuthoriseService {
     
@@ -135,12 +136,14 @@ public class WalletAuthoriseService {
 
     private void logMetrics(ChargeEntity chargeEntity,
                             GatewayResponse<BaseAuthoriseResponse> operationResponse,
-                            String successOrFailure,
+                            String requestStatus,
                             ChargeStatus chargeStatus,
                             WalletType walletType) {
-
+        String successOrFailure = (chargeStatus == AUTHORISATION_SUCCESS || chargeStatus == AUTHORISATION_3DS_REQUIRED)
+                ? "success"
+                : "failure";
         LOGGER.info("{} authorisation - charge status={}, request status={}, charge_external_id={}, payment provider response={}",
-                walletType.toString(), chargeStatus, successOrFailure, chargeEntity.getExternalId(), operationResponse.toString());
+                walletType.toString(), chargeStatus, requestStatus, chargeEntity.getExternalId(), operationResponse.toString());
         metricRegistry.counter(format("gateway-operations.%s.%s.authorise.%s.result.%s",
                 chargeEntity.getPaymentProvider(),
                 chargeEntity.getGatewayAccount().getType(),

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -82,14 +82,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
@@ -234,6 +227,14 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
         assertThat(loggingEvents.stream().anyMatch(le -> le.getFormattedMessage().contains(
                 format("APPLE_PAY authorisation - charge status=AUTHORISATION SUCCESS, request status=success, charge_external_id=%s, payment provider response=%s", charge.getExternalId(), gatewayResponse.toString()))
         ), is(true));
+
+        String expectedMetric = format("gateway-operations.%s.%s.authorise.%s.result.%s",
+                "sandbox",
+                "test",
+                "apple-pay",
+                "success");
+
+        verify(mockMetricRegistry).counter(expectedMetric);
     }
 
     @Test
@@ -344,6 +345,30 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
+    }
+
+    @Test
+    void verifyLogging_applePay_shouldLogFailure_WhenAuthorisationIsRejected() throws Exception {
+        providerWillRejectApplePay();
+
+        GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
+
+        assertThat(response.isSuccessful(), is(true));
+        assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
+
+        ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(mockAppender, atLeast(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.stream().anyMatch(le -> le.getFormattedMessage().contains("APPLE_PAY authorisation - charge status=AUTHORISATION REJECTED, request status=success")
+        ), is(true));
+
+        String expectedMetric = format("gateway-operations.%s.%s.authorise.%s.result.%s",
+                "sandbox",
+                "test",
+                "apple-pay",
+                "failure");
+        
+        verify(mockMetricRegistry).counter(expectedMetric);
     }
 
     @Test


### PR DESCRIPTION
With a previous PR[1], we have clarified the logs written by Connector when a Google Pay or an Apple Pay payment is rejected, by indicating the charge status more clearly, and then that the connection request had been successful, despite the payment didn't go through.

With this change, we are now correcting the `successOrFailure` value being passed on to metrics and alerts.

Previously we were passing success or failure depending on the connection to the Payment Gateway being successful or not.

With this change, we are now passing `success` only in two cases:
- if the payment has gone through, i.e. only for a charge status of `AUTHORISATION SUCCESS`
- if 3D Secure authorisation is required, i.e. for a charge status of `AUTHORISATION_3DS_REQUIRED`

The latter happens only in a small proportion of Google Pay payments, and we have agreed to count these as success(close enough and there will not be many of them).

For all other charge status values, we will from now on be passing on the `failure` value.

Further information in JIRA[2].

[1]
https://github.com/alphagov/pay-connector/pull/5176

[2]
https://payments-platform.atlassian.net/browse/PP-12374

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
