### PR TITLE
PP-12356 Add support for nested test blocks in integration tests

### DIFF
--- a/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
+++ b/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
@@ -148,7 +148,10 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
     
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        dropwizardAppExtension.getApplication().run("db", "migrate", CONFIG_PATH);
+        if (context.getRequiredTestClass().getEnclosingClass() == null) {
+            // Only runs if there is no enclosing class, i.e. not in a @Nested block
+            dropwizardAppExtension.getApplication().run("db", "migrate", CONFIG_PATH);
+        }
     }
 
     @Override
@@ -163,11 +166,13 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
 
     @Override
     public void afterAll(ExtensionContext context) {
-        wireMockServer.stop();
-        worldpayWireMockServer.stop();
-        stripeWireMockServer.stop();
-        ledgerWireMockServer.stop();
-        dropwizardAppExtension.after();
+        if (context.getRequiredTestClass().getEnclosingClass() == null) {
+            wireMockServer.stop();
+            worldpayWireMockServer.stop();
+            stripeWireMockServer.stop();
+            ledgerWireMockServer.stop();
+            dropwizardAppExtension.after();
+        }
     }
 
     public RequestSpecification givenSetup() {

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -4,6 +4,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Nested;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
@@ -55,6 +56,7 @@ public class GatewayAccountDaoIT {
     private GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
     private DatabaseFixtures databaseFixtures;
     private long gatewayAccountId;
+        
 
     @BeforeEach
     void setUp() {
@@ -63,35 +65,39 @@ public class GatewayAccountDaoIT {
         databaseFixtures = app.getDatabaseFixtures();
         gatewayAccountId = nextLong();
     }
+    
+    @Nested
+    class FindByServiceId {
 
-    @Test
-    void shouldFindGatewayAccountsForServiceId() {
-        String serviceId = "a-service-id";
-        
-        GatewayAccountEntity account1 = new GatewayAccountEntity(TEST);
-        account1.setExternalId(randomUuid());
-        account1.setServiceId(serviceId);
-        gatewayAccountDao.persist(account1);
+        @Test
+        void shouldFindGatewayAccountsForServiceId() {
+            String serviceId = "a-service-id";
 
-        GatewayAccountEntity account2 = new GatewayAccountEntity(TEST);
-        account2.setExternalId(randomUuid());
-        account2.setServiceId(serviceId);
-        gatewayAccountDao.persist(account2);
+            GatewayAccountEntity account1 = new GatewayAccountEntity(TEST);
+            account1.setExternalId(randomUuid());
+            account1.setServiceId(serviceId);
+            gatewayAccountDao.persist(account1);
 
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.findByServiceId(serviceId);
-        assertThat(gatewayAccounts.size(), is(2));
-        assertThat(gatewayAccounts.stream().map(GatewayAccountEntity::getExternalId).collect(Collectors.toList()), 
-                containsInAnyOrder(account1.getExternalId(), account2.getExternalId()));
-    }
+            GatewayAccountEntity account2 = new GatewayAccountEntity(TEST);
+            account2.setExternalId(randomUuid());
+            account2.setServiceId(serviceId);
+            gatewayAccountDao.persist(account2);
 
-    @Test
-    void shouldFindNoGatewayAccountForServiceId() {
-        GatewayAccountEntity account1 = new GatewayAccountEntity(TEST);
-        account1.setExternalId(randomUuid());
-        account1.setServiceId("a-service-id");
-        gatewayAccountDao.persist(account1);
-        
-        assertTrue(gatewayAccountDao.findByServiceId("non-existent").isEmpty());
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.findByServiceId(serviceId);
+            assertThat(gatewayAccounts.size(), is(2));
+            assertThat(gatewayAccounts.stream().map(GatewayAccountEntity::getExternalId).collect(Collectors.toList()),
+                    containsInAnyOrder(account1.getExternalId(), account2.getExternalId()));
+        }
+
+        @Test
+        void shouldFindNoGatewayAccountForServiceId() {
+            GatewayAccountEntity account1 = new GatewayAccountEntity(TEST);
+            account1.setExternalId(randomUuid());
+            account1.setServiceId("a-service-id");
+            gatewayAccountDao.persist(account1);
+
+            assertTrue(gatewayAccountDao.findByServiceId("non-existent").isEmpty());
+        }
     }
     
     @Test
@@ -169,115 +175,119 @@ public class GatewayAccountDaoIT {
                         hasEntry("brand", visaCardDebit.getBrand())
                 )));
     }
+    
+    @Nested
+    class FindById {
 
-    @Test
-    void findById_shouldNotFindANonexistentGatewayAccount() {
-        assertThat(gatewayAccountDao.findById(GatewayAccountEntity.class, 1234L).isPresent(), is(false));
-    }
+        @Test
+        void findById_shouldNotFindANonexistentGatewayAccount() {
+            assertThat(gatewayAccountDao.findById(GatewayAccountEntity.class, 1234L).isPresent(), is(false));
+        }
 
-    @Test
-    void findById_shouldFindGatewayAccount() {
-        final CardTypeEntity masterCardCredit = app.getDatabaseTestHelper().getMastercardCreditCard();
-        final CardTypeEntity visaCardDebit = app.getDatabaseTestHelper().getVisaCreditCard();
-        DatabaseFixtures.TestAccount accountRecord = createAccountRecordWithCards(masterCardCredit, visaCardDebit);
+        @Test
+        void findById_shouldFindGatewayAccount() {
+            final CardTypeEntity masterCardCredit = app.getDatabaseTestHelper().getMastercardCreditCard();
+            final CardTypeEntity visaCardDebit = app.getDatabaseTestHelper().getVisaCreditCard();
+            DatabaseFixtures.TestAccount accountRecord = createAccountRecordWithCards(masterCardCredit, visaCardDebit);
 
-        Optional<GatewayAccountEntity> gatewayAccountOpt =
-                gatewayAccountDao.findById(GatewayAccountEntity.class, accountRecord.getAccountId());
+            Optional<GatewayAccountEntity> gatewayAccountOpt =
+                    gatewayAccountDao.findById(GatewayAccountEntity.class, accountRecord.getAccountId());
 
-        assertTrue(gatewayAccountOpt.isPresent());
-        GatewayAccountEntity gatewayAccount = gatewayAccountOpt.get();
-        assertThat(gatewayAccount.getGatewayName(), is(accountRecord.getPaymentProvider()));
-        assertThat(gatewayAccount.getExternalId(), is(accountRecord.getExternalId()));
-        assertThat(gatewayAccount.getServiceName(), is(accountRecord.getServiceName()));
-        assertThat(gatewayAccount.getServiceId(), is(accountRecord.getServiceId()));
-        assertThat(gatewayAccount.getDescription(), is(accountRecord.getDescription()));
-        assertThat(gatewayAccount.getAnalyticsId(), is(accountRecord.getAnalyticsId()));
-        assertThat(gatewayAccount.getCorporateNonPrepaidCreditCardSurchargeAmount(), is(accountRecord.getCorporateCreditCardSurchargeAmount()));
-        assertThat(gatewayAccount.getCorporateNonPrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporateDebitCardSurchargeAmount()));
-        assertThat(gatewayAccount.getCorporatePrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporatePrepaidDebitCardSurchargeAmount()));
-        assertThat(gatewayAccount.getCardTypes(), containsInAnyOrder(
-                allOf(
-                        hasProperty("id", is(Matchers.notNullValue())),
-                        hasProperty("label", is(masterCardCredit.getLabel())),
-                        hasProperty("type", is(masterCardCredit.getType())),
-                        hasProperty("brand", is(masterCardCredit.getBrand()))
-                ), allOf(
-                        hasProperty("id", is(Matchers.notNullValue())),
-                        hasProperty("label", is(visaCardDebit.getLabel())),
-                        hasProperty("type", is(visaCardDebit.getType())),
-                        hasProperty("brand", is(visaCardDebit.getBrand()))
-                )));
-        assertThat(gatewayAccount.isAllowTelephonePaymentNotifications(), is(accountRecord.isAllowTelephonePaymentNotifications()));
-    }
+            assertTrue(gatewayAccountOpt.isPresent());
+            GatewayAccountEntity gatewayAccount = gatewayAccountOpt.get();
+            assertThat(gatewayAccount.getGatewayName(), is(accountRecord.getPaymentProvider()));
+            assertThat(gatewayAccount.getExternalId(), is(accountRecord.getExternalId()));
+            assertThat(gatewayAccount.getServiceName(), is(accountRecord.getServiceName()));
+            assertThat(gatewayAccount.getServiceId(), is(accountRecord.getServiceId()));
+            assertThat(gatewayAccount.getDescription(), is(accountRecord.getDescription()));
+            assertThat(gatewayAccount.getAnalyticsId(), is(accountRecord.getAnalyticsId()));
+            assertThat(gatewayAccount.getCorporateNonPrepaidCreditCardSurchargeAmount(), is(accountRecord.getCorporateCreditCardSurchargeAmount()));
+            assertThat(gatewayAccount.getCorporateNonPrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporateDebitCardSurchargeAmount()));
+            assertThat(gatewayAccount.getCorporatePrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporatePrepaidDebitCardSurchargeAmount()));
+            assertThat(gatewayAccount.getCardTypes(), containsInAnyOrder(
+                    allOf(
+                            hasProperty("id", is(Matchers.notNullValue())),
+                            hasProperty("label", is(masterCardCredit.getLabel())),
+                            hasProperty("type", is(masterCardCredit.getType())),
+                            hasProperty("brand", is(masterCardCredit.getBrand()))
+                    ), allOf(
+                            hasProperty("id", is(Matchers.notNullValue())),
+                            hasProperty("label", is(visaCardDebit.getLabel())),
+                            hasProperty("type", is(visaCardDebit.getType())),
+                            hasProperty("brand", is(visaCardDebit.getBrand()))
+                    )));
+            assertThat(gatewayAccount.isAllowTelephonePaymentNotifications(), is(accountRecord.isAllowTelephonePaymentNotifications()));
+        }
 
