### PR TITLE
PP-12356 Add optional prevention of database cleanup in integration tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -588,7 +588,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 166
+        "line_number": 167
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java": [
@@ -1041,5 +1041,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-13T14:14:13Z"
+  "generated_at": "2024-05-14T13:30:18Z"
 }

--- a/src/test/java/uk/gov/pay/connector/util/CleanStateAfterAll.java
+++ b/src/test/java/uk/gov/pay/connector/util/CleanStateAfterAll.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.util;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("cleanStateAfterAll")
+public @interface CleanStateAfterAll {
+}

--- a/src/test/java/uk/gov/pay/connector/util/PollutesState.java
+++ b/src/test/java/uk/gov/pay/connector/util/PollutesState.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.connector.util;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("pollutesState")
+@CleanStateAfterAll
+public @interface PollutesState {
+}


### PR DESCRIPTION
## WHAT YOU DID
 - Add `@PollutesState` annotation for use in integration tests which surpresses database cleanup step after each test
 - Database cleanup step adds ~100-150ms per test, surpressing this makes the marginal time cost of additional integration tests much smaller
 - Annotation can be added at test or class level - when added at class level, the database cleanup will be run after all tests within the class, providing a guaranteed clean slate for other tests