### PR TITLE
PP-12357 Cancel agreement by service ID

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,63 +139,63 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 2611
+        "line_number": 2649
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 2655
+        "line_number": 2693
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3122
+        "line_number": 3160
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3502
+        "line_number": 3540
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3538
+        "line_number": 3576
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 3565
+        "line_number": 3603
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 4217
+        "line_number": 4255
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4684
+        "line_number": 4722
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4695
+        "line_number": 4733
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1059,5 +1059,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-20T14:38:11Z"
+  "generated_at": "2024-05-21T09:29:43Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1389,6 +1389,44 @@ paths:
       summary: Create an agreement for a service ID and account type (test|live)
       tags:
       - Agreements
+  /v1/api/service/{serviceId}/{accountType}/agreements/{agreementId}/cancel:
+    post:
+      operationId: cancelAgreement_1
+      parameters:
+      - description: Service ID
+        example: 46eb1b601348499196c99de90482ee68
+        in: path
+        name: serviceId
+        required: true
+        schema:
+          type: string
+      - description: Account type
+        example: test
+        in: path
+        name: accountType
+        required: true
+        schema:
+          type: string
+          enum:
+          - test
+          - live
+      - in: path
+        name: agreementId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgreementCancelRequest'
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Agreements
   /v1/api/service/{serviceId}/{accountType}/credentials:
     post:
       operationId: createGatewayAccountCredentialsByServiceIdAndAccountType

--- a/src/main/java/uk/gov/pay/connector/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/dao/AgreementDao.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.agreement.dao;
 import com.google.inject.Provider;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.common.dao.JpaDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -19,7 +20,7 @@ public class AgreementDao extends JpaDao<AgreementEntity> {
         return super.findById(AgreementEntity.class, agreementId);
     }
 
