### PR TITLE
bau: Fix example for updating gateway account creds

### DIFF
--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -717,7 +717,7 @@ paths:
               example:
               - op: replace
                 path: state
-                value: ACTIVE
+                value: VERIFIED_WITH_LIVE_PAYMENT
       responses:
         "200":
           content:
@@ -1590,7 +1590,7 @@ paths:
               example:
               - op: replace
                 path: state
-                value: ACTIVE
+                value: VERIFIED_WITH_LIVE_PAYMENT
       responses:
         "200":
           content:

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
@@ -189,7 +189,7 @@ public class GatewayAccountCredentialsResource {
                     "    {" +
                     "        \"op\": \"replace\"," +
                     "        \"path\": \"state\"," +
-                    "        \"value\": \"ACTIVE\"" +
+                    "        \"value\": \"VERIFIED_WITH_LIVE_PAYMENT\"" +
                     "    }" +
                     "]"))),
             responses = {
@@ -324,7 +324,7 @@ public class GatewayAccountCredentialsResource {
                     "    {" +
                     "        \"op\": \"replace\"," +
                     "        \"path\": \"state\"," +
-                    "        \"value\": \"ACTIVE\"" +
+                    "        \"value\": \"VERIFIED_WITH_LIVE_PAYMENT\"" +
                     "    }" +
                     "]"))),
             responses = {


### PR DESCRIPTION
The example provided is incorrect as the state cannot be updated to "ACTIVE" directly. This is line with the [validation
code](https://github.com/alphagov/pay-connector/blob/master/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java#L137-L143). Furthermore, this
[commit](https://github.com/alphagov/pay-connector/commit/c915400f) states that all states, with the exception of "VERIFIED_WITH_LIVE_PAYMENT", are made internally by connector.