### PR TITLE
PP-12681 Correct get Stripe Account endpoint paths

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,63 +139,63 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 1677
+        "line_number": 1745
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 2930
+        "line_number": 2929
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 2974
+        "line_number": 2973
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3441
+        "line_number": 3440
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3830
+        "line_number": 3829
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3866
+        "line_number": 3865
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 4794
+        "line_number": 4793
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5270
+        "line_number": 5269
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5281
+        "line_number": 5280
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1075,5 +1075,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-10T10:47:16Z"
+  "generated_at": "2024-06-10T16:28:14Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1386,7 +1386,75 @@ paths:
       summary: Enables/disables email notifications for gateway account
       tags:
       - Gateway accounts
+  /v1/api/service/{serviceId}/account/{accountType}/stripe-account:
+    get:
+      operationId: getStripeAccountByServiceIdAndAccountType
+      parameters:
+      - description: Service ID
+        example: 46eb1b601348499196c99de90482ee68
+        in: path
+        name: serviceId
+        required: true
+        schema:
+          type: string
+      - description: Account type
+        example: test
+        in: path
+        name: accountType
+        required: true
+        schema:
+          type: string
+          enum:
+          - test
+          - live
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StripeAccountResponse'
+          description: OK
+        "404":
+          description: Not found - Service does not exist or service does not have
+            a Stripe gateway account of this type
+      summary: Retrieves Stripe Connect account information for a given service ID
+        and account type (test|live)
+      tags:
+      - Gateway accounts
   /v1/api/service/{serviceId}/account/{accountType}/stripe-setup:
+    get:
+      operationId: getStripeAccountSetupByServiceIdAndAccountType
+      parameters:
+      - description: Service ID
+        example: 46eb1b601348499196c99de90482ee68
+        in: path
+        name: serviceId
+        required: true
+        schema:
+          type: string
+      - description: Account type
+        example: test
+        in: path
+        name: accountType
+        required: true
+        schema:
+          type: string
+          enum:
+          - test
+          - live
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StripeAccountSetup'
+          description: OK
+        "404":
+          description: Not found
+      summary: Retrieve Stripe connect account setup tasks for a given service ID
+        and account type
+      tags:
+      - Gateway accounts
     patch:
       description: "Support patching following paths: <br>bank_account, responsible_person,\
         \ vat_number, company_number, director, government_entity_document, organisation_details"
@@ -1707,75 +1775,6 @@ paths:
       summary: Update a gateway account credential by service ID and account Type
       tags:
       - Gateway account credentials
-  /v1/api/service/{serviceId}/{accountType}/stripe-account:
-    get:
-      operationId: getStripeAccountByServiceIdAndAccountType
-      parameters:
-      - description: Service ID
-        example: 46eb1b601348499196c99de90482ee68
-        in: path
-        name: serviceId
-        required: true
-        schema:
-          type: string
-      - description: Account type
-        example: test
-        in: path
-        name: accountType
-        required: true
-        schema:
-          type: string
-          enum:
-          - test
-          - live
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StripeAccountResponse'
-          description: OK
-        "404":
-          description: Not found - Service does not exist or service does not have
-            a Stripe gateway account of this type
-      summary: Retrieves Stripe Connect account information for a given service ID
-        and account type (test|live)
-      tags:
-      - Gateway accounts
-  /v1/api/service/{serviceId}/{accountType}/stripe-setup:
-    get:
-      operationId: getStripeAccountSetupByServiceIdAndAccountType
-      parameters:
-      - description: Service ID
-        example: 46eb1b601348499196c99de90482ee68
-        in: path
-        name: serviceId
-        required: true
-        schema:
-          type: string
-      - description: Account type
-        example: test
-        in: path
-        name: accountType
-        required: true
-        schema:
-          type: string
-          enum:
-          - test
-          - live
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StripeAccountSetup'
-          description: OK
-        "404":
-          description: Not found
-      summary: Retrieve Stripe connect account setup tasks for a given service ID
-        and account type
-      tags:
-      - Gateway accounts
   /v1/api/service/{serviceId}/{accountType}/worldpay/check-3ds-flex-config:
     post:
       operationId: validateWorldpay3dsCredentialsByServiceIdAndType

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
@@ -57,7 +57,7 @@ public class StripeAccountResource {
     }
 
     @GET
