### PR TITLE
PP-12703: Update 3ds toggle by service id and account type

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -146,56 +142,56 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 2927
+        "line_number": 2971
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 2971
+        "line_number": 3015
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3438
+        "line_number": 3482
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3827
+        "line_number": 3871
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3863
+        "line_number": 3907
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 4791
+        "line_number": 4835
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5267
+        "line_number": 5318
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5278
+        "line_number": 5329
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -315,14 +311,14 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 83
+        "line_number": 84
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 141
+        "line_number": 142
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java": [
@@ -1075,5 +1071,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-11T15:12:02Z"
+  "generated_at": "2024-06-11T16:04:04Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -2394,8 +2394,8 @@ paths:
     patch:
       operationId: updateGatewayAccount3dsToggleByServiceId
       parameters:
-      - description: Gateway account ID
-        example: 1
+      - description: Service ID
+        example: 46eb1b601348499196c99de90482ee68
         in: path
         name: serviceId
         required: true

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1891,7 +1891,7 @@ paths:
       - Gateway accounts
   /v1/frontend/accounts/{accountId}/3ds-toggle:
     patch:
-      operationId: updateGatewayAccount3dsToggle
+      operationId: updateGatewayAccount3dsToggleByGatewayAccountId
       parameters:
       - description: Gateway account ID
         example: 1
@@ -1956,7 +1956,7 @@ paths:
       tags:
       - Gateway accounts
     post:
-      operationId: updateGatewayAccountAcceptedCardTypesPreDegateway
+      operationId: updateGatewayAccountAcceptedCardTypesByGatewayAccountId
       parameters:
       - description: Gateway account ID
         example: 1
@@ -2390,6 +2390,50 @@ paths:
       summary: Get Worldpay 3DS Flex DDC JWT
       tags:
       - Charges - Frontend
+  /v1/frontend/service/{serviceId}/account/{accountType}/3ds-toggle:
+    patch:
+      operationId: updateGatewayAccount3dsToggleByServiceId
+      parameters:
+      - description: Gateway account ID
+        example: 1
+        in: path
+        name: serviceId
+        required: true
+        schema:
+          type: string
+      - description: Account type
+        example: test
+        in: path
+        name: accountType
+        required: true
+        schema:
+          type: string
+          enum:
+          - test
+          - live
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+              example:
+                toggle_3ds: "true"
+      responses:
+        "200":
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "404":
+          description: Not found
+        "409":
+          description: Conflict - 3ds cannot be disabled for account
+      summary: Set requires3ds flag on a gateway account
+      tags:
+      - Gateway accounts
   /v1/frontend/service/{serviceId}/account/{accountType}/card-types:
     get:
       operationId: getAcceptedCardTypesByServiceIdAndAccountType
@@ -2432,7 +2476,7 @@ paths:
       tags:
       - Gateway accounts
     post:
-      operationId: updateGatewayAccountAcceptedCardTypesDegateway
+      operationId: updateGatewayAccountAcceptedCardTypesByServiceId
       parameters:
       - description: Service ID
         example: 1
@@ -5231,6 +5275,13 @@ components:
         updated:
           type: string
           example: 2022-06-28T10:41:40.460Z
