### PR TITLE
PP-12844 Degateway integration tests for create charge prefilled details

### DIFF
--- a/src/test/java/uk/gov/pay/connector/common/model/domain/PrefilledAddressTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/domain/PrefilledAddressTest.java
@@ -11,30 +11,30 @@ class PrefilledAddressTest {
     
     @Test
     void shouldSetCountryWhenProvidedValueIsTwoCharactersLong() {
-        var address = createPrefilledAdddressWithCountryOf("GB");
+        var address = createPrefilledAddressWithCountryOf("GB");
         assertThat(address.getCountry(), is("GB"));
     }
 
     @Test
     void shouldSetCountryToNullWhenCountryNotSupplied() {
-        var address = createPrefilledAdddressWithCountryOf(null);
+        var address = createPrefilledAddressWithCountryOf(null);
         assertThat(address.getCountry(), is(nullValue()));
     }
     
     @Test
     void shouldSetCountryToNullWhenProvidedCountryTooShort() {
-        var address = createPrefilledAdddressWithCountryOf("G");
+        var address = createPrefilledAddressWithCountryOf("G");
         assertThat(address.getCountry(), is(nullValue()));
     }
 
     @Test
     void shouldSetCountryToNullWhenProvidedCountryTooLong() {
-        var address = createPrefilledAdddressWithCountryOf("GBR");
+        var address = createPrefilledAddressWithCountryOf("GBR");
         assertThat(address.getCountry(), is(nullValue()));
     }
     
     
-    private PrefilledAddress createPrefilledAdddressWithCountryOf(String country) {
+    private PrefilledAddress createPrefilledAddressWithCountryOf(String country) {
         return new PrefilledAddress("line1", "line2", "postcode", "city", "county", country);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -140,6 +140,7 @@ public class ChargesApiResourceCreateIT {
                     .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                     .body("created_date", isWithin(10, SECONDS))
                     .body("authorisation_mode", is("web"))
+                    .body("containsKey('card_details')", is(false))
                     .contentType(JSON);
 
             String testChargeId = response.extract().path("charge_id");
@@ -529,6 +530,7 @@ public class ChargesApiResourceCreateIT {
                     .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                     .body("created_date", isWithin(10, SECONDS))
                     .body("authorisation_mode", is("web"))
+                    .body("containsKey('card_details')", is(false))
                     .contentType(JSON);
 
             String testChargeId = response.extract().path("charge_id");

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreatePrefilledCardholderDetailsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreatePrefilledCardholderDetailsIT.java
@@ -1,18 +1,25 @@
 package uk.gov.pay.connector.it.resources;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.it.base.ITestBaseExtension;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.common.model.domain.NumbersInStringsSanitizer.sanitize;
 import static uk.gov.pay.connector.it.base.ITestBaseExtension.AMOUNT;
 import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_AMOUNT_KEY;
 import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_CHARGE_KEY;
@@ -28,216 +35,396 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
 public class ChargesApiResourceCreatePrefilledCardholderDetailsIT {
+    
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-    @RegisterExtension
-    public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
+    private static final String VALID_SERVICE_ID = "valid-service-id";
+    private String gatewayAccountId;
 
-    private static final String JSON_PREFILLED_CARDHOLDER_DETAILS_KEY = "prefilled_cardholder_details";
-    private static final String JSON_BILLING_ADDRESS_KEY = "billing_address";
-    private static final String JSON_ADDRESS_LINE_1_KEY = "line1";
-    private static final String JSON_ADDRESS_LINE_2_KEY = "line2";
-    private static final String JSON_ADDRESS_POST_CODE_KEY = "postcode";
-    private static final String JSON_CARDHOLDER_NAME_KEY = "cardholder_name";
-    private static final String JSON_ADDRESS_LINE_CITY = "city";
-    private static final String JSON_ADDRESS_LINE_COUNTRY_CODE = "country";
-
-    @Test
-    void shouldReturn201WhenPrefilledCardHolderDetailsFieldsAreMaximum() {
-        String line1 = randomAlphanumeric(255);
-        String city = randomAlphanumeric(255);
-        String postCode = randomAlphanumeric(25);
-        String countryCode = "GB";
-
-        String postBody = toJson(Map.of(
-                JSON_AMOUNT_KEY, AMOUNT,
-                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
-                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
-                JSON_PREFILLED_CARDHOLDER_DETAILS_KEY, Map.of(
-                        JSON_CARDHOLDER_NAME_KEY, randomAlphanumeric(255),
-                        JSON_BILLING_ADDRESS_KEY, Map.of(
-                                JSON_ADDRESS_LINE_1_KEY, line1,
-                                JSON_ADDRESS_LINE_CITY, city,
-                                JSON_ADDRESS_POST_CODE_KEY, postCode,
-                                JSON_ADDRESS_LINE_COUNTRY_CODE, countryCode
-                        )
-                )
-        ));
-
-        testBaseExtension.getConnectorRestApiClient().postCreateCharge(postBody)
-                .statusCode(Response.Status.CREATED.getStatusCode())
-                .contentType(JSON)
-                .body(JSON_CHARGE_KEY, is(notNullValue()))
-                .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
-                .body(JSON_REFERENCE_KEY, is(JSON_REFERENCE_VALUE))
-                .body(JSON_DESCRIPTION_KEY, is(JSON_DESCRIPTION_VALUE))
-                .body(JSON_PROVIDER_KEY, is(PROVIDER_NAME))
-                .body(JSON_RETURN_URL_KEY, is(RETURN_URL));
+    @BeforeEach
+    void setup() {
+        gatewayAccountId = app.givenSetup()
+                .body(toJson(Map.of(
+                        "service_id", VALID_SERVICE_ID,
+                        "type", GatewayAccountType.TEST,
+                        "payment_provider", PaymentGatewayName.SANDBOX.getName(),
+                        "service_name", "my-test-service-name"
+                )))
+                .post("/v1/api/accounts")
+                .then()
+                .statusCode(201)
+                .extract().path("gateway_account_id");
     }
 
-    @Test
-    void shouldReturn201WithAllPrefilledCardHolderDetailsFields() {
-        String cardholderName = "Joe Bogs";
-        String line1 = "Line 1";
-        String city = "City";
-        String postCode = "AB1 CD2";
-        String countryCode = "GB";
+    @Nested
+    class ByGatewayAccountId {
 
-        String postBody = toJson(Map.of(
-                JSON_AMOUNT_KEY, AMOUNT,
-                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
-                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
-                JSON_PREFILLED_CARDHOLDER_DETAILS_KEY, Map.of(
-                        JSON_CARDHOLDER_NAME_KEY, cardholderName,
-                        JSON_BILLING_ADDRESS_KEY, Map.of(
-                                JSON_ADDRESS_LINE_1_KEY, line1,
-                                JSON_ADDRESS_LINE_CITY, city,
-                                JSON_ADDRESS_POST_CODE_KEY, postCode,
-                                JSON_ADDRESS_LINE_COUNTRY_CODE, countryCode
-                        )
-                )
-        ));
+        @Test
+        void shouldReturn201_withAllPrefilledCardHolderDetailsFields() {
+            String cardholderName = "Joe Bogs";
+            String line1 = "Line 1";
+            String line2 = "Line 2";
+            String city = "City";
+            String postcode = "AB1 CD2";
+            String country = "GB";
 
-        testBaseExtension.getConnectorRestApiClient().postCreateCharge(postBody)
-                .statusCode(Response.Status.CREATED.getStatusCode())
-                .contentType(JSON)
-                .body(JSON_CHARGE_KEY, is(notNullValue()))
-                .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
-                .body(JSON_REFERENCE_KEY, is(JSON_REFERENCE_VALUE))
-                .body(JSON_DESCRIPTION_KEY, is(JSON_DESCRIPTION_VALUE))
-                .body(JSON_PROVIDER_KEY, is(PROVIDER_NAME))
-                .body(JSON_RETURN_URL_KEY, is(RETURN_URL))
-                .body("card_details." + JSON_CARDHOLDER_NAME_KEY, is(cardholderName))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_1_KEY, is(line1))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_2_KEY, is(nullValue()))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_CITY, is(city))
-                .body("card_details.billing_address." + JSON_ADDRESS_POST_CODE_KEY, is(postCode))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_COUNTRY_CODE, is(countryCode));
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", 6234L,
+                            "reference", "Test reference",
+                            "description", "Test description",
+                            "return_url", "http://service.local/success-page/",
+                            "prefilled_cardholder_details", Map.of(
+                                    "cardholder_name", cardholderName,
+                                    "billing_address", Map.of(
+                                            "line1", line1,
+                                            "line2", line2,
+                                            "city", city,
+                                            "postcode", postcode,
+                                            "country", country
+                                    ))
+                    )))
+                    .post(format("/v1/api/accounts/%s/charges", gatewayAccountId))
+                    .then()
+                    .statusCode(Response.Status.CREATED.getStatusCode())
+                    .contentType(JSON)
+                    .log()
+                    .body()
+                    .body("charge_id", is(notNullValue()))
+                    .body("reference", is("Test reference"))
+                    .body("card_details.cardholder_name", is(cardholderName))
+                    .body("card_details.billing_address.line1", is(line1))
+                    .body("card_details.billing_address.line2", is(line2))
+                    .body("card_details.billing_address.city", is(city))
+                    .body("card_details.billing_address.postcode", is(postcode))
+                    .body("card_details.billing_address.country", is(country));
+        }
+
+
+        @Test
+        void shouldReturn201_withPrefilledCardHolderDetailsFieldsAtMaximumLength() {
+            String cardholderName = randomAlphanumeric(255);
+            String line1 = randomAlphanumeric(255);
+            String line2 = randomAlphanumeric(255);
+            String city = randomAlphanumeric(255);
+            String postcode = randomAlphanumeric(25);
+            String country = "GB";
+
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", 6234L,
+                            "reference", "Test reference",
+                            "description", "Test description",
+                            "return_url", "http://service.local/success-page/",
+                            "prefilled_cardholder_details", Map.of(
+                                    "cardholder_name", cardholderName,
+                                    "billing_address", Map.of(
+                                            "line1", line1,
+                                            "line2", line2,
+                                            "city", city,
+                                            "postcode", postcode,
+                                            "country", country
+                                    ))
+                    )))
+                    .post(format("/v1/api/accounts/%s/charges", gatewayAccountId))
+                    .then()
+                    .statusCode(Response.Status.CREATED.getStatusCode())
+                    .contentType(JSON)
+                    .log()
+                    .body()
+                    .body("charge_id", is(notNullValue()))
+                    .body("reference", is("Test reference"))
+                    .body("card_details.cardholder_name", is(cardholderName))
+                    .body("card_details.billing_address.line1", is(sanitize(line1))) // where there are more than 10 digits in the field, the digits are replaced by asterisks in the response
+                    .body("card_details.billing_address.line2", is(sanitize(line2)))
+                    .body("card_details.billing_address.city", is(sanitize(city)))
+                    .body("card_details.billing_address.postcode", is(sanitize(postcode)))
+                    .body("card_details.billing_address.country", is(country));
+        }
+
+        @Test
+        void shouldReturn201_withSomePrefilledCardHolderDetailsFields() {
+            String cardholderName = "Joe Bogs";
+            String line1 = "Line 1";
+            String postcode = "AB1 CD2";
+
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", 6234L,
+                            "reference", "Test reference",
+                            "description", "Test description",
+                            "return_url", "http://service.local/success-page/",
+                            "prefilled_cardholder_details", Map.of(
+                                    "cardholder_name", cardholderName,
+                                    "billing_address", Map.of(
+                                            "line1", line1,
+                                            "postcode", postcode
+                                    ))
+                    )))
+                    .post(format("/v1/api/accounts/%s/charges", gatewayAccountId))
+                    .then()
+                    .statusCode(Response.Status.CREATED.getStatusCode())
+                    .contentType(JSON)
+                    .log()
+                    .body()
+                    .body("charge_id", is(notNullValue()))
+                    .body("reference", is("Test reference"))
+                    .body("card_details.cardholder_name", is(cardholderName))
+                    .body("card_details.billing_address.line1", is(line1))
+                    .body("card_details.billing_address.line2", is(nullValue()))
+                    .body("card_details.billing_address.city", is(nullValue()))
+                    .body("card_details.billing_address.postcode", is(postcode))
+                    .body("card_details.billing_address.country", is(nullValue()));
+        }
+
+        @Test
+        void shouldReturn201AndNoCountryWhenSuppliedCountryIsTooLong() {
+            String cardholderName = "Joe Bogs";
+            String line1 = "Line 1";
+            String postcode = "AB1 CD2";
+            String countryThatIsTooLong = "GBR";
+
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", 6234L,
+                            "reference", "Test reference",
+                            "description", "Test description",
+                            "return_url", "http://service.local/success-page/",
+                            "prefilled_cardholder_details", Map.of(
+                                    "cardholder_name", cardholderName,
+                                    "billing_address", Map.of(
+                                            "line1", line1,
+                                            "postcode", postcode,
+                                            "country", countryThatIsTooLong
+                                    ))
+                    )))
+                    .post(format("/v1/api/accounts/%s/charges", gatewayAccountId))
+                    .then()
+                    .statusCode(Response.Status.CREATED.getStatusCode())
+                    .contentType(JSON)
+                    .log()
+                    .body()
+                    .body("charge_id", is(notNullValue()))
+                    .body("reference", is("Test reference"))
+                    .body("card_details.cardholder_name", is(cardholderName))
+                    .body("card_details.billing_address.line1", is(line1))
+                    .body("card_details.billing_address.line2", is(nullValue()))
+                    .body("card_details.billing_address.city", is(nullValue()))
+                    .body("card_details.billing_address.postcode", is(postcode))
+                    .body("card_details.billing_address.country", is(nullValue()));
+        }
+
+        @Test
+        void shouldReturn201WithNoBillingAddressWhenPrefilledCardHolderDetailsFieldsContainsCardHolderNameOnly() {
+            String cardholderName = "Joe Bogs";
+
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", 6234L,
+                            "reference", "Test reference",
+                            "description", "Test description",
+                            "return_url", "http://service.local/success-page/",
+                            "prefilled_cardholder_details", Map.of(
+                                    "cardholder_name", cardholderName
+                            )
+                    )))
+                    .post(format("/v1/api/accounts/%s/charges", gatewayAccountId))
+                    .then()
+                    .statusCode(Response.Status.CREATED.getStatusCode())
+                    .contentType(JSON)
+                    .log()
+                    .body()
+                    .body("charge_id", is(notNullValue()))
+                    .body("reference", is("Test reference"))
+                    .body("card_details.cardholder_name", is(cardholderName))
+                    .body("card_details.billing_address", is(nullValue()));
+        }
     }
 
