### PR TITLE
PP-12355: Serialise the POST body of /v1/api/accounts/{accountId}/email-notification to a java class

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -167,35 +167,35 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3705
+        "line_number": 3701
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3741
+        "line_number": 3737
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 4669
+        "line_number": 4665
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5136
+        "line_number": 5132
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5147
+        "line_number": 5143
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1066,5 +1066,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-29T15:29:00Z"
+  "generated_at": "2024-05-29T16:24:19Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -167,35 +167,35 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3692
+        "line_number": 3705
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3728
+        "line_number": 3741
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 4656
+        "line_number": 4669
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5123
+        "line_number": 5136
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5134
+        "line_number": 5147
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1066,5 +1066,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-24T14:09:39Z"
+  "generated_at": "2024-05-29T15:29:00Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3364,6 +3364,19 @@ components:
         version:
           type: integer
           format: int64
+    EmailNotificationPatchRequest:
+      type: object
+      properties:
+        op:
+          type: string
+        path:
+          type: string
+        pathTokens:
+          type: array
+          items:
+            type: string
+        value:
+          type: string
     EpdqCredentials:
       type: object
       properties:

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3371,10 +3371,6 @@ components:
           type: string
         path:
           type: string
-        pathTokens:
-          type: array
-          items:
-            type: string
         value:
           type: string
     EpdqCredentials:

