### PR TITLE
PP-12819 Increase readTimeout for refund and cancel ops

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -59,10 +59,10 @@ worldpay:
       readTimeout: 50000ms
     cancel:
       # Cancel median time is 500ms and done synchronously. Leave a bit of headroom since we don't have retries on this.
-      readTimeout: 2000ms
+      readTimeout: 4000ms
     refund:
       # Refund median time is 500ms and done synchronously. Leave a bit of headroom since we don't have retries on this.
-      readTimeout: 2000ms
+      readTimeout: 4000ms
     capture:
       # Capture median time is 200ms. We can be quite agressive in the timeout since we have a retry mechanism.
       readTimeout: 2000ms


### PR DESCRIPTION
## WHAT
- Increased the `readTimeout` for Worldpay refund and cancel ops to address the increase in `gateway connection timeout` errors.
- Most operations complete in under a second and very few (about 10 refunds & under 10 cancels - a day) which have been timing out will take a couple of seconds longer to complete the op. so user impact is small.

