### PR TITLE
PP-12360 Add Nested blocks to tests for refunds API endpoints

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.charge.model.ChargeResponse;
@@ -73,337 +74,343 @@ public class SandboxRefundsResourceIT  {
                 .withGatewayCredentialId(testBaseExtension.getCredentialParams().getId())
                 .insert();
     }
-
-    @Test
-    void shouldRespond_403_WhenGatewayAccountDisabled() {
-        Long refundAmount = 50L;
-
-        app.getDatabaseTestHelper().setDisabled(defaultTestAccount.getAccountId());
-
-        postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
-                .statusCode(FORBIDDEN_403)
-                .body("message", contains("This gateway account is disabled"))
-                .body("error_identifier", is(ErrorIdentifier.ACCOUNT_DISABLED.toString()));
-    }
     
-    @Test
-    void shouldBeAbleToRequestARefund_partialAmount() {
-        Long refundAmount = 50L;
-        ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
-
-        String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUNDED")));
-
-        assertRefundsHistoryInOrderInDBForSuccessfulOrPartialRefund(defaultTestCharge);
-    }
-
-    @Test
-    void shouldBeAbleToRefundTwoRequestsWhereAmountAvailableMatch() {
-        Long refundAmount = 50L;
-        //first refund request
-        ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
-        String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
-
-        //second refund request with updated refundAmountAvailable
-        validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount() - refundAmount);
-        String refundId_2 = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(2));
-        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUNDED")));
-        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId_2, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUNDED")));
-
-        assertRefundsHistoryInOrderInDBForTwoRefunds(defaultTestCharge);
-    }
-
-    @Test
-    void shouldRespond_412_WhenSecondRefundRequestAmountAvailableMismatches() {
-        Long refundAmount = 50L;
-        //first refund request
-        ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
-        String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
-
-        //second refund request with wrong refundAmountAvailable
-        postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
-                .statusCode(PRECONDITION_FAILED.getStatusCode())
-                .body("message", contains("Refund Amount Available Mismatch"))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH.toString()));
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUNDED")));
-
-        assertRefundsHistoryInOrderInDBForSuccessfulOrPartialRefund(defaultTestCharge);
-    }
-
-    @Test
-    void shouldBeAbleToRequestARefund_fullAmount() {
-
-        Long refundAmount = defaultTestCharge.getAmount();
-
-        ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount(),
-                userExternalId, userEmail);
-        String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUNDED")));
-        assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("user_external_id", userExternalId));
-        assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("user_email", userEmail));
-        assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
-
-        assertRefundsHistoryInOrderInDBForSuccessfulOrPartialRefund(defaultTestCharge);
-    }
-
-    @Test
-    void shouldBeAbleToRequestARefund_multiplePartialAmounts_andRefundShouldBeInFullStatus() {
-        Long firstRefundAmount = 80L;
-        Long secondRefundAmount = 20L;
-        String externalChargeId = defaultTestCharge.getExternalChargeId();
-
-        ValidatableResponse firstValidatableResponse = postRefundFor(externalChargeId, firstRefundAmount, defaultTestCharge.getAmount());
-        String firstRefundId = assertRefundResponseWith(firstRefundAmount, firstValidatableResponse, ACCEPTED.getStatusCode());
-
-        ValidatableResponse secondValidatableResponse = postRefundFor(externalChargeId, secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount);
-        String secondRefundId = assertRefundResponseWith(secondRefundAmount, secondValidatableResponse, ACCEPTED.getStatusCode());
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(externalChargeId);
-        assertThat(refundsFoundByChargeExternalId.size(), is(2));
-
-        assertThat(refundsFoundByChargeExternalId, hasItems(
-                aRefundMatching(secondRefundId, is(notNullValue()), externalChargeId, secondRefundAmount, "REFUNDED"),
-                aRefundMatching(firstRefundId, is(notNullValue()), externalChargeId, firstRefundAmount, "REFUNDED")));
-
-        assertRefundsHistoryInOrderInDBForTwoRefunds(defaultTestCharge);
-
-        testBaseExtension.getConnectorRestApiClient().withChargeId(externalChargeId)
-                .getCharge()
-                .statusCode(200)
-                .body("refund_summary.status", is("full"))
-                .body("refund_summary.amount_available", is(0))
-                .body("refund_summary.amount_submitted", is(100));
-    }
-
-    @Test
-    void shouldFailRequestingARefund_whenChargeStatusMakesItNotRefundable() {
+    @Nested
+    class ByAccountId {
+        @Nested
+        class SubmitRefund {
+            @Test
+            void shouldRespond_403_WhenGatewayAccountDisabled() {
+                Long refundAmount = 50L;
+
+                app.getDatabaseTestHelper().setDisabled(defaultTestAccount.getAccountId());
+
+                postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(FORBIDDEN_403)
+                        .body("message", contains("This gateway account is disabled"))
+                        .body("error_identifier", is(ErrorIdentifier.ACCOUNT_DISABLED.toString()));
+            }
+
+            @Test
+            void shouldBeAbleToRequestARefund_partialAmount() {
+                Long refundAmount = 50L;
+                ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
+
+                String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUNDED")));
+
+                assertRefundsHistoryInOrderInDBForSuccessfulOrPartialRefund(defaultTestCharge);
+            }
+
+            @Test
+            void shouldBeAbleToRefundTwoRequestsWhereAmountAvailableMatch() {
+                Long refundAmount = 50L;
+                //first refund request
+                ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
+                String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
+
+                //second refund request with updated refundAmountAvailable
+                validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount() - refundAmount);
+                String refundId_2 = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(2));
+                assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUNDED")));
+                assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId_2, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUNDED")));
+
+                assertRefundsHistoryInOrderInDBForTwoRefunds(defaultTestCharge);
+            }
+
+            @Test
+            void shouldRespond_412_WhenSecondRefundRequestAmountAvailableMismatches() {
+                Long refundAmount = 50L;
+                //first refund request
+                ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
+                String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
+
+                //second refund request with wrong refundAmountAvailable
+                postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(PRECONDITION_FAILED.getStatusCode())
+                        .body("message", contains("Refund Amount Available Mismatch"))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH.toString()));
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUNDED")));
+
+                assertRefundsHistoryInOrderInDBForSuccessfulOrPartialRefund(defaultTestCharge);
+            }
+
+            @Test
+            void shouldBeAbleToRequestARefund_fullAmount() {
+
+                Long refundAmount = defaultTestCharge.getAmount();
+
+                ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount(),
+                        userExternalId, userEmail);
+                String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUNDED")));
+                assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("user_external_id", userExternalId));
+                assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("user_email", userEmail));
+                assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
+
+                assertRefundsHistoryInOrderInDBForSuccessfulOrPartialRefund(defaultTestCharge);
+            }
+
+            @Test
+            void shouldBeAbleToRequestARefund_multiplePartialAmounts_andRefundShouldBeInFullStatus() {
+                Long firstRefundAmount = 80L;
+                Long secondRefundAmount = 20L;
+                String externalChargeId = defaultTestCharge.getExternalChargeId();
+
+                ValidatableResponse firstValidatableResponse = postRefundFor(externalChargeId, firstRefundAmount, defaultTestCharge.getAmount());
+                String firstRefundId = assertRefundResponseWith(firstRefundAmount, firstValidatableResponse, ACCEPTED.getStatusCode());
+
+                ValidatableResponse secondValidatableResponse = postRefundFor(externalChargeId, secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount);
+                String secondRefundId = assertRefundResponseWith(secondRefundAmount, secondValidatableResponse, ACCEPTED.getStatusCode());
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(externalChargeId);
+                assertThat(refundsFoundByChargeExternalId.size(), is(2));
+
+                assertThat(refundsFoundByChargeExternalId, hasItems(
+                        aRefundMatching(secondRefundId, is(notNullValue()), externalChargeId, secondRefundAmount, "REFUNDED"),
+                        aRefundMatching(firstRefundId, is(notNullValue()), externalChargeId, firstRefundAmount, "REFUNDED")));
+
+                assertRefundsHistoryInOrderInDBForTwoRefunds(defaultTestCharge);
 
-        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestCharge()
-                .withAmount(100L)
-                .withTestAccount(defaultTestAccount)
-                .withChargeStatus(ENTERING_CARD_DETAILS)
-                .insert();
-
-        Long refundAmount = 20L;
-
-        postRefundFor(testCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("reason", is("pending"))
-                .body("message", contains(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(0));
-    }
-
-    @Test
-    void shouldFailRequestingARefund_whenChargeRefundIsFull() {
-
-        Long refundAmount = defaultTestCharge.getAmount();
-        String externalChargeId = defaultTestCharge.getExternalChargeId();
-
-        postRefundFor(externalChargeId, refundAmount, defaultTestCharge.getAmount())
-                .statusCode(ACCEPTED.getStatusCode());
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(externalChargeId);
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-
-        postRefundFor(externalChargeId, 1L, defaultTestCharge.getAmount() - refundAmount)
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("reason", is("full"))
-                .body("message", contains(format("Charge with id [%s] not available for refund.", externalChargeId)))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
-    }
-
-    @Test
-    void shouldFailRequestingARefund_whenAmountIsBiggerThanChargeAmount() {
-        Long refundAmount = defaultTestCharge.getAmount() + 20;
-
-        postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("reason", is("amount_not_available"))
-                .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(0));
-
-        List<String> refundsHistory = app.getDatabaseTestHelper().getRefundsHistoryByChargeExternalId(defaultTestCharge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
-        assertThat(refundsHistory.size(), is(0));
-    }
-
-    @Test
-    void shouldFailRequestingARefund_whenAmountIsBiggerThanAllowedChargeAmount() {
-
-        Long refundAmount = 10000001L;
-
-        postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("reason", is("amount_not_available"))
-                .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(0));
-
-        List<String> refundsHistory = app.getDatabaseTestHelper().getRefundsHistoryByChargeExternalId(defaultTestCharge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
-        assertThat(refundsHistory.size(), is(0));
-    }
-
-    @Test
-    void shouldFailRequestingARefund_whenAmountIsLessThanOnePence() {
-
-        Long refundAmount = 0L;
-
-        postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("reason", is("amount_min_validation"))
-                .body("message", contains("Validation error for amount. Minimum amount for a refund is 1"))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(0));
-
-        List<String> refundsHistory = app.getDatabaseTestHelper().getRefundsHistoryByChargeExternalId(defaultTestCharge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
-        assertThat(refundsHistory.size(), is(0));
-    }
-
-    @Test
-    void shouldFailRequestingARefund_whenAPartialRefundMakesTotalRefundedAmountBiggerThanChargeAmount() {
-        Long firstRefundAmount = 80L;
-        Long secondRefundAmount = 30L; // 10 more than available
-
-        ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), firstRefundAmount, defaultTestCharge.getAmount());
-        String firstRefundId = assertRefundResponseWith(firstRefundAmount, validatableResponse, ACCEPTED.getStatusCode());
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(firstRefundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), firstRefundAmount, "REFUNDED")));
-
-        postRefundFor(defaultTestCharge.getExternalChargeId(), secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount)
-                .statusCode(400)
-                .body("reason", is("amount_not_available"))
-                .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId1 = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId1.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId1, hasItems(aRefundMatching(firstRefundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), firstRefundAmount, "REFUNDED")));
-
-        assertRefundsHistoryInOrderInDBForSuccessfulOrPartialRefund(defaultTestCharge);
-    }
-
-    @Test
-    void shouldFailRequestingARefundForHistoricCharge_whenPartialRefundAmountGreaterThanRemainingAmount_whenExistingPartialRefundsHaveBeenExpunged() throws Exception {
-        String chargeExternalId = "historic-charge-id";
-        
-        ChargeResponse.RefundSummary refundSummary = new ChargeResponse.RefundSummary();
-        refundSummary.setStatus("available");
-        LedgerTransaction charge = aValidLedgerTransaction()
-                .withExternalId(chargeExternalId)
-                .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withCredentialExternalId(testBaseExtension.getCredentialParams().getExternalId())
-                .withAmount(1000L)
-                .withRefundSummary(refundSummary)
-                .withPaymentProvider(testBaseExtension.getPaymentProvider())
-                .build();
-        app.getLedgerStub().returnLedgerTransaction(chargeExternalId, charge);
-
-        // add one refund that is still in connector and another that is only in ledger to check
-        // that both are used when calculating refundability
-        app.getDatabaseTestHelper().addRefund("connector-refund-id", 500L, RefundStatus.CREATED, "refund-gateway-id-1", ZonedDateTime.now(), chargeExternalId);
-
-        LedgerTransaction expungedRefund = aValidLedgerTransaction()
-                .withExternalId("ledger-refund-id")
-                .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withParentTransactionId(defaultTestCharge.getExternalChargeId())
-                .withCredentialExternalId(testBaseExtension.getCredentialParams().getExternalId())
-                .withAmount(300L)
-                .withStatus(ExternalRefundStatus.EXTERNAL_SUCCESS.getStatus())
-                .withPaymentProvider(testBaseExtension.getPaymentProvider())
-                .build();
-        app.getLedgerStub().returnRefundsForPayment(chargeExternalId, List.of(expungedRefund));
-
-        Long refundAmount = 201L;
-        postRefundFor(chargeExternalId, refundAmount, 200L)
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("reason", is("amount_not_available"))
-                .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
-    }
-
-    @Test
-    void shouldSucceedRequestingARefundForHistoricCharge_whenExistingPartialRefundsHaveBeenExpunged() throws Exception {
-        String chargeExternalId = "historic-charge-id";
-
-        ChargeResponse.RefundSummary refundSummary = new ChargeResponse.RefundSummary();
-        refundSummary.setStatus("available");
-        LedgerTransaction charge = aValidLedgerTransaction()
-                .withExternalId(chargeExternalId)
-                .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withCredentialExternalId(testBaseExtension.getCredentialParams().getExternalId())
-                .withAmount(1000L)
-                .withRefundSummary(refundSummary)
-                .withPaymentProvider(testBaseExtension.getPaymentProvider())
-                .build();
-        app.getLedgerStub().returnLedgerTransaction(chargeExternalId, charge);
-
-        // add one refund that is still in connector and another that is only in ledger to check
-        // that both are used when calculating refundability
-        app.getDatabaseTestHelper().addRefund("connector-refund-id", 500L, RefundStatus.CREATED, "refund-gateway-id-1", ZonedDateTime.now(), chargeExternalId);
-
-        LedgerTransaction expungedRefund = aValidLedgerTransaction()
-                .withExternalId("ledger-refund-id")
-                .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withCredentialExternalId(testBaseExtension.getCredentialParams().getExternalId())
-                .withParentTransactionId(defaultTestCharge.getExternalChargeId())
-                .withAmount(300L)
-                .withStatus(ExternalRefundStatus.EXTERNAL_SUCCESS.getStatus())
-                .withPaymentProvider(testBaseExtension.getPaymentProvider())
-                .build();
-        app.getLedgerStub().returnRefundsForPayment(chargeExternalId, List.of(expungedRefund));
-
-        Long refundAmount = 200L;
-        postRefundFor(chargeExternalId, refundAmount, 200L)
-                .statusCode(ACCEPTED.getStatusCode());
-    }
-
-    @Test
-    void shouldErrorRequestingARefundForHistoricCharge_whenErrorReturnedByLedger() throws Exception {
-        String chargeExternalId = "historic-charge-id";
-
-        ChargeResponse.RefundSummary refundSummary = new ChargeResponse.RefundSummary();
-        refundSummary.setStatus("available");
-        LedgerTransaction charge = aValidLedgerTransaction()
-                .withExternalId(chargeExternalId)
-                .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withCredentialExternalId(testBaseExtension.getCredentialParams().getExternalId())
-                .withAmount(1000L)
-                .withRefundSummary(refundSummary)
-                .build();
-        app.getLedgerStub().returnLedgerTransaction(chargeExternalId, charge);
-
-        app.getLedgerStub().returnErrorForFindRefundsForPayment(chargeExternalId);
-
-        postRefundFor(chargeExternalId, 200L, 200L)
-                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode());
-
-        List<Map<String, Object>> refunds = app.getDatabaseTestHelper().getRefundsByChargeExternalId(chargeExternalId);
-        assertThat(refunds, hasSize(0));
+                testBaseExtension.getConnectorRestApiClient().withChargeId(externalChargeId)
+                        .getCharge()
+                        .statusCode(200)
+                        .body("refund_summary.status", is("full"))
+                        .body("refund_summary.amount_available", is(0))
+                        .body("refund_summary.amount_submitted", is(100));
+            }
+
+            @Test
+            void shouldFailRequestingARefund_whenChargeStatusMakesItNotRefundable() {
+
+                DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
+                        .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                        .aTestCharge()
+                        .withAmount(100L)
+                        .withTestAccount(defaultTestAccount)
+                        .withChargeStatus(ENTERING_CARD_DETAILS)
+                        .insert();
+
+                Long refundAmount = 20L;
+
+                postRefundFor(testCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(BAD_REQUEST.getStatusCode())
+                        .body("reason", is("pending"))
+                        .body("message", contains(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(0));
+            }
+
+            @Test
+            void shouldFailRequestingARefund_whenChargeRefundIsFull() {
+
+                Long refundAmount = defaultTestCharge.getAmount();
+                String externalChargeId = defaultTestCharge.getExternalChargeId();
+
+                postRefundFor(externalChargeId, refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(ACCEPTED.getStatusCode());
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(externalChargeId);
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+
+                postRefundFor(externalChargeId, 1L, defaultTestCharge.getAmount() - refundAmount)
+                        .statusCode(BAD_REQUEST.getStatusCode())
+                        .body("reason", is("full"))
+                        .body("message", contains(format("Charge with id [%s] not available for refund.", externalChargeId)))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+            }
+
+            @Test
+            void shouldFailRequestingARefund_whenAmountIsBiggerThanChargeAmount() {
+                Long refundAmount = defaultTestCharge.getAmount() + 20;
+
+                postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(BAD_REQUEST.getStatusCode())
+                        .body("reason", is("amount_not_available"))
+                        .body("message", contains("Not sufficient amount available for refund"))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(0));
+
+                List<String> refundsHistory = app.getDatabaseTestHelper().getRefundsHistoryByChargeExternalId(defaultTestCharge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
+                assertThat(refundsHistory.size(), is(0));
+            }
+
+            @Test
+            void shouldFailRequestingARefund_whenAmountIsBiggerThanAllowedChargeAmount() {
+
+                Long refundAmount = 10000001L;
+
+                postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(BAD_REQUEST.getStatusCode())
+                        .body("reason", is("amount_not_available"))
+                        .body("message", contains("Not sufficient amount available for refund"))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(0));
+
+                List<String> refundsHistory = app.getDatabaseTestHelper().getRefundsHistoryByChargeExternalId(defaultTestCharge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
+                assertThat(refundsHistory.size(), is(0));
+            }
+
+            @Test
+            void shouldFailRequestingARefund_whenAmountIsLessThanOnePence() {
+
+                Long refundAmount = 0L;
+
+                postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(BAD_REQUEST.getStatusCode())
+                        .body("reason", is("amount_min_validation"))
+                        .body("message", contains("Validation error for amount. Minimum amount for a refund is 1"))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(0));
+
+                List<String> refundsHistory = app.getDatabaseTestHelper().getRefundsHistoryByChargeExternalId(defaultTestCharge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
+                assertThat(refundsHistory.size(), is(0));
+            }
+
+            @Test
+            void shouldFailRequestingARefund_whenAPartialRefundMakesTotalRefundedAmountBiggerThanChargeAmount() {
+                Long firstRefundAmount = 80L;
+                Long secondRefundAmount = 30L; // 10 more than available
+
+                ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), firstRefundAmount, defaultTestCharge.getAmount());
+                String firstRefundId = assertRefundResponseWith(firstRefundAmount, validatableResponse, ACCEPTED.getStatusCode());
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(firstRefundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), firstRefundAmount, "REFUNDED")));
+
+                postRefundFor(defaultTestCharge.getExternalChargeId(), secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount)
+                        .statusCode(400)
+                        .body("reason", is("amount_not_available"))
+                        .body("message", contains("Not sufficient amount available for refund"))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId1 = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId1.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId1, hasItems(aRefundMatching(firstRefundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), firstRefundAmount, "REFUNDED")));
+
+                assertRefundsHistoryInOrderInDBForSuccessfulOrPartialRefund(defaultTestCharge);
+            }
+
+            @Test
+            void shouldFailRequestingARefundForHistoricCharge_whenPartialRefundAmountGreaterThanRemainingAmount_whenExistingPartialRefundsHaveBeenExpunged() throws Exception {
+                String chargeExternalId = "historic-charge-id";
+
+                ChargeResponse.RefundSummary refundSummary = new ChargeResponse.RefundSummary();
+                refundSummary.setStatus("available");
+                LedgerTransaction charge = aValidLedgerTransaction()
+                        .withExternalId(chargeExternalId)
+                        .withGatewayAccountId(defaultTestAccount.getAccountId())
+                        .withCredentialExternalId(testBaseExtension.getCredentialParams().getExternalId())
+                        .withAmount(1000L)
+                        .withRefundSummary(refundSummary)
+                        .withPaymentProvider(testBaseExtension.getPaymentProvider())
+                        .build();
+                app.getLedgerStub().returnLedgerTransaction(chargeExternalId, charge);
+
+                // add one refund that is still in connector and another that is only in ledger to check
+                // that both are used when calculating refundability
+                app.getDatabaseTestHelper().addRefund("connector-refund-id", 500L, RefundStatus.CREATED, "refund-gateway-id-1", ZonedDateTime.now(), chargeExternalId);
+
+                LedgerTransaction expungedRefund = aValidLedgerTransaction()
+                        .withExternalId("ledger-refund-id")
+                        .withGatewayAccountId(defaultTestAccount.getAccountId())
+                        .withParentTransactionId(defaultTestCharge.getExternalChargeId())
+                        .withCredentialExternalId(testBaseExtension.getCredentialParams().getExternalId())
+                        .withAmount(300L)
+                        .withStatus(ExternalRefundStatus.EXTERNAL_SUCCESS.getStatus())
+                        .withPaymentProvider(testBaseExtension.getPaymentProvider())
+                        .build();
+                app.getLedgerStub().returnRefundsForPayment(chargeExternalId, List.of(expungedRefund));
+
+                Long refundAmount = 201L;
+                postRefundFor(chargeExternalId, refundAmount, 200L)
+                        .statusCode(BAD_REQUEST.getStatusCode())
+                        .body("reason", is("amount_not_available"))
+                        .body("message", contains("Not sufficient amount available for refund"))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+            }
+
+            @Test
+            void shouldSucceedRequestingARefundForHistoricCharge_whenExistingPartialRefundsHaveBeenExpunged() throws Exception {
+                String chargeExternalId = "historic-charge-id";
+
+                ChargeResponse.RefundSummary refundSummary = new ChargeResponse.RefundSummary();
+                refundSummary.setStatus("available");
+                LedgerTransaction charge = aValidLedgerTransaction()
+                        .withExternalId(chargeExternalId)
+                        .withGatewayAccountId(defaultTestAccount.getAccountId())
+                        .withCredentialExternalId(testBaseExtension.getCredentialParams().getExternalId())
+                        .withAmount(1000L)
+                        .withRefundSummary(refundSummary)
+                        .withPaymentProvider(testBaseExtension.getPaymentProvider())
+                        .build();
+                app.getLedgerStub().returnLedgerTransaction(chargeExternalId, charge);
+
+                // add one refund that is still in connector and another that is only in ledger to check
+                // that both are used when calculating refundability
+                app.getDatabaseTestHelper().addRefund("connector-refund-id", 500L, RefundStatus.CREATED, "refund-gateway-id-1", ZonedDateTime.now(), chargeExternalId);
+
+                LedgerTransaction expungedRefund = aValidLedgerTransaction()
+                        .withExternalId("ledger-refund-id")
+                        .withGatewayAccountId(defaultTestAccount.getAccountId())
+                        .withCredentialExternalId(testBaseExtension.getCredentialParams().getExternalId())
+                        .withParentTransactionId(defaultTestCharge.getExternalChargeId())
+                        .withAmount(300L)
+                        .withStatus(ExternalRefundStatus.EXTERNAL_SUCCESS.getStatus())
+                        .withPaymentProvider(testBaseExtension.getPaymentProvider())
+                        .build();
+                app.getLedgerStub().returnRefundsForPayment(chargeExternalId, List.of(expungedRefund));
+
+                Long refundAmount = 200L;
+                postRefundFor(chargeExternalId, refundAmount, 200L)
+                        .statusCode(ACCEPTED.getStatusCode());
+            }
+
+            @Test
+            void shouldErrorRequestingARefundForHistoricCharge_whenErrorReturnedByLedger() throws Exception {
+                String chargeExternalId = "historic-charge-id";
+
+                ChargeResponse.RefundSummary refundSummary = new ChargeResponse.RefundSummary();
+                refundSummary.setStatus("available");
+                LedgerTransaction charge = aValidLedgerTransaction()
+                        .withExternalId(chargeExternalId)
+                        .withGatewayAccountId(defaultTestAccount.getAccountId())
+                        .withCredentialExternalId(testBaseExtension.getCredentialParams().getExternalId())
+                        .withAmount(1000L)
+                        .withRefundSummary(refundSummary)
+                        .build();
+                app.getLedgerStub().returnLedgerTransaction(chargeExternalId, charge);
+
+                app.getLedgerStub().returnErrorForFindRefundsForPayment(chargeExternalId);
+
+                postRefundFor(chargeExternalId, 200L, 200L)
+                        .statusCode(INTERNAL_SERVER_ERROR.getStatusCode());
+
+                List<Map<String, Object>> refunds = app.getDatabaseTestHelper().getRefundsByChargeExternalId(chargeExternalId);
+                assertThat(refunds, hasSize(0));
+            }
+        }
     }
 
     private ValidatableResponse postRefundFor(String chargeId, Long refundAmount, long refundAmountAvlbl) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