-    @Test
-    void findById_shouldFindGatewayAccountWithCorporateSurcharges() {
-        DatabaseFixtures.TestAccount accountRecord = createAccountRecordWithCorporateSurcharges();
+        @Test
+        void findById_shouldFindGatewayAccountWithCorporateSurcharges() {
+            DatabaseFixtures.TestAccount accountRecord = createAccountRecordWithCorporateSurcharges();
 
-        Optional<GatewayAccountEntity> gatewayAccountOpt =
-                gatewayAccountDao.findById(GatewayAccountEntity.class, accountRecord.getAccountId());
+            Optional<GatewayAccountEntity> gatewayAccountOpt =
+                    gatewayAccountDao.findById(GatewayAccountEntity.class, accountRecord.getAccountId());
 
-        assertTrue(gatewayAccountOpt.isPresent());
-        GatewayAccountEntity gatewayAccount = gatewayAccountOpt.get();
-        assertThat(gatewayAccount.getGatewayName(), is(accountRecord.getPaymentProvider()));
-        assertThat(gatewayAccount.getExternalId(), is(accountRecord.getExternalId()));
-        assertThat(gatewayAccount.getServiceName(), is(accountRecord.getServiceName()));
-        assertThat(gatewayAccount.getDescription(), is(accountRecord.getDescription()));
-        assertThat(gatewayAccount.getAnalyticsId(), is(accountRecord.getAnalyticsId()));
-        assertThat(gatewayAccount.getCorporateNonPrepaidCreditCardSurchargeAmount(), is(accountRecord.getCorporateCreditCardSurchargeAmount()));
-        assertThat(gatewayAccount.getCorporateNonPrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporateDebitCardSurchargeAmount()));
-        assertThat(gatewayAccount.getCorporatePrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporatePrepaidDebitCardSurchargeAmount()));
+            assertTrue(gatewayAccountOpt.isPresent());
+            GatewayAccountEntity gatewayAccount = gatewayAccountOpt.get();
+            assertThat(gatewayAccount.getGatewayName(), is(accountRecord.getPaymentProvider()));
+            assertThat(gatewayAccount.getExternalId(), is(accountRecord.getExternalId()));
+            assertThat(gatewayAccount.getServiceName(), is(accountRecord.getServiceName()));
+            assertThat(gatewayAccount.getDescription(), is(accountRecord.getDescription()));
+            assertThat(gatewayAccount.getAnalyticsId(), is(accountRecord.getAnalyticsId()));
+            assertThat(gatewayAccount.getCorporateNonPrepaidCreditCardSurchargeAmount(), is(accountRecord.getCorporateCreditCardSurchargeAmount()));
+            assertThat(gatewayAccount.getCorporateNonPrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporateDebitCardSurchargeAmount()));
+            assertThat(gatewayAccount.getCorporatePrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporatePrepaidDebitCardSurchargeAmount()));
 
