### PR TITLE
PP-12619: Apply strategy for returning gateway account by service id and account type

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -360,7 +360,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/usernotification/resource/EmailNotificationResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 112
       }
     ],
     "src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java": [
@@ -1061,5 +1061,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-08T14:10:57Z"
+  "generated_at": "2024-07-11T15:48:36Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
@@ -70,15 +70,14 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
                 .getResultList().stream().findFirst();
     }
 
-    public Optional<GatewayAccountEntity> findByServiceIdAndAccountType(String serviceId, GatewayAccountType accountType) {
-        // TODO: review this query, decide what to do about multiple records
+    public List<GatewayAccountEntity> findByServiceIdAndAccountType(String serviceId, GatewayAccountType accountType) {
         String query = "SELECT g FROM GatewayAccountEntity g where g.serviceId = :serviceId and g.type = :accountType order by g.id DESC";
 
         return entityManager.get()
                 .createQuery(query, GatewayAccountEntity.class)
                 .setParameter("serviceId", serviceId)
                 .setParameter("accountType", accountType)
-                .getResultList().stream().findFirst();
+                .getResultList();
     }
 
     public List<GatewayAccountEntity> findByServiceId(String serviceId) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -547,4 +547,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return PaymentGatewayName.WORLDPAY.getName().equals(this.getGatewayName());
     }
 