@@ -62,141 +63,147 @@ public class StripeRefundsResourceIT {
 
         app.getStripeMockClient().mockGetPaymentIntent(defaultTestCharge.getTransactionId());
     }
-
-    @Test
-    void shouldSuccessfullyRefund_usingChargeId() {
-        var testChargeCreatedWithStripeChargeAPI = DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestCharge()
-                .withAmount(100L)
-                .withTransactionId("ch_123")
-                .withTestAccount(defaultTestAccount)
-                .withChargeStatus(CAPTURED)
-                .withPaymentProvider(STRIPE.getName())
-                .insert();
-        String platformAccountId = "stripe_platform_account_id";
-        String externalChargeId = testChargeCreatedWithStripeChargeAPI.getExternalChargeId();
-        long amount = 10L;
-        app.getStripeMockClient().mockTransferSuccess();
-        app.getStripeMockClient().mockRefund();
-
-        ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", testChargeCreatedWithStripeChargeAPI.getAmount());
-        String refundPayload = new Gson().toJson(refundData);
-        ValidatableResponse response = given().port(app.getLocalPort())
-                .body(refundPayload)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
-                        .replace("{accountId}", accountId)
-                        .replace("{chargeId}", externalChargeId))
-                .then()
-                .statusCode(ACCEPTED_202);
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(testChargeCreatedWithStripeChargeAPI.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId.get(0).get("status"), is("REFUNDED"));
-        assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("charge_external_id", testChargeCreatedWithStripeChargeAPI.getExternalChargeId()));
-        assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("gateway_transaction_id", "re_1DRiccHj08j21DRiccHj08j2_test"));
-        String refundId = response.extract().path("refund_id");
-        
-        app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/refunds"))
-                .withHeader("Idempotency-Key", equalTo("refund" + refundId))
-                .withRequestBody(containing("charge=ch_123"))
-                .withRequestBody(containing("amount=" + amount)));
-        app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/transfers"))
-                .withHeader("Idempotency-Key", equalTo("transfer_in" + refundId))
-                .withHeader("Stripe-Account", equalTo(stripeAccountId))
-                .withRequestBody(containing("transfer_group=" + testChargeCreatedWithStripeChargeAPI.getExternalChargeId()))
-                .withRequestBody(containing("destination=" + platformAccountId)));
-    }
-
-    @Test
-    void shouldSuccessfullyRefund_usingPaymentIntentId() {
-        String platformAccountId = "stripe_platform_account_id";
-        String externalChargeId = defaultTestCharge.getExternalChargeId();
-        long amount = 10L;
-        app.getStripeMockClient().mockGetPaymentIntent(defaultTestCharge.getTransactionId());
-        app.getStripeMockClient().mockTransferSuccess();
-        app.getStripeMockClient().mockRefund();
-
-        ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
-        String refundPayload = new Gson().toJson(refundData);
-        ValidatableResponse response = given().port(app.getLocalPort())
-                .body(refundPayload)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
-                        .replace("{accountId}", accountId)
-                        .replace("{chargeId}", externalChargeId))
-                .then()
-                .statusCode(ACCEPTED_202);
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId.get(0).get("status"), is("REFUNDED"));
-        String refundId = response.extract().path("refund_id");
-        String paymentIntentUrl = "/v1/payment_intents/" + defaultTestCharge.getTransactionId() + "?expand%5B%5D=charges.data.balance_transaction";
-        app.getStripeWireMockServer().verify(getRequestedFor(urlEqualTo(paymentIntentUrl)));
-        app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/refunds"))
-                .withHeader("Idempotency-Key", equalTo("refund" + refundId))
-                .withRequestBody(containing("charge=ch_123456"))
-                .withRequestBody(containing("amount=" + amount)));
-        app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/transfers"))
-                .withHeader("Idempotency-Key", equalTo("transfer_in" + refundId))
-                .withHeader("Stripe-Account", equalTo(stripeAccountId))
-                .withRequestBody(containing("transfer_group=" + defaultTestCharge.getExternalChargeId()))
-                .withRequestBody(containing("destination=" + platformAccountId)));
-    }
     
