### PR TITLE
PP-12360 Add submitRefund by service ID and type endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -354,6 +354,15 @@
         "line_number": 108
       }
     ],
+    "src/main/java/uk/gov/pay/connector/refund/resource/RefundsResource.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/connector/refund/resource/RefundsResource.java",
+        "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
+        "is_verified": false,
+        "line_number": 133
+      }
+    ],
     "src/main/java/uk/gov/pay/connector/usernotification/resource/EmailNotificationResource.java": [
       {
         "type": "Hex High Entropy String",
@@ -1061,5 +1070,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-15T12:59:15Z"
+  "generated_at": "2024-07-17T12:49:09Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -132,63 +132,63 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 1775
+        "line_number": 1836
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 3268
+        "line_number": 3329
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 3312
+        "line_number": 3373
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3779
+        "line_number": 3840
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4168
+        "line_number": 4229
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4204
+        "line_number": 4265
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 5132
+        "line_number": 5193
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5615
+        "line_number": 5676
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5626
+        "line_number": 5687
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1070,5 +1070,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-17T12:49:09Z"
+  "generated_at": "2024-07-17T12:58:08Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1666,6 +1666,67 @@ paths:
       summary: Get transaction history for a charge
       tags:
       - Charge events
+  /v1/api/service/{serviceId}/account/{accountType}/charges/{chargeId}/refunds:
+    post:
+      operationId: submitRefundByServiceIdAndAccountType
+      parameters:
+      - description: Service external ID
+        example: 46eb1b601348499196c99de90482ee68
+        in: path
+        name: serviceId
+        required: true
+        schema:
+          type: string
+      - description: Account Type
+        example: test
+        in: path
+        name: accountType
+        required: true
+        schema:
+          type: string
+          enum:
+          - test
+          - live
+      - description: Charge external ID
+        example: 2c6vtn9pth38ppbmnt20d57t49
+        in: path
+        name: chargeId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundRequest'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+                example:
+                  amount: 3444
+                  created_date: 2016-10-05T14:15:34.096Z
+                  refund_id: vijjk08adovg10gfqc46joem2l
+                  user_external_id: AA213FD51B3801043FBC
+                  status: success
+                  _links:
+                    self:
+                      href: https://connector.example.com/v1/api/service/46eb1b601348499196c99de90482ee68/account/test/charges/2c6vtn9pth38ppbmnt20d57t49/refunds/vijjk08adovg10gfqc46joem2l
+                    payment:
+                      href: https://connector.example.com/v1/api/service/46eb1b601348499196c99de90482ee68/account/test/charges/2c6vtn9pth38ppbmnt20d57t49
+          description: OK
+        "400":
+          description: Bad request - Invalid fields or not sufficient amount available
+            for refund
+        "404":
+          description: Not found - gateway account or charge not found
+        "500":
+          description: Internal server error
+      summary: Refund a charge
+      tags:
+      - Refunds
   /v1/api/service/{serviceId}/account/{accountType}/charges/{chargeId}/resend-confirmation-email:
     post:
       operationId: resendConfirmationEmailByServiceIdAndAccountType

--- a/src/main/java/uk/gov/pay/connector/refund/model/RefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/RefundResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.refund.model;
 
 import black.door.hate.HalRepresentation;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import javax.ws.rs.core.UriInfo;
@@ -26,6 +27,29 @@ public class RefundResponse extends HalResourceResponse {
         URI paymentLink = uriInfo.getBaseUriBuilder()
                 .path("/v1/api/accounts/{accountId}/charges/{chargeId}")
                 .build(gatewayAccountId, externalChargeId);
+
+        return new RefundResponse(HalRepresentation.builder()
+                .addProperty("refund_id", refundEntity.getExternalId())
+                .addProperty("amount", refundEntity.getAmount())
+                .addProperty("status", refundEntity.getStatus().toExternal().getStatus())
+                .addProperty("created_date", ISO_INSTANT_MILLISECOND_PRECISION.format(refundEntity.getCreatedDate()))
+                .addProperty("user_external_id", refundEntity.getUserExternalId())
+                .addLink("self", selfLink)
+                .addLink("payment", paymentLink), selfLink);
+    }
+    
+    public static RefundResponse valueOf(RefundEntity refundEntity, String serviceId, GatewayAccountType accountType, UriInfo uriInfo) {
+
+        String externalChargeId = refundEntity.getChargeExternalId();
+        String externalRefundId = refundEntity.getExternalId();
+
+        URI selfLink = uriInfo.getBaseUriBuilder()
+                .path("/v1/api/service/{serviceId}/account/{accountType}/charges/{chargeId}/refunds/{refundId}")
+                .build(serviceId, accountType, externalChargeId, externalRefundId);
+
+        URI paymentLink = uriInfo.getBaseUriBuilder()
+                .path("/v1/api/service/{serviceId}/account/{accountType}/charges/{chargeId}")
+                .build(serviceId, accountType, externalChargeId, externalRefundId);
 
         return new RefundResponse(HalRepresentation.builder()
                 .addProperty("refund_id", refundEntity.getExternalId())

--- a/src/main/java/uk/gov/pay/connector/refund/resource/RefundsResource.java
+++ b/src/main/java/uk/gov/pay/connector/refund/resource/RefundsResource.java
@@ -12,6 +12,10 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
+import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.refund.exception.RefundException;
 import uk.gov.pay.connector.refund.model.RefundRequest;
 import uk.gov.pay.connector.refund.model.RefundResponse;
@@ -21,6 +25,7 @@ import uk.gov.pay.connector.refund.service.ChargeRefundResponse;
 import uk.gov.pay.connector.refund.service.RefundService;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -46,12 +51,14 @@ public class RefundsResource {
 
     private final RefundService refundService;
     private final ChargeService chargeService;
+    private final GatewayAccountService gatewayAccountService;
     private final ChargeDao chargeDao;
 
     @Inject
-    public RefundsResource(RefundService refundService, ChargeService chargeService, ChargeDao chargeDao) {
+    public RefundsResource(RefundService refundService, ChargeService chargeService, GatewayAccountService gatewayAccountService, ChargeDao chargeDao) {
         this.refundService = refundService;
         this.chargeService = chargeService;
+        this.gatewayAccountService = gatewayAccountService;
         this.chargeDao = chargeDao;
     }
 
@@ -94,6 +101,55 @@ public class RefundsResource {
             return Response.accepted(RefundResponse.valueOf(refundServiceResponse.getRefundEntity(), accountId, uriInfo).serialize()).build();
         }
         return serviceErrorResponse(refundResponse.getError().map(GatewayError::getMessage).orElse("unknown error"));
+    }
+
+
+
+    @POST
+    @Path("/v1/api/service/{serviceId}/account/{accountType}/charges/{chargeId}/refunds")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @Operation(
+            summary = "Refund a charge",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(example = "{" +
+                                    "    \"amount\":3444," +
+                                    "    \"created_date\":\"2016-10-05T14:15:34.096Z\"," +
+                                    "    \"refund_id\":\"vijjk08adovg10gfqc46joem2l\"," +
+                                    "    \"user_external_id\":\"AA213FD51B3801043FBC\"," +
+                                    "    \"status\":\"success\"," +
+                                    "    \"_links\":{" +
+                                    "        \"self\":{\"href\":\"https://connector.example.com/v1/api/service/46eb1b601348499196c99de90482ee68/account/test/charges/2c6vtn9pth38ppbmnt20d57t49/refunds/vijjk08adovg10gfqc46joem2l\"}," +
+                                    "        \"payment\":{\"href\":\"https://connector.example.com/v1/api/service/46eb1b601348499196c99de90482ee68/account/test/charges/2c6vtn9pth38ppbmnt20d57t49\"}" +
+                                    "    }" +
+                                    "}"))),
+                    @ApiResponse(responseCode = "400", description = "Bad request - Invalid fields or not sufficient amount available for refund"),
+                    @ApiResponse(responseCode = "404", description = "Not found - gateway account or charge not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response submitRefundByServiceIdAndAccountType(
+            @Parameter(example = "46eb1b601348499196c99de90482ee68", description = "Service external ID") @PathParam("serviceId") String serviceId,
+            @Parameter(example = "test", description = "Account Type") @PathParam("accountType") GatewayAccountType accountType,
+            @Parameter(example = "2c6vtn9pth38ppbmnt20d57t49", description = "Charge external ID") @PathParam("chargeId") String chargeExternalId,
+            @Valid RefundRequest refundRequest, @Context UriInfo uriInfo
+    ) {
+        validateRefundRequest(refundRequest.getAmount());
+        
+        GatewayAccountEntity account = gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
+
+        ChargeRefundResponse refundServiceResponse = chargeService.findCharge(chargeExternalId, account.getId())
+                .map(charge -> refundService.doRefundFor(account, charge, refundRequest))
+                .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeExternalId));
+        
+        GatewayRefundResponse gatewayRefundResponse = refundServiceResponse.getGatewayRefundResponse();
+        
+        if (gatewayRefundResponse.isSuccessful()) {
+            return Response.accepted(RefundResponse.valueOf(refundServiceResponse.getRefundEntity(), serviceId, accountType, uriInfo).serialize()).build();
+        }
+        return serviceErrorResponse(gatewayRefundResponse.getError().map(GatewayError::getMessage).orElse("unknown error"));
     }
 
     private void validateRefundRequest(long amount) {


### PR DESCRIPTION
# WHAT YOU DID
 - Add `POST /v1/api/service/{serviceId}/account/{accountType}/charges/{chargeId}/refunds` endpoint to submit refund by service ID and account type
 - Adds happy path tests for Worldpay - more tests to follow in later PRs
 - Refactor `RefundService::doRefund` to allow for processing refund by service ID & type without multiple gateway account lookups

## How to test
 - Run tests