### PR TITLE
PP-12358: Refactor ITestBaseExtension's addCharge* methods

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/base/AddChargeParameters.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/AddChargeParameters.java
@@ -1,0 +1,75 @@
+package uk.gov.pay.connector.it.base;
+
+import uk.gov.pay.connector.charge.model.ServicePaymentReference;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+
+import java.time.Instant;
+
+import static org.apache.commons.lang3.RandomUtils.nextLong;
+
+public record AddChargeParameters(long chargeId, String externalChargeId, ChargeStatus chargeStatus,
+                                  ServicePaymentReference reference, Instant createdDate, String transactionId,
+                                  String paymentProvider, AuthorisationMode authorisationMode) {
+
+
+    public static final class Builder {
+        private long chargeId = nextLong();
+        private String externalChargeId;
+        private ChargeStatus chargeStatus;
+        private ServicePaymentReference reference = ServicePaymentReference.of("ref");
+        private Instant createdDate = Instant.now();
+        private String transactionId = RandomIdGenerator.newId();
+        private String paymentProvider;
+        private AuthorisationMode authorisationMode;
+
+        public static Builder anAddChargeParameters() {
+            return new Builder();
+        }
+
+        public Builder withChargeId(long chargeId) {
+            this.chargeId = chargeId;
+            return this;
+        }
+
+        public Builder withExternalChargeId(String externalChargeId) {
+            this.externalChargeId = externalChargeId;
+            return this;
+        }
+
+        public Builder withChargeStatus(ChargeStatus chargeStatus) {
+            this.chargeStatus = chargeStatus;
+            return this;
+        }
+
+        public Builder withReference(ServicePaymentReference reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        public Builder withCreatedDate(Instant createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public Builder withTransactionId(String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        public Builder withPaymentProvider(String paymentProvider) {
+            this.paymentProvider = paymentProvider;
+            return this;
+        }
+
+        public Builder withAuthorisationMode(AuthorisationMode authorisationMode) {
+            this.authorisationMode = authorisationMode;
+            return this;
+        }
+
+        public AddChargeParameters build() {
+            return new AddChargeParameters(chargeId, externalChargeId, chargeStatus, reference, createdDate, transactionId, paymentProvider, authorisationMode);
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureWithSqsQueueIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureWithSqsQueueIT.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.it.base.AddChargeParameters;
 import uk.gov.pay.connector.it.base.ITestBaseExtension;
 import uk.gov.pay.connector.queue.capture.CaptureQueue;
-import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.time.Instant;
 import java.util.List;
@@ -73,7 +73,9 @@ public class CardResourceCaptureWithSqsQueueIT {
     class DelayedCaptureApproveByChargeIdAndAccountId {
         @Test
         void shouldAddChargeToQueueAndSubmitForCapture_IfChargeWasAwaitingCapture_whenCaptureByChargeIdAndAccountId() {
-            String chargeId = testBaseExtension.addCharge(AWAITING_CAPTURE_REQUEST, "ref", Instant.now().minus(48, HOURS).plus(1, MINUTES), RandomIdGenerator.newId());
+            String chargeId = testBaseExtension.addCharge(
+                    AddChargeParameters.Builder.anAddChargeParameters().withChargeStatus(AWAITING_CAPTURE_REQUEST)
+                            .withCreatedDate(Instant.now().minus(48, HOURS)));
             
             app.givenSetup()
                     .post(format("/v1/api/accounts/%s/charges/%s/capture", testBaseExtension.getAccountId(), chargeId))
@@ -94,7 +96,9 @@ public class CardResourceCaptureWithSqsQueueIT {
     class DelayedCaptureApproveByServiceIdAndAccountType {
         @Test
         void shouldAddChargeToQueueAndSubmitForCapture_IfChargeWasAwaitingCapture_whenCaptureByChargeId() {
-            String chargeId = testBaseExtension.addCharge(AWAITING_CAPTURE_REQUEST, "ref", Instant.now().minus(48, HOURS).plus(1, MINUTES), RandomIdGenerator.newId());
+            String chargeId = testBaseExtension.addCharge(
+                    AddChargeParameters.Builder.anAddChargeParameters().withChargeStatus(AWAITING_CAPTURE_REQUEST)
+                            .withCreatedDate(Instant.now().minus(48, HOURS).plus(1, MINUTES)));
 
             app.givenSetup()
                     .post(format("/v1/api/service/%s/account/test/charges/%s/capture", SERVICE_ID, chargeId))

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceResponseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceResponseIT.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.it.base.AddChargeParameters.Builder.anAddChargeParameters;
 
 public class ChargeCancelResourceResponseIT {
     @RegisterExtension
@@ -71,7 +72,7 @@ public class ChargeCancelResourceResponseIT {
     @ParameterizedTest()
     @MethodSource("statusCode204")
     public void shouldRespond204WithNoLockingEvent_IfCancelledBeforeAuth(ChargeStatus status, int statuscode) {
-        String chargeId = testBaseExtension.addCharge(status, "ref", Instant.now().minus(1, HOURS), "irrelevant");
+        String chargeId = createNewInPastChargeWithStatus(status);
         testBaseExtension.cancelChargeAndCheckApiStatus(chargeId, ChargeStatus.SYSTEM_CANCELLED, statuscode);
 
         List<String> events = app.getDatabaseTestHelper().getInternalEvents(chargeId);
@@ -80,6 +81,7 @@ public class ChargeCancelResourceResponseIT {
     }
 
     private String createNewInPastChargeWithStatus(ChargeStatus status) {
-        return testBaseExtension.addCharge(status, "ref", Instant.now().minus(1, HOURS), "irrelavant");
+        return testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(status)
+                        .withCreatedDate(Instant.now().minus(1, HOURS)));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
@@ -41,6 +41,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_CREATED;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_STARTED;
+import static uk.gov.pay.connector.it.base.AddChargeParameters.Builder.anAddChargeParameters;
 import static uk.gov.pay.connector.it.base.ITestBaseExtension.AMOUNT;
 import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_AMOUNT_KEY;
 import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_AUTH_MODE_KEY;
@@ -178,7 +179,7 @@ public class ChargesApiResourceCreateAgreementIT {
                 .build();
         app.getDatabaseTestHelper().addAgreement(agreementParams);
 
-        String existingChargeExternalId = testBaseExtension.addCharge(CREATED);
+        String existingChargeExternalId = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(CREATED));
 
         // IMPORTANT: Do not modify this request body if the test fails. If properties are modified/removed on the 
         // create charge request, changes to the business code should be made in a way that a request stored in the 
@@ -222,7 +223,7 @@ public class ChargesApiResourceCreateAgreementIT {
                 .build();
         app.getDatabaseTestHelper().addAgreement(agreementParams);
 
-        String existingChargeExternalId = testBaseExtension.addCharge(CREATED);
+        String existingChargeExternalId = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(CREATED));
 
         // IMPORTANT: Do not modify this request body if the test fails. If properties are modified/removed on the 
         // create charge request, changes to the business code should be made in a way that a request stored in the 
@@ -271,7 +272,7 @@ public class ChargesApiResourceCreateAgreementIT {
                 .build();
         app.getDatabaseTestHelper().addAgreement(agreementParams);
 
-        String existingChargeExternalId = testBaseExtension.addCharge(CREATED);
+        String existingChargeExternalId = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(CREATED));
         
         Map<String, Object> previousRequestBodyMap = Map.of(
                 JSON_AMOUNT_KEY, AMOUNT,

--- a/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceIT.java
@@ -28,6 +28,9 @@ import static javax.ws.rs.core.MediaType.TEXT_XML;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
+import static uk.gov.pay.connector.it.base.AddChargeParameters.Builder.anAddChargeParameters;
 import static uk.gov.pay.connector.rules.WorldpayMockClient.WORLDPAY_URL;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_FAILED_RESPONSE;
@@ -43,8 +46,11 @@ public class DiscrepancyResourceIT {
 
     @Test
     void shouldReturnAllCharges_whenRequestDiscrepancyReport() {
-        String chargeId = testBaseExtension.addCharge(ChargeStatus.EXPIRED, "ref", Instant.now().minus(1, HOURS), "irrelevant");
-        String chargeId2 = testBaseExtension.addCharge(ChargeStatus.AUTHORISATION_SUCCESS, "ref", Instant.now().minus(1, HOURS), "irrelevant");
+        String chargeId = testBaseExtension.addCharge(
+                anAddChargeParameters().withChargeStatus(EXPIRED).withCreatedDate(Instant.now().minus(1, HOURS)));
+        String chargeId2 = testBaseExtension.addCharge(
+                anAddChargeParameters().withChargeStatus(AUTHORISATION_SUCCESS).withCreatedDate(Instant.now().minus(1, HOURS)));
+        
         app.getWorldpayMockClient().mockAuthorisationQuerySuccess();
 
         List<JsonNode> results = testBaseExtension.getConnectorRestApiClient()
@@ -101,7 +107,9 @@ public class DiscrepancyResourceIT {
 
     @Test
     void shouldReportOnChargesThatAreInErrorStatesInGatewayAccount() {
-        String chargeId = testBaseExtension.addCharge(ChargeStatus.EXPIRED, "ref", Instant.now().minus(8, DAYS), "irrelevant");
+        String chargeId = testBaseExtension.addCharge(
+                anAddChargeParameters().withChargeStatus(EXPIRED).withCreatedDate(Instant.now().minus(8, DAYS)));
+        
         mockAuthorisationQueryAndCancel(load(WORLDPAY_AUTHORISATION_FAILED_RESPONSE));
 
         List<JsonNode> results = testBaseExtension.getConnectorRestApiClient()
@@ -134,8 +142,11 @@ public class DiscrepancyResourceIT {
 
     @Test
     void shouldProcessDiscrepanciesWherePayStateIsExpiredAndGatewayStateIsAuthorised() {
-        String chargeId = testBaseExtension.addCharge(ChargeStatus.EXPIRED, "ref", Instant.now().minus(8, DAYS), "irrelevant");
-        String chargeId2 = testBaseExtension.addCharge(ChargeStatus.EXPIRED, "ref", Instant.now().minus(8, DAYS), "irrelevant");
+        String chargeId = testBaseExtension.addCharge(
+                anAddChargeParameters().withChargeStatus(EXPIRED).withCreatedDate(Instant.now().minus(8, DAYS)));
+        String chargeId2 = testBaseExtension.addCharge(
+                anAddChargeParameters().withChargeStatus(EXPIRED).withCreatedDate(Instant.now().minus(8, DAYS)));
+        
         mockAuthorisationQueryAndCancel(load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
 
         List<JsonNode> results = testBaseExtension.getConnectorRestApiClient()

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
@@ -21,6 +21,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
+import static uk.gov.pay.connector.it.base.AddChargeParameters.Builder.anAddChargeParameters;
 import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 
@@ -32,10 +33,10 @@ public class GatewayCleanupResourceIT {
 
     @Test
     public void shouldCleanUpChargesInAuthorisationErrorStates() {
-        String chargeId1 = testBaseExtension.addCharge(AUTHORISATION_REJECTED);
-        String chargeId2 = testBaseExtension.addCharge(AUTHORISATION_ERROR);
-        String chargeId3 = testBaseExtension.addCharge(AUTHORISATION_UNEXPECTED_ERROR);
-        String chargeId4 = testBaseExtension.addCharge(AUTHORISATION_TIMEOUT);
+        String chargeId1 = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(AUTHORISATION_REJECTED));
+        String chargeId2 = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(AUTHORISATION_ERROR));
+        String chargeId3 = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(AUTHORISATION_UNEXPECTED_ERROR));
+        String chargeId4 = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(AUTHORISATION_TIMEOUT));
 
         // add a non-Worldpay charge that shouldn't be picked up
         var sandboxAccount = withDatabaseTestHelper(app.getDatabaseTestHelper())
@@ -85,9 +86,9 @@ public class GatewayCleanupResourceIT {
 
     @Test
     public void shouldLimitChargesCleanedUp() {
-        testBaseExtension.addCharge(AUTHORISATION_ERROR);
-        testBaseExtension.addCharge(AUTHORISATION_ERROR);
-        testBaseExtension.addCharge(AUTHORISATION_ERROR);
+        testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(AUTHORISATION_ERROR));
+        testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(AUTHORISATION_ERROR));
+        testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(AUTHORISATION_ERROR));
 
         app.getWorldpayMockClient().mockCancelSuccess();
         app.getWorldpayMockClient().mockAuthorisationQuerySuccess();


### PR DESCRIPTION
There are too many ITestBaseExtension.addCharge* methods which make for difficult reading. Use the standard java builder pattern to rectify this. A new AddChargeParameters class has been added for use with the addCharge* methods. There is another separate AddChargeParams class which could be confusing but reducing these two classes to one requires some thought and should go into another PR.