-    @Test
-    void shouldReturn201WithSomePrefilledCardHolderDetailsFields() {
-        String cardholderName = "Joe Bogs";
-        String line1 = "Line 1";
-        String postCode = "AB1 CD2";
+    @Nested
+    class ByServiceIdAndAccountType {
 
-        String postBody = toJson(Map.of(
-                JSON_AMOUNT_KEY, AMOUNT,
-                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
-                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
-                JSON_PREFILLED_CARDHOLDER_DETAILS_KEY, Map.of(
-                        JSON_CARDHOLDER_NAME_KEY, cardholderName,
-                        JSON_BILLING_ADDRESS_KEY, Map.of(
-                                JSON_ADDRESS_LINE_1_KEY, line1,
-                                JSON_ADDRESS_POST_CODE_KEY, postCode
-                        )
-                )
-        ));
+        @Test
+        void shouldReturn201_withAllPrefilledCardHolderDetailsFields() {
+            String cardholderName = "Joe Bogs";
+            String line1 = "Line 1";
+            String line2 = "Line 2";
+            String city = "City";
+            String postcode = "AB1 CD2";
+            String country = "GB";
 
-        testBaseExtension.getConnectorRestApiClient().postCreateCharge(postBody)
-                .statusCode(Response.Status.CREATED.getStatusCode())
-                .contentType(JSON)
-                .body(JSON_CHARGE_KEY, is(notNullValue()))
-                .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
-                .body(JSON_REFERENCE_KEY, is(JSON_REFERENCE_VALUE))
-                .body(JSON_DESCRIPTION_KEY, is(JSON_DESCRIPTION_VALUE))
-                .body(JSON_PROVIDER_KEY, is(PROVIDER_NAME))
-                .body(JSON_RETURN_URL_KEY, is(RETURN_URL))
-                .body("card_details." + JSON_CARDHOLDER_NAME_KEY, is(cardholderName))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_1_KEY, is(line1))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_2_KEY, is(nullValue()))
-                .body("card_details.billing_address." + JSON_ADDRESS_POST_CODE_KEY, is(postCode))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_CITY, is(nullValue()))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_COUNTRY_CODE, is(nullValue()));
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", 6234L,
+                            "reference", "Test reference",
+                            "description", "Test description",
+                            "return_url", "http://service.local/success-page/",
+                            "prefilled_cardholder_details", Map.of(
+                                    "cardholder_name", cardholderName,
+                                    "billing_address", Map.of(
+                                            "line1", line1,
+                                            "line2", line2,
+                                            "city", city,
+                                            "postcode", postcode,
+                                            "country", country
+                                    ))
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges", VALID_SERVICE_ID, GatewayAccountType.TEST))
+                    .then()
+                    .statusCode(Response.Status.CREATED.getStatusCode())
+                    .contentType(JSON)
+                    .log()
+                    .body()
+                    .body("charge_id", is(notNullValue()))
+                    .body("reference", is("Test reference"))
+                    .body("card_details.cardholder_name", is(cardholderName))
+                    .body("card_details.billing_address.line1", is(line1))
+                    .body("card_details.billing_address.line2", is(line2))
+                    .body("card_details.billing_address.city", is(city))
+                    .body("card_details.billing_address.postcode", is(postcode))
+                    .body("card_details.billing_address.country", is(country));
+        }
+
+
+        @Test
+        void shouldReturn201_withPrefilledCardHolderDetailsFieldsAtMaximumLength() {
+            String cardholderName = randomAlphanumeric(255);
+            String line1 = randomAlphanumeric(255);
+            String line2 = randomAlphanumeric(255);
+            String city = randomAlphanumeric(255);
+            String postcode = randomAlphanumeric(25);
+            String country = "GB";
+
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", 6234L,
+                            "reference", "Test reference",
+                            "description", "Test description",
+                            "return_url", "http://service.local/success-page/",
+                            "prefilled_cardholder_details", Map.of(
+                                    "cardholder_name", cardholderName,
+                                    "billing_address", Map.of(
+                                            "line1", line1,
+                                            "line2", line2,
+                                            "city", city,
+                                            "postcode", postcode,
+                                            "country", country
+                                    ))
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges", VALID_SERVICE_ID, GatewayAccountType.TEST))
+                    .then()
+                    .statusCode(Response.Status.CREATED.getStatusCode())
+                    .contentType(JSON)
+                    .log()
+                    .body()
+                    .body("charge_id", is(notNullValue()))
+                    .body("reference", is("Test reference"))
+                    .body("card_details.cardholder_name", is(cardholderName))
+                    .body("card_details.billing_address.line1", is(sanitize(line1))) // where there are more than 10 digits in the field, the digits are replaced by asterisks in the response
+                    .body("card_details.billing_address.line2", is(sanitize(line2)))
+                    .body("card_details.billing_address.city", is(sanitize(city)))
+                    .body("card_details.billing_address.postcode", is(sanitize(postcode)))
+                    .body("card_details.billing_address.country", is(country));
+        }
+
+        @Test
+        void shouldReturn201_withSomePrefilledCardHolderDetailsFields() {
+            String cardholderName = "Joe Bogs";
+            String line1 = "Line 1";
+            String postcode = "AB1 CD2";
+
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", 6234L,
+                            "reference", "Test reference",
+                            "description", "Test description",
+                            "return_url", "http://service.local/success-page/",
+                            "prefilled_cardholder_details", Map.of(
+                                    "cardholder_name", cardholderName,
+                                    "billing_address", Map.of(
+                                            "line1", line1,
+                                            "postcode", postcode
+                                    ))
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges", VALID_SERVICE_ID, GatewayAccountType.TEST))
+                    .then()
+                    .statusCode(Response.Status.CREATED.getStatusCode())
+                    .contentType(JSON)
+                    .log()
+                    .body()
+                    .body("charge_id", is(notNullValue()))
+                    .body("reference", is("Test reference"))
+                    .body("card_details.cardholder_name", is(cardholderName))
+                    .body("card_details.billing_address.line1", is(line1))
+                    .body("card_details.billing_address.line2", is(nullValue()))
+                    .body("card_details.billing_address.city", is(nullValue()))
+                    .body("card_details.billing_address.postcode", is(postcode))
+                    .body("card_details.billing_address.country", is(nullValue()));
+        }
+
+        @Test
+        void shouldReturn201AndNoCountryWhenSuppliedCountryIsTooLong() {
+            String cardholderName = "Joe Bogs";
+            String line1 = "Line 1";
+            String postcode = "AB1 CD2";
+            String countryThatIsTooLong = "GBR";
+
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", 6234L,
+                            "reference", "Test reference",
+                            "description", "Test description",
+                            "return_url", "http://service.local/success-page/",
+                            "prefilled_cardholder_details", Map.of(
+                                    "cardholder_name", cardholderName,
+                                    "billing_address", Map.of(
+                                            "line1", line1,
+                                            "postcode", postcode,
+                                            "country", countryThatIsTooLong
+                                    ))
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges", VALID_SERVICE_ID, GatewayAccountType.TEST))
+                    .then()
+                    .statusCode(Response.Status.CREATED.getStatusCode())
+                    .contentType(JSON)
+                    .log()
+                    .body()
+                    .body("charge_id", is(notNullValue()))
+                    .body("reference", is("Test reference"))
+                    .body("card_details.cardholder_name", is(cardholderName))
+                    .body("card_details.billing_address.line1", is(line1))
+                    .body("card_details.billing_address.line2", is(nullValue()))
+                    .body("card_details.billing_address.city", is(nullValue()))
+                    .body("card_details.billing_address.postcode", is(postcode))
+                    .body("card_details.billing_address.country", is(nullValue()));
+        }
+
+        @Test
+        void shouldReturn201WithNoBillingAddressWhenPrefilledCardHolderDetailsFieldsContainsCardHolderNameOnly() {
+            String cardholderName = "Joe Bogs";
+
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", 6234L,
+                            "reference", "Test reference",
+                            "description", "Test description",
+                            "return_url", "http://service.local/success-page/",
+                            "prefilled_cardholder_details", Map.of(
+                                    "cardholder_name", cardholderName
+                            )
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges", VALID_SERVICE_ID, GatewayAccountType.TEST))
+                    .then()
+                    .statusCode(Response.Status.CREATED.getStatusCode())
+                    .contentType(JSON)
+                    .log()
+                    .body()
+                    .body("charge_id", is(notNullValue()))
+                    .body("reference", is("Test reference"))
+                    .body("card_details.cardholder_name", is(cardholderName))
+                    .body("card_details.billing_address", is(nullValue()));
+        }
     }
 
