### PR TITLE
PP-12730 Upgrade to Java 21

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,7 @@ updates:
     ignore:
       - dependency-name: "eclipse-temurin"
         versions:
-          - "> 11"
+          - "> 21"
     open-pull-requests-limit: 10
     labels:
       - dependencies
@@ -54,7 +54,7 @@ updates:
     ignore:
       - dependency-name: "eclipse-temurin"
         versions:
-          - "> 11"
+          - "> 21"
     open-pull-requests-limit: 10
     labels:
       - dependencies

--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -25,6 +25,7 @@ jobs:
     uses: alphagov/pay-ci/.github/workflows/_run-java-tests-and-publish-pacts.yml@master
     with:
       publish_pacts: true
+      java_version: "21"
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
@@ -50,3 +51,13 @@ jobs:
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
+    with:
+      java_version: "21"
+
+  check-docker-base-images-are-manifests:
+    uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master
+
+  check-docker-base-images-for-m1-are-manifests:
+    uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master
+    with:
+      dockerfile: "m1/arm64.Dockerfile"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,10 +36,10 @@ jobs:
             paths:
               - 'src/**'
 
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'adopt'
 
       - name: Compile project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.9.5-eclipse-temurin-11-alpine@sha256:5b8e35bd58fc6d6d78fa7faa34c0a895f897ce90a10ab1e2c31e2eb5c62ee027 AS builder
+FROM maven:3.9.7-eclipse-temurin-21-alpine@sha256:8b762a139e07e874e3830521d97bafaf963cce6bda92afe9fb532def5d011404 AS builder
 
 WORKDIR /home/build
 COPY . .
 
 RUN ["mvn", "clean", "--no-transfer-progress", "package", "-DskipTests"]
 
-FROM eclipse-temurin:11-jre-alpine@sha256:77899ea444d0c219f3a4f500923dcae6b4b28db239b80c5214f26c1167ba74b5 AS final
+FROM eclipse-temurin:21-jre-alpine@sha256:23467b3e42617ca197f43f58bc5fb03ca4cb059d68acd49c67128bfded132d67 AS final
 
 RUN ["apk", "--no-cache", "upgrade"]
 

--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -1,11 +1,13 @@
-FROM maven:3.9.5-eclipse-temurin-11@sha256:d698c543af44a1a8e4b2b2f9c1cfe3e009f2398cc7125a3d1204c71ad876800f AS builder
+FROM maven:3.9.7-eclipse-temurin-21-alpine@sha256:8b762a139e07e874e3830521d97bafaf963cce6bda92afe9fb532def5d011404 AS builder
 
 WORKDIR /home/build
 COPY . .
 
 RUN ["mvn", "clean", "--no-transfer-progress", "package", "-DskipTests"]
 
-FROM eclipse-temurin:11-jre@sha256:f31717a7a4c0d7cc9e50008544d269c90d6894dd70cdcbb28da8060913fcf8ad AS final
+FROM eclipse-temurin:21-jre-alpine@sha256:23467b3e42617ca197f43f58bc5fb03ca4cb059d68acd49c67128bfded132d67 AS final
+
+RUN ["apk", "--no-cache", "upgrade"]
 
 ARG DNS_TTL=15
 
@@ -14,11 +16,10 @@ ENV LANG C.UTF-8
 
 RUN echo networkaddress.cache.ttl=$DNS_TTL >> "$JAVA_HOME/conf/security/java.security"
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y tini wget
+COPY ./import_aws_rds_cert_bundles.sh /
+RUN /import_aws_rds_cert_bundles.sh && rm /import_aws_rds_cert_bundles.sh
 
-COPY import_aws_rds_cert_bundles.sh /
-RUN /import_aws_rds_cert_bundles.sh
-RUN rm /import_aws_rds_cert_bundles.sh
+RUN ["apk", "add", "--no-cache", "bash", "tini"]
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081

--- a/pom.xml
+++ b/pom.xml
@@ -479,7 +479,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <release>11</release>
+                    <release>21</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <pay-java-commons.version>1.0.20240528142501</pay-java-commons.version>
         <surefire.version>3.2.5</surefire.version>
         <jjwt.version>0.12.3</jjwt.version>
-        <pact.version>3.6.15</pact.version>
+        <pact.version>4.6.10</pact.version>
         <eclipselink.version>2.7.13</eclipselink.version>
         <swagger-version>2.2.22</swagger-version>
         <prometheus.version>0.16.0</prometheus.version>