-    }
+        }
 
-    @Test
-    void findById_shouldUpdateAccountCardTypes() {
-        final CardTypeEntity masterCardCredit = app.getDatabaseTestHelper().getMastercardCreditCard();
-        final CardTypeEntity visaCardCredit = app.getDatabaseTestHelper().getVisaCreditCard();
-        final CardTypeEntity visaCardDebit = app.getDatabaseTestHelper().getVisaDebitCard();
-        DatabaseFixtures.TestAccount accountRecord = createAccountRecordWithCards(masterCardCredit, visaCardCredit);
+        @Test
+        void findById_shouldUpdateAccountCardTypes() {
+            final CardTypeEntity masterCardCredit = app.getDatabaseTestHelper().getMastercardCreditCard();
+            final CardTypeEntity visaCardCredit = app.getDatabaseTestHelper().getVisaCreditCard();
+            final CardTypeEntity visaCardDebit = app.getDatabaseTestHelper().getVisaDebitCard();
+            DatabaseFixtures.TestAccount accountRecord = createAccountRecordWithCards(masterCardCredit, visaCardCredit);
 
-        Optional<GatewayAccountEntity> gatewayAccountOpt =
-                gatewayAccountDao.findById(GatewayAccountEntity.class, accountRecord.getAccountId());
+            Optional<GatewayAccountEntity> gatewayAccountOpt =
+                    gatewayAccountDao.findById(GatewayAccountEntity.class, accountRecord.getAccountId());
 
-        assertTrue(gatewayAccountOpt.isPresent());
-        GatewayAccountEntity gatewayAccount = gatewayAccountOpt.get();
+            assertTrue(gatewayAccountOpt.isPresent());
+            GatewayAccountEntity gatewayAccount = gatewayAccountOpt.get();
 
-        List<CardTypeEntity> cardTypes = gatewayAccount.getCardTypes();
+            List<CardTypeEntity> cardTypes = gatewayAccount.getCardTypes();
 
-        cardTypes.removeIf(p -> p.getId().equals(visaCardCredit.getId()));
-        cardTypes.add(visaCardDebit);
+            cardTypes.removeIf(p -> p.getId().equals(visaCardCredit.getId()));
+            cardTypes.add(visaCardDebit);
 
-        gatewayAccountDao.merge(gatewayAccount);
+            gatewayAccountDao.merge(gatewayAccount);
 
-        List<Map<String, Object>> acceptedCardTypesByAccountId = app.getDatabaseTestHelper().getAcceptedCardTypesByAccountId(accountRecord.getAccountId());
+            List<Map<String, Object>> acceptedCardTypesByAccountId = app.getDatabaseTestHelper().getAcceptedCardTypesByAccountId(accountRecord.getAccountId());
 
-        assertThat(acceptedCardTypesByAccountId, containsInAnyOrder(
-                allOf(
-                        hasEntry("label", masterCardCredit.getLabel()),
-                        hasEntry("type", masterCardCredit.getType().toString()),
-                        hasEntry("brand", masterCardCredit.getBrand())
-                ), allOf(
-                        hasEntry("label", visaCardDebit.getLabel()),
-                        hasEntry("type", visaCardDebit.getType().toString()),
-                        hasEntry("brand", visaCardDebit.getBrand())
-                )));
-    }
+            assertThat(acceptedCardTypesByAccountId, containsInAnyOrder(
+                    allOf(
+                            hasEntry("label", masterCardCredit.getLabel()),
+                            hasEntry("type", masterCardCredit.getType().toString()),
+                            hasEntry("brand", masterCardCredit.getBrand())
+                    ), allOf(
+                            hasEntry("label", visaCardDebit.getLabel()),
+                            hasEntry("type", visaCardDebit.getType().toString()),
+                            hasEntry("brand", visaCardDebit.getBrand())
+                    )));
+        }
 
