### PR TITLE
PP-12703: Move existing switch psp integration tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -304,18 +304,11 @@
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java": [
       {
-        "type": "Secret Keyword",
-        "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 82
-      },
-      {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 135
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java": [
@@ -1068,5 +1061,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-14T16:31:19Z"
+  "generated_at": "2024-06-17T09:53:41Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -78,8 +78,6 @@ public class GatewayAccountResource {
     private static final String REQUIRES_3DS_FIELD_NAME = "toggle_3ds";
     private static final String CARD_TYPES_FIELD_NAME = "card_types";
     private static final int SERVICE_NAME_FIELD_LENGTH = 50;
-    private static final String USERNAME_KEY = "username";
-    private static final String PASSWORD_KEY = "password";
     private final GatewayAccountService gatewayAccountService;
     private final CardTypeDao cardTypeDao;
     private final GatewayAccountRequestValidator validator;

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.it.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
@@ -23,59 +24,62 @@ public class GatewayAccountResourceSwitchPspIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
 
-    private static ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Test
-    public void shouldSwitchPaymentProvider() throws JsonProcessingException {
-        String gatewayAccountId = "1000024";
-        String activeExtId = randomUuid();
-        String switchToExtId = randomUuid();
+    @Nested
+    class ByGatewayAccountId {
+        @Test
+        public void shouldSwitchPaymentProvider() throws JsonProcessingException {
+            String gatewayAccountId = "1000024";
+            String activeExtId = randomUuid();
+            String switchToExtId = randomUuid();
 
-        AddGatewayAccountCredentialsParams activeParams =
-                AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder
-                        .anAddGatewayAccountCredentialsParams()
-                        .withGatewayAccountId(Long.valueOf(gatewayAccountId))
-                        .withCredentials(Map.of())
-                        .withExternalId(activeExtId)
-                        .withState(ACTIVE)
-                        .build();
+            AddGatewayAccountCredentialsParams activeParams =
+                    AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder
+                            .anAddGatewayAccountCredentialsParams()
+                            .withGatewayAccountId(Long.valueOf(gatewayAccountId))
+                            .withCredentials(Map.of())
+                            .withExternalId(activeExtId)
+                            .withState(ACTIVE)
+                            .build();
 
-        AddGatewayAccountCredentialsParams switchToParams =
-                AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder
-                        .anAddGatewayAccountCredentialsParams()
-                        .withGatewayAccountId(Long.valueOf(gatewayAccountId))
-                        .withCredentials(Map.of())
-                        .withExternalId(switchToExtId)
-                        .withState(VERIFIED_WITH_LIVE_PAYMENT)
-                        .withPaymentProvider("stripe")
-                        .build();
+            AddGatewayAccountCredentialsParams switchToParams =
+                    AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder
+                            .anAddGatewayAccountCredentialsParams()
+                            .withGatewayAccountId(Long.valueOf(gatewayAccountId))
+                            .withCredentials(Map.of())
+                            .withExternalId(switchToExtId)
+                            .withState(VERIFIED_WITH_LIVE_PAYMENT)
+                            .withPaymentProvider("stripe")
+                            .build();
 
-        app.getDatabaseTestHelper().addGatewayAccount(
-                anAddGatewayAccountParams()
-                        .withAccountId(gatewayAccountId)
-                        .withPaymentGateway("stripe")
-                        .withServiceName("a cool service")
-                        .withProviderSwitchEnabled(true)
-                        .withGatewayAccountCredentials(List.of(activeParams, switchToParams))
-                        .build());
+            app.getDatabaseTestHelper().addGatewayAccount(
+                    anAddGatewayAccountParams()
+                            .withAccountId(gatewayAccountId)
+                            .withPaymentGateway("stripe")
+                            .withServiceName("a cool service")
+                            .withProviderSwitchEnabled(true)
+                            .withGatewayAccountCredentials(List.of(activeParams, switchToParams))
+                            .build());
 
-        String payload = objectMapper.writeValueAsString(Map.of("user_external_id", "some-user-external-id",
-                "gateway_account_credential_external_id", switchToExtId));
+            String payload = objectMapper.writeValueAsString(Map.of("user_external_id", "some-user-external-id",
+                    "gateway_account_credential_external_id", switchToExtId));
 
-        app.givenSetup()
-                .body(payload)
-                .post("/v1/api/accounts/" + gatewayAccountId + "/switch-psp")
-                .then()
-                .statusCode(OK.getStatusCode());
+            app.givenSetup()
+                    .body(payload)
+                    .post("/v1/api/accounts/" + gatewayAccountId + "/switch-psp")
+                    .then()
+                    .statusCode(OK.getStatusCode());
 
-        Map<String, Object> account = app.getDatabaseTestHelper().getGatewayAccount(Long.valueOf(gatewayAccountId));
-        assertThat((Integer) account.get("integration_version_3ds"), is(2));
-        assertThat((Boolean) account.get("provider_switch_enabled"), is(false));
+            Map<String, Object> account = app.getDatabaseTestHelper().getGatewayAccount(Long.valueOf(gatewayAccountId));
+            assertThat((Integer) account.get("integration_version_3ds"), is(2));
+            assertThat((Boolean) account.get("provider_switch_enabled"), is(false));
 
-        Map<String, Object> retiredCredentials = app.getDatabaseTestHelper().getGatewayAccountCredentialByExternalId(activeExtId);
-        assertThat(retiredCredentials.get("state").toString(), is(RETIRED.name()));
+            Map<String, Object> retiredCredentials = app.getDatabaseTestHelper().getGatewayAccountCredentialByExternalId(activeExtId);
+            assertThat(retiredCredentials.get("state").toString(), is(RETIRED.name()));
 
-        Map<String, Object> activeCredentials = app.getDatabaseTestHelper().getGatewayAccountCredentialByExternalId(switchToExtId);
-        assertThat(activeCredentials.get("state").toString(), is(ACTIVE.name()));
+            Map<String, Object> activeCredentials = app.getDatabaseTestHelper().getGatewayAccountCredentialByExternalId(switchToExtId);
+            assertThat(activeCredentials.get("state").toString(), is(ACTIVE.name()));
+        }
     }
 }


### PR DESCRIPTION
This is to make later PR reviewing (for switching psp by service id and account type) easier.