@@ -459,8 +459,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>au.com.dius</groupId>
-                <artifactId>pact-jvm-provider-maven_2.12</artifactId>
+                <groupId>au.com.dius.pact.provider</groupId>
+                <artifactId>maven</artifactId>
                 <version>${pact.version}</version>
                 <configuration>
                     <pactDirectory>target/pacts</pactDirectory>

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -26,8 +26,10 @@ import javax.persistence.Table;
 import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 
+import static java.time.temporal.ChronoUnit.MICROS;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -100,7 +102,7 @@ public class RefundEntity extends AbstractVersionedEntity {
     public RefundEntity(Long amount, String userExternalId, String userEmail, String chargeExternalId) {
         this.externalId = RandomIdGenerator.newId();
         this.amount = amount;
-        this.createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+        this.createdDate = ZonedDateTime.now(ZoneId.of("UTC")).truncatedTo(MICROS);
         this.userExternalId = userExternalId;
         this.userEmail = userEmail;
         this.chargeExternalId = chargeExternalId;

--- a/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.ChronoUnit.MICROS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -173,7 +174,7 @@ public class EmittedEventDaoIT {
         final RefundSubmitted refundSubmittedEvent = aRefundSubmittedEvent(Instant.parse("2019-01-01T14:00:00Z"));
         emittedEventDao.recordEmission(paymentCreatedEvent.getResourceType(), paymentCreatedEvent.getResourceExternalId(),
                 paymentCreatedEvent.getEventType(), paymentCreatedEvent.getTimestamp(), null);
-        ZonedDateTime doNotRetryEmitUntil = ZonedDateTime.now(UTC).minusSeconds(120);
+        ZonedDateTime doNotRetryEmitUntil = ZonedDateTime.now(UTC).minusSeconds(120).truncatedTo(MICROS);
         emittedEventDao.recordEmission(refundSubmittedEvent.getResourceType(), refundSubmittedEvent.getResourceExternalId(),
                 refundSubmittedEvent.getEventType(), refundSubmittedEvent.getTimestamp(), doNotRetryEmitUntil);
         emittedEventDao.recordEmission(paymentCreatedEvent.getResourceType(), paymentCreatedEvent.getResourceExternalId(),

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -25,6 +25,7 @@ import javax.validation.ConstraintViolationException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ import java.util.Optional;
 
 import static java.time.Duration.ofMinutes;
 import static java.time.ZonedDateTime.now;
+import static java.time.temporal.ChronoUnit.MICROS;
 import static junit.framework.TestCase.assertTrue;
 import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -350,7 +352,7 @@ public class ChargeDaoIT {
 
         // given
         String transactionId = "7826782163";
-        Instant createdDate = Instant.now();
+        Instant createdDate = Instant.now().truncatedTo(MICROS);
         Long chargeId = 9999L;
         String externalChargeId = "charge9999";
 
@@ -415,7 +417,7 @@ public class ChargeDaoIT {
     @Test
     void shouldGetChargeByChargeIdWithCorrectAssociatedAccountId() {
         String transactionId = "7826782163";
-        Instant createdDate = Instant.now();
+        Instant createdDate = Instant.now().truncatedTo(MICROS);
         Long chargeId = 876786L;
         String externalChargeId = "charge876786";
 
@@ -826,7 +828,7 @@ public class ChargeDaoIT {
         TestCharge chargeToExpunge = app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withCreatedDate(Instant.now().minus(Duration.ofDays(90)))
+                .withCreatedDate(Instant.now().truncatedTo(MICROS).minus(Duration.ofDays(90)))
                 .withParityCheckStatus(ParityCheckStatus.MISSING_IN_LEDGER)
                 .insert();
 
@@ -860,7 +862,7 @@ public class ChargeDaoIT {
         TestCharge chargeToExpunge = app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withCreatedDate(Instant.now().minus(Duration.ofDays(90)))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(90)).truncatedTo(MICROS))
                 .withParityCheckDate(now(ZoneId.of("UTC")))
                 .withParityCheckStatus(ParityCheckStatus.MISSING_IN_LEDGER)
                 .insert();

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -25,12 +25,15 @@ import uk.gov.service.payments.commons.model.SupportedLanguage;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static java.time.ZonedDateTime.now;
+import static java.time.temporal.ChronoUnit.MICROS;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
@@ -161,7 +164,7 @@ public class DatabaseFixtures {
     public class TestChargeEvent {
         private long chargeId;
         private ChargeStatus chargeStatus;
-        private ZonedDateTime updated = ZonedDateTime.now();
+        private ZonedDateTime updated = now();
 
         public TestChargeEvent withTestCharge(TestCharge testCharge) {
             this.chargeId = testCharge.getChargeId();
@@ -721,7 +724,7 @@ public class DatabaseFixtures {
         SupportedLanguage language = SupportedLanguage.ENGLISH;
         boolean delayedCapture = false;
         Long corporateCardSurcharge = null;
-        Instant createdDate = Instant.now();
+        Instant createdDate = Instant.now().truncatedTo(MICROS);
         TestAccount testAccount;
         String paymentProvider = "sandbox";
         TestCardDetails cardDetails;
@@ -984,7 +987,7 @@ public class DatabaseFixtures {
         String externalRefundId = RandomIdGenerator.newId();
         long amount = 101L;
         RefundStatus status = CREATED;
-        ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+        ZonedDateTime createdDate = now(ZoneId.of("UTC")).truncatedTo(MICROS);
         TestCharge testCharge;
         String submittedByUserExternalId;
         String gatewayTransactionId;
@@ -1101,7 +1104,7 @@ public class DatabaseFixtures {
 
     public class TestFee {
         String externalId = RandomIdGenerator.newId();
-        ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+        ZonedDateTime createdDate = now(ZoneId.of("UTC"));
         TestCharge testCharge;
         private long feeDue = 100L;
         private long feeCollected = 100L;

--- a/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.now;
+import static java.time.temporal.ChronoUnit.MICROS;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -445,7 +446,7 @@ public class RefundDaoJpaIT {
         assertThat(mayBeRefundEntityFromDB.get().getParityCheckStatus(), is(nullValue()));
         assertThat(refundHistoryList.size(), is(1));
 
-        ZonedDateTime parityCheckDate = ZonedDateTime.now(UTC);
+        ZonedDateTime parityCheckDate = ZonedDateTime.now(UTC).truncatedTo(MICROS);
         refundDao.updateParityCheckStatus(refundEntity.getExternalId(), parityCheckDate, MISSING_IN_LEDGER);
 
         mayBeRefundEntityFromDB = refundDao.findByExternalId(refundEntity.getExternalId());

--- a/src/test/java/uk/gov/pay/connector/it/events/EmittedEventResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/EmittedEventResourceIT.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.dropwizard.testing.ConfigOverride.config;
+import static java.time.temporal.ChronoUnit.MICROS;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,7 +72,7 @@ public class EmittedEventResourceIT {
         long chargeId = addCharge();
         app.getDatabaseTestHelper().addEvent(chargeId, CREATED.toString());
 
-        Instant doNotRetryEmitUntil = Instant.now().minusSeconds(60);
+        Instant doNotRetryEmitUntil = Instant.now().minusSeconds(60).truncatedTo(MICROS);
         app.getDatabaseTestHelper().addEmittedEvent("payment", externalChargeId, Instant.now(),
                 "PAYMENT_CREATED", null, doNotRetryEmitUntil);
 
@@ -95,7 +96,7 @@ public class EmittedEventResourceIT {
         long chargeId = addCharge();
         app.getDatabaseTestHelper().addEvent(chargeId, CREATED.toString());
 
-        Instant doNotRetryEmitUntil = Instant.now().plusSeconds(60);
+        Instant doNotRetryEmitUntil = Instant.now().plusSeconds(60).truncatedTo(MICROS);
         app.getDatabaseTestHelper().addEmittedEvent("payment", externalChargeId, Instant.now(),
                 "PAYMENT_CREATED", null, doNotRetryEmitUntil);
 


### PR DESCRIPTION
## WHAT YOU DID
- Upgrades to Java 21
- Also upgrades pact provider plugin 
- Updated some tests for datetime granularity as they were failing on Github Actions due to Instant() returning time with nano-second granularity and values from the database are at the microsecond level. nano-second granularity shouldn't be an issue as Postgres supports timestamp only up to microsecond resolution (https://www.postgresql.org/docs/15/datatype-datetime.html) and in the API we are returning date/time in milliseconds (ex: https://github.com/alphagov/pay-connector/blob/master/openapi/connector_spec.yaml#L2906)