+    public boolean isSandboxGatewayAccount() {
+        return PaymentGatewayName.SANDBOX.getName().equals(this.getGatewayName());
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -112,7 +112,7 @@ public class GatewayAccountService {
 
     @Transactional
     public Optional<GatewayAccount> doPatch(String serviceId, GatewayAccountType accountType, JsonPatchRequest gatewayAccountRequest) {
-        return gatewayAccountDao.findByServiceIdAndAccountType(serviceId, accountType)
+        return getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
                 .flatMap(gatewayAccountEntity -> {
                     attributeUpdater.get(gatewayAccountRequest.getPath())
                             .accept(gatewayAccountRequest, gatewayAccountEntity);
@@ -147,7 +147,11 @@ public class GatewayAccountService {
     }
 
     public Optional<GatewayAccountEntity> getGatewayAccountByServiceIdAndAccountType(String serviceId, GatewayAccountType accountType) {
-        return gatewayAccountDao.findByServiceIdAndAccountType(serviceId, accountType);
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.findByServiceIdAndAccountType(serviceId, accountType);
+        return gatewayAccounts.stream().filter(GatewayAccountEntity::isStripeGatewayAccount).findFirst()
+                .or(() -> gatewayAccounts.stream().filter(GatewayAccountEntity::isSandboxGatewayAccount).findFirst())
+                .or(() -> gatewayAccounts.stream().filter(GatewayAccountEntity::isWorldpayGatewayAccount).findFirst());
+
     }
 
     public boolean isATelephonePaymentNotificationAccount(String merchantCode) {

--- a/src/main/java/uk/gov/pay/connector/usernotification/resource/EmailNotificationResource.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/resource/EmailNotificationResource.java
@@ -10,10 +10,10 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.usernotification.model.EmailNotificationPatchRequest;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
@@ -27,7 +27,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -36,17 +35,14 @@ import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
 @Path("/")
 public class EmailNotificationResource {
 
-    private static final Logger logger = LoggerFactory.getLogger(EmailNotificationResource.class);
-
     public static final String EMAIL_NOTIFICATION_TEMPLATE_BODY = "template_body";
     private static final String EMAIL_NOTIFICATION_ENABLED = "enabled";
 
-    private static final String FORMATTER = "/%s/%s";
-    private final GatewayAccountDao gatewayDao;
+    private final GatewayAccountService gatewayAccountService;
 
     @Inject
-    public EmailNotificationResource(GatewayAccountDao gatewayDao) {
-        this.gatewayDao = gatewayDao;
+    public EmailNotificationResource(GatewayAccountService gatewayAccountService) {
+        this.gatewayAccountService = gatewayAccountService;
     }
 
     @PATCH
@@ -75,7 +71,7 @@ public class EmailNotificationResource {
                                             @PathParam("accountId") Long gatewayAccountId,
                                             @Valid EmailNotificationPatchRequest request) {
 
-        return gatewayDao.findById(gatewayAccountId)
+        return gatewayAccountService.getGatewayAccount(gatewayAccountId)
                 .map(gatewayAccount -> {
                     NotificationPatchInfo patchInfo = getNotificationInfoFromPath(request);
                     EmailNotificationType type = patchInfo.getEmailNotificationType();
@@ -117,7 +113,7 @@ public class EmailNotificationResource {
             @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType,
             @Valid EmailNotificationPatchRequest request) {
 
-        return gatewayDao.findByServiceIdAndAccountType(serviceId, accountType)
+        return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
                 .map(gatewayAccount -> {
                     NotificationPatchInfo patchInfo = getNotificationInfoFromPath(request);
                     EmailNotificationType notificationType = patchInfo.getEmailNotificationType();

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -2,9 +2,9 @@ package uk.gov.pay.connector.it.dao;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.Nested;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
@@ -660,8 +660,7 @@ public class GatewayAccountDaoIT {
 
     @Test
     void findByServiceIdAndAccountType_shouldReturnMostRecentlyAddedAccount_whenMultipleAccountsExist() {
-        // TODO: update this test when decision has been made about multiple accounts
-        Long firstAccountId = nextLong();
+        long firstAccountId = nextLong();
         String firstExternalId = randomUuid();
         String serviceId = randomUuid();
         databaseFixtures
@@ -671,7 +670,7 @@ public class GatewayAccountDaoIT {
                 .withServiceId(serviceId)
                 .insert();
 
-        Long secondAccountId = firstAccountId + 1;
+        long secondAccountId = firstAccountId + 1;
         String secondExternalId = randomUuid();
         databaseFixtures
                 .aTestAccount()
@@ -680,10 +679,10 @@ public class GatewayAccountDaoIT {
                 .withServiceId(serviceId)
                 .insert();
         
-        Optional<GatewayAccountEntity> gatewayAccountOptional = gatewayAccountDao.findByServiceIdAndAccountType(serviceId, TEST);
-        assertThat(gatewayAccountOptional.isPresent(), is(true));
-        assertThat(gatewayAccountOptional.get().getId(), is(secondAccountId));
-        assertThat(gatewayAccountOptional.get().getExternalId(), is(secondExternalId));
+        List<GatewayAccountEntity> gatewayAccount = gatewayAccountDao.findByServiceIdAndAccountType(serviceId, TEST);
+        assertThat(gatewayAccount.size(), is(2));
+        assertTrue(gatewayAccount.stream().anyMatch(ga -> ga.getExternalId().equals(firstExternalId)));
+        assertTrue(gatewayAccount.stream().anyMatch(ga -> ga.getExternalId().equals(secondExternalId)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -659,7 +659,7 @@ public class GatewayAccountDaoIT {
     }
 
     @Test
-    void findByServiceIdAndAccountType_shouldReturnMostRecentlyAddedAccount_whenMultipleAccountsExist() {
+    void findByServiceIdAndAccountType_shouldReturnAllAccounts() {
         long firstAccountId = nextLong();
         String firstExternalId = randomUuid();
         String serviceId = randomUuid();

--- a/src/test/java/uk/gov/pay/connector/service/GetGatewayAccountByServiceIdAndAccountTypeTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GetGatewayAccountByServiceIdAndAccountTypeTest.java
@@ -1,0 +1,115 @@
+package uk.gov.pay.connector.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
+import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsHistoryDao;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+
+@ExtendWith(MockitoExtension.class)
+public class GetGatewayAccountByServiceIdAndAccountTypeTest {
+
+    private GatewayAccountService gatewayAccountService;
+
+    @Mock
+    private GatewayAccountDao mockGatewayAccountDao;
+
+    @Mock
+    private CardTypeDao mockCardTypeDao;
+
+    @Mock
+    private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
+    
+    private GatewayAccountEntity stripeGatewayAccount;
+    
+    private GatewayAccountEntity sandboxGatewayAccount;
+    
+    private GatewayAccountEntity worldpayGatewayAccount;
+    
+    private static final String SERVICE_ID = "a-service-id";
+
+    @BeforeEach
+    void setUp() {
+        gatewayAccountService = new GatewayAccountService(mockGatewayAccountDao, mockCardTypeDao,
+                mockGatewayAccountCredentialsService, mock(GatewayAccountCredentialsHistoryDao.class), mock(GatewayAccountCredentialsDao.class));
+        
+        stripeGatewayAccount = new GatewayAccountEntity(GatewayAccountType.TEST);
+        var stripeGatewayAccountCreds = new GatewayAccountCredentialsEntity(stripeGatewayAccount, "stripe", Map.of(), ACTIVE);
+        stripeGatewayAccount.setGatewayAccountCredentials(List.of(stripeGatewayAccountCreds));
+        
+        sandboxGatewayAccount = new GatewayAccountEntity(GatewayAccountType.TEST);
+        var sandboxGatewayAccountCreds = new GatewayAccountCredentialsEntity(sandboxGatewayAccount, "sandbox", Map.of(), ACTIVE);
+        sandboxGatewayAccount.setGatewayAccountCredentials(List.of(sandboxGatewayAccountCreds));
+        
+        worldpayGatewayAccount = new GatewayAccountEntity(GatewayAccountType.TEST);
+        var worldpayGatewayAccountCreds = new GatewayAccountCredentialsEntity(worldpayGatewayAccount, "worldpay", Map.of(), ACTIVE);
+        worldpayGatewayAccount.setGatewayAccountCredentials(List.of(worldpayGatewayAccountCreds));
+    }
+
+    @Test
+    void shouldReturnStripeGatewayAccountWhenThereAreMultipleGatewayAccounts() {
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST))
+                .thenReturn(List.of(worldpayGatewayAccount, sandboxGatewayAccount, stripeGatewayAccount));
+
+        Optional<GatewayAccountEntity> gatewayAccount = 
+                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST);
+        assertTrue(gatewayAccount.isPresent());
+        assertTrue(gatewayAccount.get().isStripeGatewayAccount());
+    }
+    
+    @Test
+    void shouldReturnNothingWhenThereAreNoGatewayAccounts() {
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST))
+                .thenReturn(List.of());
+
+        Optional<GatewayAccountEntity> gatewayAccount =
+                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST);
+        assertFalse(gatewayAccount.isPresent());
+    }
+
+    @Test
+    void shouldReturnSandboxGatewayAccountWhenThereAreSandboxAndWorldpayAccounts() {
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST))
+                .thenReturn(List.of(worldpayGatewayAccount, sandboxGatewayAccount));
+
+        Optional<GatewayAccountEntity> gatewayAccount =
+                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST);
+        assertTrue(gatewayAccount.isPresent());
+        assertTrue(gatewayAccount.get().isSandboxGatewayAccount());
+    }
+    
+    @Test
+    void shouldReturnWorldpayGatewayAccount() {
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST))
+                .thenReturn(List.of(worldpayGatewayAccount));
+
+        Optional<GatewayAccountEntity> gatewayAccount =
+                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST);
+        assertTrue(gatewayAccount.isPresent());
+        assertTrue(gatewayAccount.get().isWorldpayGatewayAccount());
+    }
+    
+    @Test
+    void shouldLogAndThrowErrorIfThereAreMultipleLiveGatewayAccounts() {
+        //TODO
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/service/GetGatewayAccountByServiceIdAndAccountTypeTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GetGatewayAccountByServiceIdAndAccountTypeTest.java
@@ -45,6 +45,8 @@ public class GetGatewayAccountByServiceIdAndAccountTypeTest {
     
     private GatewayAccountEntity worldpayGatewayAccount;
     
+    private GatewayAccountEntity smartpayGatewayAccount;
+    
     private static final String SERVICE_ID = "a-service-id";
 
     @BeforeEach
@@ -63,6 +65,10 @@ public class GetGatewayAccountByServiceIdAndAccountTypeTest {
         worldpayGatewayAccount = new GatewayAccountEntity(GatewayAccountType.TEST);
         var worldpayGatewayAccountCreds = new GatewayAccountCredentialsEntity(worldpayGatewayAccount, "worldpay", Map.of(), ACTIVE);
         worldpayGatewayAccount.setGatewayAccountCredentials(List.of(worldpayGatewayAccountCreds));
+        
+        smartpayGatewayAccount = new GatewayAccountEntity(GatewayAccountType.TEST);
+        var smartpayGatewayAccountCreds = new GatewayAccountCredentialsEntity(smartpayGatewayAccount, "smartpay", Map.of(), ACTIVE);
+        smartpayGatewayAccount.setGatewayAccountCredentials(List.of(smartpayGatewayAccountCreds));
     }
 
     @Test
@@ -106,6 +112,16 @@ public class GetGatewayAccountByServiceIdAndAccountTypeTest {
                 gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST);
         assertTrue(gatewayAccount.isPresent());
         assertTrue(gatewayAccount.get().isWorldpayGatewayAccount());
+    }
+    
+    @Test
+    void shouldNotReturnObscureGatewayAccount() {
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST))
+                .thenReturn(List.of(smartpayGatewayAccount));
+
+        Optional<GatewayAccountEntity> gatewayAccount =
+                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST);
+        assertFalse(gatewayAccount.isPresent());
     }
     
     @Test


### PR DESCRIPTION
If a service has multiple gateway accounts,
* If a Stripe test account is found, return it
* Otherwise return the sandbox test account
* Obviously, if there’s only one test account found, return that one, regardless of whether it is a sandbox, Stripe, or Worldpay test account
* The only way for a Worldpay test account to be returned is if that’s the only test gateway account found on that service
