### PR TITLE
PP-12703: Test for successfully switching PSP by service id and account type

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -135,56 +139,56 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 2963
+        "line_number": 3004
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 3007
+        "line_number": 3048
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3474
+        "line_number": 3515
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 3863
+        "line_number": 3904
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 3899
+        "line_number": 3940
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 4827
+        "line_number": 4868
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5310
+        "line_number": 5351
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5321
+        "line_number": 5362
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1057,5 +1061,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-17T13:19:39Z"
+  "generated_at": "2024-06-18T10:31:53Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1766,6 +1766,47 @@ paths:
         given service ID and account type
       tags:
       - Gateway accounts
+  /v1/api/service/{serviceId}/account/{accountType}/switch-psp:
+    post:
+      operationId: switchPaymentProvider_1
+      parameters:
+      - description: Service ID
+        example: 1
+        in: path
+        name: serviceId
+        required: true
+        schema:
+          type: string
+      - description: Account type
+        example: test
+        in: path
+        name: accountType
+        required: true
+        schema:
+          type: string
+          enum:
+          - test
+          - live
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GatewayAccountSwitchPaymentProviderRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "404":
+          description: Not found
+      summary: Switch payment provider of a gateway account
+      tags:
+      - Gateway accounts
   /v1/api/service/{serviceId}/account/{accountType}/worldpay/check-3ds-flex-config:
     post:
       operationId: validateWorldpay3dsCredentialsByServiceIdAndType

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
@@ -2,22 +2,29 @@ package uk.gov.pay.connector.it.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
+import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.util.List;
 import java.util.Map;
 