-    @Path("/v1/api/service/{serviceId}/{accountType}/stripe-account")
+    @Path("/v1/api/service/{serviceId}/account/{accountType}/stripe-account")
     @Produces(APPLICATION_JSON)
     @Operation(
             summary = "Retrieves Stripe Connect account information for a given service ID and account type (test|live)",

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java
@@ -63,7 +63,7 @@ public class StripeAccountSetupResource {
     }
 
     @GET
-    @Path("/v1/api/service/{serviceId}/{accountType}/stripe-setup")
+    @Path("/v1/api/service/{serviceId}/account/{accountType}/stripe-setup")
     @Produces(APPLICATION_JSON)
     @Operation(
             summary = "Retrieve Stripe connect account setup tasks for a given service ID and account type",

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
@@ -86,7 +86,7 @@ public class StripeAccountResourceIT {
                     .statusCode(200);
 
             app.givenSetup()
-                    .get("/v1/api/service/a-valid-service-id/TEST/stripe-account")
+                    .get("/v1/api/service/a-valid-service-id/account/TEST/stripe-account")
                     .then()
                     .statusCode(200)
                     .body("stripe_account_id", is(STRIPE_ACCOUNT_ID));
@@ -95,7 +95,7 @@ public class StripeAccountResourceIT {
         @Test
         void returnsNotFoundResponseWhenServiceIdNotFound() {
             app.givenSetup()
-                    .get("/v1/api/service/unknown-service-id/TEST/stripe-account")
+                    .get("/v1/api/service/unknown-service-id/account/TEST/stripe-account")
                     .then()
                     .statusCode(404)
                     .body("message[0]", is("Gateway account not found for service ID [unknown-service-id] and account type [test]"));
@@ -106,7 +106,7 @@ public class StripeAccountResourceIT {
             testBaseExtension.createAGatewayAccountWithServiceId("a-valid-service-id", "sandbox");
 
             app.givenSetup()
-                    .get("/v1/api/service/a-valid-service-id/TEST/stripe-account")
+                    .get("/v1/api/service/a-valid-service-id/account/TEST/stripe-account")
                     .then()
                     .statusCode(404)
                     .body("message[0]", is("Gateway account for service ID [a-valid-service-id] and account type [test] is not a Stripe account"));
@@ -117,7 +117,7 @@ public class StripeAccountResourceIT {
             testBaseExtension.createAGatewayAccountWithServiceId("a-valid-service-id", "stripe");
 
             app.givenSetup()
-                    .get("/v1/api/service/a-valid-service-id/TEST/stripe-account")
+                    .get("/v1/api/service/a-valid-service-id/account/TEST/stripe-account")
                     .then()
                     .statusCode(404)
                     .body("message", is("Stripe gateway account for service ID [a-valid-service-id] and account type [test] does not have Stripe credentials"));

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
@@ -242,7 +242,7 @@ public class StripeAccountSetupResourceIT {
                 testBaseExtension.createAGatewayAccountWithServiceId("a-valid-service-id", "stripe");
 
                 app.givenSetup()
-                        .get("/v1/api/service/a-valid-service-id/TEST/stripe-setup")
+                        .get("/v1/api/service/a-valid-service-id/account/TEST/stripe-setup")
                         .then()
                         .statusCode(200)
                         .body("bank_account", is(false))
@@ -277,7 +277,7 @@ public class StripeAccountSetupResourceIT {
                         .statusCode(200);
 
                 app.givenSetup()
-                        .get("/v1/api/service/a-valid-service-id/TEST/stripe-setup")
+                        .get("/v1/api/service/a-valid-service-id/account/TEST/stripe-setup")
                         .then()
                         .statusCode(200)
                         .body("bank_account", is(true))
@@ -291,7 +291,7 @@ public class StripeAccountSetupResourceIT {
             @Test
             void returnsNotFoundResponseWhenNoGatewayAccountFoundForService() {
                 app.givenSetup()
-                        .get("/v1/api/service/unknown-service-id/TEST/stripe-setup")
+                        .get("/v1/api/service/unknown-service-id/account/TEST/stripe-setup")
                         .then()
                         .statusCode(404)
                         .body("message[0]", is("Gateway account not found for service ID [unknown-service-id] and account type [test]"));
@@ -301,7 +301,7 @@ public class StripeAccountSetupResourceIT {
             void returnsSuccessfulResponseWhenGatewayAccountIsNotAStripeAccount() {
                 testBaseExtension.createAGatewayAccountWithServiceId("a-valid-service-id", "worldpay");
                 app.givenSetup()
-                        .get("/v1/api/service/a-valid-service-id/TEST/stripe-setup")
+                        .get("/v1/api/service/a-valid-service-id/account/TEST/stripe-setup")
                         .then()
                         .statusCode(200)
                         .body("bank_account", is(false))
@@ -341,7 +341,7 @@ public class StripeAccountSetupResourceIT {
                         .statusCode(200);
 
                 app.givenSetup()
-                        .get(format("/v1/api/service/%s/%s/stripe-setup", VALID_SERVICE_ID, TEST))
+                        .get(format("/v1/api/service/%s/account/%s/stripe-setup", VALID_SERVICE_ID, TEST))
                         .then()
                         .statusCode(200)
                         .body("bank_account", is(true))
@@ -400,7 +400,7 @@ public class StripeAccountSetupResourceIT {
                         .statusCode(200);
 
                 app.givenSetup()
-                        .get(format("/v1/api/service/%s/%s/stripe-setup", VALID_SERVICE_ID, TEST))
+                        .get(format("/v1/api/service/%s/account/%s/stripe-setup", VALID_SERVICE_ID, TEST))
                         .then()
                         .statusCode(200)
                         .body("bank_account", is(true))
@@ -483,7 +483,7 @@ public class StripeAccountSetupResourceIT {
                 addCompletedTask(gatewayAccountId, StripeAccountSetupTask.DIRECTOR);
 
                 app.givenSetup()
-                        .get(format("/v1/api/service/%s/%s/stripe-setup", VALID_SERVICE_ID, TEST))
+                        .get(format("/v1/api/service/%s/account/%s/stripe-setup", VALID_SERVICE_ID, TEST))
                         .then()
                         .statusCode(200)
                         .body("bank_account", is(false))
@@ -502,7 +502,7 @@ public class StripeAccountSetupResourceIT {
                         .statusCode(200);
 
                 app.givenSetup()
-                        .get(format("/v1/api/service/%s/%s/stripe-setup", VALID_SERVICE_ID, TEST))
+                        .get(format("/v1/api/service/%s/account/%s/stripe-setup", VALID_SERVICE_ID, TEST))
                         .then()
                         .statusCode(200)
                         .body("director", is(false));


### PR DESCRIPTION
- Correct get Stripe Account by serviceId to `v1/api/service/{serviceId}/account/{accountType}/stripe-account`
- Correct get Stripe Account Setup by serviceId to `/v1/api/service/{serviceId}/account/{accountType}/stripe-setup`