-    @Test
-    void stripeRefund_shouldResultInRefundErrorIfRefundFails() {
-        String externalChargeId = defaultTestCharge.getExternalChargeId();
-        long amount = 10L;
-        app.getStripeMockClient().mockRefundError();
+    @Nested
+    class ByAccountId {
+        @Nested
+        class SubmitRefund {
+            @Test
+            void shouldSuccessfullyRefund_usingChargeId() {
+                var testChargeCreatedWithStripeChargeAPI = DatabaseFixtures
+                        .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                        .aTestCharge()
+                        .withAmount(100L)
+                        .withTransactionId("ch_123")
+                        .withTestAccount(defaultTestAccount)
+                        .withChargeStatus(CAPTURED)
+                        .withPaymentProvider(STRIPE.getName())
+                        .insert();
+                String platformAccountId = "stripe_platform_account_id";
+                String externalChargeId = testChargeCreatedWithStripeChargeAPI.getExternalChargeId();
+                long amount = 10L;
+                app.getStripeMockClient().mockTransferSuccess();
+                app.getStripeMockClient().mockRefund();
 
-        ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
-        String refundPayload = new Gson().toJson(refundData);
-        given().port(app.getLocalPort())
-                .body(refundPayload)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
-                        .replace("{accountId}", accountId)
-                        .replace("{chargeId}", externalChargeId))
-                .then()
-                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode());
+                ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", testChargeCreatedWithStripeChargeAPI.getAmount());
+                String refundPayload = new Gson().toJson(refundData);
+                ValidatableResponse response = given().port(app.getLocalPort())
+                        .body(refundPayload)
+                        .accept(ContentType.JSON)
+                        .contentType(ContentType.JSON)
+                        .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
+                                .replace("{accountId}", accountId)
+                                .replace("{chargeId}", externalChargeId))
+                        .then()
+                        .statusCode(ACCEPTED_202);
 
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId.get(0).get("status"), is("REFUND ERROR"));
-    }
-    
-    @Test
-    void stripeRefund_shouldResultInRefundErrorIfTransferFails() {
-        String externalChargeId = defaultTestCharge.getExternalChargeId();
-        long amount = 10L;
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(testChargeCreatedWithStripeChargeAPI.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId.get(0).get("status"), is("REFUNDED"));
+                assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("charge_external_id", testChargeCreatedWithStripeChargeAPI.getExternalChargeId()));
+                assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("gateway_transaction_id", "re_1DRiccHj08j21DRiccHj08j2_test"));
+                String refundId = response.extract().path("refund_id");
 
