### PR TITLE
PP-12678 Handle null postcode when inferring North American region

### DIFF
--- a/src/main/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapper.java
@@ -29,15 +29,20 @@ public class NorthAmericanRegionMapper {
 
         switch (address.getCountry()) {
             case "US":
-                return usZipCodeToStateMapper.getState(getNormalisedPostalCode(address));
+                return getNormalisedPostalCode(address).flatMap(usZipCodeToStateMapper::getState);
             case "CA":
-                return canadaPostalcodeToProvinceOrTerritoryMapper.getProvinceOrTerritory(getNormalisedPostalCode(address));
+                return getNormalisedPostalCode(address).flatMap(canadaPostalcodeToProvinceOrTerritoryMapper::getProvinceOrTerritory);
             default:
                 return Optional.empty();
         }
     }
 
-    private String getNormalisedPostalCode(Address address) {
-        return address.getPostcode().replaceAll("\\s", "").toUpperCase(Locale.ENGLISH);
+    private Optional<String> getNormalisedPostalCode(Address address) {
+        if (address.getPostcode() == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(address.getPostcode().replaceAll("\\s", "").toUpperCase(Locale.ENGLISH));
     }
+
 }


### PR DESCRIPTION
When inferring a US state or Canadian province or territory for a cardholder address, handle there being no postal code. This can happen if a service is using the authorisation API and prefills a billing address without including a postal code (and would previously cause an error if the country was the US or Canada).

Also add some tests to ensure we normalise postal codes (by removing spaces and upper-casing them) correctly.