### PR TITLE
PP-12358 degateway resend confirmation email endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -132,70 +132,70 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 1280
+        "line_number": 1277
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 1638
+        "line_number": 1676
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 2890
+        "line_number": 2928
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 2934
+        "line_number": 2972
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3401
+        "line_number": 3439
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3790
+        "line_number": 3828
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3826
+        "line_number": 3864
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 4754
+        "line_number": 4792
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5230
+        "line_number": 5268
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5241
+        "line_number": 5279
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1075,5 +1075,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-04T11:07:44Z"
+  "generated_at": "2024-06-04T16:08:08Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -222,7 +218,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java",
         "hashed_secret": "423e3dd3782e3527b4f9af75dd9faf9ebbb7889c",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 107
       }
     ],
     "src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java": [
@@ -1075,5 +1071,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-04T16:08:08Z"
+  "generated_at": "2024-06-04T16:10:16Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1269,6 +1269,44 @@ paths:
       summary: Handle Worldpay notifications
       tags:
       - Notifications
+  /v1/api/service/{serviceId}/account/{accountType}/charges/{chargeId}/resend-confirmation-email:
+    post:
+      operationId: resendConfirmationEmailByServiceIdAndAccountType
+      parameters:
+      - description: Service ID
+        example: 46eb1b601348499196c99de90482ee68
+        in: path
+        name: serviceId
+        required: true
+        schema:
+          type: string
+      - description: Account type
+        example: test
+        in: path
+        name: accountType
+        required: true
+        schema:
+          type: string
+          enum:
+          - test
+          - live
+      - description: Charge external ID
+        example: spmh0fb7rbi1lebv1j3f7hc3m9
+        in: path
+        name: chargeId
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: No content
+        "402":
+          description: Could not send email
+        "404":
+          description: Not found - charge not found
+        "500":
+          description: Internal server error
+      summary: Resend confirmation email for a charge
   /v1/api/service/{serviceId}/account/{accountType}/email-notification:
     patch:
       description: Allowed paths <br> - /payment_confirmed/enabled (values true/false)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <version>0.1-SNAPSHOT</version>
     <artifactId>pay-connector</artifactId>
 
-   <properties>
+    <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <pay-java-commons.version>1.0.20240528142501</pay-java-commons.version>
         <surefire.version>3.2.5</surefire.version>
@@ -14,6 +14,8 @@
         <eclipselink.version>2.7.13</eclipselink.version>
         <swagger-version>2.2.22</swagger-version>
         <prometheus.version>0.16.0</prometheus.version>
+        <maven.surefire.junit5.tree.reporter.version>1.2.1</maven.surefire.junit5.tree.reporter.version>
+
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>
         <PACT_BROKER_PASSWORD/>
@@ -542,6 +544,27 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                    <reportFormat>plain</reportFormat>
+                    <consoleOutputReporter>
+                        <disable>true</disable>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter
+                            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>me.fabriciorby</groupId>
+                        <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                        <version>${maven.surefire.junit5.tree.reporter.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.2.5</version>
@@ -557,7 +580,20 @@
                     <forkCount>1</forkCount>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <reportsDirectory>${project.build.directory}/failsafe-reports</reportsDirectory>
+                    <reportFormat>plain</reportFormat>
+                    <consoleOutputReporter>
+                        <disable>true</disable>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter
+                            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>me.fabriciorby</groupId>
+                        <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                        <version>${maven.surefire.junit5.tree.reporter.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -584,8 +620,10 @@
                         </goals>
                         <configuration>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>uk.gov.pay.connector.app.ConnectorApp</mainClass>
                                 </transformer>
                             </transformers>

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceResendConfirmationEmailIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceResendConfirmationEmailIT.java
@@ -1,27 +1,41 @@
 package uk.gov.pay.connector.charge.resource;
 
 import io.dropwizard.core.setup.Environment;
-import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.ConnectorModule;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.it.base.ITestBaseExtension;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.it.util.ChargeUtils;
 import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
 import uk.gov.service.notify.NotificationClient;
+import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.restassured.RestAssured.given;
+import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -30,55 +44,100 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.PAYMENT_CONFIRMED;
 
 public class ChargesApiResourceResendConfirmationEmailIT {
-    private static final NotifyClientFactory notifyClientFactory = mock(NotifyClientFactory.class);
-    private static final NotificationClient notificationClient = mock(NotificationClient.class);
+    private static final NotifyClientFactory NOTIFY_CLIENT_FACTORY = mock(NotifyClientFactory.class);
+    private static final NotificationClient NOTIFICATION_CLIENT = mock(NotificationClient.class);
     
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(
+    private static final AppWithPostgresAndSqsExtension APP = new AppWithPostgresAndSqsExtension(
             ChargesApiResourceResendConfirmationEmailIT.ConnectorAppWithCustomInjector.class,
             config("notifyConfig.emailNotifyEnabled", "true")
     );
     
     @RegisterExtension
-    public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
-    private final String emailAddress = "a@b.com";
+    private static final ITestBaseExtension TEST_BASE_EXTENSION = new ITestBaseExtension("sandbox", APP.getLocalPort(), APP.getDatabaseTestHelper());
+
+    private static final String EMAIL_ADDRESS = "a@b.com";
+    private DatabaseFixtures.TestAccount testAccount;
+    private ChargeUtils.ExternalChargeId chargeId;
 
     @BeforeAll
     static void before() {
-        when(notifyClientFactory.getInstance()).thenReturn(notificationClient);
+        when(NOTIFY_CLIENT_FACTORY.getInstance()).thenReturn(NOTIFICATION_CLIENT);
     }
 
     @BeforeEach
-    void setup() {
-        app.getDatabaseTestHelper().addEmailNotification(Long.valueOf(testBaseExtension.getAccountId()), "a template", true, PAYMENT_CONFIRMED);
-    }   
+    void setup() throws NoSuchAlgorithmException, NotificationClientException {
+        SecureRandom secureRandom = SecureRandom.getInstanceStrong();
+        testAccount = TEST_BASE_EXTENSION.getTestAccount();
+        chargeId = createNewCharge(String.valueOf(secureRandom.nextInt()), TEST_BASE_EXTENSION.getPaymentProvider());
+        APP.getDatabaseTestHelper().addEmailNotification(Long.valueOf(TEST_BASE_EXTENSION.getAccountId()), "a template", true, PAYMENT_CONFIRMED);
+        SendEmailResponse mockResponse = mock(SendEmailResponse.class);
+        when(mockResponse.getNotificationId()).thenReturn(UUID.randomUUID());
+        when(NOTIFICATION_CLIENT.sendEmail(any(), eq(EMAIL_ADDRESS), anyMap(), eq(null), any())).thenReturn(mockResponse);
+    }
+    
+    @Nested
+    @DisplayName("Given a resend confirmation email request")
+    class ResendConfirmationEmail {
+        @Nested
+        @DisplayName("When account id is provided")
+        class ByAccountId {
+            @Test
+            @DisplayName("Then 204 is received when successful")
+            void shouldReturn204WhenEmailSuccessfullySent() {
+                given().port(APP.getLocalPort())
+                        .body("")
+                        .contentType(APPLICATION_JSON)
+                        .post(format("/v1/api/accounts/%s/charges/%s/resend-confirmation-email", TEST_BASE_EXTENSION.getAccountId(), chargeId))
+                        .then()
+                        .statusCode(204);
+            }
+        }
 
-    @Test
-    void shouldReturn204WhenEmailSuccessfullySent() throws Exception {
-        String transactionId = String.valueOf(RandomUtils.nextInt());
+        @TestInstance(PER_CLASS)
+        @Nested
+        @DisplayName("When service id and account type are provided")
+        class ByServiceIdAndAccountType {
+            @Test
+            @DisplayName("Then 204 is received when successful")
+            void shouldReturn204WhenEmailSuccessfullySent() {
+                given().port(APP.getLocalPort())
+                        .body("")
+                        .contentType(APPLICATION_JSON)
+                        .post(format("/v1/api/service/%s/account/%s/charges/%s/resend-confirmation-email", testAccount.getServiceId(), testAccount.getGatewayAccountType(), chargeId))
+                        .then()
+                        .statusCode(204);
+            }
 
-        ChargeUtils.ExternalChargeId chargeId = createNewCharge(transactionId, testBaseExtension.getPaymentProvider());
+            @ParameterizedTest
+            @DisplayName("Then 404 is received when gateway account not found")
+            @MethodSource
+            void shouldReturn404_WhenServiceIdNotFound_OrAccountTypeNotFound(String serviceId, GatewayAccountType gatewayAccountType, String expectedError) {
+                given().port(APP.getLocalPort())
+                        .body("")
+                        .contentType(APPLICATION_JSON)
+                        .post(format("/v1/api/service/%s/account/%s/charges/%s/resend-confirmation-email", serviceId, gatewayAccountType, chargeId))
+                        .then()
+                        .statusCode(404)
+                        .body("message", contains(expectedError));
+            }
 
-        var notificationId = UUID.randomUUID();
-        var mockResponse = mock(SendEmailResponse.class);
-        when(mockResponse.getNotificationId()).thenReturn(notificationId);
-        when(notificationClient.sendEmail(any(), eq(emailAddress), anyMap(), eq(null), any())).thenReturn(mockResponse);
-
-        given().port(app.getLocalPort())
-                .body("")
-                .contentType(APPLICATION_JSON)
-                .post(String.format("/v1/api/accounts/%s/charges/%s/resend-confirmation-email", testBaseExtension.getAccountId(), chargeId))
-                .then()
-                .statusCode(204);
+            private Stream<Arguments> shouldReturn404_WhenServiceIdNotFound_OrAccountTypeNotFound() {
+                return Stream.of(
+                        Arguments.of("not-this-service-id", testAccount.getGatewayAccountType(), "Gateway account not found for service ID [not-this-service-id] and account type [test]"),
+                        Arguments.of(testAccount.getServiceId(), GatewayAccountType.LIVE, format("Gateway account not found for service ID [%s] and account type [live]", testAccount.getServiceId()))
+                );
+            }
+        }
     }
     
     private ChargeUtils.ExternalChargeId createNewCharge(String transactionId, String paymentProvider) {
         return ChargeUtils.createNewChargeWithAccountId(
                 ChargeStatus.CREATED,
                 transactionId,
-                testBaseExtension.getAccountId(),
-                app.getDatabaseTestHelper(),
-                emailAddress,
+                TEST_BASE_EXTENSION.getAccountId(),
+                APP.getDatabaseTestHelper(),
+                EMAIL_ADDRESS,
                 paymentProvider);
     }
     
@@ -98,7 +157,7 @@ public class ChargesApiResourceResendConfirmationEmailIT {
 
         @Override
         protected NotifyClientFactory getNotifyClientFactory(ConnectorConfiguration connectorConfiguration) {
-            return notifyClientFactory;
+            return NOTIFY_CLIENT_FACTORY;
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceTest.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.charge.resource;
 
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.pay.connector.charge.model.domain.Charge;
@@ -11,6 +13,7 @@ import uk.gov.pay.connector.common.exception.ConstraintViolationExceptionMapper;
 import uk.gov.pay.connector.common.exception.ValidationExceptionMapper;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 import uk.gov.pay.connector.util.JsonMappingExceptionMapper;
@@ -22,10 +25,13 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,140 +51,230 @@ public class ChargesApiResourceTest {
             .addProvider(ValidationExceptionMapper.class)
             .build();
 
-    @Test
-    void createCharge_invalidAuthorisationMode_shouldReturn400() {
-        var payload = Map.of(
-                "amount", 100,
-                "reference", "ref",
-                "description", "desc",
-                "return_url", "http://service.url/success-page/",
-                "authorisation_mode", "foo"
-        );
+    @Nested
+    @DisplayName("Given a create charge request")
+    class CreateCharge {
+        @Nested
+        @DisplayName("When account id is provided")
+        class WhenAccountIdIsProvided {
+            @Test
+            @DisplayName("Then 400 is returned if authorisation mode is invalid")
+            void createCharge_invalidAuthorisationMode_shouldReturn400() {
+                var payload = Map.of(
+                        "amount", 100,
+                        "reference", "ref",
+                        "description", "desc",
+                        "return_url", "http://service.url/success-page/",
+                        "authorisation_mode", "foo"
+                );
 
-        Response response = resources
-                .target("/v1/api/accounts/1/charges")
-                .request()
-                .post(Entity.json(payload));
+                try (Response response = resources
+                        .target("/v1/api/accounts/1/charges")
+                        .request()
+                        .post(Entity.json(payload))) {
 
-        assertThat(response.getStatus(), is(400));
-        ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
-        assertThat(errorResponse.getMessages().get(0), startsWith("Cannot deserialize value of type `uk.gov.service.payments.commons.model.AuthorisationMode`"));
-        assertThat(errorResponse.getIdentifier(), is(ErrorIdentifier.GENERIC));
+                    assertThat(response.getStatus(), is(400));
+                    var errorResponse = response.readEntity(ErrorResponse.class);
+                    assertThat(errorResponse.getMessages().get(0), startsWith("Cannot deserialize value of type `uk.gov.service.payments.commons.model.AuthorisationMode`"));
+                    assertThat(errorResponse.getIdentifier(), is(ErrorIdentifier.GENERIC));
+                }
+            }
+
+            @DisplayName("Then 422 is returned if idempotency key is above maximum length")
+            @Test
+            void createCharge_idempotencyKeyAboveMaxLength_shouldReturn422() {
+                var payload = Map.of(
+                        "amount", 100,
+                        "reference", "ref",
+                        "description", "desc",
+                        "authorisation_mode", "agreement",
+                        "agreement_id", "agreement12345677890123456"
+                );
+
+                try (Response response = resources
+                        .target("/v1/api/accounts/1/charges")
+                        .request()
+                        .header("Idempotency-Key", "a".repeat(256))
+                        .post(Entity.json(payload))) {
+
+                    assertThat(response.getStatus(), is(422));
+                    var errorResponse = response.readEntity(ErrorResponse.class);
+                    assertThat(errorResponse.getMessages(), contains("Header [Idempotency-Key] can have a size between 1 and 255"));
+                    assertThat(errorResponse.getIdentifier(), is(ErrorIdentifier.GENERIC));
+                }
+            }
+
+            @DisplayName("Then 422 is returned if idempotency key is empty")
+            @Test
+            void createCharge_idempotencyKeyEmpty_shouldReturn422() {
+                var payload = Map.of(
+                        "amount", 100,
+                        "reference", "ref",
+                        "description", "desc",
+                        "authorisation_mode", "agreement",
+                        "agreement_id", "agreement12345677890123456"
+                );
+
+                try (Response response = resources
+                        .target("/v1/api/accounts/1/charges")
+                        .request()
+                        .header("Idempotency-Key", "")
+                        .post(Entity.json(payload))) {
+
+                    assertThat(response.getStatus(), is(422));
+                    var errorResponse = response.readEntity(ErrorResponse.class);
+                    assertThat(errorResponse.getMessages(), contains("Header [Idempotency-Key] can have a size between 1 and 255"));
+                    assertThat(errorResponse.getIdentifier(), is(ErrorIdentifier.GENERIC));
+                }
+            }
+        }
     }
+    
 
-    @Test
-    void createCharge_idempotencyKeyAboveMaxLength_shouldReturn422() {
-        var payload = Map.of(
-                "amount", 100,
-                "reference", "ref",
-                "description", "desc",
-                "authorisation_mode", "agreement",
-                "agreement_id", "agreement12345677890123456"
-        );
+    @Nested
+    @DisplayName("Given a resend confirmation email request")
+    class ResendConfirmationEmail {
+        private final String aChargeId = "charge-id";
+        private final GatewayAccountEntity mockGatewayAccountEntity = mock(GatewayAccountEntity.class);
+        private final Charge mockCharge = mock(Charge.class);
+        
+        @Nested
+        @DisplayName("When account id is provided")
+        class ByAccountId {
+            private final Long anAccountId = 1234L;
+            
+            @Test
+            @DisplayName("Then 404 is returned if account is not found")
+            void resendConfirmationEmail_accountNotFound_shouldReturn404() {
+                when(gatewayAccountService.getGatewayAccount(anAccountId)).thenReturn(Optional.empty());
 
-        Response response = resources
-                .target("/v1/api/accounts/1/charges")
-                .request()
-                .header("Idempotency-Key", "a".repeat(256))
-                .post(Entity.json(payload));
+                try (Response response = resources
+                        .target(String.format("/v1/api/accounts/%d/charges/%s/resend-confirmation-email", anAccountId, aChargeId))
+                        .request()
+                        .post(Entity.json(Collections.emptyMap()))) {
 
-        assertThat(response.getStatus(), is(422));
-        ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
-        assertThat(errorResponse.getMessages(), contains("Header [Idempotency-Key] can have a size between 1 and 255"));
-        assertThat(errorResponse.getIdentifier(), is(ErrorIdentifier.GENERIC));
-    }
+                    assertThat(response.getStatus(), is(404));
+                }
+            }
 
-    @Test
-    void createCharge_idempotencyKeyEmpty_shouldReturn422() {
-        var payload = Map.of(
-                "amount", 100,
-                "reference", "ref",
-                "description", "desc",
-                "authorisation_mode", "agreement",
-                "agreement_id", "agreement12345677890123456"
-        );
+            @Test
+            @DisplayName("Then 404 is returned if charge is not found")
+            void resendConfirmationEmail_chargeNotFound_shouldReturn404() {
+                when(gatewayAccountService.getGatewayAccount(anAccountId)).thenReturn(Optional.of(mockGatewayAccountEntity));
+                when(chargeService.findCharge(aChargeId, anAccountId)).thenReturn(Optional.empty());
 
-        Response response = resources
-                .target("/v1/api/accounts/1/charges")
-                .request()
-                .header("Idempotency-Key", "")
-                .post(Entity.json(payload));
+                try (Response response = resources
+                        .target(String.format("/v1/api/accounts/%d/charges/%s/resend-confirmation-email", anAccountId, aChargeId))
+                        .request()
+                        .post(Entity.json(Collections.emptyMap()))) {
 
-        assertThat(response.getStatus(), is(422));
-        ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
-        assertThat(errorResponse.getMessages(), contains("Header [Idempotency-Key] can have a size between 1 and 255"));
-        assertThat(errorResponse.getIdentifier(), is(ErrorIdentifier.GENERIC));
-    }
+                    assertThat(response.getStatus(), is(404));
+                }
+            }
 
-    @Test
-    void resendConfirmationEmail_accountNotFound_shouldReturn404() {
-        var accountId = 1234L;
-        var chargeId = "charge-id";
+            @Test
+            @DisplayName("Then 402 is returned if email is not sent")
+            void resendConfirmationEmail_emailNotSent_shouldReturn402() {
+                when(gatewayAccountService.getGatewayAccount(anAccountId)).thenReturn(Optional.of(mockGatewayAccountEntity));
+                when(chargeService.findCharge(aChargeId, anAccountId)).thenReturn(Optional.of(mockCharge));
+                when(userNotificationService.sendPaymentConfirmedEmailSynchronously(mockCharge, mockGatewayAccountEntity, true))
+                        .thenReturn(Optional.empty());
 
-        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.empty());
+                try (Response response = resources
+                        .target(String.format("/v1/api/accounts/%d/charges/%s/resend-confirmation-email", anAccountId, aChargeId))
+                        .request()
+                        .post(Entity.json(Collections.emptyMap()))) {
 
-        Response response = resources
-                .target(String.format("/v1/api/accounts/%d/charges/%s/resend-confirmation-email", accountId, chargeId))
-                .request()
-                .post(Entity.json(Collections.emptyMap()));
+                    assertThat(response.getStatus(), is(402));
+                }
+            }
 
-        assertThat(response.getStatus(), is(404));
-    }
+            @Test
+            @DisplayName("Then 204 is returned if email is sent successfully")
+            void resendConfirmationEmail_success_shouldReturn204() {
+                when(gatewayAccountService.getGatewayAccount(anAccountId)).thenReturn(Optional.of(mockGatewayAccountEntity));
+                when(chargeService.findCharge(aChargeId, anAccountId)).thenReturn(Optional.of(mockCharge));
+                when(userNotificationService.sendPaymentConfirmedEmailSynchronously(mockCharge, mockGatewayAccountEntity, true))
+                        .thenReturn(Optional.of("Email sent"));
 
-    @Test
-    void resendConfirmationEmail_chargeNotFound_shouldReturn404() {
-        var accountId = 1234L;
-        var chargeId = "charge-id";
-        var account = mock(GatewayAccountEntity.class);
+                try (Response response = resources
+                        .target(String.format("/v1/api/accounts/%d/charges/%s/resend-confirmation-email", anAccountId, aChargeId))
+                        .request()
+                        .post(Entity.json(Collections.emptyMap()))) {
 
-        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(account));
-        when(chargeService.findCharge(chargeId, accountId)).thenReturn(Optional.empty());
+                    assertThat(response.getStatus(), is(204));
+                }
+            }
+        }
 
-        Response response = resources
-                .target(String.format("/v1/api/accounts/%d/charges/%s/resend-confirmation-email", accountId, chargeId))
-                .request()
-                .post(Entity.json(Collections.emptyMap()));
+        @Nested
+        @DisplayName("When service id and account type are provided")
+        class ByServiceIdAndAccountType {
+            private final String aServiceId = "external-service-id";
+            private final GatewayAccountType aGatewayAccountType = GatewayAccountType.TEST;
+            
+            @Test
+            @DisplayName("Then 404 is returned if account is not found")
+            void resendConfirmationEmail_accountNotFound_shouldReturn404() {
+                when(gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(aServiceId, aGatewayAccountType)).thenReturn(Optional.empty());
 
-        assertThat(response.getStatus(), is(404));
-    }
+                try (Response response = resources
+                        .target(format("/v1/api/service/%s/account/%s/charges/%s/resend-confirmation-email", aServiceId, aGatewayAccountType, aChargeId))
+                        .request()
+                        .post(Entity.json(Collections.emptyMap()))) {
 
-    @Test
-    void resendConfirmationEmail_emailNotSent_shouldReturn402() {
-        var accountId = 1234L;
-        var chargeId = "charge-id";
-        var account = mock(GatewayAccountEntity.class);
-        var charge = mock(Charge.class);
+                    assertThat(response.getStatus(), is(404));
+                }
+            }
 
-        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(account));
-        when(chargeService.findCharge(chargeId, accountId)).thenReturn(Optional.of(charge));
-        when(userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, account, true))
-                .thenReturn(Optional.empty());
+            @Test
+            @DisplayName("Then 404 is returned if charge is not found")
+            void resendConfirmationEmail_chargeNotFound_shouldReturn404() {
+                when(gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(aServiceId, aGatewayAccountType)).thenReturn(Optional.of(mockGatewayAccountEntity));
+                when(chargeService.findCharge(any(), (Long) any())).thenReturn(Optional.empty());
 
-        Response response = resources
-                .target(String.format("/v1/api/accounts/%d/charges/%s/resend-confirmation-email", accountId, chargeId))
-                .request()
-                .post(Entity.json(Collections.emptyMap()));
+                try (Response response = resources
+                        .target(format("/v1/api/service/%s/account/%s/charges/%s/resend-confirmation-email", aServiceId, aGatewayAccountType, aChargeId))
+                        .request()
+                        .post(Entity.json(Collections.emptyMap()))) {
 
-        assertThat(response.getStatus(), is(402));
-    }
+                    assertThat(response.getStatus(), is(404));
+                }
+            }
 
-    @Test
-    void resendConfirmationEmail_success_shouldReturn204() {
-        var accountId = 1234L;
-        var chargeId = "charge-id";
-        var account = mock(GatewayAccountEntity.class);
-        var charge = mock(Charge.class);
+            @Test
+            @DisplayName("Then 402 is returned if email is not sent")
+            void resendConfirmationEmail_emailNotSent_shouldReturn402() {
+                when(gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(aServiceId, aGatewayAccountType)).thenReturn(Optional.of(mockGatewayAccountEntity));
+                when(chargeService.findCharge(eq(aChargeId), any())).thenReturn(Optional.of(mockCharge));
+                when(userNotificationService.sendPaymentConfirmedEmailSynchronously(mockCharge, mockGatewayAccountEntity, true))
+                        .thenReturn(Optional.empty());
 
-        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(account));
-        when(chargeService.findCharge(chargeId, accountId)).thenReturn(Optional.of(charge));
-        when(userNotificationService.sendPaymentConfirmedEmailSynchronously(charge, account, true))
-                .thenReturn(Optional.of("Email sent"));
+                try (Response response = resources
+                        .target(format("/v1/api/service/%s/account/%s/charges/%s/resend-confirmation-email", aServiceId, aGatewayAccountType, aChargeId))
+                        .request()
+                        .post(Entity.json(Collections.emptyMap()))) {
 
-        Response response = resources
-                .target(String.format("/v1/api/accounts/%d/charges/%s/resend-confirmation-email", accountId, chargeId))
-                .request()
-                .post(Entity.json(Collections.emptyMap()));
+                    assertThat(response.getStatus(), is(402));
+                }
+            }
 
-        assertThat(response.getStatus(), is(204));
+            @Test
+            @DisplayName("Then 204 is returned if email is sent successfully")
+            void resendConfirmationEmail_success_shouldReturn204() {
+                when(gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(aServiceId, aGatewayAccountType)).thenReturn(Optional.of(mockGatewayAccountEntity));
+                when(chargeService.findCharge(eq(aChargeId), any())).thenReturn(Optional.of(mockCharge));
+                when(userNotificationService.sendPaymentConfirmedEmailSynchronously(mockCharge, mockGatewayAccountEntity, true))
+                        .thenReturn(Optional.of("Email sent"));
+
+                try (Response response = resources
+                        .target(format("/v1/api/service/%s/account/%s/charges/%s/resend-confirmation-email", aServiceId, aGatewayAccountType, aChargeId))
+                        .request()
+                        .post(Entity.json(Collections.emptyMap()))) {
+
+                    assertThat(response.getStatus(), is(204));
+                }
+            }
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -411,10 +411,6 @@ public class DatabaseFixtures {
         public Map<EmailNotificationType, TestEmailNotification> getEmailNotifications() {
             return emailNotifications;
         }
-        
-        public GatewayAccountType getGatewayAccountType() {
-            return type;
-        }
 
         public boolean isAllowTelephonePaymentNotifications() {
             return allowTelephonePaymentNotifications;

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -115,6 +115,7 @@ public class DatabaseFixtures {
         private final long id;
         private final long amount;
         private final ZonedDateTime createdDate;
+        private final String userExternalId;
         private final String chargeExternalId;
 
         TestRefundHistory(TestRefund testRefund) {
@@ -122,7 +123,7 @@ public class DatabaseFixtures {
             this.externalId = testRefund.getExternalRefundId();
             this.amount = testRefund.getAmount();
             this.createdDate = testRefund.getCreatedDate();
-            String userExternalId = testRefund.getSubmittedByUserExternalId();
+            this.userExternalId = testRefund.getSubmittedByUserExternalId();
             this.chargeExternalId = testRefund.chargeExternalId;
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.dao;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.RandomUtils;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
@@ -47,7 +46,7 @@ import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
 
 public class DatabaseFixtures {
 
-    private DatabaseTestHelper databaseTestHelper;
+    private final DatabaseTestHelper databaseTestHelper;
 
     public DatabaseFixtures(DatabaseTestHelper databaseTestHelper) {
         this.databaseTestHelper = databaseTestHelper;
@@ -112,19 +111,18 @@ public class DatabaseFixtures {
 
     public class TestRefundHistory {
 
-        private String externalId;
-        private long id;
-        private long amount;
-        private ZonedDateTime createdDate;
-        private String userExternalId;
-        private String chargeExternalId;
+        private final String externalId;
+        private final long id;
+        private final long amount;
+        private final ZonedDateTime createdDate;
+        private final String chargeExternalId;
 
         TestRefundHistory(TestRefund testRefund) {
             this.id = testRefund.getId();
             this.externalId = testRefund.getExternalRefundId();
             this.amount = testRefund.getAmount();
             this.createdDate = testRefund.getCreatedDate();
-            this.userExternalId = testRefund.getSubmittedByUserExternalId();
+            String userExternalId = testRefund.getSubmittedByUserExternalId();
             this.chargeExternalId = testRefund.chargeExternalId;
         }
 
@@ -202,36 +200,30 @@ public class DatabaseFixtures {
         }
     }
 
-    public class TestAddress {
-        private String line1 = "line1";
-        private String line2 = "line2";
-        private String postcode = "postcode";
-        private String city = "city";
-        private String county = "county";
-        private String country = "country";
+    public static class TestAddress {
 
         public String getLine1() {
-            return line1;
+            return "line1";
         }
 
         public String getLine2() {
-            return line2;
+            return "line2";
         }
 
         public String getPostcode() {
-            return postcode;
+            return "postcode";
         }
 
         public String getCity() {
-            return city;
+            return "city";
         }
 
         public String getCounty() {
-            return county;
+            return "county";
         }
 
         public String getCountry() {
-            return country;
+            return "country";
         }
     }
 
@@ -342,9 +334,9 @@ public class DatabaseFixtures {
         private String serviceId = "valid-external-service-id";
         private String description = "a description";
         private String analyticsId = "an analytics id";
-        private EmailCollectionMode emailCollectionMode = EmailCollectionMode.OPTIONAL;
+        private final EmailCollectionMode emailCollectionMode = EmailCollectionMode.OPTIONAL;
         private Map<EmailNotificationType, TestEmailNotification> emailNotifications =
-                ImmutableMap.of(
+                Map.of(
                         EmailNotificationType.PAYMENT_CONFIRMED, new TestEmailNotification(),
                         EmailNotificationType.REFUND_ISSUED, new TestEmailNotification()
                 );
@@ -417,6 +409,10 @@ public class DatabaseFixtures {
 
         public Map<EmailNotificationType, TestEmailNotification> getEmailNotifications() {
             return emailNotifications;
+        }
+        
+        public GatewayAccountType getGatewayAccountType() {
+            return type;
         }
 
         public boolean isAllowTelephonePaymentNotifications() {

--- a/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
@@ -17,6 +17,10 @@ public class ChargeUtils {
         return createChargePostBody("description", 100, accountId, "http://nothing", "default@email.invalid");
     }
 
+    public static String createChargePostBody(String accountId, String email) {
+        return createChargePostBody("description", 100, accountId, "http://nothing", email);
+    }
+
     public static String createChargePostBody(String description, long expectedAmount, String accountId, String returnUrl, String email) {
         return toJson(ImmutableMap.builder()
                 .put("reference", "Test reference")


### PR DESCRIPTION
## WHAT YOU DID

- add new endpoint to charges api resource for resending confirmation emails with `serviceId` and `accountType`
- update unit and integration tests
- update surefire and failsafe configurations to show JUnit 5 'DisplayName' in the maven logs
- update OpenAPI spec

