### PR TITLE
PP-12356 Implement POST /v1/api/service/{serviceId}/[test|live]/worldpay/check-credentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -146,56 +146,56 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 2755
+        "line_number": 2801
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 2799
+        "line_number": 2845
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3266
+        "line_number": 3312
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3646
+        "line_number": 3692
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3682
+        "line_number": 3728
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 4610
+        "line_number": 4656
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5077
+        "line_number": 5123
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5088
+        "line_number": 5134
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -349,14 +349,14 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 244
+        "line_number": 245
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 341
+        "line_number": 342
       }
     ],
     "src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java": [
@@ -1066,5 +1066,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-23T09:57:00Z"
+  "generated_at": "2024-05-24T10:50:06Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1694,6 +1694,52 @@ paths:
       summary: Validate Worldpay 3DS flex credentials
       tags:
       - Gateway account credentials
+  /v1/api/service/{serviceId}/{accountType}/worldpay/check-credentials:
+    post:
+      operationId: validateWorldpayCredentialsByServiceIdAndAccountType
+      parameters:
+      - description: Service external ID
+        example: 46eb1b601348499196c99de90482ee68
+        in: path
+        name: serviceId
+        required: true
+        schema:
+          type: string
+      - description: Account type
+        example: test
+        in: path
+        name: accountType
+        required: true
+        schema:
+          type: string
+          enum:
+          - test
+          - live
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorldpayValidatableCredentials'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationResult'
+          description: OK
+        "404":
+          description: Not found - account not found or not a Worldpay gateway account
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unprocessable Entity - Invalid or missing mandatory fields
+        "500":
+          description: Internal server error
+      summary: Validate Worldpay credentials by service ID and account type
+      tags:
+      - Gateway account credentials
   /v1/frontend/accounts/external-id/{externalId}:
     get:
       description: "Get gateway account by external ID. Also returns notifications\

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountNotFoundException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountNotFoundException.java
@@ -19,4 +19,8 @@ public class GatewayAccountNotFoundException extends WebApplicationException {
     public GatewayAccountNotFoundException(String serviceId, GatewayAccountType accountType) {
         this(format("Gateway account not found for service ID [%s] and account type [%s]", serviceId, accountType));
     }
+    
+    public static GatewayAccountNotFoundException forNonWorldpayAccount(String serviceId, GatewayAccountType accountType) {
+        return new GatewayAccountNotFoundException(format("Gateway account for service ID [%s] and account type [%s] is not a Worldpay account.", serviceId, accountType));
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/support/WorldpayAccountUtils.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/support/WorldpayAccountUtils.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.gatewayaccount.resource.support;
+
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+public class WorldpayAccountUtils {
+
+    public static boolean isWorldpayGatewayAccount(GatewayAccountEntity gatewayAccountEntity) {
+        return PaymentGatewayName.WORLDPAY.getName().equals(gatewayAccountEntity.getGatewayName());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
@@ -559,6 +559,7 @@ public class GatewayAccountCredentialsResourceIT {
                     "merchant_id", "a-merchant-id",
                     "username", "a-username",
                     "password", "a-password");
+            
             @Test
             void forNonExistentGatewayAccount_shouldReturn404() {
                 app.givenSetup()
@@ -576,12 +577,11 @@ public class GatewayAccountCredentialsResourceIT {
                 app.givenSetup()
                         .body(toJson(Map.of(
                                 "payment_provider", "worldpay",
-                                "service_id", "a-valid-service-id",
-                                "service_name", "a-test-service",
+                                "service_id", VALID_SERVICE_ID,
+                                "service_name", VALID_SERVICE_NAME,
                                 "type", "test"
                         )))
-                        .post("/v1/api/accounts")
-                        .then().extract().path("gateway_account_id");
+                        .post("/v1/api/accounts");
 
                 app.givenSetup()
                         .body(toJson(worldpayCredentials))
@@ -598,12 +598,11 @@ public class GatewayAccountCredentialsResourceIT {
                 app.givenSetup()
                         .body(toJson(Map.of(
                                 "payment_provider", "worldpay",
-                                "service_id", "a-valid-service-id",
-                                "service_name", "a-test-service",
+                                "service_id", VALID_SERVICE_ID,
+                                "service_name", VALID_SERVICE_NAME,
                                 "type", "test"
                         )))
-                        .post("/v1/api/accounts")
-                        .then().extract().path("gateway_account_id");
+                        .post("/v1/api/accounts");
 
                 app.givenSetup()
                         .body(toJson(worldpayCredentials))
@@ -620,12 +619,11 @@ public class GatewayAccountCredentialsResourceIT {
                 app.givenSetup()
                         .body(toJson(Map.of(
                                 "payment_provider", "stripe",
-                                "service_id", "a-valid-service-id",
-                                "service_name", "a-test-service",
+                                "service_id", VALID_SERVICE_ID,
+                                "service_name", VALID_SERVICE_NAME,
                                 "type", "test"
                         )))
-                        .post("/v1/api/accounts")
-                        .then().extract().path("gateway_account_id");
+                        .post("/v1/api/accounts");
 
                 app.givenSetup()
                         .body(toJson(worldpayCredentials))

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
@@ -552,6 +552,89 @@ public class GatewayAccountCredentialsResourceIT {
                 assertThat(updatedCredentials, hasEntry("gateway_merchant_id", "abcdef123abcdef"));
             }
         }
+
+        @Nested
+        class ValidateWorldpayCredentials {
+            private final Map<String, String> worldpayCredentials = Map.of(
+                    "merchant_id", "a-merchant-id",
+                    "username", "a-username",
+                    "password", "a-password");
+            @Test
+            void forNonExistentGatewayAccount_shouldReturn404() {
+                app.givenSetup()
+                        .body(toJson(worldpayCredentials))
+                        .post(format("/v1/api/service/%s/%s/worldpay/check-credentials", VALID_SERVICE_ID, TEST))
+                        .then()
+                        .statusCode(404)
+                        .body("message[0]", is(format("Gateway account not found for service ID [%s] and account type [%s]", VALID_SERVICE_ID, TEST)));
+            }
+
+            @Test
+            void forValidCredentials_shouldReturn200_withResultValid() {
+                app.getWorldpayMockClient().mockCredentialsValidationValid();
+
+                app.givenSetup()
+                        .body(toJson(Map.of(
+                                "payment_provider", "worldpay",
+                                "service_id", "a-valid-service-id",
+                                "service_name", "a-test-service",
+                                "type", "test"
+                        )))
+                        .post("/v1/api/accounts")
+                        .then().extract().path("gateway_account_id");
+
+                app.givenSetup()
+                        .body(toJson(worldpayCredentials))
+                        .post(format("/v1/api/service/%s/%s/worldpay/check-credentials", VALID_SERVICE_ID, TEST))
+                        .then()
+                        .statusCode(200)
+                        .body("result", is("valid"));
+            }
+
+            @Test
+            void forInvalidCredentials_shouldReturn200_withResultInvalid() {
+                app.getWorldpayMockClient().mockCredentialsValidationInvalid();
+
+                app.givenSetup()
+                        .body(toJson(Map.of(
+                                "payment_provider", "worldpay",
+                                "service_id", "a-valid-service-id",
+                                "service_name", "a-test-service",
+                                "type", "test"
+                        )))
+                        .post("/v1/api/accounts")
+                        .then().extract().path("gateway_account_id");
+
+                app.givenSetup()
+                        .body(toJson(worldpayCredentials))
+                        .post(format("/v1/api/service/%s/%s/worldpay/check-credentials", VALID_SERVICE_ID, TEST))
+                        .then()
+                        .statusCode(200)
+                        .body("result", is("invalid"));
+            }
+
+            @Test
+            void forNonWorldpayAccount_shouldReturn404() {
+                app.getWorldpayMockClient().mockCredentialsValidationInvalid();
+
+                app.givenSetup()
+                        .body(toJson(Map.of(
+                                "payment_provider", "stripe",
+                                "service_id", "a-valid-service-id",
+                                "service_name", "a-test-service",
+                                "type", "test"
+                        )))
+                        .post("/v1/api/accounts")
+                        .then().extract().path("gateway_account_id");
+
+                app.givenSetup()
+                        .body(toJson(worldpayCredentials))
+                        .post(format("/v1/api/service/%s/%s/worldpay/check-credentials", VALID_SERVICE_ID, TEST))
+                        .then()
+                        .statusCode(404)
+                        .body("message[0]", is(format("Gateway account for service ID [%s] and account type [%s] is not a Worldpay account.", VALID_SERVICE_ID, TEST)));
+            }
+        }
     }
 
     private DatabaseFixtures.TestAccount addGatewayAccountAndCredential(


### PR DESCRIPTION
## WHAT YOU DID
 - Add `POST /v1/api/service/{serviceId}/[test|live]/worldpay/check-credentials` endpoint with tests
 - Add `WorldpayAccountUtils` class with `isWorldpayGatewayAccount` method, similar to existing `StripeAccountUtils` class
 - Add static factory `GatewayAccountNotFoundException` for non-worldpay gateway account

## How to test
Run tests