### PR TITLE
PP-12713 restrict Dropwizard upgrade to version 3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,13 @@ updates:
       time: "03:00"
     ignore:
       - dependency-name: "io.dropwizard:dropwizard-dependencies"
-        # We are still preparing to upgrade to Dropwizard 3
+        # Dropwizard 4.x only works with Jakarta EE and not Java EE
         versions:
-          - ">= 3"
+          - ">= 4"
+      - dependency-name: "io.dropwizard.modules:dropwizard-testing-junit4"
+        # dropwizard-testing-junit4 4.x only works with Dropwizard 4.x
+        versions:
+          - ">= 4"
       - dependency-name: "org.dhatim:dropwizard-sentry"
         # We essentially forked Dropwizard Sentry because it did not support
         # Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports


### PR DESCRIPTION
## WHAT YOU DID

Tell dependabot not to try to upgrade Dropwizard to version 4. Version 4 requires Jakarta EE and we are still on Java EE.
