### PR TITLE
PP-12713 Add logging for created_date mismatches

### DIFF
--- a/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
@@ -124,7 +124,7 @@ public class ChargeParityChecker {
     }
 
     private boolean matchCreatedDate(ChargeEntity chargeEntity, LedgerTransaction transaction) {
-        return getChargeEventDate(chargeEntity, List.of(CREATED, PAYMENT_NOTIFICATION_CREATED))
+        boolean createdDateMatches = getChargeEventDate(chargeEntity, List.of(CREATED, PAYMENT_NOTIFICATION_CREATED))
                 .map(connectorDate -> {
                     // Due to charge events being out of order for some historic payments, the date in ledger was 
                     // slightly different to in connector. Allow for a few seconds of difference as it is not worth 
@@ -132,6 +132,12 @@ public class ChargeParityChecker {
                     return Math.abs(Duration.between(connectorDate, ZonedDateTime.parse(transaction.getCreatedDate())).toMillis()) < 5000;
                 })
                 .orElse(false);
+
+        if (!createdDateMatches) {
+            logger.info("Field value does not match between ledger and connector [field_name=created_date]",
+                    kv(FIELD_NAME, "created_date"));
+        }
+        return createdDateMatches;
     }
 
     private boolean matchCardDetails(CardDetailsEntity cardDetailsEntity, CardDetails ledgerCardDetails) {

--- a/src/test/java/uk/gov/pay/connector/tasks/service/ChargeParityCheckerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/service/ChargeParityCheckerTest.java
@@ -301,6 +301,10 @@ class ChargeParityCheckerTest {
         ParityCheckStatus parityCheckStatus = chargeParityChecker.checkParity(chargeEntity, transaction);
 
         assertThat(parityCheckStatus, is(DATA_MISMATCH));
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logStatement.get(0).getFormattedMessage(), is("Field value does not match between ledger and connector [field_name=created_date]"));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- We don't have logging if parity_check fails on matching `created_date` (which can happen if relevant charge events don't exist).
- Added logging if created_date doesn't match with Ledger
