### PR TITLE
PP-12356 Reuse App extension in integration tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -584,7 +588,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 166
+        "line_number": 167
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java": [
@@ -660,7 +664,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java",
         "hashed_secret": "e9b6cb662f24d2346839fb0b797ad778c290994e",
         "is_verified": false,
-        "line_number": 112
+        "line_number": 113
       }
     ],
     "src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java": [
@@ -1037,5 +1041,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-14T13:08:29Z"
+  "generated_at": "2024-05-15T14:34:10Z"
 }

--- a/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceIT.java
@@ -34,7 +34,7 @@ import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentIns
 
 public class AgreementsApiResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
 
     private static final String REFERENCE_ID = "1234";
     private static final String DESCRIPTION = "a valid description";

--- a/src/test/java/uk/gov/pay/connector/cardtype/dao/CardTypeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/cardtype/dao/CardTypeDaoIT.java
@@ -19,7 +19,8 @@ import static org.hamcrest.Matchers.isA;
 
 public class CardTypeDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     private static CardTypeDao cardTypeDao;
 

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
@@ -23,7 +23,8 @@ import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccoun
 
 public class ChargesFrontendResourceWorldpayJwtIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());

--- a/src/test/java/uk/gov/pay/connector/dao/ChargeEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/dao/ChargeEventDaoIT.java
@@ -37,7 +37,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CAR
 
 public class ChargeEventDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private static final String TRANSACTION_ID = "345654";
     private static final String TRANSACTION_ID_2 = "345655";
     private static final String TRANSACTION_ID_3 = "345656";

--- a/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
@@ -25,7 +25,8 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class EmittedEventDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private EmittedEventDao emittedEventDao;
 
     @BeforeEach

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
@@ -45,7 +45,8 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class GatewayAccountCredentialsDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
     private ObjectMapper objectMapper = new ObjectMapper();
     private GatewayAccountDao gatewayAccountDao;

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDaoIT.java
@@ -28,7 +28,8 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class GatewayAccountCredentialsHistoryDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
     private GatewayAccountCredentialsHistoryDao gatewayAccountCredentialsHistoryDao;
     private GatewayAccountDao gatewayAccountDao;

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
@@ -37,7 +37,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountCredentialsResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private DatabaseFixtures.TestAccount testAccount;
     private static final String PATCH_CREDENTIALS_URL = "/v1/api/accounts/%s/credentials/%s";
     private Long credentialsId;

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpay3dsFlexIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpay3dsFlexIT.java
@@ -46,7 +46,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountCredentialsResourceWorldpay3dsFlexIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private DatabaseFixtures.TestAccount testAccount;
     private static final String SERVICE_ID = "a-valid-service-id";
     private static final String SERVICE_NAME = "a-test-service";

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpayIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpayIT.java
@@ -34,7 +34,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountCredentialsResourceWorldpayIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private DatabaseFixtures.TestAccount testAccount;
 
     private static final String PATCH_CREDENTIALS_URL = "/v1/api/accounts/%s/credentials/%s";

--- a/src/test/java/uk/gov/pay/connector/it/dao/AgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/AgreementDaoIT.java
@@ -17,7 +17,9 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 
 public class AgreementDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+//    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private AgreementDao agreementDao;
     private GatewayAccountEntity gatewayAccount1, gatewayAccount2;
     private static final String AGREEMENT_EXTERNAL_ID_ONE = "12345678901234567890123456";

--- a/src/test/java/uk/gov/pay/connector/it/dao/CardTypeDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/CardTypeDaoJpaIT.java
@@ -18,7 +18,8 @@ import static uk.gov.pay.connector.cardtype.model.domain.CardType.DEBIT;
 
 public class CardTypeDaoJpaIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private static CardTypeDao cardTypeDao;
 
     @BeforeAll

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsIT.java
@@ -37,7 +37,8 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class ChargeDaoCardDetailsIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private ChargeDao chargeDao;
     private GatewayAccountDao gatewayAccountDao;
     private GatewayAccountCredentialsDao gatewayAccountCredentialsDao;

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -67,7 +67,8 @@ import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
 
 public class ChargeDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private static final String DESCRIPTION = "Test description";
 
     private ChargeDao chargeDao;

