### PR TITLE
PP-12360 Fix issues in Worldpay SubmitRefund tests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/util/RandomIdGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/util/RandomIdGenerator.java
@@ -48,4 +48,8 @@ public class RandomIdGenerator {
         }
         return sb.toString();
     }
+    
+    public static long randomLong() {
+        return RANDOM.nextLong();
+    }
 }


### PR DESCRIPTION
## WHAT YOU DID
 - Fix `SubmitRefund` tests not using test account object created in test setup
   - This was occurring due to a missing `.insert()` call when creating the default test account
   - These tests were passing due to the default test account using the account ID from `ITestBaseExtension`, which is inserted separately, so calling `.insert()` would have caused the tests to fail due to a duplicate primary key.
   - This is fixed by removing the dependecy on `ITestBaseExtension`
 - Fix single test not running due to missing `@Test` annotations

## How to test
 - Run tests