### PR TITLE
PP-12619: Throw error if there are multiple live gateway accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/MultipleLiveGatewayAccountsException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/MultipleLiveGatewayAccountsException.java
@@ -6,8 +6,16 @@ import static java.lang.String.format;
 import static uk.gov.pay.connector.util.ResponseUtil.conflictErrorResponse;
 
 public class MultipleLiveGatewayAccountsException extends WebApplicationException {
+
+    private MultipleLiveGatewayAccountsException(String message) {
+        super(conflictErrorResponse(message));
+    }
     
-    public MultipleLiveGatewayAccountsException(String serviceId) {
-        super(conflictErrorResponse(format("Multiple live gateway accounts found for service [%s]", serviceId)));
+    public static MultipleLiveGatewayAccountsException multipleLiveGatewayAccounts(String serviceId) {
+        return new MultipleLiveGatewayAccountsException(format("Multiple live gateway accounts found for service [%s]", serviceId));
+    }
+    
+    public static MultipleLiveGatewayAccountsException liveGatewayAccountAlreadyExists(String serviceId) {
+        return new MultipleLiveGatewayAccountsException(format("There is already a live gateway account for service [%s]", serviceId));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/MultipleLiveGatewayAccountsException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/MultipleLiveGatewayAccountsException.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.connector.gatewayaccount.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.util.ResponseUtil.conflictErrorResponse;
+
+public class MultipleLiveGatewayAccountsException extends WebApplicationException {
+    
+    public MultipleLiveGatewayAccountsException(String serviceId) {
+        super(conflictErrorResponse(format("Multiple live gateway accounts found for service [%s]", serviceId)));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -9,6 +9,7 @@ import io.dropwizard.validation.ValidationMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 
+import javax.validation.constraints.NotBlank;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -27,6 +28,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 public class GatewayAccountRequest {
 
     @JsonIgnore
+    @NotBlank
     private String providerAccountType;
 
     @JsonIgnore

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -130,7 +130,7 @@ public class GatewayAccountService {
         
         if (gatewayAccountEntity.isLive() && 
                 getGatewayAccountByServiceIdAndAccountType(gatewayAccountRequest.getServiceId(), LIVE).isPresent()) {
-            throw new MultipleLiveGatewayAccountsException(gatewayAccountEntity.getServiceId());
+            throw MultipleLiveGatewayAccountsException.liveGatewayAccountAlreadyExists(gatewayAccountEntity.getServiceId());
         }
 
         LOGGER.info("Setting the new account to accept all card types by default");
@@ -157,7 +157,7 @@ public class GatewayAccountService {
         List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.findByServiceIdAndAccountType(serviceId, accountType);
 
         if (accountType.equals(LIVE) && gatewayAccounts.size() > 1) {
-            throw new MultipleLiveGatewayAccountsException(serviceId);
+            throw MultipleLiveGatewayAccountsException.multipleLiveGatewayAccounts(serviceId);
         }
         
         return gatewayAccounts.stream().filter(GatewayAccountEntity::isStripeGatewayAccount).findFirst()

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -39,6 +39,7 @@ import static java.util.Map.entry;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_APPLE_PAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_AUTHORISATION_API;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_GOOGLE_PAY;
@@ -126,6 +127,11 @@ public class GatewayAccountService {
     public CreateGatewayAccountResponse createGatewayAccount(GatewayAccountRequest gatewayAccountRequest, UriInfo uriInfo) {
 
         GatewayAccountEntity gatewayAccountEntity = GatewayAccountObjectConverter.createEntityFrom(gatewayAccountRequest);
+        
+        if (gatewayAccountEntity.isLive() && 
+                getGatewayAccountByServiceIdAndAccountType(gatewayAccountRequest.getServiceId(), LIVE).isPresent()) {
+            throw new MultipleLiveGatewayAccountsException(gatewayAccountEntity.getServiceId());
+        }
 
         LOGGER.info("Setting the new account to accept all card types by default");
 
@@ -149,8 +155,8 @@ public class GatewayAccountService {
 
     public Optional<GatewayAccountEntity> getGatewayAccountByServiceIdAndAccountType(String serviceId, GatewayAccountType accountType) {
         List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.findByServiceIdAndAccountType(serviceId, accountType);
-        
-        if (gatewayAccounts.stream().filter(GatewayAccountEntity::isLive).toList().size() > 1) {
+
+        if (accountType.equals(LIVE) && gatewayAccounts.size() > 1) {
             throw new MultipleLiveGatewayAccountsException(serviceId);
         }
         

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -5,7 +5,6 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -115,18 +114,15 @@ class ChargeExpiryServiceTest {
     @Mock
     private Appender<ILoggingEvent> mockAppender;
 
-    private static final List<ChargeStatus> EXPIRABLE_REGULAR_STATUSES = ImmutableList.of(
+    private static final List<ChargeStatus> EXPIRABLE_REGULAR_STATUSES = List.of(
             CREATED,
             ENTERING_CARD_DETAILS,
             AUTHORISATION_READY,
             AUTHORISATION_3DS_REQUIRED,
             AUTHORISATION_3DS_READY,
-            AUTHORISATION_SUCCESS
-    );
+            AUTHORISATION_SUCCESS);
 
-    private static final List<ChargeStatus> EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS = ImmutableList.of(
-            AWAITING_CAPTURE_REQUEST
-    );
+    private static final List<ChargeStatus> EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS = List.of(AWAITING_CAPTURE_REQUEST);
 
     private static final Duration TOKEN_EXPIRY_WINDOW = Duration.ofSeconds(7 * 24 * 60 * 60);
     private static final Duration IDEMPOTENCY_EXPIRY_WINDOW = Duration.ofSeconds(24 * 60 * 60);

--- a/src/test/java/uk/gov/pay/connector/service/GetGatewayAccountByServiceIdAndAccountTypeTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GetGatewayAccountByServiceIdAndAccountTypeTest.java
@@ -1,14 +1,19 @@
 package uk.gov.pay.connector.service;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.exception.MultipleLiveGatewayAccountsException;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsHistoryDao;
@@ -20,9 +25,12 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,78 +62,90 @@ public class GetGatewayAccountByServiceIdAndAccountTypeTest {
         gatewayAccountService = new GatewayAccountService(mockGatewayAccountDao, mockCardTypeDao,
                 mockGatewayAccountCredentialsService, mock(GatewayAccountCredentialsHistoryDao.class), mock(GatewayAccountCredentialsDao.class));
         
-        stripeGatewayAccount = new GatewayAccountEntity(GatewayAccountType.TEST);
+        stripeGatewayAccount = new GatewayAccountEntity(TEST);
         var stripeGatewayAccountCreds = new GatewayAccountCredentialsEntity(stripeGatewayAccount, "stripe", Map.of(), ACTIVE);
         stripeGatewayAccount.setGatewayAccountCredentials(List.of(stripeGatewayAccountCreds));
         
-        sandboxGatewayAccount = new GatewayAccountEntity(GatewayAccountType.TEST);
+        sandboxGatewayAccount = new GatewayAccountEntity(TEST);
         var sandboxGatewayAccountCreds = new GatewayAccountCredentialsEntity(sandboxGatewayAccount, "sandbox", Map.of(), ACTIVE);
         sandboxGatewayAccount.setGatewayAccountCredentials(List.of(sandboxGatewayAccountCreds));
         
-        worldpayGatewayAccount = new GatewayAccountEntity(GatewayAccountType.TEST);
+        worldpayGatewayAccount = new GatewayAccountEntity(TEST);
         var worldpayGatewayAccountCreds = new GatewayAccountCredentialsEntity(worldpayGatewayAccount, "worldpay", Map.of(), ACTIVE);
         worldpayGatewayAccount.setGatewayAccountCredentials(List.of(worldpayGatewayAccountCreds));
         
-        smartpayGatewayAccount = new GatewayAccountEntity(GatewayAccountType.TEST);
+        smartpayGatewayAccount = new GatewayAccountEntity(TEST);
         var smartpayGatewayAccountCreds = new GatewayAccountCredentialsEntity(smartpayGatewayAccount, "smartpay", Map.of(), ACTIVE);
         smartpayGatewayAccount.setGatewayAccountCredentials(List.of(smartpayGatewayAccountCreds));
     }
 
     @Test
     void shouldReturnStripeGatewayAccountWhenThereAreMultipleGatewayAccounts() {
-        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST))
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, TEST))
                 .thenReturn(List.of(worldpayGatewayAccount, sandboxGatewayAccount, stripeGatewayAccount));
 
         Optional<GatewayAccountEntity> gatewayAccount = 
-                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST);
+                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, TEST);
         assertTrue(gatewayAccount.isPresent());
         assertTrue(gatewayAccount.get().isStripeGatewayAccount());
     }
     
     @Test
     void shouldReturnNothingWhenThereAreNoGatewayAccounts() {
-        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST))
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, TEST))
                 .thenReturn(List.of());
 
         Optional<GatewayAccountEntity> gatewayAccount =
-                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST);
+                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, TEST);
         assertFalse(gatewayAccount.isPresent());
     }
 
     @Test
     void shouldReturnSandboxGatewayAccountWhenThereAreSandboxAndWorldpayAccounts() {
-        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST))
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, TEST))
                 .thenReturn(List.of(worldpayGatewayAccount, sandboxGatewayAccount));
 
         Optional<GatewayAccountEntity> gatewayAccount =