--- a/src/main/java/uk/gov/pay/connector/common/service/PatchRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/common/service/PatchRequestBuilder.java
@@ -1,11 +1,9 @@
 package uk.gov.pay.connector.common.service;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class PatchRequestBuilder {
     private final Map<String, String> patchRequestMap;
@@ -106,10 +104,6 @@ public class PatchRequestBuilder {
             return Optional.of(validPaths)
                     .map(validOps -> validOps.contains(path))
                     .orElse(true);
-        }
-        
-        public List<String> getPathTokens() {
-            return Arrays.stream(path.split("/")).skip(1).collect(Collectors.toList());
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/usernotification/model/EmailNotificationPatchRequest.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/model/EmailNotificationPatchRequest.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.usernotification.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
+import uk.gov.pay.connector.usernotification.model.validation.AllowedStrings;
+
+import javax.validation.Valid;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EmailNotificationPatchRequest {
+    
+    @Valid
+    @AllowedStrings(allowed = {"replace"},  message = "The op field must be 'replace'")
+    private String op;
+    
+    @Valid
+    @AllowedStrings(
+            allowed = {"/refund_issued/template_body", "/refund_issued/enabled", "/payment_confirmed/template_body", "/payment_confirmed/enabled"},
+            message = "The paths field must be one of: [/refund_issued/template_body, /refund_issued/enabled, /payment_confirmed/template_body, /payment_confirmed/enabled]"
+    )
+    private String path;
+    
+    private String value;
+
+    public String getOp() {
+        return op;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getValue() {
+        return value;
+    }
+    
+    public List<String> getPathTokens() {
+        return Arrays.stream(path.split("/")).skip(1).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/usernotification/model/EmailNotificationPatchRequest.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/model/EmailNotificationPatchRequest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.usernotification.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.usernotification.model.validation.AllowedStrings;
 
 import javax.validation.Valid;
@@ -39,7 +38,7 @@ public class EmailNotificationPatchRequest {
         return value;
     }
     
-    public List<String> getPathTokens() {
+    public List<String> pathTokens() {
         return Arrays.stream(path.split("/")).skip(1).collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/usernotification/model/validation/AllowedStrings.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/model/validation/AllowedStrings.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.connector.usernotification.model.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import uk.gov.pay.connector.usernotification.model.validation.AllowedStrings.List;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ FIELD })
+@Retention(RUNTIME)
+@Constraint(validatedBy = AllowedStringsValidator.class)
+@Documented
+public @interface AllowedStrings {
+
+    String message();
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+    
+    String[] allowed();
+
+    @Target({ FIELD })
+    @Retention(RUNTIME)
+    @Documented
+    @interface List {
+
+        AllowedStrings[] value();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/usernotification/model/validation/AllowedStringsValidator.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/model/validation/AllowedStringsValidator.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.usernotification.model.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Set;
+
+public class AllowedStringsValidator implements ConstraintValidator<AllowedStrings, String>  {
+
+    private Set<String> allowedStrings;
+    
+    @Override
+    public void initialize(AllowedStrings parameters) {
+        allowedStrings = Set.of(parameters.allowed());
+    }
+    
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return false;
+        return allowedStrings.contains(value);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/usernotification/resource/EmailNotificationResource.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/resource/EmailNotificationResource.java
@@ -96,7 +96,7 @@ public class EmailNotificationResource {
     }
 
     private NotificationPatchInfo getNotificationInfoFromPath(EmailNotificationPatchRequest emailPatchRequest) {
-        List<String> pathTokens = emailPatchRequest.getPathTokens();
+        List<String> pathTokens = emailPatchRequest.pathTokens();
         return new NotificationPatchInfo(EmailNotificationType.fromString(pathTokens.get(0)), pathTokens.get(1), emailPatchRequest.getValue());
     }
 

--- a/src/main/java/uk/gov/pay/connector/usernotification/resource/EmailNotificationResource.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/resource/EmailNotificationResource.java
@@ -95,7 +95,7 @@ public class EmailNotificationResource {
                 .orElseGet(() -> notFoundResponse(format("The gateway account id '%s' does not exist", gatewayAccountId)));
     }
 
-    private NotificationPatchInfo getNotificationInfoFromPath(@Valid EmailNotificationPatchRequest emailPatchRequest) {
+    private NotificationPatchInfo getNotificationInfoFromPath(EmailNotificationPatchRequest emailPatchRequest) {
         List<String> pathTokens = emailPatchRequest.getPathTokens();
         return new NotificationPatchInfo(EmailNotificationType.fromString(pathTokens.get(0)), pathTokens.get(1), emailPatchRequest.getValue());
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
@@ -50,7 +50,7 @@ public class EmailNotificationResourceIT {
             app.givenSetup().accept(JSON)
                     .body(getPatchRequestBody("/payment_confirmed/" + EmailNotificationResource.EMAIL_NOTIFICATION_TEMPLATE_BODY, templateBody))
                     .patch(ACCOUNTS_API_URL + nonExistingAccountId + "/email-notification")
-                    .then().log().body()
+                    .then()
                     .statusCode(404)
                     .body("message", contains("The gateway account id '111111111' does not exist"))
                     .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));

--- a/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
@@ -23,7 +24,7 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 public class EmailNotificationResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-
+    
     @Nested
     class PatchByGatewayAccountId {
         @Test
@@ -36,8 +37,8 @@ public class EmailNotificationResourceIT {
                     .body(new HashMap<>())
                     .patch(ACCOUNTS_API_URL + testAccount.getAccountId() + "/email-notification")
                     .then()
-                    .statusCode(400)
-                    .body("message", contains("Bad patch parameters{}"))
+                    .statusCode(422)
+                    .body("message", containsInAnyOrder("The op field must be 'replace'", "The paths field must be one of: [/refund_issued/template_body, /refund_issued/enabled, /payment_confirmed/template_body, /payment_confirmed/enabled]"))
                     .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
         }
 
@@ -49,7 +50,7 @@ public class EmailNotificationResourceIT {
             app.givenSetup().accept(JSON)
                     .body(getPatchRequestBody("/payment_confirmed/" + EmailNotificationResource.EMAIL_NOTIFICATION_TEMPLATE_BODY, templateBody))
                     .patch(ACCOUNTS_API_URL + nonExistingAccountId + "/email-notification")
-                    .then()
+                    .then().log().body()
                     .statusCode(404)
                     .body("message", contains("The gateway account id '111111111' does not exist"))
                     .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));


### PR DESCRIPTION
It's easier to use a java class as we can leverage the hibernate validators instead of manually validating the incoming Map<String,String>. This is also in line with how we do validation in other places.