-    public Optional<AgreementEntity> findByExternalId(String externalId, long gatewayAccountId) {
+    public Optional<AgreementEntity> findByExternalIdAndGatewayAccountId(String externalId, long gatewayAccountId) {
 
         String query = "SELECT ae FROM AgreementEntity ae " +
                 "WHERE ae.externalId = :externalId " +
@@ -30,6 +31,22 @@ public class AgreementDao extends JpaDao<AgreementEntity> {
                 .setParameter("externalId", externalId)
                 .setParameter("gatewayAccountId", gatewayAccountId)
                 .getResultList().stream().findFirst();
+    }
+
+    public Optional<AgreementEntity> findByExternalIdAndServiceIdAndAccountType(String externalId, String serviceId, GatewayAccountType accountType) {
+
+        String query = "SELECT ae FROM AgreementEntity ae " +
+                "WHERE ae.externalId = :externalId " +
+                "AND ae.serviceId = :serviceId";
+
+        return entityManager.get()
+                .createQuery(query, AgreementEntity.class)
+                .setParameter("externalId", externalId)
+                .setParameter("serviceId", serviceId)
+                .getResultList()
+                .stream()
+                .filter(agreementEntity -> agreementEntity.isLive() ? accountType.equals(GatewayAccountType.LIVE) : accountType.equals(GatewayAccountType.TEST))
+                .findFirst();
     }
 
     public Optional<AgreementEntity> findByExternalId(String externalId) {

--- a/src/main/java/uk/gov/pay/connector/agreement/dao/AgreementDao.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/dao/AgreementDao.java
@@ -34,18 +34,19 @@ public class AgreementDao extends JpaDao<AgreementEntity> {
     }
 
     public Optional<AgreementEntity> findByExternalIdAndServiceIdAndAccountType(String externalId, String serviceId, GatewayAccountType accountType) {
-
+        boolean live = accountType == GatewayAccountType.LIVE;
         String query = "SELECT ae FROM AgreementEntity ae " +
                 "WHERE ae.externalId = :externalId " +
-                "AND ae.serviceId = :serviceId";
+                "AND ae.serviceId = :serviceId " +
+                "AND ae.live = :live";
 
         return entityManager.get()
                 .createQuery(query, AgreementEntity.class)
                 .setParameter("externalId", externalId)
                 .setParameter("serviceId", serviceId)
+                .setParameter("live", live)
                 .getResultList()
                 .stream()
-                .filter(agreementEntity -> agreementEntity.isLive() ? accountType.equals(GatewayAccountType.LIVE) : accountType.equals(GatewayAccountType.TEST))
                 .findFirst();
     }
 

--- a/src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java
@@ -93,7 +93,20 @@ public class AgreementsApiResource {
             @PathParam("agreementId") String agreementId,
             @Valid AgreementCancelRequest agreementCancelRequest
     ) {
-        agreementService.cancel(agreementId, accountId, agreementCancelRequest);
+        agreementService.cancelByGatewayAccountId(agreementId, accountId, agreementCancelRequest);
+        return Response.noContent().build();
+    }
+
+    @POST
+    @Path("/v1/api/service/{serviceId}/{accountType}/agreements/{agreementId}/cancel")
+    @Consumes("application/json")
+    public Response cancelAgreement(
+            @Parameter(example = "46eb1b601348499196c99de90482ee68", description = "Service ID") @PathParam("serviceId") String serviceId,
+            @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType,
+            @PathParam("agreementId") String agreementId,
+            @Valid AgreementCancelRequest agreementCancelRequest
+    ) {
+        agreementService.cancelByServiceIdAndAccountType(agreementId, serviceId, accountType, agreementCancelRequest);
         return Response.noContent().build();
     }
     

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -328,7 +328,7 @@ public class ChargeService {
                     getGatewayAccountCredentialsEntity(chargeRequest, gatewayAccount);
 
             var agreementEntity = Optional.ofNullable(chargeRequest.getAgreementId()).map(agreementId ->
-                    agreementDao.findByExternalId(chargeRequest.getAgreementId(), gatewayAccount.getId())
+                    agreementDao.findByExternalIdAndGatewayAccountId(chargeRequest.getAgreementId(), gatewayAccount.getId())
                             .orElseThrow(() -> new AgreementNotFoundBadRequestException("Agreement with ID [" + chargeRequest.getAgreementId() + "] not found.")));
 
             ChargeEntity.WebChargeEntityBuilder chargeEntityBuilder = aWebChargeEntity()

--- a/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
@@ -43,183 +43,248 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class AgreementServiceTest {
 
-    private static final String SERVICE_ID = "TestAgreementServiceID";
+    private static final String SERVICE_ID = "a-valid-service-id";
 
     private static final long GATEWAY_ACCOUNT_ID = 10L;
 
     private static final String REFERENCE_ID = "test";
-
-    private GatewayAccountEntity gatewayAccount = mock(GatewayAccountEntity.class);
-
-    private AgreementDao mockedAgreementDao = mock(AgreementDao.class);
-
-    private GatewayAccountDao mockedGatewayAccountDao = mock(GatewayAccountDao.class);
-
-    private LedgerService mockedLedgerService = mock(LedgerService.class);
-
+    public static final String VALID_DESCRIPTION = "a valid description";
+    public static final String VALID_USER_REFERENCE = "a-valid-user-reference";
+    public static final String VALID_AGREEMENT_ID = "a-valid-agreement-id";
+    private static final String INSTANT_EXPECTED = "2022-03-03T10:15:30Z";
+    
+    private final GatewayAccountEntity gatewayAccount = mock(GatewayAccountEntity.class);
+    private final AgreementDao mockedAgreementDao = mock(AgreementDao.class);
+    private final GatewayAccountDao mockedGatewayAccountDao = mock(GatewayAccountDao.class);
+    private final LedgerService mockedLedgerService = mock(LedgerService.class);
+    private final TaskQueueService mockedTaskQueueService = mock(TaskQueueService.class);
     private AgreementService agreementService;
-    private TaskQueueService mockedTaskQueueService = mock(TaskQueueService.class);
-
-    String INSTANT_EXPECTED = "2022-03-03T10:15:30Z";
-
+    
     @BeforeEach
     public void setUp() {
         Clock clock = Clock.fixed(Instant.parse(INSTANT_EXPECTED), ZoneOffset.UTC);
         agreementService = new AgreementService(mockedAgreementDao, mockedGatewayAccountDao, mockedLedgerService, clock, mockedTaskQueueService);
     }
-
+    
     @Nested
-    class CreateAgreementByGatewayAccountId {
-        @Test
-        public void shouldBeSuccessful_whenRecurringEnabled() {
-            var description = "a valid description";
-            var userIdentifier = "a-valid-user-reference";
-            when(gatewayAccount.getServiceId()).thenReturn(SERVICE_ID);
-            when(gatewayAccount.isLive()).thenReturn(false);
-            when(gatewayAccount.isRecurringEnabled()).thenReturn(true);
-            when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
-
-            AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, description, userIdentifier);
-            Optional<AgreementResponse> response = agreementService.createByGatewayAccountId(agreementCreateRequest, GATEWAY_ACCOUNT_ID);
-
-            assertThat(response.isPresent(), is(true));
-            assertThat(response.get().getReference(), is(REFERENCE_ID));
-            assertThat(response.get().getServiceId(), is(SERVICE_ID));
-            assertThat(response.get().getDescription(), is(description));
-            assertThat(response.get().getUserIdentifier(), is(userIdentifier));
-        }
-
-        @Test
-        public void shouldThrowException_whenGatewayAccountNotFound() {
-            var description = "a valid description";
-            var userIdentifier = "a-valid-user-reference";
-            when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
-            AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, description, userIdentifier);
-            assertThrows(GatewayAccountNotFoundException.class, () -> agreementService.createByGatewayAccountId(agreementCreateRequest, GATEWAY_ACCOUNT_ID));
-        }
+    class ByGatewayAccountId {
         
-        @Test
-        public void shouldThrowRecurringCardPaymentsNotAllowedException_whenRecurringDisabled() {
-            var description = "a valid description";
-            var userIdentifier = "a-valid-user-reference";
-            when(gatewayAccount.isRecurringEnabled()).thenReturn(false);
-            when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
-            AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, description, userIdentifier);
-            assertThrows(RecurringCardPaymentsNotAllowedException.class, () -> agreementService.createByGatewayAccountId(agreementCreateRequest, GATEWAY_ACCOUNT_ID));
+        @Nested
+        class CreateAgreement {
+            
+            @Test
+            public void shouldBeSuccessful_whenRecurringEnabled() {
+                when(gatewayAccount.getServiceId()).thenReturn(SERVICE_ID);
+                when(gatewayAccount.isLive()).thenReturn(false);
+                when(gatewayAccount.isRecurringEnabled()).thenReturn(true);
+                when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
+
+                AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, VALID_DESCRIPTION, VALID_USER_REFERENCE);
+                Optional<AgreementResponse> response = agreementService.createByGatewayAccountId(agreementCreateRequest, GATEWAY_ACCOUNT_ID);
+
+                assertThat(response.isPresent(), is(true));
+                assertThat(response.get().getReference(), is(REFERENCE_ID));
+                assertThat(response.get().getServiceId(), is(SERVICE_ID));
+                assertThat(response.get().getDescription(), is(VALID_DESCRIPTION));
+                assertThat(response.get().getUserIdentifier(), is(VALID_USER_REFERENCE));
+            }
+
+            @Test
+            public void shouldThrowGatewayAccountNotFoundException() {
+                when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
+                AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, VALID_DESCRIPTION, VALID_USER_REFERENCE);
+                assertThrows(GatewayAccountNotFoundException.class, () -> agreementService.createByGatewayAccountId(agreementCreateRequest, GATEWAY_ACCOUNT_ID));
+            }
+
+            @Test
+            public void shouldThrowRecurringCardPaymentsNotAllowedException_whenRecurringDisabled() {
+                when(gatewayAccount.isRecurringEnabled()).thenReturn(false);
+                when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
+                AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, VALID_DESCRIPTION, VALID_USER_REFERENCE);
+                assertThrows(RecurringCardPaymentsNotAllowedException.class, () -> agreementService.createByGatewayAccountId(agreementCreateRequest, GATEWAY_ACCOUNT_ID));
+            }
+        }
+
+        @Nested
+        class CancelAgreement {
+            @Test
+            public void shouldThrowAgreementNotFoundException() {
+                when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+                when(mockedAgreementDao.findByExternalIdAndGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
+                assertThrows(AgreementNotFoundException.class, () -> agreementService.cancelByGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest()));
+            }
+
+            @Test
+            public void shouldThrowPaymentInstrumentNotActiveWhenNoPaymentInstrument() {
+                var agreementWithoutPaymentInstrument = new AgreementEntity.AgreementEntityBuilder()
+                        .withPaymentInstrument(null)
+                        .build();
+                when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+                when(mockedAgreementDao.findByExternalIdAndGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreementWithoutPaymentInstrument));
+                assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancelByGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest()));
+            }
+
+            @ParameterizedTest()
+            @EnumSource(mode = EnumSource.Mode.EXCLUDE, names = "ACTIVE")
+            public void shouldThrowPaymentInstrumentNotActive_WhenNonActiveStates(PaymentInstrumentStatus status) {
+                var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
+                        .withStatus(status)
+                        .build();
+                var agreement = new AgreementEntity.AgreementEntityBuilder()
+                        .withPaymentInstrument(paymentInstrument)
+                        .build();
+                when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+                when(mockedAgreementDao.findByExternalIdAndGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreement));
+                assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancelByGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest()));
+            }
+
+            @Test
+            public void withUserDetails_ShouldMoveToCancelStatusForActivePaymentInstrument() {
+                var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
+                        .withStatus(PaymentInstrumentStatus.ACTIVE)
+                        .build();
+                var agreement = new AgreementEntity.AgreementEntityBuilder()
+                        .withPaymentInstrument(paymentInstrument)
+                        .withGatewayAccount(GatewayAccountEntityFixture.aGatewayAccountEntity().build())
+                        .build();
+                var cancelRequest = new AgreementCancelRequest("valid-user-external-id", "valid@email.test");
+                when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+                when(mockedAgreementDao.findByExternalIdAndGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreement));
+                agreementService.cancelByGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID, cancelRequest);
+                verify(mockedTaskQueueService).addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
+                verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByUser.class));
+                assertThat(paymentInstrument.getStatus(), is(PaymentInstrumentStatus.CANCELLED));
+                assertThat(agreement.getCancelledDate(), is(Instant.parse(INSTANT_EXPECTED)));
+            }
+
+            @Test
+            public void withoutUserDetails_ShouldMoveToCancelStatusForActivePaymentInstrument() {
+                var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
+                        .withStatus(PaymentInstrumentStatus.ACTIVE)
+                        .build();
+                var agreement = new AgreementEntity.AgreementEntityBuilder()
+                        .withPaymentInstrument(paymentInstrument)
+                        .withGatewayAccount(GatewayAccountEntityFixture.aGatewayAccountEntity().build())
+                        .build();
+                when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+                when(mockedAgreementDao.findByExternalIdAndGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreement));
+                agreementService.cancelByGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest());
+                verify(mockedTaskQueueService).addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
+                verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByService.class));
+                assertThat(paymentInstrument.getStatus(), is(PaymentInstrumentStatus.CANCELLED));
+                assertThat(agreement.getCancelledDate(), is(Instant.parse(INSTANT_EXPECTED)));
+            }
         }
     }
