### PR TITLE
PP-12789 upgrade to pay-java-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <pay-java-commons.version>1.0.20240603094506</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20240711152628</pay-java-commons.version>
         <surefire.version>3.3.0</surefire.version>
         <jjwt.version>0.12.6</jjwt.version>
         <pact.version>4.6.11</pact.version>

--- a/src/test/java/uk/gov/pay/connector/client/cardid/model/CardidServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/cardid/model/CardidServiceConsumerTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.client.cardid.model;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,8 +12,8 @@ import uk.gov.pay.connector.app.RestClientFactory;
 import uk.gov.pay.connector.app.config.RestClientConfig;
 import uk.gov.pay.connector.client.cardid.service.CardidService;
 import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 public class CardidServiceConsumerTest {
     
     @Rule
-    public PactProviderRule cardidRule = new PactProviderRule("cardid", this);
+    public PayPactProviderRule cardidRule = new PayPactProviderRule("cardid", this);
     
     @Mock
     ConnectorConfiguration configuration;

--- a/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.client.ledger.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,13 +11,13 @@ import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.agreement.AgreementCreated;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.RestClientFactory;
 import uk.gov.pay.connector.app.config.RestClientConfig;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.client.ledger.model.RefundTransactionsForPayment;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
@@ -36,7 +36,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixt
 public class LedgerServiceConsumerTest {
 
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
 
     @Mock
     ConnectorConfiguration configuration;

--- a/src/test/java/uk/gov/pay/connector/pact/event/ServiceArchivedEventIT.java
+++ b/src/test/java/uk/gov/pay/connector/pact/event/ServiceArchivedEventIT.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.connector.pact.event;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
 import au.com.dius.pact.consumer.dsl.DslPart;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
## WHAT YOU DID

`pay-java-commons` was upgraded to Java 21. Some of the imports needed update as they are transative dependencies.
