### PR TITLE
PP-12356 Remove internal IDs from credential responses on new endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -349,14 +349,14 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 242
+        "line_number": 241
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 339
+        "line_number": 338
       }
     ],
     "src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java": [
@@ -1066,5 +1066,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-22T14:54:01Z"
+  "generated_at": "2024-05-23T09:30:02Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -270,7 +274,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 17
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java": [
@@ -311,14 +315,14 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 83
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 141
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java": [
@@ -345,14 +349,14 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 241
+        "line_number": 242
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 337
+        "line_number": 339
       }
     ],
     "src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java": [
@@ -1062,5 +1066,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-22T11:34:53Z"
+  "generated_at": "2024-05-22T14:47:38Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -349,14 +349,14 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 241
+        "line_number": 244
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 338
+        "line_number": 341
       }
     ],
     "src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java": [
@@ -1066,5 +1066,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-23T09:30:02Z"
+  "generated_at": "2024-05-23T09:57:00Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -181,21 +181,21 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 4361
+        "line_number": 4610
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 4828
+        "line_number": 5077
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 4839
+        "line_number": 5088
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1066,5 +1066,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-22T14:47:38Z"
+  "generated_at": "2024-05-22T14:54:01Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -184,7 +184,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GatewayAccountWithCredentialsResponse'
+                $ref: '#/components/schemas/GatewayAccountWithCredentialsWithInternalIdResponse'
           description: OK
         "404":
           description: Not found
@@ -676,7 +676,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GatewayAccountCredentials'
+                $ref: '#/components/schemas/GatewayAccountCredentialsWithInternalId'
           description: OK
         "400":
           content:
@@ -723,7 +723,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GatewayAccountCredentials'
+                $ref: '#/components/schemas/GatewayAccountCredentialsWithInternalId'
           description: OK
         "400":
           content:
@@ -1710,7 +1710,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GatewayAccountWithCredentialsResponse'
+                $ref: '#/components/schemas/GatewayAccountWithCredentialsWithInternalIdResponse'
           description: OK
         "404":
           description: Not found
@@ -3707,10 +3707,6 @@ components:
         external_id:
           type: string
           example: 787460d16d4a4d14b4c94787b8f427db
-        gateway_account_credential_id:
-          type: integer
-          format: int64
-          example: 1
         gateway_account_id:
           type: integer
           format: int64
@@ -3746,6 +3742,49 @@ components:
           type: string
           description: "Payment provider. Accepted values - stripe, worldpay"
           example: stripe
+    GatewayAccountCredentialsWithInternalId:
+      type: object
+      properties:
+        active_end_date:
+          type: string
+          format: date-time
+        active_start_date:
+          type: string
+          format: date-time
+          example: 2022-06-28T16:40:56.869Z
+        created_date:
+          type: string
+          format: date-time
+          example: 2022-06-30T15:44:19.323Z
+        credentials:
+          $ref: '#/components/schemas/GatewayCredentials'
+        external_id:
+          type: string
+          example: 787460d16d4a4d14b4c94787b8f427db
+        gateway_account_credential_id:
+          type: integer
+          format: int64
+          example: 1
+        gateway_account_id:
+          type: integer
+          format: int64
+          example: 1
+        last_updated_by_user_external_id:
+          type: string
+          description: User external ID
+          example: vdwke0d16d4a4d14b4c94787b8f427d
+        payment_provider:
+          type: string
+          example: stripe
+        state:
+          type: string
+          enum:
+          - CREATED
+          - ENTERED
+          - VERIFIED_WITH_LIVE_PAYMENT
+          - ACTIVE
+          - RETIRED
+          example: ACTIVE
     GatewayAccountRequest:
       type: object
       discriminator:
@@ -4125,6 +4164,216 @@ components:
           description: Array of the credentials configured for this account
           items:
             $ref: '#/components/schemas/GatewayAccountCredentials'
+        gateway_account_id:
+          type: integer
+          format: int64
+          description: The account ID
+          example: 1
+        integration_version_3ds:
+          type: integer
+          format: int32
+          description: 3DS version used for payments for the gateway account
+          example: 2
+        live:
+          type: boolean
+          description: Whether the account is live
+          example: true
+        moto_mask_card_number_input:
+          type: boolean
+          default: false
+          description: Indicates whether the card number is masked when being input
+            for MOTO payments. The default value is false.
+        moto_mask_card_security_code_input:
+          type: boolean
+          default: false
+          description: Indicates whether the card security code is masked when being
+            input for MOTO payments.
+        notificationCredentials:
+          $ref: '#/components/schemas/NotificationCredentials'
+        notifySettings:
+          type: object
+          additionalProperties:
+            type: string
+            description: An object containing the Notify credentials and configuration
+              for sending custom branded emails
+          description: An object containing the Notify credentials and configuration
+            for sending custom branded emails
+        payment_provider:
+          type: string
+          description: The payment provider for which this account is created
+          example: sandbox
+        provider_switch_enabled:
+          type: boolean
+          default: false
+          description: Flag to enable payment provider switching
+          example: false
+        recurring_enabled:
+          type: boolean
+          default: false
+          description: Flag to indicate whether the account is allowed to take recurring
+            card payments
+          example: true
+        requires3ds:
+          type: boolean
+          description: Flag to indicate whether 3DS is enabled
+          example: true
+        send_payer_email_to_gateway:
+          type: boolean
+          default: false
+          description: "If enabled, user email address is included in the authorisation\
+            \ request to gateway"
+          example: true
+        send_payer_ip_address_to_gateway:
+          type: boolean
+          default: false
+          description: "If enabled, user IP address is sent to to gateway"
+          example: true
+        send_reference_to_gateway:
+          type: boolean
+          default: false
+          description: "If enabled, service payment reference is sent to gateway as\
+            \ description. Otherwise payment description is sent to the gateway. Only\
+            \ applicable for Worldpay accounts. Default value is 'false'"
+          example: true
+        service_id:
+          type: string
+          description: Service external ID
+          example: cd1b871207a94a7fa157dee678146acd
+        service_name:
+          type: string
+          description: The service name for the account
+          example: service name
+        type:
+          type: string
+          description: Account type for the payment provider (test/live)
+          example: test
+        worldpay_3ds_flex:
+          $ref: '#/components/schemas/Worldpay3dsFlexCredentials'
+    GatewayAccountWithCredentialsWithInternalIdResponse:
+      type: object
+      properties:
+        _links:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
+              format: uri
+              example: "{        {            \"href\": \"https://connector.url/v1/api/accounts/1\"\
+                ,            \"rel\": \"self\",            \"method\": \"GET\"   \
+                \     }    }"
+            example: "{        {            \"href\": \"https://connector.url/v1/api/accounts/1\"\
+              ,            \"rel\": \"self\",            \"method\": \"GET\"     \
+              \   }    }"
+          example: "{        {            \"href\": \"https://connector.url/v1/api/accounts/1\"\
+            ,            \"rel\": \"self\",            \"method\": \"GET\"       \
+            \ }    }"
+        allow_apple_pay:
+          type: boolean
+          default: false
+          description: Set to true to enable Apple Pay
+          example: true
+        allow_authorisation_api:
+          type: boolean
+          default: false
+          description: Flag to indicate whether the account is allowed to initiate
+            MOTO payments that are authorised via an API request rather than the web
+            interface
+          example: true
+        allow_google_pay:
+          type: boolean
+          default: false
+          description: Set to true to enable Google Pay
+          example: true
+        allow_moto:
+          type: boolean
+          default: false
+          description: Indicates whether the Mail Order and Telephone Order (MOTO)
+            payments are allowed
+        allow_telephone_payment_notifications:
+          type: boolean
+          default: false
+          description: Indicates if the account is used for telephone payments reporting
+        allow_zero_amount:
+          type: boolean
+          default: false
+          description: Set to true to support charges with a zero amount
+          example: true
+        analytics_id:
+          type: string
+          description: An identifier used to identify the service in Google Analytics.
+            The default value is null
+        block_prepaid_cards:
+          type: boolean
+          default: false
+          description: Whether pre-paid cards are allowed as a payment method for
+            this gateway account
+          example: true
+        corporate_credit_card_surcharge_amount:
+          type: integer
+          format: int64
+          default: 0
+          description: A corporate credit card surcharge amount in pence
+          example: 250
+        corporate_debit_card_surcharge_amount:
+          type: integer
+          format: int64
+          default: 0
+          description: A corporate debit card surcharge amount in pence
+          example: 250
+        corporate_prepaid_debit_card_surcharge_amount:
+          type: integer
+          format: int64
+          description: A corporate prepaid debit card surcharge amount in pence
+          example: 0
+        description:
+          type: string
+          default: "null"
+          description: An internal description to identify the gateway account. The
+            default value is null.
+          example: Account for service xxx
+        disabled:
+          type: boolean
+          default: false
+          description: Flag to indicate whether the account is allowed to take payments
+            and make refunds
+          example: false
+        disabled_reason:
+          type: string
+          description: "The reason the account is disabled, if applicable"
+          example: No longer required
+        email_collection_mode:
+          type: string
+          description: "Whether email address is required from paying users. Can be\
+            \ MANDATORY, OPTIONAL or OFF"
+          enum:
+          - MANDATORY
+          - OPTIONAL
+          - "OFF"
+        email_notifications:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/EmailNotificationEntity'
+          description: The settings for the different emails (payments/refunds) that
+            are sent out
+          example:
+            PAYMENT_CONFIRMED:
+              enabled: true
+              template_body: null
+              version: 1
+            REFUND_ISSUED:
+              enabled: true
+              template_body: null
+              version: 1
+        external_id:
+          type: string
+          description: External ID for the gateway account
+          example: fbf905a3f7ea416c8c252410eb45ddbd
+        gateway_account_credentials:
+          type: array
+          description: Array of the credentials configured for this account
+          items:
+            $ref: '#/components/schemas/GatewayAccountCredentialsWithInternalId'
         gateway_account_id:
           type: integer
           format: int64

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
@@ -56,18 +56,6 @@ public class GatewayAccountCredentials {
         this.gatewayAccountId = entity.getGatewayAccountEntity().getId();
         this.credentials = entity.getCredentialsObject();
     }
-    
-    public GatewayAccountCredentials(GatewayAccountCredentialsWithInternalId credentialsWithInternalId) {
-        this.externalId = credentialsWithInternalId.getExternalId();
-        this.paymentProvider = credentialsWithInternalId.getPaymentProvider();
-        this.state = credentialsWithInternalId.getState();
-        this.lastUpdatedByUserExternalId = credentialsWithInternalId.getLastUpdatedByUserExternalId();
-        this.createdDate = credentialsWithInternalId.getCreatedDate();
-        this.activeStartDate = credentialsWithInternalId.getActiveStartDate();
-        this.activeEndDate = credentialsWithInternalId.getActiveEndDate();
-        this.gatewayAccountId = credentialsWithInternalId.getGatewayAccountId();
-        this.credentials = credentialsWithInternalId.getCredentials();
-    }
 
     public String getExternalId() {
         return externalId;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
@@ -14,10 +14,6 @@ import java.time.Instant;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GatewayAccountCredentials {
 
-    @JsonProperty("gateway_account_credential_id")
-    @Schema(example = "1")
-    private Long id;
-
     @Schema(example = "787460d16d4a4d14b4c94787b8f427db")
     private String externalId;
 
@@ -50,7 +46,6 @@ public class GatewayAccountCredentials {
     private Long gatewayAccountId;
 
     public GatewayAccountCredentials(GatewayAccountCredentialsEntity entity) {
-        this.id = entity.getId();
         this.externalId = entity.getExternalId();
         this.paymentProvider = entity.getPaymentProvider();
         this.state = entity.getState();
@@ -60,10 +55,6 @@ public class GatewayAccountCredentials {
         this.activeEndDate = entity.getActiveEndDate();
         this.gatewayAccountId = entity.getGatewayAccountEntity().getId();
         this.credentials = entity.getCredentialsObject();
-    }
-
-    public Long getId() {
-        return id;
     }
 
     public String getExternalId() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
@@ -56,6 +56,18 @@ public class GatewayAccountCredentials {
         this.gatewayAccountId = entity.getGatewayAccountEntity().getId();
         this.credentials = entity.getCredentialsObject();
     }
+    
+    public GatewayAccountCredentials(GatewayAccountCredentialsWithInternalId credentialsWithInternalId) {
+        this.externalId = credentialsWithInternalId.getExternalId();
+        this.paymentProvider = credentialsWithInternalId.getPaymentProvider();
+        this.state = credentialsWithInternalId.getState();
+        this.lastUpdatedByUserExternalId = credentialsWithInternalId.getLastUpdatedByUserExternalId();
+        this.createdDate = credentialsWithInternalId.getCreatedDate();
+        this.activeStartDate = credentialsWithInternalId.getActiveStartDate();
+        this.activeEndDate = credentialsWithInternalId.getActiveEndDate();
+        this.gatewayAccountId = credentialsWithInternalId.getGatewayAccountId();
+        this.credentials = credentialsWithInternalId.getCredentials();
+    }
 
     public String getExternalId() {
         return externalId;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsWithInternalId.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsWithInternalId.java
@@ -16,8 +16,4 @@ public class GatewayAccountCredentialsWithInternalId extends GatewayAccountCrede
     public Long getId() {
         return id;
     }
-    
-    public GatewayAccountCredentials stripInternalId() {
-        return new GatewayAccountCredentials(this);
-    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsWithInternalId.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsWithInternalId.java
@@ -18,6 +18,6 @@ public class GatewayAccountCredentialsWithInternalId extends GatewayAccountCrede
     }
     
     public GatewayAccountCredentials stripInternalId() {
-        return this;
+        return new GatewayAccountCredentials(this);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsWithInternalId.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsWithInternalId.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+
+public class GatewayAccountCredentialsWithInternalId extends GatewayAccountCredentials {
+    @JsonProperty("gateway_account_credential_id")
+    @Schema(example = "1")
+    private Long id;
+    public GatewayAccountCredentialsWithInternalId(GatewayAccountCredentialsEntity entity) {
+        super(entity);
+        this.id = entity.getId();
+    }
+
+    public Long getId() {
+        return id;
+    }
+    
+    public GatewayAccountCredentials stripInternalId() {
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsWithInternalIdResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsWithInternalIdResponse.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+public class GatewayAccountWithCredentialsWithInternalIdResponse extends GatewayAccountWithCredentialsResponse {
+    @JsonProperty("gateway_account_credentials")
+    @Schema(description = "Array of the credentials configured for this account")
+    private final List<GatewayAccountCredentialsWithInternalId> gatewayAccountCredentialsWithInternalIds;
+
+    public GatewayAccountWithCredentialsWithInternalIdResponse(GatewayAccountEntity gatewayAccountEntity) {
+        super(gatewayAccountEntity);
+        this.gatewayAccountCredentialsWithInternalIds = gatewayAccountEntity.getGatewayAccountCredentials()
+                .stream()
+                .map(GatewayAccountCredentialsWithInternalId::new)
+                .collect(Collectors.toList());
+    }
+
+    public List<GatewayAccountCredentialsWithInternalId> getGatewayAccountCredentialsWithInternalIds() {
+        return gatewayAccountCredentialsWithInternalIds;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -26,6 +26,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountWithCredentialsWithInternalIdResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountWithCredentialsResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountsListDTO;
 import uk.gov.pay.connector.gatewayaccount.model.UpdateServiceNameRequest;
@@ -111,15 +112,15 @@ public class GatewayAccountResource {
             tags = {"Gateway accounts"},
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",
-                            content = @Content(schema = @Schema(implementation = GatewayAccountWithCredentialsResponse.class))),
+                            content = @Content(schema = @Schema(implementation = GatewayAccountWithCredentialsWithInternalIdResponse.class))),
                     @ApiResponse(responseCode = "404", description = "Not found")
             }
     )
-    public GatewayAccountWithCredentialsResponse getGatewayAccount(@Parameter(example = "1", description = "Gateway account ID")
+    public GatewayAccountWithCredentialsWithInternalIdResponse getGatewayAccount(@Parameter(example = "1", description = "Gateway account ID")
                                                                    @PathParam("accountId") Long gatewayAccountId) {
 
         return gatewayAccountService.getGatewayAccount(gatewayAccountId)
-                .map(GatewayAccountWithCredentialsResponse::new)
+                .map(GatewayAccountWithCredentialsWithInternalIdResponse::new)
                 .orElseThrow(() -> new GatewayAccountNotFoundException(gatewayAccountId));
     }
 
@@ -139,10 +140,9 @@ public class GatewayAccountResource {
     public GatewayAccountWithCredentialsResponse getGatewayAccountByServiceIdAndAccountType(
             @Parameter(example = "46eb1b601348499196c99de90482ee68", description = "Service ID") @PathParam("serviceId") String serviceId,
             @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType) {
-        GatewayAccountWithCredentialsResponse response = gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
+        return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
                 .map(GatewayAccountWithCredentialsResponse::new)
                 .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
-        return response;
     }
 
     @GET
@@ -192,14 +192,14 @@ public class GatewayAccountResource {
             tags = {"Gateway accounts"},
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",
-                            content = @Content(schema = @Schema(name = "accounts", implementation = GatewayAccountWithCredentialsResponse.class))),
+                            content = @Content(schema = @Schema(name = "accounts", implementation = GatewayAccountWithCredentialsWithInternalIdResponse.class))),
                     @ApiResponse(responseCode = "404", description = "Not found")
             }
     )
-    public GatewayAccountWithCredentialsResponse getFrontendGatewayAccountByExternalId(@PathParam("externalId") String externalId) {
+    public GatewayAccountWithCredentialsWithInternalIdResponse getFrontendGatewayAccountByExternalId(@PathParam("externalId") String externalId) {
         return gatewayAccountService
                 .getGatewayAccountByExternal(externalId)
-                .map(GatewayAccountWithCredentialsResponse::new)
+                .map(GatewayAccountWithCredentialsWithInternalIdResponse::new)
                 .orElseThrow(() -> new GatewayAccountNotFoundException(format("Account with external id %s not found.", externalId)));
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsReques
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsWithInternalId;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountWithCredentialsWithInternalIdResponse;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsRequest;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayValidatableCredentials;
@@ -174,6 +175,7 @@ public class GatewayAccountCredentialsResource {
                     Map<String, String> credentials = gatewayAccountCredentialsRequest.getCredentialsAsMap() == null ? Map.of() : gatewayAccountCredentialsRequest.getCredentialsAsMap();
                     return gatewayAccountCredentialsService.createGatewayAccountCredentials(gatewayAccount, gatewayAccountCredentialsRequest.getPaymentProvider(), credentials);
                 })
+                .map(GatewayAccountCredentialsWithInternalId::new)
                 .orElseThrow(() -> new GatewayAccountNotFoundException(gatewayAccountId));
     }
 
@@ -220,6 +222,7 @@ public class GatewayAccountCredentialsResource {
                             return gatewayAccountCredentialsService.updateGatewayAccountCredentials(gatewayAccountCredentialsEntity, updateRequests);
                         })
                         .orElseThrow(() -> new GatewayAccountCredentialsNotFoundException(credentialsId)))
+                .map(GatewayAccountCredentialsWithInternalId::new)
                 .orElseThrow(() -> new GatewayAccountNotFoundException(gatewayAccountId));
     }
 
@@ -248,7 +251,7 @@ public class GatewayAccountCredentialsResource {
                     Map<String, String> credentials = gatewayAccountCredentialsRequest.getCredentialsAsMap() == null ? Map.of() : gatewayAccountCredentialsRequest.getCredentialsAsMap();
                     return gatewayAccountCredentialsService.createGatewayAccountCredentials(gatewayAccount, gatewayAccountCredentialsRequest.getPaymentProvider(), credentials);
                 })
-                .map(GatewayAccountCredentialsWithInternalId::stripInternalId)
+                .map(GatewayAccountCredentials::new)
                 .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
     }
 
@@ -359,7 +362,7 @@ public class GatewayAccountCredentialsResource {
                             .collect(Collectors.toList());
                     return gatewayAccountCredentialsService.updateGatewayAccountCredentials(gatewayAccountCredentialsEntity, updateRequests);
                 })
-                .map(GatewayAccountCredentialsWithInternalId::stripInternalId)
+                .map(GatewayAccountCredentials::new)
                 .orElseThrow(IllegalStateException::new);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountCredentialsNo
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsWithInternalId;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
@@ -157,13 +158,13 @@ public class GatewayAccountCredentialsResource {
             summary = "Create credentials for a gateway account",
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",
-                            content = @Content(schema = @Schema(implementation = GatewayAccountCredentials.class))),
+                            content = @Content(schema = @Schema(implementation = GatewayAccountCredentialsWithInternalId.class))),
                     @ApiResponse(responseCode = "400", description = "Bad request - Invalid or missing mandatory fields",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "Not found - account not found")
             }
     )