-        app.getStripeMockClient().mockRefund();
-        app.getStripeMockClient().mockTransferFailure();
+                app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/refunds"))
+                        .withHeader("Idempotency-Key", equalTo("refund" + refundId))
+                        .withRequestBody(containing("charge=ch_123"))
+                        .withRequestBody(containing("amount=" + amount)));
+                app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/transfers"))
+                        .withHeader("Idempotency-Key", equalTo("transfer_in" + refundId))
+                        .withHeader("Stripe-Account", equalTo(stripeAccountId))
+                        .withRequestBody(containing("transfer_group=" + testChargeCreatedWithStripeChargeAPI.getExternalChargeId()))
+                        .withRequestBody(containing("destination=" + platformAccountId)));
+            }
 
-        ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
-        String refundPayload = new Gson().toJson(refundData);
+            @Test
+            void shouldSuccessfullyRefund_usingPaymentIntentId() {
+                String platformAccountId = "stripe_platform_account_id";
+                String externalChargeId = defaultTestCharge.getExternalChargeId();
+                long amount = 10L;
+                app.getStripeMockClient().mockGetPaymentIntent(defaultTestCharge.getTransactionId());
+                app.getStripeMockClient().mockTransferSuccess();
+                app.getStripeMockClient().mockRefund();
 
-        given().port(app.getLocalPort())
-                .body(refundPayload)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
-                        .replace("{accountId}", accountId)
-                        .replace("{chargeId}", externalChargeId))
-                .then()
-                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
-                .body("message", contains("Stripe refund response (error code: expired_card, error: Your card has expired.)"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
+                String refundPayload = new Gson().toJson(refundData);
+                ValidatableResponse response = given().port(app.getLocalPort())
+                        .body(refundPayload)
+                        .accept(ContentType.JSON)
+                        .contentType(ContentType.JSON)
+                        .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
+                                .replace("{accountId}", accountId)
+                                .replace("{chargeId}", externalChargeId))
+                        .then()
+                        .statusCode(ACCEPTED_202);
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId.get(0).get("status"), is("REFUNDED"));
+                String refundId = response.extract().path("refund_id");
+                String paymentIntentUrl = "/v1/payment_intents/" + defaultTestCharge.getTransactionId() + "?expand%5B%5D=charges.data.balance_transaction";
+                app.getStripeWireMockServer().verify(getRequestedFor(urlEqualTo(paymentIntentUrl)));
+                app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/refunds"))
+                        .withHeader("Idempotency-Key", equalTo("refund" + refundId))
+                        .withRequestBody(containing("charge=ch_123456"))
+                        .withRequestBody(containing("amount=" + amount)));
+                app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/transfers"))
+                        .withHeader("Idempotency-Key", equalTo("transfer_in" + refundId))
+                        .withHeader("Stripe-Account", equalTo(stripeAccountId))
+                        .withRequestBody(containing("transfer_group=" + defaultTestCharge.getExternalChargeId()))
+                        .withRequestBody(containing("destination=" + platformAccountId)));
+            }
+
+            @Test
+            void stripeRefund_shouldResultInRefundErrorIfRefundFails() {
+                String externalChargeId = defaultTestCharge.getExternalChargeId();
+                long amount = 10L;
+                app.getStripeMockClient().mockRefundError();
+
+                ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
+                String refundPayload = new Gson().toJson(refundData);
+                given().port(app.getLocalPort())
+                        .body(refundPayload)
+                        .accept(ContentType.JSON)
+                        .contentType(ContentType.JSON)
+                        .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
+                                .replace("{accountId}", accountId)
+                                .replace("{chargeId}", externalChargeId))
+                        .then()
+                        .statusCode(INTERNAL_SERVER_ERROR.getStatusCode());
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId.get(0).get("status"), is("REFUND ERROR"));
+            }
+
+            @Test
+            void stripeRefund_shouldResultInRefundErrorIfTransferFails() {
+                String externalChargeId = defaultTestCharge.getExternalChargeId();
+                long amount = 10L;
+
+                app.getStripeMockClient().mockRefund();
+                app.getStripeMockClient().mockTransferFailure();
+
+                ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
+                String refundPayload = new Gson().toJson(refundData);
+
+                given().port(app.getLocalPort())
+                        .body(refundPayload)
+                        .accept(ContentType.JSON)
+                        .contentType(ContentType.JSON)
+                        .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
+                                .replace("{accountId}", accountId)
+                                .replace("{chargeId}", externalChargeId))
+                        .then()
+                        .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
+                        .body("message", contains("Stripe refund response (error code: expired_card, error: Your card has expired.)"))
+                        .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
 