-
+    
     @Nested
-    class CreateAgreementByServiceIdAndAccountType {
-        @Test
-        public void shouldBeSuccessful_whenRecurringEnabled() {
-            var description = "a valid description";
-            var userIdentifier = "a-valid-user-reference";
-            when(gatewayAccount.getServiceId()).thenReturn(SERVICE_ID);
-            when(gatewayAccount.isLive()).thenReturn(false);
-            when(gatewayAccount.isRecurringEnabled()).thenReturn(true);
-            when(mockedGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.of(gatewayAccount));
+    class ByServiceIdAndAccountType {
 
-            AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, description, userIdentifier);
-            Optional<AgreementResponse> response = agreementService.createByServiceIdAndAccountType(agreementCreateRequest, SERVICE_ID, GatewayAccountType.TEST);
+        @Nested
+        class CreateAgreement {
+            
+            @Test
+            public void shouldBeSuccessful_whenRecurringEnabled() {
+                when(gatewayAccount.getServiceId()).thenReturn(SERVICE_ID);
+                when(gatewayAccount.isLive()).thenReturn(false);
+                when(gatewayAccount.isRecurringEnabled()).thenReturn(true);
+                when(mockedGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.of(gatewayAccount));
 
-            assertThat(response.isPresent(), is(true));
-            assertThat(response.get().getReference(), is(REFERENCE_ID));
-            assertThat(response.get().getServiceId(), is(SERVICE_ID));
-            assertThat(response.get().getDescription(), is(description));
-            assertThat(response.get().getUserIdentifier(), is(userIdentifier));
+                AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, VALID_DESCRIPTION, VALID_USER_REFERENCE);
+                Optional<AgreementResponse> response = agreementService.createByServiceIdAndAccountType(agreementCreateRequest, SERVICE_ID, GatewayAccountType.TEST);
+
+                assertThat(response.isPresent(), is(true));
+                assertThat(response.get().getReference(), is(REFERENCE_ID));
+                assertThat(response.get().getServiceId(), is(SERVICE_ID));
+                assertThat(response.get().getDescription(), is(VALID_DESCRIPTION));
+                assertThat(response.get().getUserIdentifier(), is(VALID_USER_REFERENCE));
+            }
+
+            @Test
+            public void shouldThrowGatewayAccountNotFoundException() {
+                when(mockedGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.empty());
+                AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, VALID_DESCRIPTION, VALID_USER_REFERENCE);
+                assertThrows(GatewayAccountNotFoundException.class, () -> agreementService.createByServiceIdAndAccountType(agreementCreateRequest, SERVICE_ID, GatewayAccountType.TEST));
+            }
+
+            @Test
+            public void shouldThrowRecurringCardPaymentsNotAllowedException_whenRecurringDisabled() {
+                when(gatewayAccount.isRecurringEnabled()).thenReturn(false);
+                when(mockedGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.of(gatewayAccount));
+                AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, VALID_DESCRIPTION, VALID_USER_REFERENCE);
+                assertThrows(RecurringCardPaymentsNotAllowedException.class, () -> agreementService.createByServiceIdAndAccountType(agreementCreateRequest, SERVICE_ID, GatewayAccountType.TEST));
+            }
         }
 
-        @Test
-        public void shouldThrowException_whenGatewayAccountNotFound() {
-            var description = "a valid description";
-            var userIdentifier = "a-valid-user-reference";
-            when(mockedGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.empty());
-            AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, description, userIdentifier);
-            assertThrows(GatewayAccountNotFoundException.class, () -> agreementService.createByServiceIdAndAccountType(agreementCreateRequest, SERVICE_ID, GatewayAccountType.TEST));
+        @Nested
+        class CancelAgreement {
+            @Test
+            public void shouldThrowAgreementNotFoundException() {
+                when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+                when(mockedAgreementDao.findByExternalIdAndServiceIdAndAccountType(VALID_AGREEMENT_ID, SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.empty());
+                assertThrows(AgreementNotFoundException.class, () -> agreementService.cancelByServiceIdAndAccountType(VALID_AGREEMENT_ID, SERVICE_ID, GatewayAccountType.TEST, new AgreementCancelRequest()));
+            }
+
+            @Test
+            public void shouldThrowPaymentInstrumentNotActiveWhenNoPaymentInstrument() {
+                var agreementWithoutPaymentInstrument = new AgreementEntity.AgreementEntityBuilder()
+                        .withPaymentInstrument(null)
+                        .build();
+                when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+                when(mockedAgreementDao.findByExternalIdAndServiceIdAndAccountType(VALID_AGREEMENT_ID, SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.of(agreementWithoutPaymentInstrument));
+                assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancelByServiceIdAndAccountType(VALID_AGREEMENT_ID, SERVICE_ID, GatewayAccountType.TEST, new AgreementCancelRequest()));
+            }
+
+            @ParameterizedTest()
+            @EnumSource(mode = EnumSource.Mode.EXCLUDE, names = "ACTIVE")
+            public void shouldThrowPaymentInstrumentNotActive_WhenNonActiveStates(PaymentInstrumentStatus status) {
+                var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
+                        .withStatus(status)
+                        .build();
+                var agreement = new AgreementEntity.AgreementEntityBuilder()
+                        .withPaymentInstrument(paymentInstrument)
+                        .build();
+                when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+                when(mockedAgreementDao.findByExternalIdAndServiceIdAndAccountType(VALID_AGREEMENT_ID, SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.of(agreement));
+                assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancelByServiceIdAndAccountType(VALID_AGREEMENT_ID, SERVICE_ID, GatewayAccountType.TEST, new AgreementCancelRequest()));
+            }
+
+            @Test
+            public void withUserDetails_ShouldMoveToCancelStatusForActivePaymentInstrument() {
+                var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
+                        .withStatus(PaymentInstrumentStatus.ACTIVE)
+                        .build();
+                var agreement = new AgreementEntity.AgreementEntityBuilder()
+                        .withPaymentInstrument(paymentInstrument)
+                        .withGatewayAccount(GatewayAccountEntityFixture.aGatewayAccountEntity().build())
+                        .build();
+                var cancelRequest = new AgreementCancelRequest("valid-user-external-id", "valid@email.test");
+                when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+                when(mockedAgreementDao.findByExternalIdAndServiceIdAndAccountType(VALID_AGREEMENT_ID, SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.of(agreement));
+                agreementService.cancelByServiceIdAndAccountType(VALID_AGREEMENT_ID, SERVICE_ID, GatewayAccountType.TEST, cancelRequest);
+                verify(mockedTaskQueueService).addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
+                verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByUser.class));
+                assertThat(paymentInstrument.getStatus(), is(PaymentInstrumentStatus.CANCELLED));
+                assertThat(agreement.getCancelledDate(), is(Instant.parse(INSTANT_EXPECTED)));
+            }
+
+            @Test
+            public void withoutUserDetails_ShouldMoveToCancelStatusForActivePaymentInstrument() {
+                var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
+                        .withStatus(PaymentInstrumentStatus.ACTIVE)
+                        .build();
+                var agreement = new AgreementEntity.AgreementEntityBuilder()
+                        .withPaymentInstrument(paymentInstrument)
+                        .withGatewayAccount(GatewayAccountEntityFixture.aGatewayAccountEntity().build())
+                        .build();
+                when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
+                when(mockedAgreementDao.findByExternalIdAndServiceIdAndAccountType(VALID_AGREEMENT_ID, SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.of(agreement));
+                agreementService.cancelByServiceIdAndAccountType(VALID_AGREEMENT_ID, SERVICE_ID, GatewayAccountType.TEST,new AgreementCancelRequest());
+                verify(mockedTaskQueueService).addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
+                verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByService.class));
+                assertThat(paymentInstrument.getStatus(), is(PaymentInstrumentStatus.CANCELLED));
+                assertThat(agreement.getCancelledDate(), is(Instant.parse(INSTANT_EXPECTED)));
+            }
         }