-    @Test
-    void findById_shouldFindAccountInfoByIdWhenFindingByIdReturningGatewayAccount() {
-        String paymentProvider = "test provider";
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId))
-                .withPaymentGateway(paymentProvider)
-                .withServiceName("a cool service")
-                .build());
+        @Test
+        void findById_shouldFindAccountInfoByIdWhenFindingByIdReturningGatewayAccount() {
+            String paymentProvider = "test provider";
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId))
+                    .withPaymentGateway(paymentProvider)
+                    .withServiceName("a cool service")
+                    .build());
 
-        Optional<GatewayAccountEntity> gatewayAccountOpt = gatewayAccountDao.findById(gatewayAccountId);
+            Optional<GatewayAccountEntity> gatewayAccountOpt = gatewayAccountDao.findById(gatewayAccountId);
 
-        assertTrue(gatewayAccountOpt.isPresent());
-        GatewayAccountEntity gatewayAccount = gatewayAccountOpt.get();
-        assertThat(gatewayAccount.getGatewayName(), is(paymentProvider));
+            assertTrue(gatewayAccountOpt.isPresent());
+            GatewayAccountEntity gatewayAccount = gatewayAccountOpt.get();
+            assertThat(gatewayAccount.getGatewayName(), is(paymentProvider));
+        }
     }
 
     @Test
