### PR TITLE
PP-12678 Handle null country when inferring North American region

### DIFF
--- a/src/main/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapper.java
@@ -7,7 +7,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 public class NorthAmericanRegionMapper {
-    
+
     private final UsZipCodeToStateMapper usZipCodeToStateMapper;
     private final CanadaPostalcodeToProvinceOrTerritoryMapper canadaPostalcodeToProvinceOrTerritoryMapper;
 
@@ -21,8 +21,12 @@ public class NorthAmericanRegionMapper {
         this.usZipCodeToStateMapper = usZipCodeToStateMapper;
         this.canadaPostalcodeToProvinceOrTerritoryMapper = canadaPostalcodeToProvinceOrTerritoryMapper;
     }
-    
+
     public Optional<? extends NorthAmericaRegion> getNorthAmericanRegionForCountry(Address address) {
+        if (address.getCountry() == null) {
+            return Optional.empty();
+        }
+
         switch (address.getCountry()) {
             case "US":
                 return usZipCodeToStateMapper.getState(getNormalisedPostalCode(address));

--- a/src/test/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapperTest.java
@@ -24,7 +24,18 @@ public class NorthAmericanRegionMapperTest {
         address.setLine1("Line 1");
         address.setLine2("Line 2");
     }
-    
+
+    @Test
+    public void shouldNotReturnRegionForNullCountry() {
+        address.setCountry(null);
+        address.setCity("Nowhere");
+        address.setPostcode("20500");
+
+        Optional<? extends NorthAmericaRegion> northAmericaRegion = mapper.getNorthAmericanRegionForCountry(address);
+
+        assertThat(northAmericaRegion.isEmpty(), is (true));
+    }
+
     @Test
     public void shouldNotReturnRegionForCountryOutsideNorthAmerica() {
         address.setCountry("GB");
@@ -59,4 +70,5 @@ public class NorthAmericanRegionMapperTest {
         assertThat(northAmericaRegion.isPresent(), is (true));
         assertThat(northAmericaRegion.get(), is (CanadaProvinceOrTerritory.NUNAVUT));
     }
+
 }


### PR DESCRIPTION
When inferring a US state or Canadian province or territory for a cardholder address, handle there being no country. This can happen if a service is using the authorisation API and prefills a billing address without including a country.