-        
-        @Test
-        public void shouldThrowRecurringCardPaymentsNotAllowedException_whenRecurringDisabled() {
-            var description = "a valid description";
-            var userIdentifier = "a-valid-user-reference";
-            when(gatewayAccount.isRecurringEnabled()).thenReturn(false);
-            when(mockedGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.of(gatewayAccount));
-            AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, description, userIdentifier);
-            assertThrows(RecurringCardPaymentsNotAllowedException.class, () -> agreementService.createByServiceIdAndAccountType(agreementCreateRequest, SERVICE_ID, GatewayAccountType.TEST));
-        }
-    }
-        
-    @Test
-    public void cancelAnAgreement_ThrowsAgreementNotFound() {
-        var agreementId = "an-external-id";
-        when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
-        when(mockedAgreementDao.findByExternalId(agreementId, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
-        assertThrows(AgreementNotFoundException.class, () -> agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest()));
-    }
-
-    @Test
-    public void cancelAnAgreement_ThrowsPaymentInstrumentNotActiveWhenNoPaymentInstrument() {
-        var agreementId = "an-external-id";
-        var agreementWithoutPaymentInstrument = new AgreementEntity.AgreementEntityBuilder()
-                .withPaymentInstrument(null)
-                .build();
-        when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
-        when(mockedAgreementDao.findByExternalId(agreementId, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreementWithoutPaymentInstrument));
-        assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest()));
-    }
-
-    @ParameterizedTest()
-    @EnumSource(mode = EnumSource.Mode.EXCLUDE, names = "ACTIVE")
-    public void cancelAnAgreement_ThrowsPaymentInstrumentNotActiveWhenNonActiveStates(PaymentInstrumentStatus status) {
-        var agreementId = "an-external-id";
-        var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
-                .withStatus(status)
-                .build();
-        var agreement = new AgreementEntity.AgreementEntityBuilder()
-                .withPaymentInstrument(paymentInstrument)
-                .build();
-        when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
-        when(mockedAgreementDao.findByExternalId(agreementId, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreement));
-        assertThrows(PaymentInstrumentNotActiveException.class, () -> agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest()));
-    }
-
-    @Test
-    public void cancelAnAgreementWithUserDetails_ShouldMoveToCancelStatusForActivePaymentInstrument() {
-        var agreementId = "an-external-id";
-        var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
-                .withStatus(PaymentInstrumentStatus.ACTIVE)
-                .build();
-        var agreement = new AgreementEntity.AgreementEntityBuilder()
-                .withPaymentInstrument(paymentInstrument)
-                .withGatewayAccount(GatewayAccountEntityFixture.aGatewayAccountEntity().build())
-                .build();
-        var cancelRequest = new AgreementCancelRequest("valid-user-external-id", "valid@email.test");
-        when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
-        when(mockedAgreementDao.findByExternalId(agreementId, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreement));
-        agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, cancelRequest);
-        verify(mockedTaskQueueService).addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
-        verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByUser.class));
-        assertThat(paymentInstrument.getStatus(), is(PaymentInstrumentStatus.CANCELLED));
-        assertThat(agreement.getCancelledDate(), is(Instant.parse(INSTANT_EXPECTED)));
-    }
-
-    @Test
-    public void cancelAnAgreementWithoutUserDetails_ShouldMoveToCancelStatusForActivePaymentInstrument() {
-        var agreementId = "an-external-id";
-        var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
-                .withStatus(PaymentInstrumentStatus.ACTIVE)
-                .build();
-        var agreement = new AgreementEntity.AgreementEntityBuilder()
-                .withPaymentInstrument(paymentInstrument)
-                .withGatewayAccount(GatewayAccountEntityFixture.aGatewayAccountEntity().build())
-                .build();
-        when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
-        when(mockedAgreementDao.findByExternalId(agreementId, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreement));
-        agreementService.cancel(agreementId, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest());
-        verify(mockedTaskQueueService).addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
-        verify(mockedLedgerService).postEvent(Mockito.any(AgreementCancelledByService.class));
-        assertThat(paymentInstrument.getStatus(), is(PaymentInstrumentStatus.CANCELLED));
-        assertThat(agreement.getCancelledDate(), is(Instant.parse(INSTANT_EXPECTED)));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
@@ -44,9 +44,7 @@ import static org.mockito.Mockito.when;
 public class AgreementServiceTest {
 
     private static final String SERVICE_ID = "a-valid-service-id";
-
     private static final long GATEWAY_ACCOUNT_ID = 10L;
-
     private static final String REFERENCE_ID = "test";
     public static final String VALID_DESCRIPTION = "a valid description";
     public static final String VALID_USER_REFERENCE = "a-valid-user-reference";
@@ -90,7 +88,7 @@ public class AgreementServiceTest {
             }
 
             @Test
-            public void shouldThrowGatewayAccountNotFoundException() {
+            public void shouldThrowException_whenGatewayAccountNotFound() {
                 when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
                 AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, VALID_DESCRIPTION, VALID_USER_REFERENCE);
                 assertThrows(GatewayAccountNotFoundException.class, () -> agreementService.createByGatewayAccountId(agreementCreateRequest, GATEWAY_ACCOUNT_ID));
@@ -108,7 +106,7 @@ public class AgreementServiceTest {
         @Nested
         class CancelAgreement {
             @Test
-            public void shouldThrowAgreementNotFoundException() {
+            public void shouldThrowException_whenGatewayAccountNotFound() {
                 when(gatewayAccount.getId()).thenReturn(GATEWAY_ACCOUNT_ID);
                 when(mockedAgreementDao.findByExternalIdAndGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
                 assertThrows(AgreementNotFoundException.class, () -> agreementService.cancelByGatewayAccountId(VALID_AGREEMENT_ID, GATEWAY_ACCOUNT_ID, new AgreementCancelRequest()));
@@ -139,7 +137,7 @@ public class AgreementServiceTest {
             }
 
             @Test
-            public void withUserDetails_ShouldMoveToCancelStatusForActivePaymentInstrument() {
+            public void shouldCancelAgreementSuccessfully_whenUserDetailsProvided() {
                 var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
                         .withStatus(PaymentInstrumentStatus.ACTIVE)
                         .build();
@@ -158,7 +156,7 @@ public class AgreementServiceTest {
             }
 
             @Test
-            public void withoutUserDetails_ShouldMoveToCancelStatusForActivePaymentInstrument() {
+            public void shouldCancelAgreementSuccessfully_whenUserDetailsNotProvided() {
                 var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
                         .withStatus(PaymentInstrumentStatus.ACTIVE)
                         .build();
@@ -201,7 +199,7 @@ public class AgreementServiceTest {
             }
 
             @Test
-            public void shouldThrowGatewayAccountNotFoundException() {
+            public void shouldThrowNotFoundException_whenGatewayAccountDoesNotExist() {
                 when(mockedGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST)).thenReturn(Optional.empty());
                 AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, VALID_DESCRIPTION, VALID_USER_REFERENCE);
                 assertThrows(GatewayAccountNotFoundException.class, () -> agreementService.createByServiceIdAndAccountType(agreementCreateRequest, SERVICE_ID, GatewayAccountType.TEST));
@@ -250,7 +248,7 @@ public class AgreementServiceTest {
             }
 
             @Test
-            public void withUserDetails_ShouldMoveToCancelStatusForActivePaymentInstrument() {
+            public void shouldCancelAgreementSuccessfully_whenUserDetailsProvided() {
                 var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
                         .withStatus(PaymentInstrumentStatus.ACTIVE)
                         .build();
@@ -269,7 +267,7 @@ public class AgreementServiceTest {
             }
 
             @Test
-            public void withoutUserDetails_ShouldMoveToCancelStatusForActivePaymentInstrument() {
+            public void shouldCancelAgreementSuccessfully_whenUserDetailsNotProvided() {
                 var paymentInstrument = new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
                         .withStatus(PaymentInstrumentStatus.ACTIVE)
                         .build();

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateAgreementTest.java
@@ -198,7 +198,7 @@ class ChargeServiceCreateAgreementTest {
 
     @Test
     void shouldCreateChargeWithSavePaymentInstrumentToAgreement() {
-        when(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
+        when(mockAgreementDao.findByExternalIdAndGatewayAccountId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockedUriInfo.getBaseUriBuilder()).thenReturn(fromUri(SERVICE_HOST));
         when(mockLinksConfig.getFrontendUrl()).thenReturn(FRONTEND_URL);
         when(mockProviders.byName(PaymentGatewayName.SANDBOX)).thenReturn(mockPaymentProvider);
@@ -223,7 +223,7 @@ class ChargeServiceCreateAgreementTest {
 
     @Test
     void shouldCreateChargeWithAuthorisationModeAgreement() {
-        when(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
+        when(mockAgreementDao.findByExternalIdAndGatewayAccountId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
         when(mockPaymentInstrumentEntity.getStatus()).thenReturn(PaymentInstrumentStatus.ACTIVE);
         when(mockedUriInfo.getBaseUriBuilder()).thenReturn(fromUri(SERVICE_HOST));
@@ -426,7 +426,7 @@ class ChargeServiceCreateAgreementTest {
 
         String UNKNOWN_AGREEMENT_ID = "unknownId";
         ChargeCreateRequest request = requestBuilder.withAmount(1000).withAgreementId(UNKNOWN_AGREEMENT_ID).withSavePaymentInstrumentToAgreement(true).build();
-        when(mockAgreementDao.findByExternalId(UNKNOWN_AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
+        when(mockAgreementDao.findByExternalIdAndGatewayAccountId(UNKNOWN_AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
 
         assertThrows(AgreementNotFoundBadRequestException.class, () -> chargeService.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo, null));
 
@@ -451,7 +451,7 @@ class ChargeServiceCreateAgreementTest {
     @Test
     void shouldThrowExceptionWhenAgreementHasNoPaymentInstrumentForAuthorisationModeAgreement() {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
-        when(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
+        when(mockAgreementDao.findByExternalIdAndGatewayAccountId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.empty());
 
         final ChargeCreateRequest request = requestBuilder.withAmount(1000)
@@ -469,7 +469,7 @@ class ChargeServiceCreateAgreementTest {
     @EnumSource(mode = EXCLUDE, names = "ACTIVE")
     void shouldThrowExceptionWhenAgreementHasPaymentInstrumentInIncorrectStateForAuthorisationModeAgreement(PaymentInstrumentStatus paymentInstrumentStatus) {
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
-        when(mockAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
+        when(mockAgreementDao.findByExternalIdAndGatewayAccountId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockAgreementEntity));
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
         when(mockPaymentInstrumentEntity.getStatus()).thenReturn(paymentInstrumentStatus);
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
@@ -754,7 +754,7 @@ class ChargeServiceCreateTest {
         when(mockedPaymentProvider.getExternalChargeRefundAvailability(any(Charge.class), anyList())).thenReturn(EXTERNAL_AVAILABLE);
         when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
         when(mockGatewayAccountCredentialsService.getCurrentOrActiveCredential(gatewayAccount)).thenReturn(gatewayAccountCredentialsEntity);
-        when(mockedAgreementDao.findByExternalId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreementEntity));
+        when(mockedAgreementDao.findByExternalIdAndGatewayAccountId(AGREEMENT_ID, GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(agreementEntity));
         when(mockExternalTransactionStateFactory.newExternalTransactionState(any(ChargeEntity.class))).thenReturn(externalTransactionState);
         populateChargeEntity();
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/AgreementsApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/AgreementsApiResourceIT.java
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
@@ -32,13 +30,15 @@ import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
 import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
 import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
+import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class AgreementsApiResourceIT {
-    public static final String VALID_SERVICE_ID = "a-valid-service-id";
+    
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions("stripe", app.getLocalPort());
-
+    
+    public static final String VALID_SERVICE_ID = "a-valid-service-id";
     private static final String REFERENCE_ID = "1234";
     private static final String DESCRIPTION = "a valid description";
     private static final String USER_IDENTIFIER = "a-valid-user-identifier";
@@ -47,9 +47,9 @@ public class AgreementsApiResourceIT {
     private static final String CREATE_AGREEMENT_URL = "/v1/api/accounts/%s/agreements";
     private static final String CREATE_AGREEMENT_BY_SERVICE_ID_URL = "/v1/api/service/%s/%s/agreements";
     private static final String CANCEL_AGREEMENT_URL = "/v1/api/accounts/%s/agreements/%s/cancel";
+    private static final String CANCEL_AGREEMENT_BY_SERVICE_ID_URL = "/v1/api/service/%s/%s/agreements/%s/cancel";
     private DatabaseFixtures.TestAccount testAccount;
     private Long accountId;
-    private ObjectMapper objectMapper = new ObjectMapper();
 
     @Nested
     class ByGatewayAccountId {
@@ -59,255 +59,254 @@ public class AgreementsApiResourceIT {
             accountId = testAccount.getAccountId();
         }
 
-        @Test
-        void shouldCreateAgreement() throws JsonProcessingException {
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "reference", REFERENCE_ID,
-                    "description", DESCRIPTION,
-                    "user_identifier", USER_IDENTIFIER
-            ));
+        @Nested
+        class CreateAgreement {
+            @Test
+            void shouldCreateAgreement() {
+                String payload = toJson(Map.of(
+                        "reference", REFERENCE_ID,
+                        "description", DESCRIPTION,
+                        "user_identifier", USER_IDENTIFIER
+                ));
 
-            ValidatableResponse o = app.givenSetup()
-                    .body(payload)
-                    .post(format(CREATE_AGREEMENT_URL, accountId))
-                    .then()
-                    .statusCode(SC_CREATED)
-                    .body("reference", equalTo(REFERENCE_ID))
-                    .body("service_id", equalTo("valid-external-service-id"))
-                    .body("agreement_id", notNullValue())
-                    .body("description", equalTo(DESCRIPTION))
-                    .body("user_identifier", equalTo(USER_IDENTIFIER))
-                    .body("created_date", notNullValue())
-                    .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
-                    .body("created_date", isWithin(10, SECONDS));
+                ValidatableResponse o = app.givenSetup()
+                        .body(payload)
+                        .post(format(CREATE_AGREEMENT_URL, accountId))
+                        .then()
+                        .statusCode(SC_CREATED)
+                        .body("reference", equalTo(REFERENCE_ID))
+                        .body("service_id", equalTo("valid-external-service-id"))
+                        .body("agreement_id", notNullValue())
+                        .body("description", equalTo(DESCRIPTION))
+                        .body("user_identifier", equalTo(USER_IDENTIFIER))
+                        .body("created_date", notNullValue())
+                        .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
+                        .body("created_date", isWithin(10, SECONDS));
+            }
+
+            @Test
+            void shouldReturn422WhenReferenceIdTooLong() {
+                String payload = toJson(Map.of(
+                        "reference", REFERENCE_ID_TOO_LONG,
+                        "description", DESCRIPTION
+                ));
+
+                app.givenSetup()
+                        .body(payload)
+                        .post(format(CREATE_AGREEMENT_URL, accountId))
+                        .then()
+                        .statusCode(SC_UNPROCESSABLE_ENTITY);
+            }
+
+            @Test
+            void shouldReturn422WhenReferenceIdEmpty() {
+                String payload = toJson(Map.of(
+                        "reference", REFERENCE_ID_EMPTY,
+                        "description", DESCRIPTION
+                ));
+
+                app.givenSetup()
+                        .body(payload)
+                        .post(format(CREATE_AGREEMENT_URL, accountId))
+                        .then()
+                        .statusCode(SC_UNPROCESSABLE_ENTITY);
+            }
+
+            @Test
+            void shouldReturn422WhenDescriptionEmpty() {
+                String payload = toJson(Map.of(
+                        "reference", REFERENCE_ID
+                ));
+
+                app.givenSetup()
+                        .body(payload)
+                        .post(format(CREATE_AGREEMENT_URL, accountId))
+                        .then()
+                        .statusCode(SC_UNPROCESSABLE_ENTITY);
+            }
+
+            @Test
+            void shouldReturn422WhenRecurringDisabled() {
+                testAccount = createTestAccount("worldpay", false);
+                accountId = testAccount.getAccountId();
+                String payload = toJson(Map.of(
+                        "reference", REFERENCE_ID,
+                        "description", DESCRIPTION,
+                        "user_identifier", USER_IDENTIFIER
+                ));
+                
+                app.givenSetup()
+                        .body(payload)
+                        .post(format(CREATE_AGREEMENT_URL, accountId))
+                        .then()
+                        .statusCode(SC_UNPROCESSABLE_ENTITY)
+                        .body("message", contains("Recurring payment agreements are not enabled on this account"))
+                        .body("error_identifier", is(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED.toString()));
+            }
         }
+        
+        @Nested
+        class CancelAgreement {
+            @Test
+            void shouldReturn204AndCancelAgreement() {
+                var agreementId = "an-external-id";
+                AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
+                        .withPaymentInstrumentId(nextLong())
+                        .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
+                        .build();
+                app.getDatabaseTestHelper().addPaymentInstrument(paymentInstrumentParams);
+                AddAgreementParams agreementParams = anAddAgreementParams()
+                        .withGatewayAccountId(String.valueOf(accountId))
+                        .withExternalAgreementId(agreementId)
+                        .withPaymentInstrumentId(paymentInstrumentParams.getPaymentInstrumentId())
+                        .build();
+                app.getDatabaseTestHelper().addAgreement(agreementParams);
 
-        @Test
-        void shouldReturn422WhenReferenceIdTooLong() throws JsonProcessingException {
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "reference", REFERENCE_ID_TOO_LONG,
-                    "description", DESCRIPTION
-            ));
+                app.givenSetup()
+                        .post(format(CANCEL_AGREEMENT_URL, accountId, agreementId))
+                        .then()
+                        .statusCode(NO_CONTENT_204);
 
-            app.givenSetup()
-                    .body(payload)
-                    .post(format(CREATE_AGREEMENT_URL, accountId))
-                    .then()
-                    .statusCode(SC_UNPROCESSABLE_ENTITY);
+                var paymentInstrumentMap = app.getDatabaseTestHelper().getPaymentInstrument(paymentInstrumentParams.getPaymentInstrumentId());
+                assertThat(paymentInstrumentMap.get("status"), is("CANCELLED"));
+                var agreementMap = app.getDatabaseTestHelper().getAgreementByExternalId(agreementId);
+                assertThat(agreementMap.get("cancelled_date"), is(notNullValue()));
+            }
         }
-
-        @Test
-        void shouldReturn422WhenReferenceIdEmpty() throws JsonProcessingException {
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "reference", REFERENCE_ID_EMPTY,
-                    "description", DESCRIPTION
-            ));
-
-            app.givenSetup()
-                    .body(payload)
-                    .post(format(CREATE_AGREEMENT_URL, accountId))
-                    .then()
-                    .statusCode(SC_UNPROCESSABLE_ENTITY);
-        }
-
-        @Test
-        void shouldReturn422WhenDescriptionEmpty() throws JsonProcessingException {
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "reference", REFERENCE_ID
-            ));
-
-            app.givenSetup()
-                    .body(payload)
-                    .post(format(CREATE_AGREEMENT_URL, accountId))
-                    .then()
-                    .statusCode(SC_UNPROCESSABLE_ENTITY);
-        }
-
-        @Test
-        void shouldReturn422WhenRecurringDisabled() throws JsonProcessingException {
-            testAccount = createTestAccount("worldpay", false);
-            accountId = testAccount.getAccountId();
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "reference", REFERENCE_ID,
-                    "description", DESCRIPTION,
-                    "user_identifier", USER_IDENTIFIER
-            ));
-            app.givenSetup()
-                    .body(payload)
-                    .post(format(CREATE_AGREEMENT_URL, accountId))
-                    .then()
-                    .statusCode(SC_UNPROCESSABLE_ENTITY)
-                    .body("message", contains("Recurring payment agreements are not enabled on this account"))
-                    .body("error_identifier", is(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED.toString()));
-        }
-
-        @Test
-        void shouldReturn204AndCancelAgreement() {
-            var agreementId = "an-external-id";
-            AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
-                    .withPaymentInstrumentId(nextLong())
-                    .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
-                    .build();
-            app.getDatabaseTestHelper().addPaymentInstrument(paymentInstrumentParams);
-            AddAgreementParams agreementParams = anAddAgreementParams()
-                    .withGatewayAccountId(String.valueOf(accountId))
-                    .withExternalAgreementId(agreementId)
-                    .withPaymentInstrumentId(paymentInstrumentParams.getPaymentInstrumentId())
-                    .build();
-            app.getDatabaseTestHelper().addAgreement(agreementParams);
-
-            app.givenSetup()
-                    .post(format(CANCEL_AGREEMENT_URL, accountId, agreementId))
-                    .then()
-                    .statusCode(NO_CONTENT_204);
-
-            var paymentInstrumentMap = app.getDatabaseTestHelper().getPaymentInstrument(paymentInstrumentParams.getPaymentInstrumentId());
-            assertThat(paymentInstrumentMap.get("status"), is("CANCELLED"));
-            var agreementMap = app.getDatabaseTestHelper().getAgreementByExternalId(agreementId);
-            assertThat(agreementMap.get("cancelled_date"), is(notNullValue()));
-        }
-
-        private DatabaseFixtures.TestAccount createTestAccount(String paymentProvider, boolean recurringEnabled) {
-            long accountId = nextLong(2, 10000);
-
-            return app.getDatabaseFixtures().aTestAccount().withPaymentProvider(paymentProvider)
-                    .withIntegrationVersion3ds(2)
-                    .withAccountId(accountId)
-                    .withRecurringEnabled(recurringEnabled)
-                    .insert();
-        }
+        
     }
 
     @Nested
     class ByServiceIdAndAccountType {
-        @Test
-        void shouldCreateAgreement_forValidRequest() throws JsonProcessingException {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
-            testBaseExtension.updateGatewayAccount(gatewayAccountId, "recurring_enabled", true);
 
-            String createAgreementPayload = objectMapper.writeValueAsString(Map.of(
-                    "reference", REFERENCE_ID,
-                    "description", DESCRIPTION,
-                    "user_identifier", USER_IDENTIFIER
-            ));
+        @Nested
+        class CreateAgreement {
+            @Test
+            void shouldCreateAgreement_forValidRequest() {
+                String gatewayAccountId = testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
+                testBaseExtension.updateGatewayAccount(gatewayAccountId, "recurring_enabled", true);
 
-            String agreementId = app.givenSetup()
-                    .body(createAgreementPayload)
-                    .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, "test"))
-                    .then()
-                    .statusCode(SC_CREATED)
-                    .body("reference", equalTo(REFERENCE_ID))
-                    .body("service_id", equalTo(VALID_SERVICE_ID))
-                    .body("agreement_id", notNullValue())
-                    .body("description", equalTo(DESCRIPTION))
-                    .body("user_identifier", equalTo(USER_IDENTIFIER))
-                    .body("created_date", notNullValue())
-                    .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
-                    .body("created_date", isWithin(10, SECONDS))
-                    .extract().path("agreement_id");
-            
-            Map<String, Object> agreement = app.getDatabaseTestHelper().getAgreementByExternalId(agreementId);
-            assertThat(agreement.get("reference"), is(REFERENCE_ID));
-            assertThat(agreement.get("service_id"), is(VALID_SERVICE_ID));
-            assertThat(agreement.get("description"), is(DESCRIPTION));
-        }
+                String createAgreementPayload = toJson(Map.of(
+                        "reference", REFERENCE_ID,
+                        "description", DESCRIPTION,
+                        "user_identifier", USER_IDENTIFIER
+                ));
 
+                String agreementId = app.givenSetup()
+                        .body(createAgreementPayload)
+                        .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, "test"))
+                        .then()
+                        .statusCode(SC_CREATED)
+                        .body("reference", equalTo(REFERENCE_ID))
+                        .body("service_id", equalTo(VALID_SERVICE_ID))
+                        .body("agreement_id", notNullValue())
+                        .body("description", equalTo(DESCRIPTION))
+                        .body("user_identifier", equalTo(USER_IDENTIFIER))
+                        .body("created_date", notNullValue())
+                        .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
+                        .body("created_date", isWithin(10, SECONDS))
+                        .extract().path("agreement_id");
 
-        @Test
-        void shouldReturn422WhenReferenceIdTooLong() throws JsonProcessingException {
-            testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
+                Map<String, Object> agreement = app.getDatabaseTestHelper().getAgreementByExternalId(agreementId);
+                assertThat(agreement.get("reference"), is(REFERENCE_ID));
+                assertThat(agreement.get("service_id"), is(VALID_SERVICE_ID));
+                assertThat(agreement.get("description"), is(DESCRIPTION));
+            }
 
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "reference", REFERENCE_ID_TOO_LONG,
-                    "description", DESCRIPTION
-            ));
+            @Test
+            void shouldReturn422WhenReferenceIdTooLong() {
+                testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
 
-            app.givenSetup()
-                    .body(payload)
-                    .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
-                    .then()
-                    .statusCode(SC_UNPROCESSABLE_ENTITY)
-                    .body("message[0]", is("Field [reference] can have a size between 1 and 255"));
-        }
+                String payload = toJson(Map.of(
+                        "reference", REFERENCE_ID_TOO_LONG,
+                        "description", DESCRIPTION
+                ));
 
-        @Test
-        void shouldReturn422WhenReferenceIdEmpty() throws JsonProcessingException {
-            testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
+                app.givenSetup()
+                        .body(payload)
+                        .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
+                        .then()
+                        .statusCode(SC_UNPROCESSABLE_ENTITY)
+                        .body("message[0]", is("Field [reference] can have a size between 1 and 255"));
+            }
 
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "reference", REFERENCE_ID_EMPTY,
-                    "description", DESCRIPTION
-            ));
+            @Test
+            void shouldReturn422WhenReferenceIdEmpty() {
+                testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
 
-            app.givenSetup()
-                    .body(payload)
-                    .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
-                    .then()
-                    .statusCode(SC_UNPROCESSABLE_ENTITY)
-                    .body("message[0]", is("Field [reference] can have a size between 1 and 255"));
-        }
+                String payload = toJson(Map.of(
+                        "reference", REFERENCE_ID_EMPTY,
+                        "description", DESCRIPTION
+                ));
 
-        @Test
-        void shouldReturn422WhenReferenceIdNotProvided() throws JsonProcessingException {
-            testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
+                app.givenSetup()
+                        .body(payload)
+                        .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
+                        .then()
+                        .statusCode(SC_UNPROCESSABLE_ENTITY)
+                        .body("message[0]", is("Field [reference] can have a size between 1 and 255"));
+            }
 
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "description", DESCRIPTION
-            ));
+            @Test
+            void shouldReturn422WhenReferenceIdNotProvided() {
+                testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
 
-            app.givenSetup()
-                    .body(payload)
-                    .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
-                    .then()
-                    .statusCode(SC_UNPROCESSABLE_ENTITY)
-                    .body("message[0]", is("Field [reference] cannot be null"));
+                String payload = toJson(Map.of(
+                        "description", DESCRIPTION
+                ));
 
-        }
+                app.givenSetup()
+                        .body(payload)
+                        .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
+                        .then()
+                        .statusCode(SC_UNPROCESSABLE_ENTITY)
+                        .body("message[0]", is("Field [reference] cannot be null"));
 
-        @Test
-        void shouldReturn422WhenDescriptionNotProvided() throws JsonProcessingException {
-            testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
+            }
 
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "reference", REFERENCE_ID
-            ));
+            @Test
+            void shouldReturn422WhenDescriptionNotProvided() {
+                testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
 
-            app.givenSetup()
-                    .body(payload)
-                    .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
-                    .then()
-                    .statusCode(SC_UNPROCESSABLE_ENTITY)
-                    .body("message[0]", is("Field [description] cannot be null"));
+                String payload = toJson(Map.of(
+                        "reference", REFERENCE_ID
+                ));
 
+                app.givenSetup()
+                        .body(payload)
+                        .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
+                        .then()
+                        .statusCode(SC_UNPROCESSABLE_ENTITY)
+                        .body("message[0]", is("Field [description] cannot be null"));
+            }
 
-        }
+            @Test
+            void shouldReturn422WhenDescriptionEmpty() {
+                testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
 
-        @Test
-        void shouldReturn422WhenDescriptionEmpty() throws JsonProcessingException {
-            testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
+                String payload = toJson(Map.of(
+                        "reference", REFERENCE_ID,
+                        "description", ""
+                ));
 
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "reference", REFERENCE_ID,
-                    "description", ""
-            ));
+                app.givenSetup()
+                        .body(payload)
+                        .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
+                        .then()
+                        .statusCode(SC_UNPROCESSABLE_ENTITY)
+                        .body("message[0]", is("Field [description] can have a size between 1 and 255"));
+            }
 
-            app.givenSetup()
-                    .body(payload)
-                    .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
-                    .then()
-                    .statusCode(SC_UNPROCESSABLE_ENTITY)
-                    .body("message[0]", is("Field [description] can have a size between 1 and 255"));
-        }
+            @Test
+            void shouldReturn422WhenRecurringPaymentsDisabled() {
+                testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
 
-        @Test
-        void shouldReturn422WhenRecurringPaymentsDisabled() throws JsonProcessingException {
-            testBaseExtension.createAGatewayAccountWithServiceId(VALID_SERVICE_ID);
-            
-            String payload = objectMapper.writeValueAsString(Map.of(
-                    "reference", REFERENCE_ID,
-                    "description", DESCRIPTION,
-                    "user_identifier", USER_IDENTIFIER
-            ));
+                String payload = toJson(Map.of(
+                        "reference", REFERENCE_ID,
+                        "description", DESCRIPTION,
+                        "user_identifier", USER_IDENTIFIER
+                ));
+                
                 app.givenSetup()
                         .body(payload)
                         .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
@@ -315,6 +314,54 @@ public class AgreementsApiResourceIT {
                         .statusCode(SC_UNPROCESSABLE_ENTITY)
                         .body("message", contains("Recurring payment agreements are not enabled on this account"))
                         .body("error_identifier", is(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED.toString()));
+            }
         }
+        
+        @Nested
+        class CancelAgreement {
+            
+            @BeforeEach
+            void setUp() {
+                testAccount = createTestAccount("worldpay", true);
+                accountId = testAccount.getAccountId();
+            }
+            
+            @Test
+            void shouldReturn204AndCancelAgreement() {
+                var agreementId = "an-agreement-external-id";
+                AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
+                        .withPaymentInstrumentId(nextLong())
+                        .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
+                        .build();
+                app.getDatabaseTestHelper().addPaymentInstrument(paymentInstrumentParams);
+                AddAgreementParams agreementParams = anAddAgreementParams()
+                        .withGatewayAccountId(String.valueOf(accountId))
+                        .withExternalAgreementId(agreementId)
+                        .withPaymentInstrumentId(paymentInstrumentParams.getPaymentInstrumentId())
+                        .withServiceId(VALID_SERVICE_ID)
+                        .withLive(false)
+                        .build();
+                app.getDatabaseTestHelper().addAgreement(agreementParams);
+
+                app.givenSetup()
+                        .post(format(CANCEL_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, "test", agreementId))
+                        .then()
+                        .statusCode(NO_CONTENT_204);
+
+                var paymentInstrumentMap = app.getDatabaseTestHelper().getPaymentInstrument(paymentInstrumentParams.getPaymentInstrumentId());
+                assertThat(paymentInstrumentMap.get("status"), is("CANCELLED"));
+                var agreementMap = app.getDatabaseTestHelper().getAgreementByExternalId(agreementId);
+                assertThat(agreementMap.get("cancelled_date"), is(notNullValue()));
+            }
+        }
+    }
+    private DatabaseFixtures.TestAccount createTestAccount(String paymentProvider, boolean recurringEnabled) {
+        long accountId = nextLong(2, 10000);
+
+        return app.getDatabaseFixtures().aTestAccount().withPaymentProvider(paymentProvider)
+                .withIntegrationVersion3ds(2)
+                .withAccountId(accountId)
+                .withRecurringEnabled(recurringEnabled)
+                .insert();
     }
 }


### PR DESCRIPTION
- add endpoint to cancel agreement by service ID and account type
- add method to find agreement by external ID, service ID and account type
- make AgreementDAO find agreement method names more specific as this is clearer than overloading
- add unit and integration tests