-    @Test
-    void shouldReturn201AndNoCountryWhenSuppliedCountryIsTooLong() {
-        String cardholderName = "Joe Bogs";
-        String line1 = "Line 1";
-        String postCode = "AB1 CD2";
-        String countryThatIsTooLong = "GBR";
-
-        String postBody = toJson(Map.of(
-                JSON_AMOUNT_KEY, AMOUNT,
-                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
-                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
-                JSON_PREFILLED_CARDHOLDER_DETAILS_KEY, Map.of(
-                        JSON_CARDHOLDER_NAME_KEY, cardholderName,
-                        JSON_BILLING_ADDRESS_KEY, Map.of(
-                                JSON_ADDRESS_LINE_1_KEY, line1,
-                                JSON_ADDRESS_POST_CODE_KEY, postCode,
-                                JSON_ADDRESS_LINE_COUNTRY_CODE, countryThatIsTooLong
-                        )
-                )
-        ));
-
-        testBaseExtension.getConnectorRestApiClient().postCreateCharge(postBody)
-                .statusCode(Response.Status.CREATED.getStatusCode())
-                .contentType(JSON)
-                .body(JSON_CHARGE_KEY, is(notNullValue()))
-                .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
-                .body(JSON_REFERENCE_KEY, is(JSON_REFERENCE_VALUE))
-                .body(JSON_DESCRIPTION_KEY, is(JSON_DESCRIPTION_VALUE))
-                .body(JSON_PROVIDER_KEY, is(PROVIDER_NAME))
-                .body(JSON_RETURN_URL_KEY, is(RETURN_URL))
-                .body("card_details." + JSON_CARDHOLDER_NAME_KEY, is(cardholderName))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_1_KEY, is(line1))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_2_KEY, is(nullValue()))
-                .body("card_details.billing_address." + JSON_ADDRESS_POST_CODE_KEY, is(postCode))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_CITY, is(nullValue()))
-                .body("card_details.billing_address." + JSON_ADDRESS_LINE_COUNTRY_CODE, is(nullValue()));
-    }
-
-    @Test
-    void shouldReturn201WithNoCardDetailsWhenPrefilledCardHolderDetailsFieldsAreNotPresent() {
-        String postBody = toJson(Map.of(
-                JSON_AMOUNT_KEY, AMOUNT,
-                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
-                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL
-        ));
-
-        testBaseExtension.getConnectorRestApiClient().postCreateCharge(postBody)
-                .statusCode(Response.Status.CREATED.getStatusCode())
-                .contentType(JSON)
-                .body(JSON_CHARGE_KEY, is(notNullValue()))
-                .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
-                .body(JSON_REFERENCE_KEY, is(JSON_REFERENCE_VALUE))
-                .body(JSON_DESCRIPTION_KEY, is(JSON_DESCRIPTION_VALUE))
-                .body(JSON_PROVIDER_KEY, is(PROVIDER_NAME))
-                .body(JSON_RETURN_URL_KEY, is(RETURN_URL))
-                .body("containsKey('card_details')", is(false));
-    }
-
-    @Test
-    void shouldReturn201WithBillingAddresssWhenPrefilledCardHolderDetailsFieldsContainsCardHolderNameOnly() {
-        String cardholderName = "Joe Bogs";
-        String postBody = toJson(Map.of(
-                JSON_AMOUNT_KEY, AMOUNT,
-                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
-                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
-                JSON_PREFILLED_CARDHOLDER_DETAILS_KEY, Map.of(
-                        JSON_CARDHOLDER_NAME_KEY, cardholderName
-                )
-        ));
-
-        testBaseExtension.getConnectorRestApiClient().postCreateCharge(postBody)
-                .statusCode(Response.Status.CREATED.getStatusCode())
-                .contentType(JSON)
-                .body(JSON_CHARGE_KEY, is(notNullValue()))
-                .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
-                .body(JSON_REFERENCE_KEY, is(JSON_REFERENCE_VALUE))
-                .body(JSON_DESCRIPTION_KEY, is(JSON_DESCRIPTION_VALUE))
-                .body(JSON_PROVIDER_KEY, is(PROVIDER_NAME))
-                .body(JSON_RETURN_URL_KEY, is(RETURN_URL))
-                .body("card_details." + JSON_CARDHOLDER_NAME_KEY, is(cardholderName))
-                .body("containsKey('billing_address')", is(false));
-    }
 
 }


### PR DESCRIPTION
- Add integration tests for prefilled cardholder details for degatewayed create charge endpoint
- Update existing tests for consistency
- Move tests/assertions to other test classes where appropriate
- Still to do in a subsequent PR: degateway tests for provider credentials