@@ -308,299 +318,303 @@ public class GatewayAccountDaoIT {
         assertThat(retrievedGatewayAccount.getNotificationCredentials().getUserName(), is("username"));
         assertThat(retrievedGatewayAccount.getNotificationCredentials().getPassword(), is("password"));
     }
-
-    @Test
-    void shouldReturnAllAccountsWhenNoSearchParameters() {
-        long gatewayAccountId_1 = nextLong();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
-                .build());
-        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_2))
-                .build());
-
-        var params = new GatewayAccountSearchParams();
-
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(2));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
-        assertThat(gatewayAccounts.get(1).getId(), is(gatewayAccountId_2));
-    }
-
-    @Test
-    void shouldSearchForAccountsById() {
-        long gatewayAccountId_1 = nextLong();
-        String externalId_1 = randomUuid();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
-                .withExternalId(externalId_1)
-                .build());
-        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
-        String externalId_2 = randomUuid();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_2))
-                .withExternalId(externalId_2)
-                .build());
-        long gatewayAccountId_3 = gatewayAccountId_2 + 1;
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_3))
-                .build());
-
-        var params = new GatewayAccountSearchParams();
-        params.setAccountIds(gatewayAccountId_1 + "," + gatewayAccountId_2);
-
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(2));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
-        assertThat(gatewayAccounts.get(0).getExternalId(), is(externalId_1));
-        assertThat(gatewayAccounts.get(1).getId(), is(gatewayAccountId_2));
-        assertThat(gatewayAccounts.get(1).getExternalId(), is(externalId_2));
-    }
-
-    @Test
-    void shouldSearchForAccountsByMotoEnabled() {
-        long gatewayAccountId_1 = nextLong();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
-                .withAllowMoto(false)
-                .build());
-        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_2))
-                .withAllowMoto(true)
-                .build());
-
-        var params = new GatewayAccountSearchParams();
-        params.setMotoEnabled("true");
-
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
-    }
-
-    @Test
-    void shouldSearchForAccountsByApplePayEnabled() {
-        long gatewayAccountId_1 = nextLong();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
-                .withAllowApplePay(false)
-                .build());
-        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_2))
-                .withAllowApplePay(true)
-                .build());
-
-        var params = new GatewayAccountSearchParams();
-        params.setApplePayEnabled("true");
-
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
-    }
-
-    @Test
-    void shouldSearchForAccountsByGooglePayEnabled() {
-        long gatewayAccountId_1 = nextLong();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
-                .withAllowGooglePay(false)
-                .build());
-        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_2))
-                .withAllowGooglePay(true)
-                .build());
-
-        var params = new GatewayAccountSearchParams();
-        params.setGooglePayEnabled("true");
-
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
-    }
-
-    @Test
-    void shouldSearchForAccountsByRequires3ds() {
-        long gatewayAccountId_1 = nextLong();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
-                .withRequires3ds(false)
-                .build());
-        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_2))
-                .withRequires3ds(true)
-                .build());
-
-        var params = new GatewayAccountSearchParams();
-        params.setRequires3ds("true");
-
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
-    }
-
-    @Test
-    void shouldSearchForAccountsByType() {
-        long gatewayAccountId_1 = nextLong();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
-                .withType(TEST)
-                .build());
-        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_2))
-                .withType(LIVE)
-                .build());
-
-        var params = new GatewayAccountSearchParams();
-        params.setType("live");
-
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
-    }
-
-    @Test
-    void shouldSearchForAccountsByPaymentProvider() {
-        long gatewayAccountId1 = nextLong();
-        long gatewayAccountId2 = nextLong();
-        long gatewayAccountId3 = nextLong();
-        AddGatewayAccountCredentialsParams account1_credentials1 = anAddGatewayAccountCredentialsParams()
-                .withPaymentProvider(WORLDPAY.getName())
-                .withState(CREATED)
-                .withGatewayAccountId(gatewayAccountId1)
-                .build();
-        AddGatewayAccountCredentialsParams account1_credentials2 = anAddGatewayAccountCredentialsParams()
-                .withPaymentProvider(STRIPE.getName())
-                .withState(ACTIVE)
-                .withGatewayAccountId(gatewayAccountId1)
-                .build();
-        AddGatewayAccountCredentialsParams account2_credentials = anAddGatewayAccountCredentialsParams()
-                .withPaymentProvider(WORLDPAY.getName())
-                .withState(ACTIVE)
-                .withGatewayAccountId(gatewayAccountId2)
-                .build();
-        AddGatewayAccountCredentialsParams account3_credentials = anAddGatewayAccountCredentialsParams()
-                .withPaymentProvider(WORLDPAY.getName())
-                .withState(CREATED)
-                .withGatewayAccountId(gatewayAccountId3)
-                .build();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId1))
-                .withGatewayAccountCredentials(List.of(account1_credentials1, account1_credentials2))
-                .build());
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId2))
-                .withGatewayAccountCredentials(List.of(account2_credentials))
-                .build());
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId3))
-                .withGatewayAccountCredentials(List.of(account3_credentials))
-                .build());
-
-        var params = new GatewayAccountSearchParams();
-        params.setPaymentProvider("worldpay");
-
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(2));
-        assertThat(gatewayAccounts, containsInAnyOrder(
-                hasProperty("id", is(gatewayAccountId2)),
-                hasProperty("id", is(gatewayAccountId3))
-        ));
-    }
-
-    @Test
-    void shouldSearchForAccountsByProviderSwitchEnabled() {
-        long gatewayAccountId_1 = nextLong();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
-                .withPaymentGateway("sandbox")
-                .withProviderSwitchEnabled(true)
-                .build());
-        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_2))
-                .withProviderSwitchEnabled(false)
-                .withPaymentGateway("sandbox")
-                .build());
-
-        var params = new GatewayAccountSearchParams();
-        params.setProviderSwitchEnabled("true");
-
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
-    }    
     
