### PR TITLE
PP-12826 Update GatewayAccountResponse classes to records

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -276,14 +276,14 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 25
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 49
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsRequest.java": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -276,7 +276,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 22
       },
       {
         "type": "Hex High Entropy String",

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -4333,6 +4333,9 @@ components:
         type:
           type: string
           description: Account type for the payment provider (test/live)
+          enum:
+          - test
+          - live
           example: test
         worldpay_3ds_flex:
           $ref: '#/components/schemas/Worldpay3dsFlexCredentials'
@@ -4557,6 +4560,9 @@ components:
         type:
           type: string
           description: Account type for the payment provider (test/live)
+          enum:
+          - test
+          - live
           example: test
         worldpay_3ds_flex:
           $ref: '#/components/schemas/Worldpay3dsFlexCredentials'
@@ -4767,6 +4773,9 @@ components:
         type:
           type: string
           description: Account type for the payment provider (test/live)
+          enum:
+          - test
+          - live
           example: test
         worldpay_3ds_flex:
           $ref: '#/components/schemas/Worldpay3dsFlexCredentials'

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -4333,9 +4333,6 @@ components:
         type:
           type: string
           description: Account type for the payment provider (test/live)
-          enum:
-          - test
-          - live
           example: test
         worldpay_3ds_flex:
           $ref: '#/components/schemas/Worldpay3dsFlexCredentials'
@@ -4560,9 +4557,6 @@ components:
         type:
           type: string
           description: Account type for the payment provider (test/live)
-          enum:
-          - test
-          - live
           example: test
         worldpay_3ds_flex:
           $ref: '#/components/schemas/Worldpay3dsFlexCredentials'
@@ -4773,9 +4767,6 @@ components:
         type:
           type: string
           description: Account type for the payment provider (test/live)
-          enum:
-          - test
-          - live
           example: test
         worldpay_3ds_flex:
           $ref: '#/components/schemas/Worldpay3dsFlexCredentials'

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/DefaultGatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/DefaultGatewayAccountResponse.java
@@ -1,20 +1,12 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
-import uk.gov.pay.connector.usernotification.model.domain.NotificationCredentials;
 
 import java.net.URI;
-import java.util.List;
 import java.util.Map;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-
-@JsonInclude(NON_NULL)
-public record GatewayAccountWithCredentialsResponse (
+public record DefaultGatewayAccountResponse (
         long accountId,
         String externalId,
         String paymentProvider,
@@ -48,21 +40,12 @@ public record GatewayAccountWithCredentialsResponse (
         boolean isAllowAuthorisationApi,
         boolean isRecurringEnabled,
         boolean isDisabled,
-        String disabledReason,
-        
-        @JsonProperty("notifySettings")
-        @Schema(description = "An object containing the Notify credentials and configuration for sending custom branded emails")
-        Map<String, String> notifySettings,
-
-        @JsonProperty("notificationCredentials")
-        @Schema(description = "The gateway credentials for receiving notifications. Only present for Smartpay accounts")
-        NotificationCredentials notificationCredentials,
-
-        @JsonProperty("gateway_account_credentials")
-        @Schema(description = "Array of the credentials configured for this account")
-        List<GatewayAccountCredentials> gatewayAccountCredentials
+        String disabledReason
 ) implements GatewayAccountResponse {
-    public GatewayAccountWithCredentialsResponse(GatewayAccountEntity gatewayAccountEntity) {
+    public DefaultGatewayAccountResponse(GatewayAccountEntity gatewayAccountEntity) {
+        this(gatewayAccountEntity, null);
+    }
+    public DefaultGatewayAccountResponse(GatewayAccountEntity gatewayAccountEntity, Map<String, Map<String, URI>> links) {
         this(
                 gatewayAccountEntity.getId(),
                 gatewayAccountEntity.getExternalId(),
@@ -76,7 +59,7 @@ public record GatewayAccountWithCredentialsResponse (
                 gatewayAccountEntity.getCorporateNonPrepaidCreditCardSurchargeAmount(),
                 gatewayAccountEntity.getCorporateNonPrepaidDebitCardSurchargeAmount(),
                 gatewayAccountEntity.getCorporatePrepaidDebitCardSurchargeAmount(),
-                null,
+                links,
                 gatewayAccountEntity.isAllowApplePay(),
                 gatewayAccountEntity.isAllowGooglePay(),
                 gatewayAccountEntity.isBlockPrepaidCards(),
@@ -97,16 +80,10 @@ public record GatewayAccountWithCredentialsResponse (
                 gatewayAccountEntity.isAllowAuthorisationApi(),
                 gatewayAccountEntity.isRecurringEnabled(),
                 gatewayAccountEntity.isDisabled(),
-                gatewayAccountEntity.getDisabledReason(),
-                gatewayAccountEntity.getNotifySettings(),
-                gatewayAccountEntity.getNotificationCredentials(),
-                gatewayAccountEntity.getGatewayAccountCredentials()
-                        .stream()
-                        .map(GatewayAccountCredentials::new)
-                        .toList()
+                gatewayAccountEntity.getDisabledReason()
         );
     }
-
+    
     public String getType() {
         return type.toString();
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/DefaultGatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/DefaultGatewayAccountResponse.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 
@@ -10,7 +11,8 @@ public record DefaultGatewayAccountResponse (
         long accountId,
         String externalId,
         String paymentProvider,
-        GatewayAccountType type,
+        @JsonIgnore
+        GatewayAccountType accountType,
         boolean isLive,
         String description,
         String serviceName,
@@ -84,7 +86,7 @@ public record DefaultGatewayAccountResponse (
         );
     }
     
-    public String getType() {
-        return type.toString();
+    public String type() {
+        return accountType.toString();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,6 +14,7 @@ import java.util.Map;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface GatewayAccountResponse {
 
     @JsonProperty("gateway_account_id")
@@ -28,7 +31,7 @@ public interface GatewayAccountResponse {
     
     @JsonProperty("type")
     @Schema(example = "test", description = "Account type for the payment provider (test/live)")
-    GatewayAccountType type();
+    String type();
 
     @JsonProperty("live")
     @Schema(example = "true", description = "Whether the account is live")
@@ -169,7 +172,6 @@ public interface GatewayAccountResponse {
     @Schema(example = "No longer required", description = "The reason the account is disabled, if applicable")
     String disabledReason();
     
-    String getType();
     static DefaultGatewayAccountResponse of(GatewayAccountEntity gatewayAccountEntity) {
         return new DefaultGatewayAccountResponse(gatewayAccountEntity);
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java
@@ -2,65 +2,65 @@ package uk.gov.pay.connector.gatewayaccount.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 
 import java.net.URI;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonInclude(NON_NULL)
-public class GatewayAccountResponse {
+public interface GatewayAccountResponse {
 
     @JsonProperty("gateway_account_id")
     @Schema(example = "1", description = "The account ID")
-    private long accountId;
+    long accountId();
 
     @JsonProperty("external_id")
     @Schema(example = "fbf905a3f7ea416c8c252410eb45ddbd", description = "External ID for the gateway account")
-    private String externalId;
+    String externalId();
 
     @JsonProperty("payment_provider")
     @Schema(example = "sandbox", description = "The payment provider for which this account is created")
-    private String paymentProvider;
-
-    @Schema(example = "test", description = "Account type for the payment provider (test/live)")
-    private GatewayAccountType type;
+    String paymentProvider();
     
-    @Schema(example = "true", description = "Whether the account is live")
-    private boolean live;
+    @JsonProperty("type")
+    @Schema(example = "test", description = "Account type for the payment provider (test/live)")
+    GatewayAccountType type();
 
+    @JsonProperty("live")
+    @Schema(example = "true", description = "Whether the account is live")
+    boolean isLive();
+
+    @JsonProperty("description")
     @Schema(example = "Account for service xxx", description = "An internal description to identify the gateway account. The default value is null.", defaultValue = "null")
-    private String description;
+    String description();
 
     @JsonProperty("service_name")
     @Schema(example = "service name", description = "The service name for the account")
-    private String serviceName;
+    String serviceName();
 
     @JsonProperty("service_id")
     @Schema(example = "cd1b871207a94a7fa157dee678146acd", description = "Service external ID")
-    private String serviceId;
+    String serviceId();
 
     @JsonProperty("analytics_id")
     @Schema(description = "An identifier used to identify the service in Google Analytics. The default value is null")
-    private String analyticsId;
+    String analyticsId();
 
     @JsonProperty("corporate_credit_card_surcharge_amount")
     @Schema(example = "250", description = "A corporate credit card surcharge amount in pence", defaultValue = "0")
-    private long corporateCreditCardSurchargeAmount;
+    long corporateCreditCardSurchargeAmount();
 
     @JsonProperty("corporate_debit_card_surcharge_amount")
     @Schema(example = "250", description = "A corporate debit card surcharge amount in pence", defaultValue = "0")
-    private long corporateDebitCardSurchargeAmount;
+    long corporateDebitCardSurchargeAmount();
 
     @JsonProperty("corporate_prepaid_debit_card_surcharge_amount")
     @Schema(example = "0", description = "A corporate prepaid debit card surcharge amount in pence")
-    private long corporatePrepaidDebitCardSurchargeAmount;
+    long corporatePrepaidDebitCardSurchargeAmount();
 
     @JsonProperty("_links")
     @Schema(example = "{" +
@@ -70,19 +70,19 @@ public class GatewayAccountResponse {
             "            \"method\": \"GET\"" +
             "        }" +
             "    }")
-    private Map<String, Map<String, URI>> links = new HashMap<>();
+    Map<String, Map<String, URI>> links();
 
     @JsonProperty("allow_apple_pay")
     @Schema(example = "true", description = "Set to true to enable Apple Pay", defaultValue = "false")
-    private boolean allowApplePay;
+    boolean isAllowApplePay();
 
     @JsonProperty("allow_google_pay")
     @Schema(example = "true", description = "Set to true to enable Google Pay", defaultValue = "false")
-    private boolean allowGooglePay;
+    boolean isAllowGooglePay();
 
     @JsonProperty("block_prepaid_cards")
     @Schema(example = "true", description = "Whether pre-paid cards are allowed as a payment method for this gateway account", defaultValue = "false")
-    private boolean blockPrepaidCards;
+    boolean isBlockPrepaidCards();
 
     @JsonProperty("email_notifications")
     @Schema(description = "The settings for the different emails (payments/refunds) that are sent out", example = "{" +
@@ -97,255 +97,85 @@ public class GatewayAccountResponse {
             "            \"template_body\": null" +
             "        }" +
             "    }")
-    private Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
+    Map<EmailNotificationType, EmailNotificationEntity> emailNotifications();
 
     @JsonProperty("email_collection_mode")
     @Schema(description = "Whether email address is required from paying users. Can be MANDATORY, OPTIONAL or OFF")
-    private EmailCollectionMode emailCollectionMode = EmailCollectionMode.MANDATORY;
+    EmailCollectionMode emailCollectionMode();
 
     @JsonProperty("requires3ds")
     @Schema(example = "true", description = "Flag to indicate whether 3DS is enabled")
-    private boolean requires3ds;
+    boolean isRequires3ds();
 
     @JsonProperty("allow_zero_amount")
     @Schema(example = "true", description = "Set to true to support charges with a zero amount", defaultValue = "false")
-    private boolean allowZeroAmount;
+    boolean isAllowZeroAmount();
 
     @JsonProperty("integration_version_3ds")
     @Schema(example = "2", description = "3DS version used for payments for the gateway account")
-    private int integrationVersion3ds;
+    int integrationVersion3ds();
 
     @JsonProperty("allow_moto")
     @Schema(description = "Indicates whether the Mail Order and Telephone Order (MOTO) payments are allowed", defaultValue = "false")
-    private boolean allowMoto;
+    boolean isAllowMoto();
 
     @JsonProperty("allow_telephone_payment_notifications")
     @Schema(description = "Indicates if the account is used for telephone payments reporting", defaultValue = "false")
-    private boolean allowTelephonePaymentNotifications;
+    boolean isAllowTelephonePaymentNotifications();
 
     @JsonProperty("moto_mask_card_number_input")
     @Schema(description = "Indicates whether the card number is masked when being input for MOTO payments. The default value is false.", defaultValue = "false")
-    private boolean motoMaskCardNumberInput;
+    boolean isMotoMaskCardNumberInput();
 
     @JsonProperty("moto_mask_card_security_code_input")
     @Schema(description = "Indicates whether the card security code is masked when being input for MOTO payments.", defaultValue = "false")
-    private boolean motoMaskCardSecurityCodeInput;
+    boolean isMotoMaskCardSecurityCodeInput();
 
     @JsonProperty("provider_switch_enabled")
     @Schema(example = "false", description = "Flag to enable payment provider switching", defaultValue = "false")
-    private boolean providerSwitchEnabled;
+    boolean isProviderSwitchEnabled();
 
     @JsonInclude(NON_NULL)
     @JsonProperty("worldpay_3ds_flex")
-    private Worldpay3dsFlexCredentials worldpay3dsFlexCredentials;
+    Worldpay3dsFlexCredentials worldpay3dsFlexCredentials();
 
     @JsonProperty("send_payer_ip_address_to_gateway")
     @Schema(example = "true", description = "If enabled, user IP address is sent to to gateway", defaultValue = "false")
-    private boolean sendPayerIpAddressToGateway;
+    boolean isSendPayerIpAddressToGateway();
 
     @JsonProperty("send_payer_email_to_gateway")
     @Schema(example = "true", description = "If enabled, user email address is included in the authorisation request to gateway", defaultValue = "false")
-    private boolean sendPayerEmailToGateway;
+    boolean isSendPayerEmailToGateway();
 
     @JsonProperty("send_reference_to_gateway")
     @Schema(example = "true", description = "If enabled, service payment reference is sent to gateway as description. " +
             "Otherwise payment description is sent to the gateway. Only applicable for Worldpay accounts. Default value is 'false'", defaultValue = "false")
-    private boolean sendReferenceToGateway;
+    boolean isSendReferenceToGateway();
 
     @JsonProperty("allow_authorisation_api")
     @Schema(example = "true", description = "Flag to indicate whether the account is allowed to initiate MOTO payments that are authorised via " +
             "an API request rather than the web interface", defaultValue = "false")
-    private boolean allowAuthorisationApi;
+    boolean isAllowAuthorisationApi();
 
     @JsonProperty("recurring_enabled")
     @Schema(example = "true", description = "Flag to indicate whether the account is allowed to take recurring card payments", defaultValue = "false")
-    private boolean recurringEnabled;
+    boolean isRecurringEnabled();
 
     @JsonProperty("disabled")
     @Schema(example = "false", description = "Flag to indicate whether the account is allowed to take payments and make refunds", defaultValue = "false")
-    private boolean disabled;
+    boolean isDisabled();
 
     @JsonProperty("disabled_reason")
     @Schema(example = "No longer required", description = "The reason the account is disabled, if applicable")
-    private String disabledReason;
-
-    public GatewayAccountResponse() {
+    String disabledReason();
+    
+    String getType();
+    static DefaultGatewayAccountResponse of(GatewayAccountEntity gatewayAccountEntity) {
+        return new DefaultGatewayAccountResponse(gatewayAccountEntity);
     }
-
-    public GatewayAccountResponse(GatewayAccountEntity gatewayAccountEntity) {
-        this.accountId = gatewayAccountEntity.getId();
-        this.externalId = gatewayAccountEntity.getExternalId();
-        this.paymentProvider = gatewayAccountEntity.getGatewayName();
-        this.type = GatewayAccountType.fromString(gatewayAccountEntity.getType());
-        this.live = gatewayAccountEntity.isLive();
-        this.description = gatewayAccountEntity.getDescription();
-        this.serviceName = gatewayAccountEntity.getServiceName();
-        this.analyticsId = gatewayAccountEntity.getAnalyticsId();
-        this.corporateCreditCardSurchargeAmount = gatewayAccountEntity.getCorporateNonPrepaidCreditCardSurchargeAmount();
-        this.corporateDebitCardSurchargeAmount = gatewayAccountEntity.getCorporateNonPrepaidDebitCardSurchargeAmount();
-        this.allowApplePay = gatewayAccountEntity.isAllowApplePay();
-        this.allowGooglePay = gatewayAccountEntity.isAllowGooglePay();
-        this.blockPrepaidCards = gatewayAccountEntity.isBlockPrepaidCards();
-        this.corporatePrepaidDebitCardSurchargeAmount = gatewayAccountEntity.getCorporatePrepaidDebitCardSurchargeAmount();
-        this.emailNotifications = gatewayAccountEntity.getEmailNotifications();
-        this.emailCollectionMode = gatewayAccountEntity.getEmailCollectionMode();
-        this.requires3ds = gatewayAccountEntity.isRequires3ds();
-        this.allowZeroAmount = gatewayAccountEntity.isAllowZeroAmount();
-        this.integrationVersion3ds = gatewayAccountEntity.getIntegrationVersion3ds();
-        this.allowMoto = gatewayAccountEntity.isAllowMoto();
-        this.motoMaskCardNumberInput = gatewayAccountEntity.isMotoMaskCardNumberInput();
-        this.motoMaskCardSecurityCodeInput = gatewayAccountEntity.isMotoMaskCardSecurityCodeInput();
-        this.allowTelephonePaymentNotifications = gatewayAccountEntity.isAllowTelephonePaymentNotifications();
-        this.worldpay3dsFlexCredentials = gatewayAccountEntity.getWorldpay3dsFlexCredentials().orElse(null);
-        this.providerSwitchEnabled = gatewayAccountEntity.isProviderSwitchEnabled();
-        this.sendPayerEmailToGateway = gatewayAccountEntity.isSendPayerEmailToGateway();
-        this.sendReferenceToGateway = gatewayAccountEntity.isSendReferenceToGateway();
-        this.sendPayerIpAddressToGateway = gatewayAccountEntity.isSendPayerIpAddressToGateway();
-        this.serviceId = gatewayAccountEntity.getServiceId();
-        this.allowAuthorisationApi = gatewayAccountEntity.isAllowAuthorisationApi();
-        this.recurringEnabled = gatewayAccountEntity.isRecurringEnabled();
-        this.disabled = gatewayAccountEntity.isDisabled();
-        this.disabledReason = gatewayAccountEntity.getDisabledReason();
+    static DefaultGatewayAccountResponse of(GatewayAccountEntity gatewayAccountEntity, String key, URI uri) {
+        return new DefaultGatewayAccountResponse(gatewayAccountEntity, Map.of(
+                key, Map.of("href", uri)
+        ));
     }
-
-    public long getAccountId() {
-        return accountId;
-    }
-
-    public String getExternalId() {
-        return externalId;
-    }
-
-    public String getPaymentProvider() {
-        return paymentProvider;
-    }
-
-    public String getType() {
-        return type.toString();
-    }
-
-    public boolean isLive() {
-        return live;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public String getServiceName() {
-        return serviceName;
-    }
-
-    public String getServiceId() {
-        return serviceId;
-    }
-
-    public String getAnalyticsId() {
-        return analyticsId;
-    }
-
-    public long getCorporateCreditCardSurchargeAmount() {
-        return corporateCreditCardSurchargeAmount;
-    }
-
-    public long getCorporateDebitCardSurchargeAmount() {
-        return corporateDebitCardSurchargeAmount;
-    }
-
-    public Map<String, Map<String, URI>> getLinks() {
-        return links;
-    }
-
-    public void addLink(String key, URI uri) {
-        links.put(key, ImmutableMap.of("href", uri));
-    }
-
-    public long getCorporatePrepaidDebitCardSurchargeAmount() {
-        return corporatePrepaidDebitCardSurchargeAmount;
-    }
-
-    public boolean isAllowApplePay() {
-        return allowApplePay;
-    }
-
-    public boolean isAllowGooglePay() {
-        return allowGooglePay;
-    }
-
-    public boolean isBlockPrepaidCards() {
-        return blockPrepaidCards;
-    }
-
-    public Map<EmailNotificationType, EmailNotificationEntity> getEmailNotifications() {
-        return emailNotifications;
-    }
-
-    public EmailCollectionMode getEmailCollectionMode() {
-        return emailCollectionMode;
-    }
-
-    public boolean isRequires3ds() {
-        return requires3ds;
-    }
-
-    public boolean isAllowZeroAmount() {
-        return allowZeroAmount;
-    }
-
-    public int getIntegrationVersion3ds() {
-        return integrationVersion3ds;
-    }
-
-    public boolean isAllowMoto() {
-        return allowMoto;
-    }
-
-    public boolean isMotoMaskCardNumberInput() {
-        return motoMaskCardNumberInput;
-    }
-
-    public boolean isMotoMaskCardSecurityCodeInput() {
-        return motoMaskCardSecurityCodeInput;
-    }
-
-    public boolean isAllowTelephonePaymentNotifications() {
-        return allowTelephonePaymentNotifications;
-    }
-
-    public boolean isProviderSwitchEnabled() {
-        return providerSwitchEnabled;
-    }
-
-    public boolean isSendPayerIpAddressToGateway() {
-        return sendPayerIpAddressToGateway;
-    }
-
-    public boolean isSendPayerEmailToGateway() {
-        return sendPayerEmailToGateway;
-    }
-
-    public boolean isSendReferenceToGateway() {
-        return sendReferenceToGateway;
-    }
-
-    public Optional<Worldpay3dsFlexCredentials> getWorldpay3dsFlexCredentials() {
-        return Optional.ofNullable(worldpay3dsFlexCredentials);
-    }
-
-    public boolean isAllowAuthorisationApi() {
-        return allowAuthorisationApi;
-    }
-
-    public boolean isRecurringEnabled() {
-        return recurringEnabled;
-    }
-
-    public boolean isDisabled() {
-        return disabled;
-    }
-
-    public String getDisabledReason() {
-        return disabledReason;
-    }
-
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsResponse.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,7 +19,8 @@ public record GatewayAccountWithCredentialsResponse (
         long accountId,
         String externalId,
         String paymentProvider,
-        GatewayAccountType type,
+        @JsonIgnore
+        GatewayAccountType accountType,
         boolean isLive,
         String description,
         String serviceName,
@@ -107,7 +109,7 @@ public record GatewayAccountWithCredentialsResponse (
         );
     }
 
-    public String getType() {
-        return type.toString();
+    public String type() {
+        return accountType.toString();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsWithInternalIdResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsWithInternalIdResponse.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,7 +19,8 @@ public record GatewayAccountWithCredentialsWithInternalIdResponse (
         long accountId,
         String externalId,
         String paymentProvider,
-        GatewayAccountType type,
+        @JsonIgnore
+        GatewayAccountType accountType,
         boolean isLive,
         String description,
         String serviceName,
@@ -107,7 +109,7 @@ public record GatewayAccountWithCredentialsWithInternalIdResponse (
         );
     }
 
-    public String getType() {
-        return type.toString();
+    public String type() {
+        return accountType.toString();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsWithInternalIdResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountWithCredentialsWithInternalIdResponse.java
@@ -3,27 +3,111 @@ package uk.gov.pay.connector.gatewayaccount.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
+import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
+import uk.gov.pay.connector.usernotification.model.domain.NotificationCredentials;
 
+import java.net.URI;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonInclude(NON_NULL)
-public class GatewayAccountWithCredentialsWithInternalIdResponse extends GatewayAccountWithCredentialsResponse {
-    @JsonProperty("gateway_account_credentials")
-    @Schema(description = "Array of the credentials configured for this account")
-    private final List<GatewayAccountCredentialsWithInternalId> gatewayAccountCredentialsWithInternalIds;
+public record GatewayAccountWithCredentialsWithInternalIdResponse (
+        long accountId,
+        String externalId,
+        String paymentProvider,
+        GatewayAccountType type,
+        boolean isLive,
+        String description,
+        String serviceName,
+        String serviceId,
+        String analyticsId,
+        long corporateCreditCardSurchargeAmount,
+        long corporateDebitCardSurchargeAmount,
+        long corporatePrepaidDebitCardSurchargeAmount,
+        Map<String, Map<String, URI>> links,
+        boolean isAllowApplePay,
+        boolean isAllowGooglePay,
+        boolean isBlockPrepaidCards,
+        Map<EmailNotificationType, EmailNotificationEntity> emailNotifications,
+        EmailCollectionMode emailCollectionMode,
+        boolean isRequires3ds,
+        boolean isAllowZeroAmount,
+        int integrationVersion3ds,
+        boolean isAllowMoto,
+        boolean isAllowTelephonePaymentNotifications,
+        boolean isMotoMaskCardNumberInput,
+        boolean isMotoMaskCardSecurityCodeInput,
+        boolean isProviderSwitchEnabled,
+        Worldpay3dsFlexCredentials worldpay3dsFlexCredentials,
+        boolean isSendPayerIpAddressToGateway,
+        boolean isSendPayerEmailToGateway,
+        boolean isSendReferenceToGateway,
+        boolean isAllowAuthorisationApi,
+        boolean isRecurringEnabled,
+        boolean isDisabled,
+        String disabledReason,
 
+        @JsonProperty("notifySettings")
+        @Schema(description = "An object containing the Notify credentials and configuration for sending custom branded emails")
+        Map<String, String> notifySettings,
+
+        @JsonProperty("notificationCredentials")
+        @Schema(description = "The gateway credentials for receiving notifications. Only present for Smartpay accounts")
+        NotificationCredentials notificationCredentials,
+
+        @JsonProperty("gateway_account_credentials")
+        @Schema(description = "Array of the credentials configured for this account")
+        List<GatewayAccountCredentialsWithInternalId> gatewayAccountCredentials
+) implements GatewayAccountResponse {
     public GatewayAccountWithCredentialsWithInternalIdResponse(GatewayAccountEntity gatewayAccountEntity) {
-        super(gatewayAccountEntity);
-        this.gatewayAccountCredentialsWithInternalIds = gatewayAccountEntity.getGatewayAccountCredentials()
-                .stream()
-                .map(GatewayAccountCredentialsWithInternalId::new)
-                .collect(Collectors.toList());
+        this(
+                gatewayAccountEntity.getId(),
+                gatewayAccountEntity.getExternalId(),
+                gatewayAccountEntity.getGatewayName(),
+                GatewayAccountType.fromString(gatewayAccountEntity.getType()),
+                gatewayAccountEntity.isLive(),
+                gatewayAccountEntity.getDescription(),
+                gatewayAccountEntity.getServiceName(),
+                gatewayAccountEntity.getServiceId(),
+                gatewayAccountEntity.getAnalyticsId(),
+                gatewayAccountEntity.getCorporateNonPrepaidCreditCardSurchargeAmount(),
+                gatewayAccountEntity.getCorporateNonPrepaidDebitCardSurchargeAmount(),
+                gatewayAccountEntity.getCorporatePrepaidDebitCardSurchargeAmount(),
+                null,
+                gatewayAccountEntity.isAllowApplePay(),
+                gatewayAccountEntity.isAllowGooglePay(),
+                gatewayAccountEntity.isBlockPrepaidCards(),
+                gatewayAccountEntity.getEmailNotifications(),
+                gatewayAccountEntity.getEmailCollectionMode(),
+                gatewayAccountEntity.isRequires3ds(),
+                gatewayAccountEntity.isAllowZeroAmount(),
+                gatewayAccountEntity.getIntegrationVersion3ds(),
+                gatewayAccountEntity.isAllowMoto(),
+                gatewayAccountEntity.isAllowTelephonePaymentNotifications(),
+                gatewayAccountEntity.isMotoMaskCardNumberInput(),
+                gatewayAccountEntity.isMotoMaskCardSecurityCodeInput(),
+                gatewayAccountEntity.isProviderSwitchEnabled(),
+                gatewayAccountEntity.getWorldpay3dsFlexCredentials().orElse(null),
+                gatewayAccountEntity.isSendPayerIpAddressToGateway(),
+                gatewayAccountEntity.isSendPayerEmailToGateway(),
+                gatewayAccountEntity.isSendReferenceToGateway(),
+                gatewayAccountEntity.isAllowAuthorisationApi(),
+                gatewayAccountEntity.isRecurringEnabled(),
+                gatewayAccountEntity.isDisabled(),
+                gatewayAccountEntity.getDisabledReason(),
+                gatewayAccountEntity.getNotifySettings(),
+                gatewayAccountEntity.getNotificationCredentials(),
+                gatewayAccountEntity.getGatewayAccountCredentials()
+                        .stream()
+                        .map(GatewayAccountCredentialsWithInternalId::new)
+                        .toList()
+        );
     }
 
-    public List<GatewayAccountCredentialsWithInternalId> getGatewayAccountCredentialsWithInternalIds() {
-        return gatewayAccountCredentialsWithInternalIds;
+    public String getType() {
+        return type.toString();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -163,8 +163,11 @@ public class GatewayAccountResource {
     private Response getGatewayAccounts(@BeanParam GatewayAccountSearchParams gatewayAccountSearchParams, @Context UriInfo uriInfo) {
         logger.info(format("Searching gateway accounts by parameters %s", gatewayAccountSearchParams.toString()));
 
-        List<GatewayAccountResponse> gatewayAccounts = gatewayAccountService.searchGatewayAccounts(gatewayAccountSearchParams);
-        gatewayAccounts.forEach(account -> account.addLink("self", buildUri(uriInfo, account.getAccountId())));
+        List<GatewayAccountEntity> gatewayAccountEntitiesList = gatewayAccountService.searchGatewayAccounts(gatewayAccountSearchParams);
+        List<GatewayAccountResponse> gatewayAccounts = gatewayAccountEntitiesList.stream().map(
+                account -> GatewayAccountResponse.of(account, "self", buildUri(uriInfo, account.getId()))
+        ).collect(Collectors.toList());
+//        gatewayAccounts.forEach(account -> account.addLink("self", buildUri(uriInfo, account.getAccountId())));
 
         return Response
                 .ok(GatewayAccountsListDTO.of(gatewayAccounts))

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -93,10 +93,8 @@ public class GatewayAccountService {
         return gatewayAccountDao.findById(gatewayAccountId);
     }
 
-    public List<GatewayAccountResponse> searchGatewayAccounts(GatewayAccountSearchParams params) {
-        return gatewayAccountDao.search(params).stream()
-                .map(GatewayAccountResponse::new)
-                .collect(Collectors.toList());
+    public List<GatewayAccountEntity> searchGatewayAccounts(GatewayAccountSearchParams params) {
+        return gatewayAccountDao.search(params);
     }
 
     @Transactional

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponseTest.java
@@ -61,32 +61,32 @@ class GatewayAccountResponseTest {
         emailNotifications.put(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(new GatewayAccountEntity(), "testTemplate", true));
         entity.setEmailNotifications(emailNotifications);
         
-        GatewayAccountResponse dto = new GatewayAccountResponse(entity);
-        assertThat(dto.getAccountId(), is(entity.getId()));
-        assertThat(dto.getExternalId(), is(entity.getExternalId()));
-        assertThat(dto.getPaymentProvider(), is(entity.getGatewayName()));
-        assertThat(dto.getType(), is(entity.getType()));
+        GatewayAccountResponse dto = GatewayAccountResponse.of(entity);
+        assertThat(dto.accountId(), is(entity.getId()));
+        assertThat(dto.externalId(), is(entity.getExternalId()));
+        assertThat(dto.paymentProvider(), is(entity.getGatewayName()));
+        assertThat(dto.type().toString(), is(entity.getType()));
         assertThat(dto.isLive(), is(entity.isLive()));
-        assertThat(dto.getDescription(), is(entity.getDescription()));
-        assertThat(dto.getServiceName(), is(entity.getServiceName()));
-        assertThat(dto.getAnalyticsId(), is(entity.getAnalyticsId()));
-        assertThat(dto.getCorporateCreditCardSurchargeAmount(), is(entity.getCorporateNonPrepaidCreditCardSurchargeAmount()));
-        assertThat(dto.getCorporateDebitCardSurchargeAmount(), is(entity.getCorporateNonPrepaidDebitCardSurchargeAmount()));
-        assertThat(dto.getCorporatePrepaidDebitCardSurchargeAmount(), is(entity.getCorporatePrepaidDebitCardSurchargeAmount()));
+        assertThat(dto.description(), is(entity.getDescription()));
+        assertThat(dto.serviceName(), is(entity.getServiceName()));
+        assertThat(dto.analyticsId(), is(entity.getAnalyticsId()));
+        assertThat(dto.corporateCreditCardSurchargeAmount(), is(entity.getCorporateNonPrepaidCreditCardSurchargeAmount()));
+        assertThat(dto.corporateDebitCardSurchargeAmount(), is(entity.getCorporateNonPrepaidDebitCardSurchargeAmount()));
+        assertThat(dto.corporatePrepaidDebitCardSurchargeAmount(), is(entity.getCorporatePrepaidDebitCardSurchargeAmount()));
         assertThat(dto.isAllowApplePay(), is(entity.isAllowApplePay()));
         assertThat(dto.isAllowGooglePay(), is(entity.isAllowGooglePay()));
         assertThat(dto.isRequires3ds(), is(entity.isRequires3ds()));
         assertThat(dto.isAllowZeroAmount(), is(entity.isAllowZeroAmount()));
-        assertThat(dto.getEmailCollectionMode(), is(entity.getEmailCollectionMode()));
-        assertThat(dto.getEmailNotifications().size(), is(1));
-        assertThat(dto.getEmailNotifications().get(EmailNotificationType.PAYMENT_CONFIRMED).getTemplateBody(), is("testTemplate"));
-        assertThat(dto.getIntegrationVersion3ds(), is(entity.getIntegrationVersion3ds()));
+        assertThat(dto.emailCollectionMode(), is(entity.getEmailCollectionMode()));
+        assertThat(dto.emailNotifications().size(), is(1));
+        assertThat(dto.emailNotifications().get(EmailNotificationType.PAYMENT_CONFIRMED).getTemplateBody(), is("testTemplate"));
+        assertThat(dto.integrationVersion3ds(), is(entity.getIntegrationVersion3ds()));
         assertThat(dto.isBlockPrepaidCards(), is(entity.isBlockPrepaidCards()));
         assertThat(dto.isAllowMoto(), is(entity.isAllowMoto()));
         assertThat(dto.isMotoMaskCardNumberInput(), is(entity.isMotoMaskCardNumberInput()));
         assertThat(dto.isMotoMaskCardSecurityCodeInput(), is(entity.isMotoMaskCardSecurityCodeInput()));
         assertThat(dto.isAllowTelephonePaymentNotifications(), is(entity.isAllowTelephonePaymentNotifications()));
-        assertThat(dto.getWorldpay3dsFlexCredentials(), is(entity.getWorldpay3dsFlexCredentials()));
+        assertThat(dto.worldpay3dsFlexCredentials(), is(entity.getWorldpay3dsFlexCredentials().get()));
         assertThat(dto.isProviderSwitchEnabled(), is(entity.isProviderSwitchEnabled()));
         assertThat(dto.isSendPayerIpAddressToGateway(), is(true));
         assertThat(dto.isSendPayerEmailToGateway(), is(true));
@@ -94,6 +94,6 @@ class GatewayAccountResponseTest {
         assertThat(dto.isAllowAuthorisationApi(), is(entity.isAllowAuthorisationApi()));
         assertThat(dto.isRecurringEnabled(), is(entity.isRecurringEnabled()));
         assertThat(dto.isDisabled(), is(entity.isDisabled()));
-        assertThat(dto.getDisabledReason(), is(entity.getDisabledReason()));
+        assertThat(dto.disabledReason(), is(entity.getDisabledReason()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponseTest.java
@@ -65,7 +65,7 @@ class GatewayAccountResponseTest {
         assertThat(dto.accountId(), is(entity.getId()));
         assertThat(dto.externalId(), is(entity.getExternalId()));
         assertThat(dto.paymentProvider(), is(entity.getGatewayName()));
-        assertThat(dto.type().toString(), is(entity.getType()));
+        assertThat(dto.type(), is(entity.getType()));
         assertThat(dto.isLive(), is(entity.isLive()));
         assertThat(dto.description(), is(entity.getDescription()));
         assertThat(dto.serviceName(), is(entity.getServiceName()));

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -117,7 +117,7 @@ class GatewayAccountServiceTest {
         when(mockGatewayAccountDao.search(gatewayAccountSearchParams))
                 .thenReturn(Arrays.asList(getMockGatewayAccountEntity1, getMockGatewayAccountEntity2));
 
-        List<GatewayAccountResponse> gatewayAccounts = gatewayAccountService.searchGatewayAccounts(gatewayAccountSearchParams);
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountService.searchGatewayAccounts(gatewayAccountSearchParams);
 
         assertThat(gatewayAccounts, hasSize(2));
         assertThat(gatewayAccounts.get(0).getServiceName(), is("service one"));


### PR DESCRIPTION
## WHAT YOU DID
 - Modify `GatewayAccountResponse` to be an interface to replace extensible class
 - Create new `DefaultGatewayAccountResponse` record to replace existing `GatewayAccountResponse`
 - Update `GatewayAccountWithCredentialsResponse` and `GatewayAccountWithCredentialsWithInternalIdResponse` to records