-        List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId.get(0).get("status"), is("REFUND ERROR"));
+                List<Map<String, Object>> refundsFoundByChargeExternalId = app.getDatabaseTestHelper().getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId.get(0).get("status"), is("REFUND ERROR"));
+            }
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
@@ -6,6 +6,7 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
@@ -87,386 +88,401 @@ public class WorldpayRefundsResourceIT {
                 .withGatewayCredentialId(testBaseExtension.getCredentialParams().getId())
                 .insert();
     }
-
-    @Test
-    void shouldBeAbleToRequestARefund_partialAmount() {
-        Long refundAmount = 50L;
-
-        app.getWorldpayMockClient().mockRefundSuccess();
-        ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
-        String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUND SUBMITTED")));
-
-        List<String> refundsHistory = (app.getDatabaseTestHelper()).getRefundsHistoryByChargeExternalId(defaultTestCharge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
-        assertThat(refundsHistory.size(), is(2));
-        assertThat(refundsHistory, containsInAnyOrder("REFUND SUBMITTED", "CREATED"));
-    }
-
-    @Test
-    void shouldBeAbleToRequestARefund_fullAmount() {
-
-        Long refundAmount = defaultTestCharge.getAmount();
-
-        app.getWorldpayMockClient().mockRefundSuccess();
-        ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
-        String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
-
-        List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUND SUBMITTED")));
-        assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
-        assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("gateway_transaction_id", refundId));
-
-        String expectedRequestBody = TestTemplateResourceLoader.load(WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST)
-                .replace("{{merchantCode}}", "merchant-id")
-                .replace("{{transactionId}}", "MyUniqueTransactionId!")
-                .replace("{{refundReference}}", refundsFoundByChargeExternalId.get(0).get("external_id").toString())
-                .replace("{{amount}}", "100");
-
-        verifyRequestBodyToWorldpay(WORLDPAY_URL, expectedRequestBody);
-    }
-
-    void shouldBeAbleToRequestForRetiredCredentials() {
-        long accountId = RandomUtils.nextInt();
-        AddGatewayAccountCredentialsParams stripeCredentialsParams = anAddGatewayAccountCredentialsParams()
-                .withPaymentProvider(STRIPE.getName())
-                .withGatewayAccountId(accountId)
-                .withState(ACTIVE)
-                .build();
-        AddGatewayAccountCredentialsParams worldpayCredentialsParams = anAddGatewayAccountCredentialsParams()
-                .withPaymentProvider(WORLDPAY.getName())
-                .withGatewayAccountId(accountId)
-                .withState(RETIRED)
-                .withCredentials(Map.of(
-                        ONE_OFF_CUSTOMER_INITIATED, Map.of(
-                                CREDENTIALS_MERCHANT_CODE, "a-merchant-code",
-                                CREDENTIALS_USERNAME, "a-username",
-                                CREDENTIALS_PASSWORD, "a-password")))
-                .build();
-        DatabaseFixtures.TestAccount testAccount = withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestAccount()
-                .withAccountId(accountId)
-                .withGatewayAccountCredentials(List.of(stripeCredentialsParams, worldpayCredentialsParams));
-        DatabaseFixtures.TestCharge charge = DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestCharge()
-                .withAmount(100L)
-                .withTransactionId("MyUniqueTransactionId2!")
-                .withTestAccount(testAccount)
-                .withChargeStatus(CAPTURED)
-                .withPaymentProvider(WORLDPAY.getName())
-                .insert();
+    
+    @Nested
+    class ByAccountId {
         
-        Long refundAmount = 100L;
+        @Nested
+        class SubmitRefund {
 
-        app.getWorldpayMockClient().mockRefundSuccess();
-        ValidatableResponse validatableResponse = postRefundFor(charge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
-        assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
+            @Test
+            void shouldBeAbleToRequestARefund_partialAmount() {
+                Long refundAmount = 50L;
 
-        app.getWorldpayWireMockServer().verify(postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
-    }
+                app.getWorldpayMockClient().mockRefundSuccess();
+                ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
+                String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
 
-    private void verifyRequestBodyToWorldpay(String path, String body) {
-        app.getWorldpayWireMockServer().verify(
-                postRequestedFor(urlPathEqualTo(path))
-                        .withHeader("Content-Type", equalTo("application/xml"))
-                        .withHeader("Authorization", equalTo("Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ="))
-                        .withRequestBody(equalToXml(body)));
-    }
+                List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUND SUBMITTED")));
 
-    @Test
-    void shouldBeAbleToRequestARefund_multiplePartialAmounts_andRefundShouldBeInFullStatus() {
+                List<String> refundsHistory = (app.getDatabaseTestHelper()).getRefundsHistoryByChargeExternalId(defaultTestCharge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
+                assertThat(refundsHistory.size(), is(2));
+                assertThat(refundsHistory, containsInAnyOrder("REFUND SUBMITTED", "CREATED"));
+            }
 
-        Long firstRefundAmount = 80L;
-        Long secondRefundAmount = 20L;
-        String externalChargeId = defaultTestCharge.getExternalChargeId();
+            @Test
+            void shouldBeAbleToRequestARefund_fullAmount() {
 
-        app.getWorldpayMockClient().mockRefundSuccess();
-        ValidatableResponse firstValidatableResponse = postRefundFor(externalChargeId, firstRefundAmount, defaultTestCharge.getAmount());
-        String firstRefundId = assertRefundResponseWith(firstRefundAmount, firstValidatableResponse, ACCEPTED.getStatusCode());
+                Long refundAmount = defaultTestCharge.getAmount();
 
-        app.getWorldpayMockClient().mockRefundSuccess();
-        ValidatableResponse secondValidatableResponse = postRefundFor(externalChargeId, secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount);
-        String secondRefundId = assertRefundResponseWith(secondRefundAmount, secondValidatableResponse, ACCEPTED.getStatusCode());
+                app.getWorldpayMockClient().mockRefundSuccess();
+                ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
+                String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
 
-        List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(externalChargeId);
-        assertThat(refundsFoundByChargeExternalId.size(), is(2));
+                List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUND SUBMITTED")));
+                assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
+                assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("gateway_transaction_id", refundId));
 
-        assertThat(refundsFoundByChargeExternalId, hasItems(
-                aRefundMatching(secondRefundId, is(notNullValue()), externalChargeId, secondRefundAmount, "REFUND SUBMITTED"),
-                aRefundMatching(firstRefundId, is(notNullValue()), externalChargeId, firstRefundAmount, "REFUND SUBMITTED")));
+                String expectedRequestBody = TestTemplateResourceLoader.load(WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST)
+                        .replace("{{merchantCode}}", "merchant-id")
+                        .replace("{{transactionId}}", "MyUniqueTransactionId!")
+                        .replace("{{refundReference}}", refundsFoundByChargeExternalId.get(0).get("external_id").toString())
+                        .replace("{{amount}}", "100");
 
-        testBaseExtension.getConnectorRestApiClient().withChargeId(externalChargeId)
-                .getCharge()
-                .statusCode(200)
-                .body("refund_summary.status", is("full"))
-                .body("refund_summary.amount_available", is(0))
-                .body("refund_summary.amount_submitted", is(100));
-    }
+                verifyRequestBodyToWorldpay(WORLDPAY_URL, expectedRequestBody);
+            }
 
-    @Test
-    void shouldFailRequestingARefund_whenChargeStatusMakesItNotRefundable() {
+            void shouldBeAbleToRequestForRetiredCredentials() {
+                long accountId = RandomUtils.nextInt();
+                AddGatewayAccountCredentialsParams stripeCredentialsParams = anAddGatewayAccountCredentialsParams()
+                        .withPaymentProvider(STRIPE.getName())
+                        .withGatewayAccountId(accountId)
+                        .withState(ACTIVE)
+                        .build();
+                AddGatewayAccountCredentialsParams worldpayCredentialsParams = anAddGatewayAccountCredentialsParams()
+                        .withPaymentProvider(WORLDPAY.getName())
+                        .withGatewayAccountId(accountId)
+                        .withState(RETIRED)
+                        .withCredentials(Map.of(
+                                ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                                        CREDENTIALS_MERCHANT_CODE, "a-merchant-code",
+                                        CREDENTIALS_USERNAME, "a-username",
+                                        CREDENTIALS_PASSWORD, "a-password")))
+                        .build();
+                DatabaseFixtures.TestAccount testAccount = withDatabaseTestHelper(app.getDatabaseTestHelper())
+                        .aTestAccount()
+                        .withAccountId(accountId)
+                        .withGatewayAccountCredentials(List.of(stripeCredentialsParams, worldpayCredentialsParams));
+                DatabaseFixtures.TestCharge charge = DatabaseFixtures
+                        .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                        .aTestCharge()
+                        .withAmount(100L)
+                        .withTransactionId("MyUniqueTransactionId2!")
+                        .withTestAccount(testAccount)
+                        .withChargeStatus(CAPTURED)
+                        .withPaymentProvider(WORLDPAY.getName())
+                        .insert();
 
-        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestCharge()
-                .withAmount(100L)
-                .withTestAccount(defaultTestAccount)
-                .withChargeStatus(CAPTURE_SUBMITTED)
-                .withPaymentProvider(testBaseExtension.getPaymentProvider())
-                .withGatewayCredentialId(testBaseExtension.getCredentialParams().getId())
-                .insert();
+                Long refundAmount = 100L;
 
-        Long refundAmount = 20L;
+                app.getWorldpayMockClient().mockRefundSuccess();
+                ValidatableResponse validatableResponse = postRefundFor(charge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
+                assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
 
-        app.getWorldpayMockClient().mockRefundSuccess();
-        postRefundFor(testCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("reason", is("pending"))
-                .body("message", contains(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+                app.getWorldpayWireMockServer().verify(postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
+            }
 
-        List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(0));
-    }
+            private void verifyRequestBodyToWorldpay(String path, String body) {
+                app.getWorldpayWireMockServer().verify(
+                        postRequestedFor(urlPathEqualTo(path))
+                                .withHeader("Content-Type", equalTo("application/xml"))
+                                .withHeader("Authorization", equalTo("Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ="))
+                                .withRequestBody(equalToXml(body)));
+            }
 
-    @Test
-    void shouldFailRequestingARefund_whenChargeRefundIsFull() {
+            @Test
+            void shouldBeAbleToRequestARefund_multiplePartialAmounts_andRefundShouldBeInFullStatus() {
 
-        Long refundAmount = defaultTestCharge.getAmount();
-        String externalChargeId = defaultTestCharge.getExternalChargeId();
-        Long chargeId = defaultTestCharge.getChargeId();
+                Long firstRefundAmount = 80L;
+                Long secondRefundAmount = 20L;
+                String externalChargeId = defaultTestCharge.getExternalChargeId();
 
-        app.getWorldpayMockClient().mockRefundSuccess();
-        postRefundFor(externalChargeId, refundAmount, defaultTestCharge.getAmount())
-                .statusCode(ACCEPTED.getStatusCode());
+                app.getWorldpayMockClient().mockRefundSuccess();
+                ValidatableResponse firstValidatableResponse = postRefundFor(externalChargeId, firstRefundAmount, defaultTestCharge.getAmount());
+                String firstRefundId = assertRefundResponseWith(firstRefundAmount, firstValidatableResponse, ACCEPTED.getStatusCode());
 
-        postRefundFor(externalChargeId, 1L, 0L)
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("reason", is("full"))
-                .body("message", contains(format("Charge with id [%s] not available for refund.", externalChargeId)))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+                app.getWorldpayMockClient().mockRefundSuccess();
+                ValidatableResponse secondValidatableResponse = postRefundFor(externalChargeId, secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount);
+                String secondRefundId = assertRefundResponseWith(secondRefundAmount, secondValidatableResponse, ACCEPTED.getStatusCode());
 
-        List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(externalChargeId);
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-    }
+                List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(externalChargeId);
+                assertThat(refundsFoundByChargeExternalId.size(), is(2));
 
-    @Test
-    void shouldFailRequestingARefund_whenAmountIsBiggerThanChargeAmount() {
-        Long refundAmount = defaultTestCharge.getAmount() + 20;
-        app.getWorldpayMockClient().mockRefundSuccess();
-        postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("reason", is("amount_not_available"))
-                .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+                assertThat(refundsFoundByChargeExternalId, hasItems(
+                        aRefundMatching(secondRefundId, is(notNullValue()), externalChargeId, secondRefundAmount, "REFUND SUBMITTED"),
+                        aRefundMatching(firstRefundId, is(notNullValue()), externalChargeId, firstRefundAmount, "REFUND SUBMITTED")));
 
-        List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(0));
-    }
+                testBaseExtension.getConnectorRestApiClient().withChargeId(externalChargeId)
+                        .getCharge()
+                        .statusCode(200)
+                        .body("refund_summary.status", is("full"))
+                        .body("refund_summary.amount_available", is(0))
+                        .body("refund_summary.amount_submitted", is(100));
+            }
 
-    @Test
-    void shouldFailRequestingARefund_whenAmountIsBiggerThanAllowedChargeAmount() {
+            @Test
+            void shouldFailRequestingARefund_whenChargeStatusMakesItNotRefundable() {
 
-        Long refundAmount = 10000001L;
+                DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
+                        .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                        .aTestCharge()
+                        .withAmount(100L)
+                        .withTestAccount(defaultTestAccount)
+                        .withChargeStatus(CAPTURE_SUBMITTED)
+                        .withPaymentProvider(testBaseExtension.getPaymentProvider())
+                        .withGatewayCredentialId(testBaseExtension.getCredentialParams().getId())
+                        .insert();
 
-        postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("reason", is("amount_not_available"))
-                .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+                Long refundAmount = 20L;
 
-        List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(0));
-    }
+                app.getWorldpayMockClient().mockRefundSuccess();
+                postRefundFor(testCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(BAD_REQUEST.getStatusCode())
+                        .body("reason", is("pending"))
+                        .body("message", contains(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
-    @Test
-    void shouldFailRequestingARefund_whenAmountIsLessThanOnePence() {
+                List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(0));
+            }
 
-        Long refundAmount = 0L;
+            @Test
+            void shouldFailRequestingARefund_whenChargeRefundIsFull() {
 
-        postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("reason", is("amount_min_validation"))
-                .body("message", contains("Validation error for amount. Minimum amount for a refund is 1"))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+                Long refundAmount = defaultTestCharge.getAmount();
+                String externalChargeId = defaultTestCharge.getExternalChargeId();
+                Long chargeId = defaultTestCharge.getChargeId();
 
-        List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(0));
-    }
+                app.getWorldpayMockClient().mockRefundSuccess();
+                postRefundFor(externalChargeId, refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(ACCEPTED.getStatusCode());
 
-    @Test
-    void shouldFailRequestingARefund_whenAPartialRefundMakesTotalRefundedAmountBiggerThanChargeAmount() {
-        Long firstRefundAmount = 80L;
-        Long secondRefundAmount = 30L; // 10 more than available
+                postRefundFor(externalChargeId, 1L, 0L)
+                        .statusCode(BAD_REQUEST.getStatusCode())
+                        .body("reason", is("full"))
+                        .body("message", contains(format("Charge with id [%s] not available for refund.", externalChargeId)))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
-        app.getWorldpayMockClient().mockRefundSuccess();
-        ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), firstRefundAmount, defaultTestCharge.getAmount());
-        String firstRefundId = assertRefundResponseWith(firstRefundAmount, validatableResponse, ACCEPTED.getStatusCode());
+                List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(externalChargeId);
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+            }
 
-        List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(firstRefundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), firstRefundAmount, "REFUND SUBMITTED")));
+            @Test
+            void shouldFailRequestingARefund_whenAmountIsBiggerThanChargeAmount() {
+                Long refundAmount = defaultTestCharge.getAmount() + 20;
+                app.getWorldpayMockClient().mockRefundSuccess();
+                postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(BAD_REQUEST.getStatusCode())
+                        .body("reason", is("amount_not_available"))
+                        .body("message", contains("Not sufficient amount available for refund"))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
-        app.getWorldpayMockClient().mockRefundSuccess();
-        postRefundFor(defaultTestCharge.getExternalChargeId(), secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount)
-                .statusCode(400)
-                .body("reason", is("amount_not_available"))
-                .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+                List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(0));
+            }
 
-        List<Map<String, Object>> refundsFoundByChargeExternalId1 = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId1.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId1, hasItems(aRefundMatching(firstRefundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), firstRefundAmount, "REFUND SUBMITTED")));
-    }
+            @Test
+            void shouldFailRequestingARefund_whenAmountIsBiggerThanAllowedChargeAmount() {
 
-    @Test
-    void shouldFailRequestingARefund_whenGatewayOperationFails() {
-        Long refundAmount = defaultTestCharge.getAmount();
+                Long refundAmount = 10000001L;
 
-        app.getWorldpayMockClient().mockRefundError();
-        postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
-                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
-                .body("message", contains("Worldpay refund response (error code: 2, error: Something went wrong.)"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(BAD_REQUEST.getStatusCode())
+                        .body("reason", is("amount_not_available"))
+                        .body("message", contains("Not sufficient amount available for refund"))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
-        java.util.List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId, contains(
-                allOf(
-                        hasEntry("amount", (Object) refundAmount),
-                        hasEntry("status", RefundStatus.REFUND_ERROR.getValue()),
-                        hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId())
-                )));
-    }
+                List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(0));
+            }
 