+import static java.lang.String.format;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.VERIFIED_WITH_LIVE_PAYMENT;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
+import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class GatewayAccountResourceSwitchPspIT {
@@ -27,9 +34,122 @@ public class GatewayAccountResourceSwitchPspIT {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Nested
-    class ByGatewayAccountId {
+    class ByServiceIdAndAccountType {
+
+        private final String serviceId = RandomIdGenerator.newId();
+
         @Test
-        public void shouldSwitchPaymentProvider() throws JsonProcessingException {
+        void switchPaymentProviderFromWorldpayToStripeSuccessfully() {
+            setupWorldpayGatewayAccount();
+            String worldpayCredentialsId = setupCredentialsForWorldpayGatewayAccount();
+            updateProviderSwitchEnabledOnWorldpayGatewayAccount();
+            verifyWorldpayCredentialsIsActiveAndProviderSwitchIsEnabled();
+            String stripeCredentialsExternalId = addStripeCredentialsOnTheGatewayAccount();
+
+            String switchPspPayload = toJson(Map.of("user_external_id", "some-user-external-id",
+                    "gateway_account_credential_external_id", stripeCredentialsExternalId));
+
+            app.givenSetup()
+                    .body(switchPspPayload)
+                    .post(format("/v1/api/service/%s/account/test/switch-psp", serviceId))
+                    .then()
+                    .statusCode(OK.getStatusCode());
+
+            app.givenSetup()
+                    .get(format("/v1/api/service/%s/account/test", serviceId))
+                    .then()
+                    .statusCode(OK.getStatusCode())
+                    .body("provider_switch_enabled", is(false))
+                    .body("gateway_account_credentials[0].state", is("RETIRED"))
+                    .body("gateway_account_credentials[0].external_id", is(worldpayCredentialsId))
+                    .body("gateway_account_credentials[1].state", is("ACTIVE"))
+                    .body("gateway_account_credentials[1].external_id", is(stripeCredentialsExternalId));
+        }
+
+        private String addStripeCredentialsOnTheGatewayAccount() {
+            String stripeCredentialsExternalId = app.givenSetup()
+                    .body(toJson(Map.of("payment_provider", "stripe",
+                            "credentials", Map.of("stripe_account_id", "some-account-id"))))
+                    .post(format("/v1/api/service/%s/account/test/credentials", serviceId))
+                    .then()
+                    .statusCode(OK.getStatusCode())
+                    .extract()
+                    .path("external_id");
+
+            app.givenSetup()
+                    .body(toJson(List.of(
+                            Map.of("op", "replace",
+                                    "path", "state",
+                                    "value", "VERIFIED_WITH_LIVE_PAYMENT")
+                    )))
+                    .patch(format("/v1/api/service/%s/account/test/credentials/%s", serviceId, stripeCredentialsExternalId))
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasKey("credentials"))
+                    .body("credentials.stripe_account_id", is("some-account-id"))
+                    .body("state", CoreMatchers.is("VERIFIED_WITH_LIVE_PAYMENT"));
+            
+            return stripeCredentialsExternalId;
+        }
+
+        private void verifyWorldpayCredentialsIsActiveAndProviderSwitchIsEnabled() {
+            app.givenSetup()
+                    .get(format("/v1/api/service/%s/account/test", serviceId))
+                    .then()
+                    .statusCode(OK.getStatusCode())
+                    .body("provider_switch_enabled", is(true))
+                    .body("gateway_account_credentials", hasSize(1))
+                    .body("gateway_account_credentials[0].payment_provider", is("worldpay"))
+                    .body("gateway_account_credentials[0].state", is("ACTIVE"));
+        }
+
+        private void updateProviderSwitchEnabledOnWorldpayGatewayAccount() {
+            app.givenSetup()
+                    .body(toJson(Map.of("op", "replace",
+                            "path", "provider_switch_enabled",
+                            "value", true)))
+                    .patch(format("/v1/api/service/%s/account/test", serviceId))
+                    .then()
+                    .statusCode(OK.getStatusCode());
+        }
+
+        private String setupCredentialsForWorldpayGatewayAccount() {
+            String worldpayCredentialsId = app.givenSetup()
+                    .get(format("/v1/api/service/%s/account/test", serviceId))
+                    .then()
+                    .extract()
+                    .path("gateway_account_credentials[0].external_id");
+
+            app.givenSetup()
+                    .body(toJson(List.of(
+                            Map.of("op", "replace",
+                                    "path", "credentials/worldpay/one_off_customer_initiated",
+                                    "value", Map.of("merchant_code", "new-merchant-code",
+                                            "username", "new-username",
+                                            "password", "new-password")))))
+                    .patch(format("/v1/api/service/%s/account/test/credentials/%s", serviceId, worldpayCredentialsId))
+                    .then()
+                    .statusCode(200);
+            
+            return worldpayCredentialsId;
+        }
+
+        private void setupWorldpayGatewayAccount() {
+            Map<String, String> gatewayAccountRequest = Map.of(
+                    "payment_provider", "worldpay",
+                    "service_id", serviceId,
+                    "service_name", "Service Name",
+                    "type", "test");
+
+            app.givenSetup().body(toJson(gatewayAccountRequest)).post(ACCOUNTS_API_URL);
+        }
+    }
+    
+    @Nested
+    class ByGatewayAccountId {
+        
+        @Test
+        void shouldSwitchPaymentProvider() throws JsonProcessingException {
             String gatewayAccountId = "1000024";
             String activeExtId = randomUuid();
             String switchToExtId = randomUuid();


### PR DESCRIPTION
This commit migrates the old ByGatewayAccountId.shouldSwitchPaymentProvider test to switch by service id and account type. The old test asserts the integration_version_3ds is 2; however existing code in the GatewayAccountSwitchPaymentProviderService does not set the integration_version_3ds to 2. Historically, the integration_version_3ds should be set to 2 when switching from Worldpay to Stripe (see acceptance criteria on PP-8191); however this has been superseded by PP-11591 where a Worldpay account will always have integration_version_3ds set to 2. Therefore the old assertion is no longer necessary.

Also unlike many other tests, the new
ByServiceIdAndAccountType.switchPaymentProviderFromWorldpayToStripeSuccessfully test sets up test data using APIs only (as opposed to setting up state by directly inserting data into the database). I'm not sure using APIs only should always be done, but at least we now have one place where anyone can easily understand how the state for a switching psp scenario is set up from an API point of view.