### PR TITLE
PP-12938: Some code improvements

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -91,7 +91,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_SUBMITTED;
 
 public class PaymentGatewayStateTransitions {
-    private static PaymentGatewayStateTransitions instance;
+    private static final PaymentGatewayStateTransitions instance = new PaymentGatewayStateTransitions();
 
     private static Map<ChargeStatus, ModelledTypedEvent> eventsForForceUpdatingStatus = Map.of(
             CAPTURED, new ModelledTypedEvent<>(StatusCorrectedToCapturedToMatchGatewayStatus.class),
@@ -100,9 +100,6 @@ public class PaymentGatewayStateTransitions {
     );
 
     public static PaymentGatewayStateTransitions getInstance() {
-        if (instance == null) {
-            instance = new PaymentGatewayStateTransitions();
-        }
         return instance;
     }
 

--- a/src/main/java/uk/gov/pay/connector/refund/model/RefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/RefundRequest.java
@@ -3,6 +3,33 @@ package uk.gov.pay.connector.refund.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+/**
+ * The refund_amount_available field is a mechanism that acts as idempotency-lite, which is especially important when 
+ * performing partial refunds. By having the consumer specify the amount available to refund at the time of the call, 
+ * one can check to see if there’s still that much refundable before performing the refund.
+ * <p> 
+ * For example if a request goes through and gets to connector but then the HTTP response fails and terminates early, 
+ * the client might retry the refund that they thought failed; because they’d still be passing the original 
+ * “amount left to refund” connector can reject it because that refund has already been processed.
+ * <p>
+ * Example:
+ * Payment: £20
+ * <p>
+ * /refund 
+ * - amount £5
+ * - amount available: £20
+ * :green-tick: 
+ * <p>
+ * /refund
+ * - amount £5
+ * - amount available: £20 
+ * :fail: 
+ * <p>
+ * /refund
+ * - amount £5
+ * - amount available: £15
+ * :green-tick:
+ */
 public class RefundRequest {
 
     @JsonProperty("amount")


### PR DESCRIPTION
Add javadoc to explain why the caller of `POST
/v1/api/accounts/{accountId}/charges/{chargeId}/refunds` needs to specify the refund amount available.

The `PaymentGatewayStateTransitions.getInstance` was not thread safe. The solution here would be use the double-checked locking solution, but since the connector will pretty much always need to transition a charge state, let's eagerly create the instance.