-    @Test
-    void shouldSearchForAccountsByPaymentProviderAccountId() {
-        long gatewayAccountId = nextLong();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId))
-                .withPaymentGateway("sandbox")
-                .withCredentials(Map.of("stripe_account_id", "acc123"))
-                .build());
+    @Nested
+    class Search {
 
-        var params = new GatewayAccountSearchParams();
-        params.setPaymentProviderAccountId("acc123");
+        @Test
+        void shouldReturnAllAccountsWhenNoSearchParameters() {
+            long gatewayAccountId_1 = nextLong();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_1))
+                    .build());
+            long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_2))
+                    .build());
 
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
-    }    
-    
-    @Test
-    void shouldSearchForAccountsByWorldpayMerchantCodeInOneOffPaymentCredentials() {
-        long gatewayAccountId = nextLong();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId))
-                .withPaymentGateway("worldpay")
-                .withCredentials(Map.of("one_off_customer_initiated", Map.of("merchant_code", "acc123")))
-                .build());
+            var params = new GatewayAccountSearchParams();
 
-        var params = new GatewayAccountSearchParams();
-        params.setPaymentProviderAccountId("acc123");
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(2));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
+            assertThat(gatewayAccounts.get(1).getId(), is(gatewayAccountId_2));
+        }
 
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
-    }
+        @Test
+        void shouldSearchForAccountsById() {
+            long gatewayAccountId_1 = nextLong();
+            String externalId_1 = randomUuid();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_1))
+                    .withExternalId(externalId_1)
+                    .build());
+            long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+            String externalId_2 = randomUuid();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_2))
+                    .withExternalId(externalId_2)
+                    .build());
+            long gatewayAccountId_3 = gatewayAccountId_2 + 1;
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_3))
+                    .build());
 
