### PR TITLE
PP-12727 Remove duplicate maven-surefire plugin

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -39,6 +39,7 @@ jobs:
     with:
       consumer: "connector"
       provider: ${{ matrix.provider }}
+      java_version: "21"
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
         <eclipselink.version>2.7.13</eclipselink.version>
         <swagger-version>2.2.22</swagger-version>
         <prometheus.version>0.16.0</prometheus.version>
-        <maven.surefire.junit5.tree.reporter.version>1.2.1</maven.surefire.junit5.tree.reporter.version>
 
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>
@@ -544,27 +543,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
-                <configuration>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-                    <reportFormat>plain</reportFormat>
-                    <consoleOutputReporter>
-                        <disable>true</disable>
-                    </consoleOutputReporter>
-                    <statelessTestsetInfoReporter
-                            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>me.fabriciorby</groupId>
-                        <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
-                        <version>${maven.surefire.junit5.tree.reporter.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.2.5</version>
@@ -580,20 +558,7 @@
                     <forkCount>1</forkCount>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <reportsDirectory>${project.build.directory}/failsafe-reports</reportsDirectory>
-                    <reportFormat>plain</reportFormat>
-                    <consoleOutputReporter>
-                        <disable>true</disable>
-                    </consoleOutputReporter>
-                    <statelessTestsetInfoReporter
-                            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>me.fabriciorby</groupId>
-                        <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
-                        <version>${maven.surefire.junit5.tree.reporter.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## WHAT YOU DID
- Removed duplicate maven-surefire plugin (already defined in profiles) and some config added recently as it is breaking provider pact tests output.

example PR https://github.com/alphagov/pay-connector/actions/runs/9447024535/job/26021829259?pr=5322

and the output looks like below:

```
[INFO] +--ContractTestSuite uk.gov.pay.connector.pact.SelfServiceContractTest uk.gov.pay.connector.pact.SelfServiceContractTest selfservice - Upon a valid patch 3DS integration version to 1 request - 5.150 ss
[INFO] |  +-- [OK] null - 0.168 ss
[INFO] |  +-- [OK] null - 0.142 ss
[INFO] |  +-- [OK] null - 0.177 ss
[INFO] |  +-- [OK] null - 0.149 ss
[INFO] |  +-- [OK] null - 0.143 ss
[INFO] |  +-- [OK] null - 0.128 ss
[INFO] |  +-- [OK] null - 0.115 ss
[INFO] |  +-- [OK] null - 0.089 ss
[INFO] |  +-- [OK] null - 0.099 ss
[INFO] |  +-- [OK] null - 0.115 ss
```

- Also sets JDK version to 21 when running provider tests (as CardID is already on Java 21)