### PR TITLE
PP-12819 Increase capture readTimeout duration

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -65,7 +65,7 @@ worldpay:
       readTimeout: 2000ms
     capture:
       # Capture median time is 200ms. We can be quite agressive in the timeout since we have a retry mechanism.
-      readTimeout: 1000ms
+      readTimeout: 2000ms
 
 sandbox:
   allowedCidrs: ${SANDBOX_ALLOWED_CIDRS}


### PR DESCRIPTION
## WHAT YOU DID
- We are seeing an increase in the number of `gateway connection timeout` errors for all Worldpay operations other than authorise (since upgrading to Dropwizard 3). This is because all ops have `readTimeout` configured between 1 and 2 seconds whereas for authorisation it is 50 seconds.

- Increased `readTimeout` config for capture operations and if this addresses the issue, the same can be done for cancel & refund
     - There should be no impact as captures are done by background processes with a retry mechanism.