-    @Test
-    void shouldSearchForAccountsByWorldpayMerchantCodeInRecurringCustomerInitiatedCredentials() {
-        long gatewayAccountId = nextLong();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId))
-                .withPaymentGateway("worldpay")
-                .withCredentials(Map.of("recurring_customer_initiated", Map.of("merchant_code", "acc123")))
-                .build());
+            var params = new GatewayAccountSearchParams();
+            params.setAccountIds(gatewayAccountId_1 + "," + gatewayAccountId_2);
 
-        var params = new GatewayAccountSearchParams();
-        params.setPaymentProviderAccountId("acc123");
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(2));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
+            assertThat(gatewayAccounts.get(0).getExternalId(), is(externalId_1));
+            assertThat(gatewayAccounts.get(1).getId(), is(gatewayAccountId_2));
+            assertThat(gatewayAccounts.get(1).getExternalId(), is(externalId_2));
+        }
 
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
-    }
+        @Test
+        void shouldSearchForAccountsByMotoEnabled() {
+            long gatewayAccountId_1 = nextLong();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_1))
+                    .withAllowMoto(false)
+                    .build());
+            long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_2))
+                    .withAllowMoto(true)
+                    .build());
 
-    @Test
-    void shouldSearchForAccountsByWorldpayMerchantCodeInRecurringMerchantInitiatedCredentials() {
-        long gatewayAccountId = nextLong();
-        app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId))
-                .withPaymentGateway("worldpay")
-                .withCredentials(Map.of("recurring_merchant_initiated", Map.of("merchant_code", "acc123")))
-                .build());
+            var params = new GatewayAccountSearchParams();
+            params.setMotoEnabled("true");
 