--- a/src/test/java/uk/gov/pay/connector/it/dao/FeeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/FeeDaoIT.java
@@ -21,7 +21,8 @@ import static org.hamcrest.core.Is.is;
 
 public class FeeDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private FeeDao feeDao;
     private DatabaseFixtures.TestCharge defaultTestCharge;
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -50,7 +50,8 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class GatewayAccountDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private GatewayAccountDao gatewayAccountDao;
     private GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
     private DatabaseFixtures databaseFixtures;

--- a/src/test/java/uk/gov/pay/connector/it/dao/IdempotencyDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/IdempotencyDaoIT.java
@@ -23,7 +23,8 @@ import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccoun
 
 public class IdempotencyDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+    
     @RegisterExtension
     static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
     private IdempotencyDao idempotencyDao;

--- a/src/test/java/uk/gov/pay/connector/it/dao/PaymentInstrumentDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/PaymentInstrumentDaoIT.java
@@ -20,7 +20,8 @@ import static org.hamcrest.Matchers.is;
 
 public class PaymentInstrumentDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private PaymentInstrumentDao paymentInstrumentDao;
     
     private static final String PAYMENT_INSTRUMENT_EXTERNAL_ID_ONE = "12345678901234567890123456";

--- a/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
@@ -44,7 +44,8 @@ import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMI
 
 public class RefundDaoJpaIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private RefundDao refundDao;
     private DatabaseFixtures.TestCharge chargeTestRecord;
     private DatabaseFixtures.TestRefund refundTestRecord;

--- a/src/test/java/uk/gov/pay/connector/it/dao/StripeAccountSetupDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/StripeAccountSetupDaoIT.java
@@ -21,7 +21,9 @@ import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccoun
 
 public class StripeAccountSetupDaoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+//    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private StripeAccountSetupDao stripeAccountSetupDao;
 
     @BeforeEach

--- a/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
@@ -22,7 +22,8 @@ import static org.hamcrest.core.Is.is;
 
 public class TokenDaoJpaIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     private TokenDao tokenDao;
     private ChargeDao chargeDao;
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
@@ -19,7 +19,8 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDe
 
 public class CardAuthorizeDelayedGatewayResponseIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
     

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayIT.java
@@ -38,7 +38,8 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonApplePayAuthori
 
 public class CardResourceAuthoriseApplePayIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
     

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
@@ -63,7 +63,8 @@ import static uk.gov.pay.connector.util.TransactionId.randomId;
 
 public class CardResourceAuthoriseIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureIT.java
@@ -27,7 +27,8 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL
 
 public class CardResourceCaptureIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
@@ -42,7 +42,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_
 
 public class ChargeCancelFrontendResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
     

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceIT.java
@@ -30,7 +30,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCE
 
 public class ChargeCancelResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceResponseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceResponseIT.java
@@ -24,7 +24,8 @@ import static org.hamcrest.Matchers.is;
 
 public class ChargeCancelResourceResponseIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeEventsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeEventsResourceIT.java
