### PR TITLE
BAU enable junit5 displayname in maven lifecycle output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <pay-java-commons.version>1.0.20240603094506</pay-java-commons.version>
-        <surefire.version>3.3.0</surefire.version>
         <jjwt.version>0.12.3</jjwt.version>
         <pact.version>4.6.10</pact.version>
         <eclipselink.version>2.7.13</eclipselink.version>
         <swagger-version>2.2.22</swagger-version>
         <prometheus.version>0.16.0</prometheus.version>
+        <maven.surefire.junit5.tree.reporter.version>1.2.1</maven.surefire.junit5.tree.reporter.version>
 
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>
@@ -558,7 +558,25 @@
                     <forkCount>1</forkCount>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <reportsDirectory>${project.build.directory}/failsafe-reports</reportsDirectory>
+                    <reportFormat>plain</reportFormat>
+                    <consoleOutputReporter>
+                        <disable>true</disable>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter
+                            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>me.fabriciorby</groupId>
+                        <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                        <version>${maven.surefire.junit5.tree.reporter.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.3.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -641,13 +659,27 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.version}</version>
                         <configuration>
                             <excludes>
                                 <exclude>**/*ContractTest.java</exclude>
                                 <exclude>**/*ContractTestSuite.java</exclude>
                             </excludes>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                            <reportFormat>plain</reportFormat>
+                            <consoleOutputReporter>
+                                <disable>true</disable>
+                            </consoleOutputReporter>
+                            <statelessTestsetInfoReporter
+                                    implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                         </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>me.fabriciorby</groupId>
+                                <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                                <version>${maven.surefire.junit5.tree.reporter.version}</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>
@@ -663,7 +695,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.version}</version>
                         <configuration>
                             <includes>
                                 <include>**/*ContractTestSuite.java</include>


### PR DESCRIPTION
## WHAT YOU DID

- update surefire and failsafe plugin configurations to show junit5 display names and nested test blocks in maven lifecycle output
  - ![image](https://github.com/alphagov/pay-connector/assets/1949148/1455ca2b-6d7f-47e3-bf41-a27d94ef21b1)

-  exclude contract tests profile as pact tests aren't compatible with the new report format
  - ![image](https://github.com/alphagov/pay-connector/assets/1949148/5081f99a-f042-4e9b-8ed2-2565c149ef0e)
  - ![image](https://github.com/alphagov/pay-connector/assets/1949148/b99c50ac-59d1-4e38-b74e-7c54565de083)

 