+    Update3dsToggleRequest:
+      type: object
+      properties:
+        toggle_3ds:
+          type: boolean
+      required:
+      - toggle_3ds
     UpdateServiceNameRequest:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Update3dsToggleRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Update3dsToggleRequest.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotNull;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Update3dsToggleRequest {
+    
+    @NotNull
+    @JsonProperty(value = "toggle_3ds")
+    boolean toggle3ds;
+
+    public boolean isToggle3ds() {
+        return toggle3ds;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -463,9 +463,11 @@ public class GatewayAccountResource {
                     @ApiResponse(responseCode = "409", description = "Conflict - 3ds cannot be disabled for account")
             }
     )
-    public Response updateGatewayAccount3dsToggleByServiceId(@Parameter(example = "1", description = "Gateway account ID") @PathParam("serviceId") String serviceId,
-                                                             @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType,
-                                                             Update3dsToggleRequest update3dsToggleRequest) {
+    public Response updateGatewayAccount3dsToggleByServiceId(
+            @Parameter(example = "46eb1b601348499196c99de90482ee68", description = "Service ID") @PathParam("serviceId") String serviceId,
+            @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType,
+            Update3dsToggleRequest update3dsToggleRequest) {
+        
         return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
                 .map(gatewayAccount ->
                         {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -29,6 +29,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountWithCredentialsWithInternalIdResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountWithCredentialsResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountsListDTO;
+import uk.gov.pay.connector.gatewayaccount.model.Update3dsToggleRequest;
 import uk.gov.pay.connector.gatewayaccount.model.UpdateServiceNameRequest;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
@@ -442,6 +443,41 @@ public class GatewayAccountResource {
                 .orElseGet(() ->
                         notFoundResponse(format("The gateway account id '%s' does not exist", gatewayAccountId)));
     }
+
+    @PATCH
+    @Path("/v1/frontend/service/{serviceId}/account/{accountType}/3ds-toggle")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @Transactional
+    @Operation(
+            summary = "Set requires3ds flag on a gateway account",
+            tags = {"Gateway accounts"},
+            requestBody = @RequestBody(content = @Content(schema = @Schema(example = "{" +
+                    "  \"toggle_3ds\": \"true\"" +
+                    "}"))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "400", description = "Bad request",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not found"),
+                    @ApiResponse(responseCode = "409", description = "Conflict - 3ds cannot be disabled for account")
+            }
+    )
+    public Response updateGatewayAccount3dsToggleByServiceId(@Parameter(example = "1", description = "Gateway account ID") @PathParam("serviceId") String serviceId,
+                                                             @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType,
+                                                             Update3dsToggleRequest update3dsToggleRequest) {
+        return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
+                .map(gatewayAccount ->
+                        {
+                            if (!update3dsToggleRequest.isToggle3ds() && gatewayAccount.hasAnyAcceptedCardType3dsRequired()) {
+                                return Response.status(Status.CONFLICT).build();
+                            }
+                            gatewayAccount.setRequires3ds(update3dsToggleRequest.isToggle3ds());
+                            return Response.ok().build();
+                        }
+                )
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
+    }
     
     @PATCH
     @Path("/v1/frontend/accounts/{accountId}/3ds-toggle")
@@ -462,8 +498,8 @@ public class GatewayAccountResource {
                     @ApiResponse(responseCode = "409", description = "Conflict - 3ds cannot be disabled for account")
             }
     )
-    public Response updateGatewayAccount3dsToggle(@Parameter(example = "1", description = "Gateway account ID") @PathParam("accountId") Long gatewayAccountId,
-                                                  Map<String, String> gatewayAccountPayload) {
+    public Response updateGatewayAccount3dsToggleByGatewayAccountId(@Parameter(example = "1", description = "Gateway account ID") @PathParam("accountId") Long gatewayAccountId,
+                                                                    Map<String, String> gatewayAccountPayload) {
         if (!gatewayAccountPayload.containsKey(REQUIRES_3DS_FIELD_NAME)) {
             return fieldsMissingResponse(Collections.singletonList(REQUIRES_3DS_FIELD_NAME));
         }
@@ -505,7 +541,7 @@ public class GatewayAccountResource {
                     @ApiResponse(responseCode = "409", description = "Conflict - requires3DS is false on gateway account but atleast one card type requires 3DS to be enabled. ")
             }
     )
-    public Response updateGatewayAccountAcceptedCardTypesPreDegateway(
+    public Response updateGatewayAccountAcceptedCardTypesByGatewayAccountId(
             @Parameter(example = "1", description = "Gateway account ID") @PathParam("accountId") Long gatewayAccountId,
             Map<String, List<UUID>> cardTypes) {
 
@@ -542,7 +578,7 @@ public class GatewayAccountResource {
                     @ApiResponse(responseCode = "409", description = "Conflict - requires3DS is false on gateway account but atleast one card type requires 3DS to be enabled. ")
             }
     )
-    public Response updateGatewayAccountAcceptedCardTypesDegateway(
+    public Response updateGatewayAccountAcceptedCardTypesByServiceId(
             @Parameter(example = "1", description = "Service ID") @PathParam("serviceId") String serviceId,
             @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType,
             Map<String, List<UUID>> cardTypes) {


### PR DESCRIPTION
Add a new endpoint `PATCH /v1/frontend/service/{serviceId}/account/{accountType}/3ds-toggle` to update a gateway account's 3ds toggle setting based on the service id and account type.