-    @Test
-    void shouldBeAbleRetrieveARefund() {
+            @Test
+            void shouldFailRequestingARefund_whenAmountIsLessThanOnePence() {
 
-        DatabaseFixtures.TestRefund testRefund = DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestRefund()
-                .withTestCharge(defaultTestCharge)
-                .withType(RefundStatus.REFUND_SUBMITTED)
-                .withGatewayTransactionId(randomAlphanumeric(10))
-                .withChargeExternalId(defaultTestCharge.getExternalChargeId())
-                .insert();
+                Long refundAmount = 0L;
 
-        ValidatableResponse validatableResponse = getRefundFor(
-                defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId(), testRefund.getExternalRefundId());
-        String refundId = assertRefundResponseWith(testRefund.getAmount(), validatableResponse, OK.getStatusCode());
+                postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(BAD_REQUEST.getStatusCode())
+                        .body("reason", is("amount_min_validation"))
+                        .body("message", contains("Validation error for amount. Minimum amount for a refund is 1"))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(0));
+            }
+
+            @Test
+            void shouldFailRequestingARefund_whenAPartialRefundMakesTotalRefundedAmountBiggerThanChargeAmount() {
+                Long firstRefundAmount = 80L;
+                Long secondRefundAmount = 30L; // 10 more than available
+
+                app.getWorldpayMockClient().mockRefundSuccess();
+                ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), firstRefundAmount, defaultTestCharge.getAmount());
+                String firstRefundId = assertRefundResponseWith(firstRefundAmount, validatableResponse, ACCEPTED.getStatusCode());
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(firstRefundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), firstRefundAmount, "REFUND SUBMITTED")));
+
+                app.getWorldpayMockClient().mockRefundSuccess();
+                postRefundFor(defaultTestCharge.getExternalChargeId(), secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount)
+                        .statusCode(400)
+                        .body("reason", is("amount_not_available"))
+                        .body("message", contains("Not sufficient amount available for refund"))
+                        .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+                List<Map<String, Object>> refundsFoundByChargeExternalId1 = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId1.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId1, hasItems(aRefundMatching(firstRefundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), firstRefundAmount, "REFUND SUBMITTED")));
+            }
+
+            @Test
+            void shouldFailRequestingARefund_whenGatewayOperationFails() {
+                Long refundAmount = defaultTestCharge.getAmount();
+
+                app.getWorldpayMockClient().mockRefundError();
+                postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+                        .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
+                        .body("message", contains("Worldpay refund response (error code: 2, error: Something went wrong.)"))
+                        .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+
+                java.util.List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId, contains(
+                        allOf(
+                                hasEntry("amount", (Object) refundAmount),
+                                hasEntry("status", RefundStatus.REFUND_ERROR.getValue()),
+                                hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId())
+                        )));
+            }
+        }
+        
+        @Nested
+        class GetRefunds {
+
+            @Test
+            void shouldBeAbleToRetrieveAllRefundsForACharge() {
+
+                DatabaseFixtures.TestRefund testRefund1 = DatabaseFixtures
+                        .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                        .aTestRefund()
+                        .withAmount(10L)
+                        .withCreatedDate(ZonedDateTime.of(2016, 8, 1, 0, 0, 0, 0, ZoneId.of("UTC")))
+                        .withTestCharge(defaultTestCharge)
+                        .withType(RefundStatus.REFUND_SUBMITTED)
+                        .withChargeExternalId(defaultTestCharge.getExternalChargeId())
+                        .insert();
+
+                DatabaseFixtures.TestRefund testRefund2 = DatabaseFixtures
+                        .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                        .aTestRefund()
+                        .withAmount(20L)
+                        .withCreatedDate(ZonedDateTime.of(2016, 8, 2, 0, 0, 0, 0, ZoneId.of("UTC")))
+                        .withTestCharge(defaultTestCharge)
+                        .withType(RefundStatus.REFUND_SUBMITTED)
+                        .withChargeExternalId(defaultTestCharge.getExternalChargeId())
+                        .insert();
+
+                String paymentUrl = format("https://localhost:%s/v1/api/accounts/%s/charges/%s",
+                        app.getLocalPort(), defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId());
+
+                getRefundsFor(defaultTestAccount.getAccountId(),
+                        defaultTestCharge.getExternalChargeId())
+                        .statusCode(OK.getStatusCode())
+                        .body("payment_id", is(defaultTestCharge.getExternalChargeId()))
+                        .body("_links.self.href", is(paymentUrl + "/refunds"))
+                        .body("_links.payment.href", is(paymentUrl))
+                        .body("_embedded.refunds", hasSize(2))
+                        .body("_embedded.refunds[0].refund_id", is(testRefund1.getExternalRefundId()))
+                        .body("_embedded.refunds[0].amount", is(10))
+                        .body("_embedded.refunds[0].status", is("submitted"))
+                        .body("_embedded.refunds[0].created_date", is("2016-08-01T00:00:00.000Z"))
+                        .body("_embedded.refunds[0]._links.self.href", is(paymentUrl + "/refunds/" + testRefund1.getExternalRefundId()))
+                        .body("_embedded.refunds[0]._links.payment.href", is(paymentUrl))
+                        .body("_embedded.refunds[1].refund_id", is(testRefund2.getExternalRefundId()))
+                        .body("_embedded.refunds[1].amount", is(20))
+                        .body("_embedded.refunds[1].status", is("submitted"))
+                        .body("_embedded.refunds[1].created_date", is("2016-08-02T00:00:00.000Z"))
+                        .body("_embedded.refunds[1]._links.self.href", is(paymentUrl + "/refunds/" + testRefund2.getExternalRefundId()))
+                        .body("_embedded.refunds[1]._links.payment.href", is(paymentUrl));
+            }
+        }
+        
+        @Nested
+        class GetRefund {
+            @Test
+            void shouldBeAbleRetrieveARefund() {
+
+                DatabaseFixtures.TestRefund testRefund = DatabaseFixtures
+                        .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                        .aTestRefund()
+                        .withTestCharge(defaultTestCharge)
+                        .withType(RefundStatus.REFUND_SUBMITTED)
+                        .withGatewayTransactionId(randomAlphanumeric(10))
+                        .withChargeExternalId(defaultTestCharge.getExternalChargeId())
+                        .insert();
+
+                ValidatableResponse validatableResponse = getRefundFor(
+                        defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId(), testRefund.getExternalRefundId());
+                String refundId = assertRefundResponseWith(testRefund.getAmount(), validatableResponse, OK.getStatusCode());
 
 
-        List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
-        assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), testRefund.getAmount(), "REFUND SUBMITTED")));
-    }
+                List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+                assertThat(refundsFoundByChargeExternalId.size(), is(1));
+                assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), testRefund.getAmount(), "REFUND SUBMITTED")));
+            }
 
