### PR TITLE
PP-12830 remove spotify

### DIFF
--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,7 +1,6 @@
 <configuration debug="false">
   <logger name="liquibase" level="WARN" />
   <logger name="org.apache.http" level="WARN" />
-  <logger name="com.spotify" level="WARN" />
   <logger name="uk.gov.pay." level="WARN" />
   <root level="WARN"/>
 </configuration>


### PR DESCRIPTION
## WHAT YOU DID

When we upgraded to Dropwizard 3, a few scattered code was left behind that refers to com.spotify.