-        var params = new GatewayAccountSearchParams();
-        params.setPaymentProviderAccountId("acc123");
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(1));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+        }
 
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
-        assertThat(gatewayAccounts, hasSize(1));
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
+        @Test
+        void shouldSearchForAccountsByApplePayEnabled() {
+            long gatewayAccountId_1 = nextLong();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_1))
+                    .withAllowApplePay(false)
+                    .build());
+            long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_2))
+                    .withAllowApplePay(true)
+                    .build());
+
+            var params = new GatewayAccountSearchParams();
+            params.setApplePayEnabled("true");
+
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(1));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+        }
+
+        @Test
+        void shouldSearchForAccountsByGooglePayEnabled() {
+            long gatewayAccountId_1 = nextLong();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_1))
+                    .withAllowGooglePay(false)
+                    .build());
+            long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_2))
+                    .withAllowGooglePay(true)
+                    .build());
+
+            var params = new GatewayAccountSearchParams();
+            params.setGooglePayEnabled("true");
+
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(1));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+        }
+
+        @Test
+        void shouldSearchForAccountsByRequires3ds() {
+            long gatewayAccountId_1 = nextLong();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_1))
+                    .withRequires3ds(false)
+                    .build());
+            long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_2))
+                    .withRequires3ds(true)
+                    .build());
+
+            var params = new GatewayAccountSearchParams();
+            params.setRequires3ds("true");
+
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(1));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+        }
+
+        @Test
+        void shouldSearchForAccountsByType() {
+            long gatewayAccountId_1 = nextLong();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_1))
+                    .withType(TEST)
+                    .build());
+            long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_2))
+                    .withType(LIVE)
+                    .build());
+
+            var params = new GatewayAccountSearchParams();
+            params.setType("live");
+
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(1));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+        }
+
+        @Test
+        void shouldSearchForAccountsByPaymentProvider() {
+            long gatewayAccountId1 = nextLong();
+            long gatewayAccountId2 = nextLong();
+            long gatewayAccountId3 = nextLong();
+            AddGatewayAccountCredentialsParams account1_credentials1 = anAddGatewayAccountCredentialsParams()
+                    .withPaymentProvider(WORLDPAY.getName())
+                    .withState(CREATED)
+                    .withGatewayAccountId(gatewayAccountId1)
+                    .build();
+            AddGatewayAccountCredentialsParams account1_credentials2 = anAddGatewayAccountCredentialsParams()
+                    .withPaymentProvider(STRIPE.getName())
+                    .withState(ACTIVE)
+                    .withGatewayAccountId(gatewayAccountId1)
+                    .build();
+            AddGatewayAccountCredentialsParams account2_credentials = anAddGatewayAccountCredentialsParams()
+                    .withPaymentProvider(WORLDPAY.getName())
+                    .withState(ACTIVE)
+                    .withGatewayAccountId(gatewayAccountId2)
+                    .build();
+            AddGatewayAccountCredentialsParams account3_credentials = anAddGatewayAccountCredentialsParams()
+                    .withPaymentProvider(WORLDPAY.getName())
+                    .withState(CREATED)
+                    .withGatewayAccountId(gatewayAccountId3)
+                    .build();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId1))
+                    .withGatewayAccountCredentials(List.of(account1_credentials1, account1_credentials2))
+                    .build());
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId2))
+                    .withGatewayAccountCredentials(List.of(account2_credentials))
+                    .build());
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId3))
+                    .withGatewayAccountCredentials(List.of(account3_credentials))
+                    .build());
+
+            var params = new GatewayAccountSearchParams();
+            params.setPaymentProvider("worldpay");
+
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(2));
+            assertThat(gatewayAccounts, containsInAnyOrder(
+                    hasProperty("id", is(gatewayAccountId2)),
+                    hasProperty("id", is(gatewayAccountId3))
+            ));
+        }
+
+        @Test
+        void shouldSearchForAccountsByProviderSwitchEnabled() {
+            long gatewayAccountId_1 = nextLong();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_1))
+                    .withPaymentGateway("sandbox")
+                    .withProviderSwitchEnabled(true)
+                    .build());
+            long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId_2))
+                    .withProviderSwitchEnabled(false)
+                    .withPaymentGateway("sandbox")
+                    .build());
+
+            var params = new GatewayAccountSearchParams();
+            params.setProviderSwitchEnabled("true");
+
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(1));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
+        }
+
+        @Test
+        void shouldSearchForAccountsByPaymentProviderAccountId() {
+            long gatewayAccountId = nextLong();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId))
+                    .withPaymentGateway("sandbox")
+                    .withCredentials(Map.of("stripe_account_id", "acc123"))
+                    .build());
+
+            var params = new GatewayAccountSearchParams();
+            params.setPaymentProviderAccountId("acc123");
+
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(1));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
+        }
+
+        @Test
+        void shouldSearchForAccountsByWorldpayMerchantCodeInOneOffPaymentCredentials() {
+            long gatewayAccountId = nextLong();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId))
+                    .withPaymentGateway("worldpay")
+                    .withCredentials(Map.of("one_off_customer_initiated", Map.of("merchant_code", "acc123")))
+                    .build());
+
+            var params = new GatewayAccountSearchParams();
+            params.setPaymentProviderAccountId("acc123");
+
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(1));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
+        }
+
+        @Test
+        void shouldSearchForAccountsByWorldpayMerchantCodeInRecurringCustomerInitiatedCredentials() {
+            long gatewayAccountId = nextLong();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId))
+                    .withPaymentGateway("worldpay")
+                    .withCredentials(Map.of("recurring_customer_initiated", Map.of("merchant_code", "acc123")))
+                    .build());
+
+            var params = new GatewayAccountSearchParams();
+            params.setPaymentProviderAccountId("acc123");
+
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(1));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
+        }
+
+        @Test
+        void shouldSearchForAccountsByWorldpayMerchantCodeInRecurringMerchantInitiatedCredentials() {
+            long gatewayAccountId = nextLong();
+            app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
+                    .withAccountId(String.valueOf(gatewayAccountId))
+                    .withPaymentGateway("worldpay")
+                    .withCredentials(Map.of("recurring_merchant_initiated", Map.of("merchant_code", "acc123")))
+                    .build());
+
+            var params = new GatewayAccountSearchParams();
+            params.setPaymentProviderAccountId("acc123");
+
+            List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+            assertThat(gatewayAccounts, hasSize(1));
+            assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
+        }
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
Update `AppWithPostgresAndSqsExtension` to only run code in `beforeAll` and `afterAll` callbacks when there is no enclosing class
 - This allows for using `@Nested` test blocks in integration tests - previously the Dropwizard app would be stopped by the `afterAll` callback in `AppWithPostgresAndSqsExtension` after tests in a nested block were run, even if there were additional tests in the class yet to run

Added `@Nested` blocks to `GatewayAccountDaoIT` to illustrate the working behaviour

## How to test
Run integration tests