### PR TITLE
PP-12720 Add Notify wiremock for integration tests

### DIFF
--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceResendConfirmationEmailIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceResendConfirmationEmailIT.java
@@ -1,26 +1,17 @@
 package uk.gov.pay.connector.charge.resource;
 
-import io.dropwizard.core.setup.Environment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.app.ConnectorModule;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
-import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
-import uk.gov.service.notify.NotificationClient;
-import uk.gov.service.notify.NotificationClientException;
-import uk.gov.service.notify.SendEmailResponse;
 
 import java.util.Map;
 import java.util.UUID;
@@ -30,23 +21,12 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.it.util.ChargeUtils.createChargePostBody;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class ChargesApiResourceResendConfirmationEmailIT {
-    private static final NotifyClientFactory mockNotifyClientFactory = mock(NotifyClientFactory.class);
-    private static final NotificationClient mockNotificationClient = mock(NotificationClient.class);
-    private static final SendEmailResponse mockSendEmailResponse = mock(SendEmailResponse.class);
-
-
     @RegisterExtension
     private static final AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(
-            ChargesApiResourceResendConfirmationEmailIT.ConnectorAppWithCustomInjector.class,
             config("notifyConfig.emailNotifyEnabled", "true")
     );
 
@@ -57,15 +37,10 @@ public class ChargesApiResourceResendConfirmationEmailIT {
     private static final PaymentGatewayName PAYMENT_GATEWAY_NAME = PaymentGatewayName.STRIPE;
     
     private static String gatewayAccountId;
-    private static String chargeId; 
-
-    @BeforeAll
-    static void before() {
-        when(mockNotifyClientFactory.getInstance()).thenReturn(mockNotificationClient);
-    }
+    private static String chargeId;
 
     @BeforeEach
-    void setup() throws NotificationClientException {
+    void setup() {
         gatewayAccountId = app.givenSetup()
                 .body(toJson(Map.of(
                         "service_id", SERVICE_ID,
@@ -90,8 +65,8 @@ public class ChargesApiResourceResendConfirmationEmailIT {
                 .body(toJson(Map.of("op", "replace", "path", "/payment_confirmed/template_body", "value", "my cool template")))
                 .patch(format("/v1/api/accounts/%s/email-notification", gatewayAccountId))
                 .then().statusCode(200);
-        when(mockSendEmailResponse.getNotificationId()).thenReturn(UUID.randomUUID());
-        when(mockNotificationClient.sendEmail(any(), eq(EMAIL_ADDRESS), anyMap(), eq(null), any())).thenReturn(mockSendEmailResponse);
+        
+        app.getNotifyStub().returnSuccess();
     }
 
     @Nested
@@ -126,6 +101,8 @@ public class ChargesApiResourceResendConfirmationEmailIT {
             @Test
             @DisplayName("Should return 204 when successful")
             void shouldReturn204WhenEmailSuccessfullySent() {
+//                app.getNotifyStub().returnSuccess();
+                        
                 app.givenSetup()
                         .body("")
                         .post(format("/v1/api/service/%s/account/%s/charges/%s/resend-confirmation-email", SERVICE_ID, GATEWAY_ACCOUNT_TYPE, chargeId))
@@ -151,26 +128,6 @@ public class ChargesApiResourceResendConfirmationEmailIT {
                         Arguments.of(SERVICE_ID, GatewayAccountType.LIVE, format("Gateway account not found for service ID [%s] and account type [live]", SERVICE_ID))
                 );
             }
-        }
-    }
-
-    public static class ConnectorAppWithCustomInjector extends ConnectorApp {
-
-        @Override
-        protected ConnectorModule getModule(ConnectorConfiguration configuration, Environment environment) {
-            return new ConnectorModuleWithOverrides(configuration, environment);
-        }
-    }
-
-    private static class ConnectorModuleWithOverrides extends ConnectorModule {
-
-        public ConnectorModuleWithOverrides(ConnectorConfiguration configuration, Environment environment) {
-            super(configuration, environment);
-        }
-
-        @Override
-        protected NotifyClientFactory getNotifyClientFactory(ConnectorConfiguration connectorConfiguration) {
-            return mockNotifyClientFactory;
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
@@ -45,7 +45,7 @@ public class SendRefundEmailIT {
     private final String accountId = String.valueOf(RandomUtils.nextInt());
     @Test
     void shouldSendEmailFollowingASuccessfulRefund() throws Exception {
-        app.getNotifyStub().returnSuccess();
+        app.getNotifyStub().respondWithSuccess();
         addGatewayAccount();
 
         String transactionId = String.valueOf(RandomUtils.nextInt());

--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
@@ -1,31 +1,20 @@
 package uk.gov.pay.connector.it;
 
 import com.google.common.collect.ImmutableMap;
-import io.dropwizard.core.setup.Environment;
 import org.apache.commons.lang3.RandomUtils;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.app.ConnectorModule;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.it.util.ChargeUtils;
-import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
-import uk.gov.service.notify.NotificationClient;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.MediaType.TEXT_XML;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
@@ -40,11 +29,8 @@ import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccoun
 
 public class SendRefundEmailIT {
     private static final String WORLDPAY_IP_ADDRESS = "some-worldpay-ip";
-    private static NotifyClientFactory notifyClientFactory = mock(NotifyClientFactory.class);
-    private static NotificationClient notificationClient = mock(NotificationClient.class);
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(
-            SendRefundEmailIT.ConnectorAppWithCustomInjector.class,
             config("notifyConfig.emailNotifyEnabled", "true"),
             config("worldpay.secureNotificationEnabled", "false")
     );
@@ -57,18 +43,12 @@ public class SendRefundEmailIT {
             CREDENTIALS_SHA_OUT_PASSPHRASE, "test-sha-out-passphrase"
     );
     private final String accountId = String.valueOf(RandomUtils.nextInt());
-
-    @BeforeAll
-    static void before() {
-        when(notifyClientFactory.getInstance()).thenReturn(notificationClient);
-    }
-
     @Test
     void shouldSendEmailFollowingASuccessfulRefund() throws Exception {
+        app.getNotifyStub().returnSuccess();
         addGatewayAccount();
 
         String transactionId = String.valueOf(RandomUtils.nextInt());
-        String payIdSub = "2";
         String refundExternalId = "999999";
 
         ChargeUtils.ExternalChargeId chargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, app.getDatabaseTestHelper(), "worldpay");
@@ -82,8 +62,10 @@ public class SendRefundEmailIT {
                 .post("/v1/api/notifications/worldpay");
 
         Thread.sleep(500L); // Email sent using ExecutorService task: give it some time to complete
-
-        verify(notificationClient).sendEmail(anyString(), anyString(), anyMap(), isNull(), isNull());
+        
+        app.getNotifyWireMockServer().verify(postRequestedFor(
+                urlEqualTo("/v2/notifications/email"))
+        );
     }
 
     private void addGatewayAccount() {
@@ -93,23 +75,5 @@ public class SendRefundEmailIT {
                 .withCredentials(credentials)
                 .build());
         app.getDatabaseTestHelper().addEmailNotification(Long.valueOf(accountId), "a template", true, REFUND_ISSUED);
-    }
-
-    public static class ConnectorAppWithCustomInjector extends ConnectorApp {
-        @Override
-        protected ConnectorModule getModule(ConnectorConfiguration configuration, Environment environment) {
-            return new ConnectorModuleWithOverrides(configuration, environment);
-        }
-    }
-
-    private static class ConnectorModuleWithOverrides extends ConnectorModule {
-        public ConnectorModuleWithOverrides(ConnectorConfiguration configuration, Environment environment) {
-            super(configuration, environment);
-        }
-
-        @Override
-        protected NotifyClientFactory getNotifyClientFactory(ConnectorConfiguration connectorConfiguration) {
-            return notifyClientFactory;
-        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/NotifyStub.java
+++ b/src/test/java/uk/gov/pay/connector/rules/NotifyStub.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.rules;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import org.apache.commons.lang3.RandomUtils;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.connector.util.JsonEncoder.toJson;
+
+
+import java.util.Map;
+import java.util.UUID;
+
+public class NotifyStub {
+    private final WireMockServer wireMockServer;
+    
+    public NotifyStub(WireMockServer wireMockServer) {
+        this.wireMockServer = wireMockServer;
+    }
+    
+    public StubMapping returnSuccess() {
+        return returnSuccess(UUID.randomUUID().toString());
+    }
+    
+    public StubMapping returnSuccess(String notificationId) {
+        Map<String, Object> payload = Map.of(
+                "id", notificationId,
+                "content", Map.of(
+                        "body", "",
+                        "subject", ""
+                ),
+                "template", Map.of(
+                        "id", "c60e7068-27fc-4551-8ae9-2dbc3a9a080d",
+                        "version", String.valueOf(RandomUtils.nextInt()),
+                        "uri", ""
+                )
+        );
+        
+        return wireMockServer.stubFor(
+                post(urlPathEqualTo("/v2/notifications/email"))
+                        .willReturn(
+                                aResponse()
+                                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                                        .withStatus(201)
+                                        .withBody(toJson(payload))
+                        )
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/rules/NotifyStub.java
+++ b/src/test/java/uk/gov/pay/connector/rules/NotifyStub.java
@@ -22,12 +22,8 @@ public class NotifyStub {
     }
     
     public StubMapping respondWithSuccess() {
-        return respondWithSuccess(UUID.randomUUID().toString());
-    }
-    
-    public StubMapping respondWithSuccess(String notificationId) {
         Map<String, Object> payload = Map.of(
-                "id", notificationId,
+                "id", "60b922b3-c41a-4e7e-8c12-efa7ea9ee7d2",
                 "content", Map.of(
                         "body", "",
                         "subject", ""

--- a/src/test/java/uk/gov/pay/connector/rules/NotifyStub.java
+++ b/src/test/java/uk/gov/pay/connector/rules/NotifyStub.java
@@ -22,11 +22,11 @@ public class NotifyStub {
         this.wireMockServer = wireMockServer;
     }
     
-    public StubMapping returnSuccess() {
-        return returnSuccess(UUID.randomUUID().toString());
+    public StubMapping respondWithSuccess() {
+        return respondWithSuccess(UUID.randomUUID().toString());
     }
     
-    public StubMapping returnSuccess(String notificationId) {
+    public StubMapping respondWithSuccess(String notificationId) {
         Map<String, Object> payload = Map.of(
                 "id", notificationId,
                 "content", Map.of(
@@ -35,7 +35,7 @@ public class NotifyStub {
                 ),
                 "template", Map.of(
                         "id", "c60e7068-27fc-4551-8ae9-2dbc3a9a080d",
-                        "version", String.valueOf(RandomUtils.nextInt()),
+                        "version", "1",
                         "uri", ""
                 )
         );
@@ -47,6 +47,18 @@ public class NotifyStub {
                                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                                         .withStatus(201)
                                         .withBody(toJson(payload))
+                        )
+        );
+    }
+    
+    public StubMapping respondWithFailure() {
+        return wireMockServer.stubFor(
+                post(urlPathEqualTo("/v2/notifications/email"))
+                        .willReturn(
+                                aResponse()
+                                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                                        .withStatus(400)
+                                        .withBody(toJson(Map.of()))
                         )
         );
     }

--- a/src/test/java/uk/gov/pay/connector/rules/NotifyStub.java
+++ b/src/test/java/uk/gov/pay/connector/rules/NotifyStub.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.rules;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import org.apache.commons.lang3.RandomUtils;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;


### PR DESCRIPTION
## WHAT YOU DID
 - Add Wiremock for Notify API to `AppWithPostgresAndSqsExtension` to allow for stubbing Notify requests at network level
 - Remove Custom ConnectorApp from `ChargesApiResourceResendConfirmationEmailIT` and `SendRefundEmailIT`
   - Replace Notify client stubs with stubs set on Notify Wiremock 

## How to test
 - Run integration tests