-                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST);
+                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, TEST);
         assertTrue(gatewayAccount.isPresent());
         assertTrue(gatewayAccount.get().isSandboxGatewayAccount());
     }
     
     @Test
     void shouldReturnWorldpayGatewayAccount() {
-        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST))
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, TEST))
                 .thenReturn(List.of(worldpayGatewayAccount));
 
         Optional<GatewayAccountEntity> gatewayAccount =
-                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST);
+                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, TEST);
         assertTrue(gatewayAccount.isPresent());
         assertTrue(gatewayAccount.get().isWorldpayGatewayAccount());
     }
     
     @Test
     void shouldNotReturnObscureGatewayAccount() {
-        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST))
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, TEST))
                 .thenReturn(List.of(smartpayGatewayAccount));
 
         Optional<GatewayAccountEntity> gatewayAccount =
-                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, GatewayAccountType.TEST);
+                gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, TEST);
         assertFalse(gatewayAccount.isPresent());
     }
     
     @Test
     void shouldLogAndThrowErrorIfThereAreMultipleLiveGatewayAccounts() {
-        //TODO
+        var stripeLiveGatewayAccount = new GatewayAccountEntity(LIVE);
+        var stripeGatewayAccountCreds = new GatewayAccountCredentialsEntity(stripeLiveGatewayAccount, "stripe", Map.of(), ACTIVE);
+        stripeLiveGatewayAccount.setGatewayAccountCredentials(List.of(stripeGatewayAccountCreds));
+        
+        var worldpayLiveGatewayAccount = new GatewayAccountEntity(LIVE);
+        var worldpayGatewayAccountCreds = new GatewayAccountCredentialsEntity(worldpayLiveGatewayAccount, "worldpay", Map.of(), ACTIVE);
+        worldpayLiveGatewayAccount.setGatewayAccountCredentials(List.of(worldpayGatewayAccountCreds));
+
+        when(mockGatewayAccountDao.findByServiceIdAndAccountType(SERVICE_ID, LIVE))
+                .thenReturn(List.of(stripeLiveGatewayAccount, worldpayLiveGatewayAccount));
+
+        assertThrows(MultipleLiveGatewayAccountsException.class, 
+                () -> gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(SERVICE_ID, LIVE));
     }
 }


### PR DESCRIPTION
Throw error if there are multiple live gateway accounts associated with a service.
It should also not be possible to create another live gateway account associated with a service.