### PR TITLE
PP-12767 Remove unnecessary logging

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -154,7 +154,6 @@ public class ChargesFrontendResource {
         }
 
         if (!validateChargePatchParams(chargePatchRequest)) {
-            logger.error("Charge {}: InvalidPatchParameters", chargeId);
             return badRequestResponse("Invalid patch parameters" + chargePatchMap.toString());
         }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -108,7 +108,6 @@ public class CardResource {
     public Response authoriseApplePay(@Parameter(example = "b02b63b370fd35418ad66b0101", description = "Charge external ID")
                                       @PathParam("chargeId") String chargeId,
                                       @NotNull @Valid ApplePayAuthRequest applePayAuthRequest) {
-        logger.info("Received encrypted payload for charge with id {} ", chargeId);
         return walletService.authorise(chargeId, applePayAuthRequest);
     }
 

--- a/src/main/java/uk/gov/pay/connector/token/resource/SecurityTokensResource.java
+++ b/src/main/java/uk/gov/pay/connector/token/resource/SecurityTokensResource.java
@@ -57,7 +57,6 @@ public class SecurityTokensResource {
     public TokenResponse getToken(@Parameter(example = "a69a2cf3-d5d1-408f-b196-4b716767b507")
                                   @PathParam("chargeTokenId") String chargeTokenId,
                                   @Context UriInfo uriInfo) {
-        logger.debug("get token {}", chargeTokenId);
         return tokenDao.findByTokenId(chargeTokenId)
                 .filter(tokenEntity -> tokenEntity.getChargeEntity().getAuthorisationMode() != MOTO_API)
                 .map(tokenEntity -> new TokenResponse(tokenEntity.isUsed(), chargeService.buildChargeResponse(uriInfo, tokenEntity.getChargeEntity())))


### PR DESCRIPTION
The latest IT Healthcheck identified a number of logging statements which could potentially result in unsanitised PII being logged. In several of these cases, these logging statements were found to be unnecessary as the relevant information is already logged in the API call, so they are being removed rather than spending time investigating the risk around logging PII.

- remove unnecessary logging statements