### PR TITLE
PP-12915: Java API to perform actions required to create Stripe test accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequest.java
@@ -46,7 +46,7 @@ public class StripeAuthoriseRequest extends StripePostRequest {
                 authorisationRequest.getGatewayAccount(),
                 authorisationRequest.getGovUkPayPaymentId(),
                 stripeGatewayConfig,
-                (StripeCredentials) authorisationRequest.getGatewayCredentials()
+                authorisationRequest.getGatewayCredentials()
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
@@ -1,14 +1,52 @@
 package uk.gov.pay.connector.gatewayaccount.service;
 
+import com.stripe.exception.StripeException;
+import com.stripe.model.Account;
+import com.stripe.model.Person;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.AccountCreateParams;
+import com.stripe.param.AccountCreateParams.BusinessProfile;
+import com.stripe.param.AccountCreateParams.Capabilities;
+import com.stripe.param.AccountCreateParams.Capabilities.CardPayments;
+import com.stripe.param.AccountCreateParams.Capabilities.Transfers;
+import com.stripe.param.AccountCreateParams.Settings;
+import com.stripe.param.AccountCreateParams.Settings.Payouts.Schedule;
+import com.stripe.param.AccountCreateParams.TosAcceptance;
+import com.stripe.param.PersonCollectionCreateParams;
+import com.stripe.param.PersonCollectionCreateParams.Dob;
+import com.stripe.param.PersonCollectionCreateParams.Relationship;
+import com.stripe.param.PersonCollectionCreateParams.Verification.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 
+import javax.inject.Inject;
+import java.util.Map;
 import java.util.Optional;
 
+import static com.stripe.param.AccountCreateParams.Company.Address;
+import static com.stripe.param.AccountCreateParams.Company.Builder;
+import static com.stripe.param.AccountCreateParams.Company.builder;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+import static uk.gov.pay.connector.gatewayaccount.service.StripeAccountService.StripeTestAccountDefaults.businessProfile;
+import static uk.gov.pay.connector.gatewayaccount.service.StripeAccountService.StripeTestAccountDefaults.capabilities;
+import static uk.gov.pay.connector.gatewayaccount.service.StripeAccountService.StripeTestAccountDefaults.companyBuilder;
+import static uk.gov.pay.connector.gatewayaccount.service.StripeAccountService.StripeTestAccountDefaults.settings;
+import static uk.gov.pay.connector.gatewayaccount.service.StripeAccountService.StripeTestAccountDefaults.tosAcceptance;
 
 public class StripeAccountService {
+
+    private static final Logger logger = LoggerFactory.getLogger(StripeAccountService.class);
+    
+    private static RequestOptions requestOptions;
+    
+//    @Inject
+//    public StripeAccountService(StripeGatewayConfig stripeGatewayConfig) {
+//        requestOptions = RequestOptions.builder().setApiKey(stripeGatewayConfig.getAuthTokens().getTest()).build();
+//    }
 
     public Optional<StripeAccountResponse> buildStripeAccountResponse(GatewayAccountEntity gatewayAccountEntity) {
         return Optional.ofNullable(gatewayAccountEntity.getGatewayAccountCredentialsEntity(STRIPE.getName()))
@@ -16,4 +54,106 @@ public class StripeAccountService {
                 .map(StripeAccountResponse::new);
     }
 
+    public Account createTestAccount(String serviceName) {
+        var accountCreateParams = AccountCreateParams.builder()
+                .setType(AccountCreateParams.Type.CUSTOM)
+                .setCountry("GB")
+                .setBusinessType(AccountCreateParams.BusinessType.COMPANY)
+                .setCompany(companyBuilder.setName(serviceName).build())
+                .setCapabilities(capabilities)
+                .setDefaultCurrency("GBP")
+                .setSettings(settings)
+                .setBusinessProfile(businessProfile)
+                .setTosAcceptance(tosAcceptance)
+                .build();
+
+        Account account;
+        
+        try {
+            account = Account.create(accountCreateParams, requestOptions);
+            logger.info("Created account {}", account.getId());
+            account.getExternalAccounts().create(StripeTestAccountDefaults.bankAccount, requestOptions);
+            return account;
+        } catch (StripeException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public Person associateDefaultPersonWithTestAccount(String stripeAccountId) {
+        try {
+            Account account = Account.retrieve(stripeAccountId, requestOptions);
+            Person person = account.persons(Map.of(), requestOptions).create(StripeTestAccountDefaults.person, requestOptions);
+            logger.info("Created person {}", person.getId());
+            return person;
+        } catch (StripeException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public static class StripeTestAccountDefaults {
+        
+        public static final Map<String, Object> bankAccount = Map.of("external_account",
+                Map.of("account_number", "00012345",
+                        "routing_number", "108800",
+                        "account_holder_type", "individual",
+                        "account_holder_name", "Jane Doe",
+                        "object", "bank_account",
+                        "currency", "gbp",
+                        "country", "gb"));
+
+        public static final Builder companyBuilder = builder()
+                .setAddress(Address.builder()
+                        .setLine1("address_full_match")
+                        .setLine2("WCB")
+                        .setCity("London")
+                        .setPostalCode("E1 8QS")
+                        .setCountry("GB").build())
+                .setPhone("+441212345678")
+                .setTaxId("000000000")
+                .setVatId("NOTAPPLI")
+                .setOwnersProvided(true)
+                .setDirectorsProvided(true)
+                .setExecutivesProvided(true);
+
+        public static final Capabilities capabilities = Capabilities.builder()
+                .setCardPayments(CardPayments.builder().setRequested(true).build())
+                .setTransfers(Transfers.builder().setRequested(true).build())
+                .build();
+
+        public static final Settings settings = Settings.builder()
+                .setPayouts(Settings.Payouts.builder()
+                        .setSchedule(Schedule.builder()
+                                .setInterval(Schedule.Interval.DAILY)
+                                .setDelayDays(7L).build())
+                        .setStatementDescriptor("TEST ACCOUNT").build())
+                .build();
+
+        public static final BusinessProfile businessProfile = BusinessProfile.builder()
+                .setMcc("9399")
+                .setProductDescription("Test account for a service")
+                .build();
+
+        public static final TosAcceptance tosAcceptance = TosAcceptance.builder()
+                .setIp("0.0.0.0")
+                .setDate(System.currentTimeMillis() / 1000).build();
+
+        public static final PersonCollectionCreateParams person = PersonCollectionCreateParams.builder()
+                .setFirstName("Jane")
+                .setLastName("Doe")
+                .setDob(Dob.builder().setDay(1L).setMonth(1L).setYear(1901L).build())
+                .setRelationship(Relationship.builder().setRepresentative(true).setExecutive(true).setTitle("CEO").build())
+                .setAddress(PersonCollectionCreateParams.Address.builder()
+                        .setLine1("address_full_match")
+                        .setLine2("WCB")
+                        .setCity("London")
+                        .setPostalCode("E1 8QS")
+                        .setCountry("GB").
+                        build())
+                .setPhone("8888675309")
+                .setEmail("test@example.org")
+                .setVerification(PersonCollectionCreateParams.Verification.builder()
+                        .setDocument(Document.builder().setFront("file_identity_document_success").build())
+                        .build())
+                .build();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
@@ -18,24 +18,15 @@ import com.stripe.param.PersonCollectionCreateParams.Relationship;
 import com.stripe.param.PersonCollectionCreateParams.Verification.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 
-import javax.inject.Inject;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.stripe.param.AccountCreateParams.Company.Address;
-import static com.stripe.param.AccountCreateParams.Company.Builder;
-import static com.stripe.param.AccountCreateParams.Company.builder;
+import static com.stripe.param.AccountCreateParams.Company;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
-import static uk.gov.pay.connector.gatewayaccount.service.StripeAccountService.StripeTestAccountDefaults.businessProfile;
-import static uk.gov.pay.connector.gatewayaccount.service.StripeAccountService.StripeTestAccountDefaults.capabilities;
-import static uk.gov.pay.connector.gatewayaccount.service.StripeAccountService.StripeTestAccountDefaults.companyBuilder;
-import static uk.gov.pay.connector.gatewayaccount.service.StripeAccountService.StripeTestAccountDefaults.settings;
-import static uk.gov.pay.connector.gatewayaccount.service.StripeAccountService.StripeTestAccountDefaults.tosAcceptance;
 
 public class StripeAccountService {
 
@@ -59,18 +50,16 @@ public class StripeAccountService {
                 .setType(AccountCreateParams.Type.CUSTOM)
                 .setCountry("GB")
                 .setBusinessType(AccountCreateParams.BusinessType.COMPANY)
-                .setCompany(companyBuilder.setName(serviceName).build())
-                .setCapabilities(capabilities)
+                .setCompany(StripeTestAccountDefaults.companyBuilder.setName(serviceName).build())
+                .setCapabilities(StripeTestAccountDefaults.capabilities)
                 .setDefaultCurrency("GBP")
-                .setSettings(settings)
-                .setBusinessProfile(businessProfile)
-                .setTosAcceptance(tosAcceptance)
+                .setSettings(StripeTestAccountDefaults.settings)
+                .setBusinessProfile(StripeTestAccountDefaults.businessProfile)
+                .setTosAcceptance(StripeTestAccountDefaults.tosAcceptance)
                 .build();
 
-        Account account;
-        
         try {
-            account = Account.create(accountCreateParams, requestOptions);
+            Account account = Account.create(accountCreateParams, requestOptions);
             logger.info("Created account {}", account.getId());
             account.getExternalAccounts().create(StripeTestAccountDefaults.bankAccount, requestOptions);
             return account;
@@ -79,12 +68,11 @@ public class StripeAccountService {
         }
     }
     
-    public Person associateDefaultPersonWithTestAccount(String stripeAccountId) {
+    public void createDefaultPersonForAccount(String stripeAccountId) {
         try {
             Account account = Account.retrieve(stripeAccountId, requestOptions);
             Person person = account.persons(Map.of(), requestOptions).create(StripeTestAccountDefaults.person, requestOptions);
             logger.info("Created person {}", person.getId());
-            return person;
         } catch (StripeException e) {
             throw new RuntimeException(e);
         }
@@ -101,8 +89,8 @@ public class StripeAccountService {
                         "currency", "gbp",
                         "country", "gb"));
 
-        public static final Builder companyBuilder = builder()
-                .setAddress(Address.builder()
+        public static final Company.Builder companyBuilder = Company.builder()
+                .setAddress(Company.Address.builder()
                         .setLine1("address_full_match")
                         .setLine2("WCB")
                         .setCity("London")

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountServiceTest.java
@@ -1,6 +1,11 @@
 package uk.gov.pay.connector.gatewayaccount.service;
 
+import com.stripe.Stripe;
+import com.stripe.model.Account;
+import com.stripe.model.Person;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -29,6 +34,32 @@ import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccoun
     @BeforeEach
      void setUp() {
         stripeAccountService = new StripeAccountService();
+    }
+    
+    /*
+     * These tests are meant to be run manually to give confidence the Java API works. In order to run a valid
+     * apiKey needs to be provided.
+     */
+    @Nested
+    @Disabled
+    class ManualStripeIntegrationTests {
+        
+        @BeforeEach
+        void setUp() {
+            Stripe.apiKey = System.getenv("STRIPE_API_KEY"); // pragma: allowlist secret
+        }
+        
+        @Test
+        void createTestAccount() {
+            Account createdTestAccount = stripeAccountService.createTestAccount("fill-me-in");
+            System.out.println("Created account " + createdTestAccount.getId());
+        }
+
+        @Test
+        void associateDefaultPersonWithTestAccount() {
+            Person person = stripeAccountService.associateDefaultPersonWithTestAccount("fill-me-in");
+            System.out.println("Created person " + person.getId());
+        }
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountServiceTest.java
@@ -57,8 +57,7 @@ import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccoun
 
         @Test
         void associateDefaultPersonWithTestAccount() {
-            Person person = stripeAccountService.associateDefaultPersonWithTestAccount("fill-me-in");
-            System.out.println("Created person " + person.getId());
+            stripeAccountService.createDefaultPersonForAccount("fill-the-created-account-id-from-above");
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.it.resources.worldpay;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.amazonaws.util.json.Jackson;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -11,7 +10,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.it.base.ITestBaseExtension;
@@ -39,7 +37,6 @@ public class WorldpayAuthoriseGooglePayIT {
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
 
     private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
-    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
     
     @BeforeEach
     void setUpLogger() {


### PR DESCRIPTION
This commit duplicates the
[createStripeTestAccount](https://github.com/alphagov/pay-toolbox/blob/master/src/web/modules/stripe/test-account.http.ts#L110) function in toolbox to create a Stripe test account. The API calls that need to happen are:
* create test account
* create external bank account on the test account
* create a representative on the test account

## How to test

* Get a stripe test api key from pay-low-pass and paste it in [here](https://github.com/alphagov/pay-connector/pull/5457/files#diff-ce3e79b54132ef8113bf08120a0d50443aea616e5b5ee2b826861069d989b6ccR49).
* Provide a dummy service name to `StripeAccountServiceTest.ManualStripeIntegrationTests.createTestAccount`, run the test and verify the account is created in the Stripe dashboard with default bank account.
* Take the printed test account id from above, paste it in `StripeAccountServiceTest.ManualStripeIntegrationTests.associateDefaultPersonWithTestAccount`, run the test and verify a test person is associated with the account.

I've manually tested this myself and this [account](https://dashboard.stripe.com/test/connect/accounts/acct_1PfkBfQaLJqrMz93) was created.
