### PR TITLE
PP-12356 Update degatewayed endpoints to use consistent 404 error message

### DIFF
--- a/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
@@ -67,7 +67,7 @@ public class AgreementService {
     public Optional<AgreementResponse> createByServiceIdAndAccountType(AgreementCreateRequest agreementCreateRequest, String serviceId, GatewayAccountType accountType) {
         return gatewayAccountDao.findByServiceIdAndAccountType(serviceId, accountType)
                 .or(() -> {
-                    throw new GatewayAccountNotFoundException(String.format("Gateway account not found for service ID [%s] and account type [%s]", serviceId, accountType));
+                    throw new GatewayAccountNotFoundException(serviceId, accountType);
                 })
                 .map(gatewayAccountEntity -> create(agreementCreateRequest, gatewayAccountEntity));
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -141,7 +141,7 @@ public class GatewayAccountResource {
             @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType) {
         GatewayAccountWithCredentialsResponse response = gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
                 .map(GatewayAccountWithCredentialsResponse::new)
-                .orElseThrow(() -> new GatewayAccountNotFoundException(format("Gateway account for service external id %s and account type %s not found.", serviceId, accountType)));
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
         return response;
     }
 
@@ -261,7 +261,7 @@ public class GatewayAccountResource {
         logger.info("Getting accepted card types for service id {}, account type {}", serviceId, accountType.toString());
         return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
                 .map(gatewayAccount -> successResponseWithEntity(Map.of(CARD_TYPES_FIELD_NAME, gatewayAccount.getCardTypes())))
-                .orElseGet(() -> notFoundResponse(format("Gateway account for service external id %s and account type %s not found.", serviceId, accountType)));
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
     }
 
     @POST
@@ -398,8 +398,7 @@ public class GatewayAccountResource {
                             return Response.ok().build();
                         }
                 )
-                .orElseGet(() ->
-                        notFoundResponse(format("A service with service id '%s' and account type '%s' does not exist", serviceId, accountType)));
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
     }
     
     @PATCH
@@ -554,7 +553,7 @@ public class GatewayAccountResource {
 
         return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
                 .map(gatewayAccountEntity -> updateGatewayAccountAcceptedCardTypes(cardTypeIds, gatewayAccountEntity))
-                .orElseGet(() -> notFoundResponse(format("The gateway account for service id '%s' and account type '%s' does not exist", serviceId, accountType)));
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
     }
 
     private Response updateGatewayAccountAcceptedCardTypes(List<UUID> cardTypeIds, GatewayAccountEntity gatewayAccountToEdit) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
@@ -72,7 +72,7 @@ public class StripeAccountResource {
             @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType) {
         return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
                 .or(() -> {
-                    throw new GatewayAccountNotFoundException(String.format("Gateway account not found for service ID [%s] and account type [%s]", serviceId, accountType));
+                    throw new GatewayAccountNotFoundException(serviceId, accountType);
                 })
                 .filter(StripeAccountUtils::isStripeGatewayAccount)
                 .or(() -> {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java
@@ -82,7 +82,7 @@ public class StripeAccountSetupResource {
             @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType) {
         return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
                 .map(gatewayAccountEntity -> stripeAccountSetupService.getCompletedTasks(gatewayAccountEntity.getId()))
-                .orElseThrow(() -> new GatewayAccountNotFoundException(String.format("Gateway account not found for service ID [%s] and account type [%s]", serviceId, accountType)));
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
     }
 
     @PATCH

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
@@ -248,7 +248,7 @@ public class GatewayAccountCredentialsResource {
                     Map<String, String> credentials = gatewayAccountCredentialsRequest.getCredentialsAsMap() == null ? Map.of() : gatewayAccountCredentialsRequest.getCredentialsAsMap();
                     return gatewayAccountCredentialsService.createGatewayAccountCredentials(gatewayAccount, gatewayAccountCredentialsRequest.getPaymentProvider(), credentials);
                 })
-                .orElseThrow(() -> new GatewayAccountNotFoundException(String.format("Gateway account not found for service ID [%s] and account type [%s]", serviceId, accountType)));
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
     }
 
     @PUT
@@ -272,7 +272,7 @@ public class GatewayAccountCredentialsResource {
             @Valid Worldpay3dsFlexCredentialsRequest worldpay3dsCredentials) {
         return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
                 .or(() -> {
-                    throw new GatewayAccountNotFoundException(String.format("Gateway account not found for service ID [%s] and account type [%s]", serviceId, accountType));
+                    throw new GatewayAccountNotFoundException(serviceId, accountType);
                 })
                 .filter(gatewayAccountEntity ->
                         gatewayAccountEntity.getGatewayName().equals(PaymentGatewayName.WORLDPAY.getName()))
@@ -307,7 +307,7 @@ public class GatewayAccountCredentialsResource {
                 .map(gatewayAccountEntity ->
                         worldpay3dsFlexCredentialsValidationService.validateCredentials(gatewayAccountEntity, Worldpay3dsFlexCredentials.from(worldpay3dsCredentials)))
                 .map(ValidationResult::new)
-                .orElseThrow(() -> new GatewayAccountNotFoundException(String.format("Gateway account not found for service ID [%s] and account type [%s]", serviceId, accountType)));
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
     }
     
     @PATCH

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -258,7 +258,7 @@ public class GatewayAccountFrontendResourceIT {
                     .patch("/v1/frontend/service/nexiste-pas/test/servicename")
                     .then()
                     .statusCode(404)
-                    .body("message", contains("A service with service id 'nexiste-pas' and account type 'test' does not exist"))
+                    .body("message", contains("Gateway account not found for service ID [nexiste-pas] and account type [test]"))
                     .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
         }
     }


### PR DESCRIPTION
## WHAT YOU DID
 - Use `GatewayAccountNotFoundException` to generate consistent error messages for degatewayed endpoints

## How to test
 - Run tests