@@ -35,7 +35,8 @@ import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccoun
 public class ChargeEventsResourceIT {
 
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
     

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceIT.java
@@ -35,7 +35,8 @@ import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.a
 
 public class ChargeExpiryResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
     

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
@@ -36,7 +36,8 @@ import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGa
 
 public class ChargesApiResourceAllowWebPaymentsIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     
     private static ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
@@ -65,7 +65,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class ChargesApiResourceCreateAgreementIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
     

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateLanguageIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateLanguageIT.java
@@ -28,7 +28,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class ChargesApiResourceCreateLanguageIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateMetadataIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateMetadataIT.java
@@ -43,7 +43,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJsonWithNulls;
 
 public class ChargesApiResourceCreateMetadataIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateMotoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateMotoIT.java
@@ -24,7 +24,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class ChargesApiResourceCreateMotoIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreatePrefilledCardholderDetailsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreatePrefilledCardholderDetailsIT.java
@@ -29,7 +29,8 @@ import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
 public class ChargesApiResourceCreatePrefilledCardholderDetailsIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateProviderCredentialsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateProviderCredentialsIT.java
@@ -35,7 +35,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class ChargesApiResourceCreateProviderCredentialsIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateReturnUrlIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateReturnUrlIT.java
@@ -26,7 +26,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class ChargesApiResourceCreateReturnUrlIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
     

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateSourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateSourceIT.java
@@ -31,7 +31,8 @@ import static uk.gov.service.payments.commons.model.Source.CARD_API;
 
 public class ChargesApiResourceCreateSourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateZeroAmountIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateZeroAmountIT.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.it.resources;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import scala.App;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.it.base.ITestBaseExtension;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
@@ -24,7 +25,9 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class ChargesApiResourceCreateZeroAmountIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+//    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -59,7 +59,8 @@ import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter
 
 public class ChargesApiResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
@@ -29,7 +29,8 @@ import static uk.gov.service.payments.commons.model.Source.CARD_EXTERNAL_TELEPHO
 
 public class ChargesApiResourceTelephonePaymentsIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
     private static final HashMap<String, Object> postBody = new HashMap<>();

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
@@ -65,7 +65,8 @@ import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
 public class ChargesFrontendResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     public static final String AGREEMENT_ID = "12345678901234567890123456";
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceIT.java
@@ -37,7 +37,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 public class DiscrepancyResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
@@ -22,7 +22,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class EmailNotificationResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     @Test
     void patchEmailNotification_shouldNotUpdateIfMissingField() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
@@ -45,7 +45,8 @@ import static uk.gov.service.payments.commons.model.SupportedLanguage.ENGLISH;
 
 public class ExpungeResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     EmittedEventDao emittedEventDao;
     private DatabaseFixtures.TestCharge expungeableCharge1;
     private DatabaseTestHelper databaseTestHelper;

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -49,7 +49,8 @@ import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExte
 
 public class GatewayAccountFrontendResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     
     public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions("sandbox", app.getLocalPort());
     private static final String ACCOUNTS_CARD_TYPE_FRONTEND_URL = "v1/frontend/accounts/{accountId}/card-types";

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
@@ -35,7 +35,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountResourceCreateIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     GatewayAccountDao gatewayAccountDao;
 
     @BeforeEach

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -54,7 +54,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions("sandbox", app.getLocalPort());
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private DatabaseFixtures.TestAccount defaultTestAccount;

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
@@ -21,7 +21,8 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class GatewayAccountResourceSwitchPspIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     private static ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
@@ -26,7 +26,8 @@ import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.a
 
 public class GatewayCleanupResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/HealthCheckResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/HealthCheckResourceIT.java
@@ -10,7 +10,8 @@ import static org.hamcrest.Matchers.is;
 
 public class HealthCheckResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/SecurityTokensResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SecurityTokensResourceIT.java
@@ -20,7 +20,8 @@ import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 
 public class SecurityTokensResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
@@ -14,7 +14,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class StripeAccountResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions("stripe", app.getLocalPort());
 
     private static final String STRIPE_ACCOUNT_ID = "acct_123example123";

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
@@ -17,7 +17,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class StripeAccountSetupResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions("sandbox", app.getLocalPort());
 
     @Nested

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqChargeApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqChargeApiResourceIT.java
@@ -10,7 +10,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 
 public class EpdqChargeApiResourceIT  {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("epdq", app.getLocalPort(), app.getDatabaseTestHelper());

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxNotificationResourceIT.java
@@ -9,7 +9,8 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 public class SandboxNotificationResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     private static final String SANDBOX_IP_ADDRESS = "1.1.1.1, 3.3.3.3";
     private static final String UNEXPECTED_IP_ADDRESS = "3.4.3.1, 1.1.1.1";

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
@@ -46,7 +46,8 @@ import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternal
 
 public class SandboxRefundsResourceIT  {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
@@ -65,7 +65,8 @@ import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccoun
 
 public class StripeCardResourceAuthoriseIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("stripe", app.getLocalPort(), app.getDatabaseTestHelper());
     private static final String CARD_HOLDER_NAME = "Scrooge McDuck";

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeNotificationResourceIT.java
@@ -40,7 +40,8 @@ import static uk.gov.pay.connector.util.TransactionId.randomId;
 
 public class StripeNotificationResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     private static final String NOTIFICATION_PATH = "/v1/api/notifications/stripe";
     private static final String RESPONSE_EXPECTED_BY_STRIPE = "[OK]";

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
@@ -32,7 +32,9 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 
 public class StripeRefundsResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+//    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     private String stripeAccountId = "stripe_account_id";
     private String accountId = String.valueOf(nextLong());

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceCancelIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceCancelIT.java
@@ -35,7 +35,8 @@ import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccoun
 
 public class StripeResourceCancelIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
 
     private static final String AMOUNT = "6234";
     private static final String DESCRIPTION = "Test description";

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
@@ -34,7 +34,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CAR
 
 public class WorldpayAuthoriseGooglePayIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -48,7 +48,8 @@ import static uk.gov.pay.connector.rules.WorldpayMockClient.WORLDPAY_URL;
 
 public class WorldpayCardResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayChargeCancelResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayChargeCancelResourceIT.java
@@ -17,7 +17,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 
 public class WorldpayChargeCancelResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
@@ -60,7 +60,9 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 
 public class WorldpayRefundsResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+//    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceIT.java
@@ -21,7 +21,8 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class CardAuthoriseServiceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceIT.java
@@ -27,7 +27,8 @@ import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.a
 
 public class CardCaptureServiceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("stripe", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/StripeCardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/StripeCardAuthoriseServiceIT.java
@@ -20,7 +20,8 @@ import static uk.gov.pay.connector.gateway.stripe.StripeAuthorisationResponse.ST
 
 public class StripeCardAuthoriseServiceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("stripe", app.getLocalPort(), app.getDatabaseTestHelper());
     

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceIT.java
@@ -20,7 +20,8 @@ import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.
 
 public class WorldpayCardAuthoriseServiceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
     

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/AuthoriseWithUserNotPresentTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/AuthoriseWithUserNotPresentTaskHandlerIT.java
@@ -52,7 +52,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class AuthoriseWithUserNotPresentTaskHandlerIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
     private static final String JSON_AGREEMENT_ID_KEY = "agreement_id";

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/CollectFeesForFailedPaymentsTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/CollectFeesForFailedPaymentsTaskHandlerIT.java
@@ -23,7 +23,8 @@ import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.a
 
 public class CollectFeesForFailedPaymentsTaskHandlerIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("stripe", app.getLocalPort(), app.getDatabaseTestHelper());
 

--- a/src/test/java/uk/gov/pay/connector/refund/resource/EpdqRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/refund/resource/EpdqRefundsResourceIT.java
@@ -17,7 +17,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 
 public class EpdqRefundsResourceIT {
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = AppWithPostgresAndSqsExtension.withPersistence();
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("epdq", app.getLocalPort(), app.getDatabaseTestHelper());
     private DatabaseFixtures.TestCharge charge;


### PR DESCRIPTION
## WHAT YOU DID
 - Add option to use persistent Dropwizard app in integration tests using `AppWithPostgresAndSqsExtension` singleton
 - Update integration tests using standard Connector app (with no config overrides or custom `ConnectorApp` class) to use persistent version of app
 - Add environmnt variable to override use of persistent app
 
This gives a significant reduction in the wallclock time integration tests take to run (measured at ~3m 10s, reduced from ~3m 40s)

## How to test
 - Run tests normally
 - Run tests with environment variable `ALLOW_PERSISTENT_APP=false`
