### PR TITLE
PP-12681 Correct endpoint paths

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -146,56 +146,56 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 2928
+        "line_number": 2927
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 2972
+        "line_number": 2971
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3439
+        "line_number": 3438
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3828
+        "line_number": 3827
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3864
+        "line_number": 3863
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 4792
+        "line_number": 4791
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5268
+        "line_number": 5267
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5279
+        "line_number": 5278
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1075,5 +1075,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-11T09:50:37Z"
+  "generated_at": "2024-06-11T13:26:40Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -2431,7 +2431,6 @@ paths:
         type
       tags:
       - Gateway accounts
-  /v1/frontend/service/{serviceId}/{accountType}/card-types:
     post:
       operationId: updateGatewayAccountAcceptedCardTypesDegateway
       parameters:
@@ -2480,7 +2479,7 @@ paths:
       summary: Update accepted card types for a gateway account
       tags:
       - Gateway accounts
-  /v1/frontend/service/{serviceId}/{accountType}/servicename:
+  /v1/frontend/service/{serviceId}/account/{accountType}/servicename:
     patch:
       operationId: updateGatewayAccountServiceNameByServiceId
       parameters:

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -371,7 +371,7 @@ public class GatewayAccountResource {
     }
 
     @PATCH
-    @Path("/v1/frontend/service/{serviceId}/{accountType}/servicename")
+    @Path("/v1/frontend/service/{serviceId}/account/{accountType}/servicename")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Transactional
@@ -521,7 +521,7 @@ public class GatewayAccountResource {
     }
 
     @POST
-    @Path("/v1/frontend/service/{serviceId}/{accountType}/card-types")
+    @Path("/v1/frontend/service/{serviceId}/account/{accountType}/card-types")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Transactional

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -214,7 +214,7 @@ public class GatewayAccountFrontendResourceIT {
 
             app.givenSetup().accept(JSON)
                     .body(Map.of("service_name", "New Service Name"))
-                    .patch(format("/v1/frontend/service/%s/test/servicename", serviceId))
+                    .patch(format("/v1/frontend/service/%s/account/test/servicename", serviceId))
                     .then()
                     .statusCode(200);
 
@@ -233,7 +233,7 @@ public class GatewayAccountFrontendResourceIT {
 
             app.givenSetup().accept(JSON)
                     .body(Map.of())
-                    .patch(format("/v1/frontend/service/%s/test/servicename", serviceId))
+                    .patch(format("/v1/frontend/service/%s/account/test/servicename", serviceId))
                     .then()
                     .statusCode(422)
                     .body("message", contains("Field [service_name] cannot be null"))
@@ -246,7 +246,7 @@ public class GatewayAccountFrontendResourceIT {
 
             app.givenSetup().accept(JSON)
                     .body(Map.of("service_name", "service-name-more-than-fifty-chars-service-name-more-than-fifty-chars"))
-                    .patch(format("/v1/frontend/service/%s/test/servicename", serviceId))
+                    .patch(format("/v1/frontend/service/%s/account/test/servicename", serviceId))
                     .then()
                     .statusCode(422)
                     .body("message", contains("Field [service_name] can have a size between 1 and 50"))
@@ -257,7 +257,7 @@ public class GatewayAccountFrontendResourceIT {
         void assertNotFoundForNonExistentServiceId() {
             app.givenSetup().accept(JSON)
                     .body(Map.of("service_name", "New Service Name"))
-                    .patch("/v1/frontend/service/nexiste-pas/test/servicename")
+                    .patch("/v1/frontend/service/nexiste-pas/account/test/servicename")
                     .then()
                     .statusCode(404)
                     .body("message", contains("Gateway account not found for service ID [nexiste-pas] and account type [test]"))
@@ -417,7 +417,7 @@ public class GatewayAccountFrontendResourceIT {
         }
 
         private Response updateGatewayAccountCardTypesWith(String serviceId, GatewayAccountType accountType, String body) {
-            String url = format("/v1/frontend/service/%s/%s/card-types", serviceId, accountType.toString());
+            String url = format("/v1/frontend/service/%s/account/%s/card-types", serviceId, accountType.toString());
             return app.givenSetup()
                     .contentType(ContentType.JSON)
                     .accept(JSON)


### PR DESCRIPTION
- correct endpoint path for adding accepted card types to `/v1/frontend/service/{serviceId}/account/{accountType}/card-types`
- correct endpoint path for patching servicename to `/v1/frontend/service/{serviceId}/account/{accountType}/servicename`