-    public GatewayAccountCredentials createGatewayAccountCredentials(@Parameter(example = "1", description = "Gateway account ID")
+    public GatewayAccountCredentialsWithInternalId createGatewayAccountCredentials(@Parameter(example = "1", description = "Gateway account ID")
                                                                      @PathParam("accountId") Long gatewayAccountId,
                                                                      @NotNull GatewayAccountCredentialsRequest gatewayAccountCredentialsRequest) {
         gatewayAccountCredentialsRequestValidator.validateCreate(gatewayAccountCredentialsRequest);
@@ -191,13 +192,13 @@ public class GatewayAccountCredentialsResource {
                     "]"))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",
-                            content = @Content(schema = @Schema(implementation = GatewayAccountCredentials.class))),
+                            content = @Content(schema = @Schema(implementation = GatewayAccountCredentialsWithInternalId.class))),
                     @ApiResponse(responseCode = "400", description = "Bad request - Invalid or missing mandatory fields",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "Not found - account or credential not found")
             }
     )
-    public GatewayAccountCredentials updateGatewayAccountCredentials(
+    public GatewayAccountCredentialsWithInternalId updateGatewayAccountCredentials(
             @Parameter(example = "1", description = "Gateway account ID")
             @PathParam("accountId") Long gatewayAccountId,
             @Parameter(example = "1", description = "Credential ID")
@@ -229,7 +230,6 @@ public class GatewayAccountCredentialsResource {
     @Operation(
             summary = "Create credentials for a gateway account by service external ID and account type (test|live)",
             responses = {
-                    // TODO Update GatewayAccountCredentials to not return gateway_account_credential_id
                     @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(implementation = GatewayAccountCredentials.class))),
                     @ApiResponse(responseCode = "400", description = "Bad request - Invalid or missing mandatory fields",
@@ -248,6 +248,7 @@ public class GatewayAccountCredentialsResource {
                     Map<String, String> credentials = gatewayAccountCredentialsRequest.getCredentialsAsMap() == null ? Map.of() : gatewayAccountCredentialsRequest.getCredentialsAsMap();
                     return gatewayAccountCredentialsService.createGatewayAccountCredentials(gatewayAccount, gatewayAccountCredentialsRequest.getPaymentProvider(), credentials);
                 })
+                .map(GatewayAccountCredentialsWithInternalId::stripInternalId)
                 .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
     }
 
@@ -358,6 +359,7 @@ public class GatewayAccountCredentialsResource {
                             .collect(Collectors.toList());
                     return gatewayAccountCredentialsService.updateGatewayAccountCredentials(gatewayAccountCredentialsEntity, updateRequests);
                 })
+                .map(GatewayAccountCredentialsWithInternalId::stripInternalId)
                 .orElseThrow(IllegalStateException::new);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -8,7 +8,7 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountCredentialsNotFoundException;
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsWithInternalId;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
@@ -79,7 +79,7 @@ public class GatewayAccountCredentialsService {
     }
 
     @Transactional
-    public GatewayAccountCredentials createGatewayAccountCredentials(GatewayAccountEntity gatewayAccountEntity,
+    public GatewayAccountCredentialsWithInternalId createGatewayAccountCredentials(GatewayAccountEntity gatewayAccountEntity,
                                                                      String paymentProvider,
                                                                      Map<String, String> credentials) {
         GatewayAccountCredentialState state = calculateStateForNewCredentials(gatewayAccountEntity, paymentProvider, credentials);
@@ -94,7 +94,7 @@ public class GatewayAccountCredentialsService {
         gatewayAccountCredentialsEntity.setExternalId(randomUuid());
 
         gatewayAccountCredentialsDao.persist(gatewayAccountCredentialsEntity);
-        return new GatewayAccountCredentials(gatewayAccountCredentialsEntity);
+        return new GatewayAccountCredentialsWithInternalId(gatewayAccountCredentialsEntity);
     }
 
     private GatewayAccountCredentialState calculateStateForNewCredentials(GatewayAccountEntity gatewayAccountEntity,
@@ -121,7 +121,7 @@ public class GatewayAccountCredentialsService {
     }
 
     @Transactional
-    public GatewayAccountCredentials updateGatewayAccountCredentials(
+    public GatewayAccountCredentialsWithInternalId updateGatewayAccountCredentials(
             GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity,
             Iterable<JsonPatchRequest> updateRequests) {
         for (JsonPatchRequest updateRequest : updateRequests) {
@@ -140,7 +140,7 @@ public class GatewayAccountCredentialsService {
                 kv(USER_EXTERNAL_ID, gatewayAccountCredentialsEntity.getLastUpdatedByUserExternalId())
         );
 
-        return new GatewayAccountCredentials(gatewayAccountCredentialsEntity);
+        return new GatewayAccountCredentialsWithInternalId(gatewayAccountCredentialsEntity);
     }
 
     private void updateGatewayAccountCredentialField(JsonPatchRequest patchRequest,

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -79,7 +79,7 @@ public class GatewayAccountCredentialsService {
     }
 
     @Transactional
-    public GatewayAccountCredentialsWithInternalId createGatewayAccountCredentials(GatewayAccountEntity gatewayAccountEntity,
+    public GatewayAccountCredentialsEntity createGatewayAccountCredentials(GatewayAccountEntity gatewayAccountEntity,
                                                                      String paymentProvider,
                                                                      Map<String, String> credentials) {
         GatewayAccountCredentialState state = calculateStateForNewCredentials(gatewayAccountEntity, paymentProvider, credentials);
@@ -94,7 +94,7 @@ public class GatewayAccountCredentialsService {
         gatewayAccountCredentialsEntity.setExternalId(randomUuid());
 
         gatewayAccountCredentialsDao.persist(gatewayAccountCredentialsEntity);
-        return new GatewayAccountCredentialsWithInternalId(gatewayAccountCredentialsEntity);
+        return gatewayAccountCredentialsEntity;
     }
 
     private GatewayAccountCredentialState calculateStateForNewCredentials(GatewayAccountEntity gatewayAccountEntity,
@@ -121,7 +121,7 @@ public class GatewayAccountCredentialsService {
     }
 
     @Transactional
-    public GatewayAccountCredentialsWithInternalId updateGatewayAccountCredentials(
+    public GatewayAccountCredentialsEntity updateGatewayAccountCredentials(
             GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity,
             Iterable<JsonPatchRequest> updateRequests) {
         for (JsonPatchRequest updateRequest : updateRequests) {
@@ -140,7 +140,7 @@ public class GatewayAccountCredentialsService {
                 kv(USER_EXTERNAL_ID, gatewayAccountCredentialsEntity.getLastUpdatedByUserExternalId())
         );
 
-        return new GatewayAccountCredentialsWithInternalId(gatewayAccountCredentialsEntity);
+        return gatewayAccountCredentialsEntity;
     }
 
     private void updateGatewayAccountCredentialField(JsonPatchRequest patchRequest,

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
@@ -276,7 +276,8 @@ public class GatewayAccountCredentialsResourceIT {
                         .body(toJson(Map.of("payment_provider", "stripe", "credentials", validStripeCredentials)))
                         .post(format("/v1/api/service/%s/%s/credentials", VALID_SERVICE_ID, TEST))
                         .then()
-                        .statusCode(OK.getStatusCode());
+                        .statusCode(OK.getStatusCode())
+                        .body(not(hasKey("gateway_account_credential_id")));;
 
                 app.givenSetup()
                         .get("/v1/api/accounts/" + gatewayAccountId)
@@ -350,7 +351,8 @@ public class GatewayAccountCredentialsResourceIT {
                     .body("last_updated_by_user_external_id", is("a-new-user-external-id"))
                     .body("state", is("VERIFIED_WITH_LIVE_PAYMENT"))
                     .body("external_id", is(credentialsId))
-                    .body("payment_provider", is("stripe"));
+                    .body("payment_provider", is("stripe"))
+                    .body(not(hasKey("gateway_account_credential_id")));
 
                 app.givenSetup()
                     .get(format("/v1/api/service/%s/%s", VALID_SERVICE_ID, TEST))

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -99,7 +99,8 @@ public class GatewayAccountFrontendResourceIT {
                 .body("block_prepaid_cards", is(false))
                 .body("allow_moto", is(false))
                 .body("allow_telephone_payment_notifications", is(false))
-                .body("worldpay_3ds_flex", nullValue());
+                .body("worldpay_3ds_flex", nullValue())
+                .body("gateway_account_credentials[0]", hasKey("gateway_account_credential_id"));
     }
     
     @Test
@@ -120,7 +121,8 @@ public class GatewayAccountFrontendResourceIT {
                 .body("worldpay_3ds_flex", not(hasKey("jwt_mac_key")))
                 .body("worldpay_3ds_flex", not(hasKey("version")))
                 .body("worldpay_3ds_flex", not(hasKey("gateway_account_id")))
-                .body("worldpay_3ds_flex.exemption_engine_enabled", is(false));
+                .body("worldpay_3ds_flex.exemption_engine_enabled", is(false))
+                .body("gateway_account_credentials[0]", hasKey("gateway_account_credential_id"));
     }
 
     private void validateNon3dsCardType(ValidatableResponse response, String brand, String label, String... type) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -475,7 +475,8 @@ public class GatewayAccountResourceIT {
                     .body("gateway_account_credentials[0].credentials", hasKey("recurring_merchant_initiated"))
                     .body("gateway_account_credentials[0].credentials.recurring_merchant_initiated", hasEntry("merchant_code", "mit-merchant-code"))
                     .body("gateway_account_credentials[0].credentials.recurring_merchant_initiated", hasEntry("username", "mit-username"))
-                    .body("gateway_account_credentials[0].credentials.recurring_merchant_initiated", not(hasKey("password")));
+                    .body("gateway_account_credentials[0].credentials.recurring_merchant_initiated", not(hasKey("password")))
+                    .body("gateway_account_credentials[0]", hasKey("gateway_account_credential_id"));
         }
 
         @Test
@@ -506,7 +507,8 @@ public class GatewayAccountResourceIT {
                     .body("gateway_account_credentials[0].payment_provider", is("stripe"))
                     .body("gateway_account_credentials[0].state", is("ACTIVE"))
                     .body("gateway_account_credentials[0].gateway_account_id", is(accountIdAsInt))
-                    .body("gateway_account_credentials[0].credentials", hasEntry("stripe_account_id", "a-stripe-account-id"));
+                    .body("gateway_account_credentials[0].credentials", hasEntry("stripe_account_id", "a-stripe-account-id"))
+                    .body("gateway_account_credentials[0]", hasKey("gateway_account_credential_id"));
         }
 
         @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.it.resources;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.http.ContentType;
 import org.apache.commons.lang.math.RandomUtils;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -184,6 +185,7 @@ public class GatewayAccountResourceIT {
                     .body("gateway_account_credentials[0].credentials.recurring_merchant_initiated", hasEntry("merchant_code", "mit-merchant-code"))
                     .body("gateway_account_credentials[0].credentials.recurring_merchant_initiated", hasEntry("username", "mit-username"))
                     .body("gateway_account_credentials[0].credentials.recurring_merchant_initiated", not(hasKey("password")))
+                    .body("gateway_account_credentials[0]", not(Matchers.hasKey("gateway_account_credential_id")))
                     .body("$", hasKey("worldpay_3ds_flex"))
                     .body("worldpay_3ds_flex.issuer", is("issuer"))
                     .body("worldpay_3ds_flex.organisational_unit_id", is("org_unit_id"))
@@ -264,7 +266,8 @@ public class GatewayAccountResourceIT {
                     .body("gateway_account_credentials[0].payment_provider", is("stripe"))
                     .body("gateway_account_credentials[0].state", is("ACTIVE"))
                     .body("gateway_account_credentials[0].gateway_account_id", is(Math.toIntExact(defaultTestAccount.getAccountId())))
-                    .body("gateway_account_credentials[0].credentials", hasEntry("stripe_account_id", "a-stripe-account-id"));
+                    .body("gateway_account_credentials[0].credentials", hasEntry("stripe_account_id", "a-stripe-account-id"))
+                    .body("gateway_account_credentials[0]", not(Matchers.hasKey("gateway_account_credential_id")));
         }
 
         @Test


### PR DESCRIPTION
## WHAT YOU DID
 - Update `GatewayAccountCredentials` and `GatewayAccountWithCredentialsResponse` to remove internal IDs from returned credentials
   - This modifies the de-gateway-accountified endpoints to not return internal IDs of credential objects
 - Add new `GatewayAccountCredentialsWithInternalId` and `GatewayAccountWithCredentialsWithInternalIdResponse` to replace `GatewayAccountCredentials`/`GatewayAccountWithCredentialsResponse` for existing endpoints

   - This preserves the behaviour of existing endpoints and avoids this being a breaking change
 - Move construction of `GatewayAccountCredentials` objects (and new `GatewayAccountCredentialsWithInternalId` objects) from methods in `GatewayAccountCredentialsService` to `GatewayAccountCredentialsResource`, making the mapping into response objects cleaner and easier to modify in future.
 
   - This makes it easier to deprecate `GatewayAccountCredentialsWithInternalId` if the endpoints using it are deprecated/removed, as it is clear which endpoints make use of it
  
 - Add assertions to tests that internal IDs are returned/not returned where required

## HOW TO TEST
 - Run tests