-    @Test
-    void shouldBeAbleToRetrieveAllRefundsForACharge() {
+            @Test
+            void shouldFailRetrieveARefund_whenNonExistentAccountId() {
+                DatabaseFixtures.TestRefund testRefund = DatabaseFixtures
+                        .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                        .aTestRefund()
+                        .withTestCharge(defaultTestCharge)
+                        .withType(RefundStatus.REFUND_SUBMITTED)
+                        .insert();
 
-        DatabaseFixtures.TestRefund testRefund1 = DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestRefund()
-                .withAmount(10L)
-                .withCreatedDate(ZonedDateTime.of(2016, 8, 1, 0, 0, 0, 0, ZoneId.of("UTC")))
-                .withTestCharge(defaultTestCharge)
-                .withType(RefundStatus.REFUND_SUBMITTED)
-                .withChargeExternalId(defaultTestCharge.getExternalChargeId())
-                .insert();
+                Long nonExistentAccountId = 999L;
 
-        DatabaseFixtures.TestRefund testRefund2 = DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestRefund()
-                .withAmount(20L)
-                .withCreatedDate(ZonedDateTime.of(2016, 8, 2, 0, 0, 0, 0, ZoneId.of("UTC")))
-                .withTestCharge(defaultTestCharge)
-                .withType(RefundStatus.REFUND_SUBMITTED)
-                .withChargeExternalId(defaultTestCharge.getExternalChargeId())
-                .insert();
+                ValidatableResponse validatableResponse = getRefundFor(
+                        nonExistentAccountId, defaultTestCharge.getExternalChargeId(), testRefund.getExternalRefundId());
 
-        String paymentUrl = format("https://localhost:%s/v1/api/accounts/%s/charges/%s",
-                app.getLocalPort(), defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId());
+                validatableResponse.statusCode(NOT_FOUND.getStatusCode())
+                        .body("message", contains(format("Charge with id [%s] not found.", defaultTestCharge.getExternalChargeId())))
+                        .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+            }
 
-        getRefundsFor(defaultTestAccount.getAccountId(),
-                defaultTestCharge.getExternalChargeId())
-                .statusCode(OK.getStatusCode())
-                .body("payment_id", is(defaultTestCharge.getExternalChargeId()))
-                .body("_links.self.href", is(paymentUrl + "/refunds"))
-                .body("_links.payment.href", is(paymentUrl))
-                .body("_embedded.refunds", hasSize(2))
-                .body("_embedded.refunds[0].refund_id", is(testRefund1.getExternalRefundId()))
-                .body("_embedded.refunds[0].amount", is(10))
-                .body("_embedded.refunds[0].status", is("submitted"))
-                .body("_embedded.refunds[0].created_date", is("2016-08-01T00:00:00.000Z"))
-                .body("_embedded.refunds[0]._links.self.href", is(paymentUrl + "/refunds/" + testRefund1.getExternalRefundId()))
-                .body("_embedded.refunds[0]._links.payment.href", is(paymentUrl))
-                .body("_embedded.refunds[1].refund_id", is(testRefund2.getExternalRefundId()))
-                .body("_embedded.refunds[1].amount", is(20))
-                .body("_embedded.refunds[1].status", is("submitted"))
-                .body("_embedded.refunds[1].created_date", is("2016-08-02T00:00:00.000Z"))
-                .body("_embedded.refunds[1]._links.self.href", is(paymentUrl + "/refunds/" + testRefund2.getExternalRefundId()))
-                .body("_embedded.refunds[1]._links.payment.href", is(paymentUrl));
-    }
+            @Test
+            void shouldFailRetrieveARefund_whenNonExistentChargeId() {
+                DatabaseFixtures.TestRefund testRefund = DatabaseFixtures
+                        .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                        .aTestRefund()
+                        .withTestCharge(defaultTestCharge)
+                        .withType(RefundStatus.REFUND_SUBMITTED)
+                        .insert();
 
-    @Test
-    void shouldFailRetrieveARefund_whenNonExistentAccountId() {
-        DatabaseFixtures.TestRefund testRefund = DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestRefund()
-                .withTestCharge(defaultTestCharge)
-                .withType(RefundStatus.REFUND_SUBMITTED)
-                .insert();
+                String nonExistentChargeId = "999";
 
-        Long nonExistentAccountId = 999L;
+                ValidatableResponse validatableResponse = getRefundFor(
+                        defaultTestAccount.getAccountId(), nonExistentChargeId, testRefund.getExternalRefundId());
 
-        ValidatableResponse validatableResponse = getRefundFor(
-                nonExistentAccountId, defaultTestCharge.getExternalChargeId(), testRefund.getExternalRefundId());
+                validatableResponse.statusCode(NOT_FOUND.getStatusCode())
+                        .body("message", contains(format("Charge with id [%s] not found.", nonExistentChargeId)))
+                        .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+            }
 
-        validatableResponse.statusCode(NOT_FOUND.getStatusCode())
-                .body("message", contains(format("Charge with id [%s] not found.", defaultTestCharge.getExternalChargeId())))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
-    }
+            @Test
+            void shouldFailRetrieveARefund_whenNonExistentRefundId() {
+                DatabaseFixtures
+                        .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                        .aTestRefund()
+                        .withTestCharge(defaultTestCharge)
+                        .withType(RefundStatus.REFUND_SUBMITTED)
+                        .insert();
 
-    @Test
-    void shouldFailRetrieveARefund_whenNonExistentChargeId() {
-        DatabaseFixtures.TestRefund testRefund = DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestRefund()
-                .withTestCharge(defaultTestCharge)
-                .withType(RefundStatus.REFUND_SUBMITTED)
-                .insert();
+                String nonExistentRefundId = "999";
 
-        String nonExistentChargeId = "999";
+                ValidatableResponse validatableResponse = getRefundFor(
+                        defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId(), nonExistentRefundId);
 
-        ValidatableResponse validatableResponse = getRefundFor(
-                defaultTestAccount.getAccountId(), nonExistentChargeId, testRefund.getExternalRefundId());
-
-        validatableResponse.statusCode(NOT_FOUND.getStatusCode())
-                .body("message", contains(format("Charge with id [%s] not found.", nonExistentChargeId)))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
-    }
-
-    @Test
-    void shouldFailRetrieveARefund_whenNonExistentRefundId() {
-        DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestRefund()
-                .withTestCharge(defaultTestCharge)
-                .withType(RefundStatus.REFUND_SUBMITTED)
-                .insert();
-
-        String nonExistentRefundId = "999";
-
-        ValidatableResponse validatableResponse = getRefundFor(
-                defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId(), nonExistentRefundId);
-
-        validatableResponse.statusCode(NOT_FOUND.getStatusCode())
-                .body("message", contains(format("Refund with id [%s] not found.", nonExistentRefundId)))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                validatableResponse.statusCode(NOT_FOUND.getStatusCode())
+                        .body("message", contains(format("Refund with id [%s] not found.", nonExistentRefundId)))
+                        .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+            }
+        }
     }
 
     private ValidatableResponse postRefundFor(String chargeId, Long refundAmount, Long refundAmountAvlbl) {


### PR DESCRIPTION
## WHAT YOU DID
 - Adds `@Nested` blocks to tests for refund endpoints

## How to test
 - Run tests