### PR TITLE
PP-12355: Refactor test

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.it.resources;
 
-import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
@@ -24,150 +24,153 @@ public class EmailNotificationResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
 
-    @Test
-    void patchEmailNotification_shouldNotUpdateIfMissingField() {
-        DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
-                .aTestAccount()
-                .insert();
+    @Nested
+    class PatchByGatewayAccountId {
+        @Test
+        void patchEmailNotification_shouldNotUpdateIfMissingField() {
+            DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .insert();
 
-        app.givenSetup().accept(JSON)
-                .body(new HashMap<>())
-                .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
-                .then()
-                .statusCode(400)
-                .body("message", contains("Bad patch parameters{}"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+            app.givenSetup().accept(JSON)
+                    .body(new HashMap<>())
+                    .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
+                    .then()
+                    .statusCode(400)
+                    .body("message", contains("Bad patch parameters{}"))
+                    .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+        }
+
+        @Test
+        void patchEmailNotification_shouldNotUpdateIfAccountIdDoesNotExist() {
+            String nonExistingAccountId = "111111111";
+            String templateBody = "lorem ipsum";
+
+            app.givenSetup().accept(JSON)
+                    .body(getPatchRequestBody("/payment_confirmed/" + EmailNotificationResource.EMAIL_NOTIFICATION_TEMPLATE_BODY, templateBody))
+                    .patch(ACCOUNTS_API_URL + nonExistingAccountId + "/email-notification")
+                    .then()
+                    .statusCode(404)
+                    .body("message", contains("The gateway account id '111111111' does not exist"))
+                    .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+        }
+
+        @Test
+        void patchEnableNotification_shouldUpdateSuccessfullyRefundNotifications() {
+            DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .insert();
+
+            app.givenSetup().accept(JSON)
+                    .body(getPatchRequestBody("/refund_issued/enabled", true))
+                    .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
+                    .then()
+                    .statusCode(200);
+
+            Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
+            Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
+            assertThat(confirmationEmail.get("enabled"), is(true));
+            assertThat(refundEmail.get("enabled"), is(true));
+        }
+
+        @Test
+        void patchEnableNotification_shouldUpdateSuccessfullyConfirmationNotifications() {
+            DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .insert();
+
+            app.givenSetup().accept(JSON)
+                    .body(getPatchRequestBody("/payment_confirmed/enabled", false))
+                    .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
+                    .then()
+                    .statusCode(200);
+
+            Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
+            Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
+            assertThat(confirmationEmail.get("enabled"), is(false));
+            assertThat(refundEmail.get("enabled"), is(true));
+        }
+
+        @Test
+        void patchTemplateBodyNotification_shouldUpdateSuccessfullyRefundNotifications() {
+            DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .insert();
+            String newTemplateBody = "new value";
+
+            app.givenSetup().accept(JSON)
+                    .body(getPatchRequestBody("/refund_issued/template_body", newTemplateBody))
+                    .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
+                    .then()
+                    .statusCode(200);
+
+            Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
+            Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
+            assertThat(confirmationEmail.get("template_body"), is("Lorem ipsum dolor sit amet, consectetur adipiscing elit."));
+            assertThat(refundEmail.get("template_body"), is(newTemplateBody));
+        }
+
+        @Test
+        void patchTemplateBodyNotification_shouldUpdateSuccessfullyConfirmationNotifications() {
+            DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .insert();
+            String newTemplateBody = "new value";
+
+            app.givenSetup().accept(JSON)
+                    .body(getPatchRequestBody(
+                            "/payment_confirmed/template_body", newTemplateBody))
+                    .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
+                    .then()
+                    .statusCode(200);
+
+            Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
+            Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
+            assertThat(confirmationEmail.get("template_body"), is(newTemplateBody));
+            assertThat(refundEmail.get("template_body"), is("Lorem ipsum dolor sit amet, consectetur adipiscing elit."));
+        }
+
+        @Test
+        void patchTemplateBodyNotification_shouldUpdateSuccessfullyNotificationIfMissing() {
+            DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .withEmailNotifications(new HashMap<>())
+                    .insert();
+            String newTemplateBody = "new value";
+
+            app.givenSetup().accept(JSON)
+                    .body(getPatchRequestBody("/payment_confirmed/template_body", newTemplateBody))
+                    .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
+                    .then()
+                    .statusCode(200);
+
+            Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
+            Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
+            assertThat(confirmationEmail.get("template_body"), is(newTemplateBody));
+            assertThat(refundEmail, is(nullValue()));
+        }
+
+        @Test
+        void patchEnabledNotification_shouldUpdateSuccessfullyNotificationIfMissing() {
+            DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .withEmailNotifications(new HashMap<>())
+                    .insert();
+            app.givenSetup().accept(JSON)
+                    .body(getPatchRequestBody("/refund_issued/enabled", false))
+                    .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
+                    .then()
+                    .statusCode(200);
+
+            Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
+            Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
+            assertThat(confirmationEmail, is(nullValue()));
+            assertThat(refundEmail.get("enabled"), is(false));
+        }
     }
 
-    @Test
-    void patchEmailNotification_shouldNotUpdateIfAccountIdDoesNotExist() {
-        String nonExistingAccountId = "111111111";
-        String templateBody = "lorem ipsum";
 
-        app.givenSetup().accept(JSON)
-                .body(getPatchRequestBody("replace", "/payment_confirmed/" + EmailNotificationResource.EMAIL_NOTIFICATION_TEMPLATE_BODY, templateBody))
-                .patch(ACCOUNTS_API_URL + nonExistingAccountId + "/email-notification")
-                .then()
-                .statusCode(404)
-                .body("message", contains("The gateway account id '111111111' does not exist"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
-    }
-
-    @Test
-    void patchEnableNotification_shouldUpdateSuccessfullyRefundNotifications() {
-        DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
-                .aTestAccount()
-                .insert();
-
-        app.givenSetup().accept(JSON)
-                .body(getPatchRequestBody("replace", "/refund_issued/enabled", true))
-                .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
-                .then()
-                .statusCode(200);
-
-        Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
-        Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
-        assertThat(confirmationEmail.get("enabled"), is(true));
-        assertThat(refundEmail.get("enabled"), is(true));
-    }
-
-    @Test
-    void patchEnableNotification_shouldUpdateSuccessfullyConfirmationNotifications() {
-        DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
-                .aTestAccount()
-                .insert();
-
-        app.givenSetup().accept(JSON)
-                .body(getPatchRequestBody("replace", "/payment_confirmed/enabled", false))
-                .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
-                .then()
-                .statusCode(200);
-
-        Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
-        Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
-        assertThat(confirmationEmail.get("enabled"), is(false));
-        assertThat(refundEmail.get("enabled"), is(true));
-    }
-
-    @Test
-    void patchTemplateBodyNotification_shouldUpdateSuccessfullyRefundNotifications() {
-        DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
-                .aTestAccount()
-                .insert();
-        String newTemplateBody = "new value";
-
-        app.givenSetup().accept(JSON)
-                .body(getPatchRequestBody("replace", "/refund_issued/template_body", newTemplateBody))
-                .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
-                .then()
-                .statusCode(200);
-
-        Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
-        Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
-        assertThat(confirmationEmail.get("template_body"), is("Lorem ipsum dolor sit amet, consectetur adipiscing elit."));
-        assertThat(refundEmail.get("template_body"), is(newTemplateBody));
-    }
-
-    @Test
-    void patchTemplateBodyNotification_shouldUpdateSuccessfullyConfirmationNotifications() {
-        DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
-                .aTestAccount()
-                .insert();
-        String newTemplateBody = "new value";
-
-        app.givenSetup().accept(JSON)
-                .body(getPatchRequestBody("replace",
-                        "/payment_confirmed/template_body", newTemplateBody))
-                .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
-                .then()
-                .statusCode(200);
-
-        Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
-        Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
-        assertThat(confirmationEmail.get("template_body"), is(newTemplateBody));
-        assertThat(refundEmail.get("template_body"), is("Lorem ipsum dolor sit amet, consectetur adipiscing elit."));
-    }
-
-    @Test
-    void patchTemplateBodyNotification_shouldUpdateSuccessfullyNotificationIfMissing() {
-        DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
-                .aTestAccount()
-                .withEmailNotifications(new HashMap<>())
-                .insert();
-        String newTemplateBody = "new value";
-
-        app.givenSetup().accept(JSON)
-                .body(getPatchRequestBody("replace", "/payment_confirmed/template_body", newTemplateBody))
-                .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
-                .then()
-                .statusCode(200);
-
-        Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
-        Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
-        assertThat(confirmationEmail.get("template_body"), is(newTemplateBody));
-        assertThat(refundEmail, is(nullValue()));
-    }
-
-    @Test
-    void patchEnabledNotification_shouldUpdateSuccessfullyNotificationIfMissing() {
-        DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
-                .aTestAccount()
-                .withEmailNotifications(new HashMap<>())
-                .insert();
-        app.givenSetup().accept(JSON)
-                .body(getPatchRequestBody("replace", "/refund_issued/enabled", false))
-                .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
-                .then()
-                .statusCode(200);
-
-        Map<String, Object> confirmationEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.PAYMENT_CONFIRMED);
-        Map<String, Object> refundEmail = app.getDatabaseTestHelper().getEmailForAccountAndType(testAccount.getAccountId(), EmailNotificationType.REFUND_ISSUED);
-        assertThat(confirmationEmail, is(nullValue()));
-        assertThat(refundEmail.get("enabled"), is(false));
-    }
-
-
-    private String getPatchRequestBody(String operation, String path, Object value) {
-        return toJson(ImmutableMap.of("op", operation, "path", path, "value", value));
+    private String getPatchRequestBody(String path, Object value) {
+        return toJson(Map.of("op", "replace", "path", path, "value", value));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
@@ -56,7 +56,7 @@ public class EmailNotificationResourceIT {
         }
 
         @Test
-        void patchEnableNotification_shouldUpdateSuccessfullyRefundNotifications() {
+        void updateRefundIssuedEmailToBeEnabledSuccessfully() {
             DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
                     .aTestAccount()
                     .insert();
@@ -74,7 +74,7 @@ public class EmailNotificationResourceIT {
         }
 
         @Test
-        void patchEnableNotification_shouldUpdateSuccessfullyConfirmationNotifications() {
+        void updatePaymentConfirmedEmailToBeDisabledSuccessfully() {
             DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
                     .aTestAccount()
                     .insert();
@@ -92,7 +92,7 @@ public class EmailNotificationResourceIT {
         }
 
         @Test
-        void patchTemplateBodyNotification_shouldUpdateSuccessfullyRefundNotifications() {
+        void updateRefundIssuedTemplateBodySuccessfully() {
             DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
                     .aTestAccount()
                     .insert();
@@ -111,7 +111,7 @@ public class EmailNotificationResourceIT {
         }
 
         @Test
-        void patchTemplateBodyNotification_shouldUpdateSuccessfullyConfirmationNotifications() {
+        void updatePaymentConfirmedTemplateBodySuccessfully() {
             DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
                     .aTestAccount()
                     .insert();
@@ -131,7 +131,7 @@ public class EmailNotificationResourceIT {
         }
 
         @Test
-        void patchTemplateBodyNotification_shouldUpdateSuccessfullyNotificationIfMissing() {
+        void updatePaymentConfirmedTemplateBodySuccessfully_ifAccountHasNoExistingEmailNotificationsSettings() {
             DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
                     .aTestAccount()
                     .withEmailNotifications(new HashMap<>())
@@ -151,7 +151,7 @@ public class EmailNotificationResourceIT {
         }
 
         @Test
-        void patchEnabledNotification_shouldUpdateSuccessfullyNotificationIfMissing() {
+        void updateRefundIssuedTemplateBodySuccessfully_ifAccountHasNoExistingEmailNotificationsSettings() {
             DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
                     .aTestAccount()
                     .withEmailNotifications(new HashMap<>())


### PR DESCRIPTION
This commit moves all existing tests under a nested `PatchByGatewayAccountId`. The only purpose of this commit is to avoid making a later PR hard to review when we introduce tests for PATCHing by service id and account type.