### PR TITLE
PP-12360 Worldpay integration tests for degatewayed submitRefund

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,14 +125,14 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 1245
+        "line_number": 1247
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 1836
+        "line_number": 1840
       },
       {
         "type": "Base64 High Entropy String",
@@ -360,7 +360,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/refund/resource/RefundsResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 139
       }
     ],
     "src/main/java/uk/gov/pay/connector/usernotification/resource/EmailNotificationResource.java": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,56 +139,56 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 3352
+        "line_number": 3356
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 3396
+        "line_number": 3400
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3863
+        "line_number": 3867
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4252
+        "line_number": 4256
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4288
+        "line_number": 4292
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 5216
+        "line_number": 5220
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5699
+        "line_number": 5703
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5710
+        "line_number": 5714
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1079,5 +1079,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-29T16:17:52Z"
+  "generated_at": "2024-07-30T13:30:36Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -572,6 +572,8 @@ paths:
             for refund
         "404":
           description: Not found - gateway account or charge not found
+        "412":
+          description: Precondition failed - Refund amount available does not match
         "500":
           description: Internal server error
       summary: Refund a charge
@@ -1722,6 +1724,8 @@ paths:
             for refund
         "404":
           description: Not found - gateway account or charge not found
+        "412":
+          description: Precondition failed - Refund amount available does not match
         "500":
           description: Internal server error
       summary: Refund a charge

--- a/src/main/java/uk/gov/pay/connector/refund/resource/RefundsResource.java
+++ b/src/main/java/uk/gov/pay/connector/refund/resource/RefundsResource.java
@@ -83,6 +83,7 @@ public class RefundsResource {
                                     "}"))),
                     @ApiResponse(responseCode = "400", description = "Bad request - Invalid fields or not sufficient amount available for refund"),
                     @ApiResponse(responseCode = "404", description = "Not found - gateway account or charge not found"),
+                    @ApiResponse(responseCode = "412", description = "Precondition failed - Refund amount available does not match"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
@@ -130,6 +131,7 @@ public class RefundsResource {
                                     "}"))),
                     @ApiResponse(responseCode = "400", description = "Bad request - Invalid fields or not sufficient amount available for refund"),
                     @ApiResponse(responseCode = "404", description = "Not found - gateway account or charge not found"),
+                    @ApiResponse(responseCode = "412", description = "Precondition failed - Refund amount available does not match"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundSubmitResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundSubmitResourceIT.java
@@ -4,9 +4,13 @@ import com.google.gson.Gson;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
@@ -14,9 +18,11 @@ import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToXml;
@@ -42,7 +48,6 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
@@ -56,7 +61,7 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomLong;
 public class WorldpayRefundSubmitResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-    private static String SERVICE_ID = "a-valid-service-id";
+    private final static String SERVICE_ID = "a-valid-service-id";
     
     private long defaultAccountId;
     private long defaultCredentialsId;
@@ -69,6 +74,8 @@ public class WorldpayRefundSubmitResourceIT {
                     CREDENTIALS_USERNAME, "test-user",
                     CREDENTIALS_PASSWORD, "test-password")
     );
+    
+    private static final List<ChargeStatus> NON_REFUNDABLE_CHARGE_STATUSES = Arrays.stream(ChargeStatus.values()).filter(chargeStatus -> !chargeStatus.equals(CAPTURED)).toList();
 
     @BeforeEach
     void setUpCharge() {
@@ -125,10 +132,9 @@ public class WorldpayRefundSubmitResourceIT {
 
         @Test
         void shouldBeAbleToRequestARefund_fullAmount() {
-
             Long refundAmount = defaultTestCharge.getAmount();
-
             app.getWorldpayMockClient().mockRefundSuccess();
+            
             ValidatableResponse validatableResponse = postRefundFor(defaultAccountId, defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
             String refundId = assertRefundResponseWith(defaultAccountId, defaultTestCharge.getExternalChargeId(), refundAmount, validatableResponse, ACCEPTED.getStatusCode());
 
@@ -144,7 +150,7 @@ public class WorldpayRefundSubmitResourceIT {
                     .replace("{{refundReference}}", refundsFoundByChargeExternalId.get(0).get("external_id").toString())
                     .replace("{{amount}}", "100");
 
-            verifyRequestBodyToWorldpay(WORLDPAY_URL, expectedRequestBody);
+            verifyRequestBodyToWorldpay(expectedRequestBody);
         }
 
         @Test
@@ -192,7 +198,6 @@ public class WorldpayRefundSubmitResourceIT {
 
         @Test
         void shouldBeAbleToRequestARefund_multiplePartialAmounts_andRefundShouldBeInFullStatus() {
-
             Long firstRefundAmount = 80L;
             Long secondRefundAmount = 20L;
             String externalChargeId = defaultTestCharge.getExternalChargeId();
@@ -223,7 +228,6 @@ public class WorldpayRefundSubmitResourceIT {
 
         @Test
         void shouldFailRequestingARefund_whenChargeStatusMakesItNotRefundable() {
-
             DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
                     .withDatabaseTestHelper(app.getDatabaseTestHelper())
                     .aTestCharge()
@@ -249,7 +253,6 @@ public class WorldpayRefundSubmitResourceIT {
 
         @Test
         void shouldFailRequestingARefund_whenChargeRefundIsFull() {
-
             Long refundAmount = defaultTestCharge.getAmount();
             String externalChargeId = defaultTestCharge.getExternalChargeId();
             Long chargeId = defaultTestCharge.getChargeId();
@@ -284,7 +287,6 @@ public class WorldpayRefundSubmitResourceIT {
 
         @Test
         void shouldFailRequestingARefund_whenAmountIsBiggerThanAllowedChargeAmount() {
-
             Long refundAmount = 10000001L;
 
             postRefundFor(defaultAccountId, defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
@@ -299,7 +301,6 @@ public class WorldpayRefundSubmitResourceIT {
 
         @Test
         void shouldFailRequestingARefund_whenAmountIsLessThanOnePence() {
-
             Long refundAmount = 0L;
 
             postRefundFor(defaultAccountId, defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
@@ -361,10 +362,12 @@ public class WorldpayRefundSubmitResourceIT {
     @Nested
     class ByServiceIdAndType {
         @Test
+        @DisplayName("Should create refund, send refund request to Worldpay, and update refund state to 'REFUND SUBMITTED' for partial refund")
         void shouldBeAbleToRequestARefund_partialAmount() {
-            Long refundAmount = 50L;
+            int refundAmount = 50;
             app.getWorldpayMockClient().mockRefundSuccess();
 
+            // Request partial refund
             var response = app.givenSetup()
                     .body(toJson(Map.of(
                             "amount", refundAmount,
@@ -374,40 +377,43 @@ public class WorldpayRefundSubmitResourceIT {
                     .then()
                     .statusCode(202)
                     .body("refund_id", is(notNullValue()))
-                    .body("amount", is(refundAmount.intValue()))
+                    .body("amount", is(refundAmount))
                     .body("status", is("submitted"))
                     .body("created_date", is(notNullValue()));
-            
             String refundId = response.extract().path("refund_id");
-
+            
+            // Validate links in response
             String paymentUrl = format("https://localhost:%s/v1/api/service/%s/account/%s/charges/%s",
                     app.getLocalPort(), SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId());
-
             response.body("_links.self.href", is(paymentUrl + "/refunds/" + refundId))
                     .body("_links.payment.href", is(paymentUrl));
             
+            // Verify refund entity is created in database
             List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
             assertThat(refundsFoundByChargeExternalId.size(), is(1));
             assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUND SUBMITTED")));
 
-            List<String> refundsHistory = (app.getDatabaseTestHelper()).getRefundsHistoryByChargeExternalId(defaultTestCharge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
-            assertThat(refundsHistory.size(), is(2));
-            assertThat(refundsHistory, containsInAnyOrder("REFUND SUBMITTED", "CREATED"));
+            // Verify updates to refund status appear in refund history
+            List<String> refundsStatusHistory = (app.getDatabaseTestHelper()).getRefundsHistoryByChargeExternalId(defaultTestCharge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
+            assertThat(refundsStatusHistory.size(), is(2));
+            assertThat(refundsStatusHistory, containsInAnyOrder("REFUND SUBMITTED", "CREATED"));
 
+            // Verify request body sent to Worldpay
             String expectedRequestBody = TestTemplateResourceLoader.load(WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST)
                     .replace("{{merchantCode}}", "merchant-id")
                     .replace("{{transactionId}}", "MyUniqueTransactionId!")
-                    .replace("{{refundReference}}", refundsFoundByChargeExternalId.get(0).get("external_id").toString())
+                    .replace("{{refundReference}}", refundsFoundByChargeExternalId.getFirst().get("external_id").toString())
                     .replace("{{amount}}", "50");
-
-            verifyRequestBodyToWorldpay(WORLDPAY_URL, expectedRequestBody);
+            verifyRequestBodyToWorldpay(expectedRequestBody);
         }
 
         @Test
+        @DisplayName("Should create refund, send refund request to Worldpay, and update refund state to 'REFUND SUBMITTED' for full refund")
         void shouldBeAbleToRequestARefund_fullAmount() {
-            Long refundAmount = defaultTestCharge.getAmount();
+            int refundAmount = (int) defaultTestCharge.getAmount();
             app.getWorldpayMockClient().mockRefundSuccess();
 
+            // Request full refund
             String refundId = app.givenSetup()
                     .body(toJson(Map.of(
                             "amount", refundAmount,
@@ -417,24 +423,410 @@ public class WorldpayRefundSubmitResourceIT {
                     .then()
                     .statusCode(202)
                     .body("refund_id", is(notNullValue()))
-                    .body("amount", is(refundAmount.intValue()))
+                    .body("amount", is(refundAmount))
                     .body("status", is("submitted"))
                     .body("created_date", is(notNullValue()))
                     .extract().path("refund_id");
             
+            // Verify refund entity is created
             List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
             assertThat(refundsFoundByChargeExternalId.size(), is(1));
             assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUND SUBMITTED")));
-            assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
-            assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("gateway_transaction_id", refundId));
+            assertThat(refundsFoundByChargeExternalId.getFirst(), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
+            assertThat(refundsFoundByChargeExternalId.getFirst(), hasEntry("gateway_transaction_id", refundId));
 
+            // Verify updates to refund status appear in refund history
+            List<String> refundsStatusHistory = (app.getDatabaseTestHelper()).getRefundsHistoryByChargeExternalId(defaultTestCharge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
+            assertThat(refundsStatusHistory.size(), is(2));
+            assertThat(refundsStatusHistory, containsInAnyOrder("REFUND SUBMITTED", "CREATED"));
+            
+            // Verify request sent to Worldpay
             String expectedRequestBody = TestTemplateResourceLoader.load(WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST)
                     .replace("{{merchantCode}}", "merchant-id")
                     .replace("{{transactionId}}", "MyUniqueTransactionId!")
-                    .replace("{{refundReference}}", refundsFoundByChargeExternalId.get(0).get("external_id").toString())
+                    .replace("{{refundReference}}", refundsFoundByChargeExternalId.getFirst().get("external_id").toString())
                     .replace("{{amount}}", "100");
+            verifyRequestBodyToWorldpay(expectedRequestBody);
+        }
 
-            verifyRequestBodyToWorldpay(WORLDPAY_URL, expectedRequestBody);
+        @Test
+        @DisplayName("Should create refund, send refund request to Worldpay, and update refund state to 'REFUND SUBMITTED' when requesting a refund using retired credentials")
+        void shouldBeAbleToRequestForRetiredCredentials() {
+            app.getWorldpayMockClient().mockRefundSuccess();
+            long accountId = randomLong();
+            String serviceId = "another-valid-service-id";
+
+            var activeStripeCredentialsParams = anAddGatewayAccountCredentialsParams()
+                    .withPaymentProvider(STRIPE.getName())
+                    .withGatewayAccountId(accountId)
+                    .withState(ACTIVE)
+                    .build();
+
+            var retiredWorldpayCredentialsParams = anAddGatewayAccountCredentialsParams()
+                    .withPaymentProvider(WORLDPAY.getName())
+                    .withGatewayAccountId(accountId)
+                    .withState(RETIRED)
+                    .withCredentials(validWorldpayCredentials)
+                    .build();
+
+            var testAccountWithRetiredCredentials = DatabaseFixtures
+                    .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                    .aTestAccount()
+                    .withAccountId(accountId)
+                    .withServiceId(serviceId)
+                    .withType(TEST)
+                    .withGatewayAccountCredentials(List.of(activeStripeCredentialsParams, retiredWorldpayCredentialsParams))
+                    .insert();
+
+            DatabaseFixtures.TestCharge charge = DatabaseFixtures
+                    .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                    .aTestCharge()
+                    .withAmount(100L)
+                    .withTransactionId("MyUniqueTransactionId2!")
+                    .withTestAccount(testAccountWithRetiredCredentials)
+                    .withChargeStatus(CAPTURED)
+                    .withPaymentProvider(WORLDPAY.getName())
+                    .insert();
+
+            int refundAmount = 100;
+
+            // Request refund
+            var response = app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", refundAmount,
+                            "refund_amount_available", charge.getAmount()
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", serviceId, TEST, charge.getExternalChargeId()))
+                    .then()
+                    .statusCode(202)
+                    .body("refund_id", is(notNullValue()))
+                    .body("amount", is(refundAmount))
+                    .body("status", is("submitted"))
+                    .body("created_date", is(notNullValue()));
+            String refundId = response.extract().path("refund_id");
+
+            // Validate links in response
+            String paymentUrl = format("https://localhost:%s/v1/api/service/%s/account/%s/charges/%s",
+                    app.getLocalPort(), serviceId, TEST, charge.getExternalChargeId());
+            response.body("_links.self.href", is(paymentUrl + "/refunds/" + refundId))
+                    .body("_links.payment.href", is(paymentUrl));
+
+            // Verify refund entity is created in database
+            List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(charge.getExternalChargeId());
+            assertThat(refundsFoundByChargeExternalId.size(), is(1));
+            assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), charge.getExternalChargeId(), refundAmount, "REFUND SUBMITTED")));
+
+            // Verify updates to refund status appear in refund history
+            List<String> refundsStatusHistory = (app.getDatabaseTestHelper()).getRefundsHistoryByChargeExternalId(charge.getExternalChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
+            assertThat(refundsStatusHistory.size(), is(2));
+            assertThat(refundsStatusHistory, containsInAnyOrder("REFUND SUBMITTED", "CREATED"));
+
+            // Verify request sent to Worldpay
+            String expectedRequestBody = TestTemplateResourceLoader.load(WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST)
+                    .replace("{{merchantCode}}", "merchant-id")
+                    .replace("{{transactionId}}", "MyUniqueTransactionId2!")
+                    .replace("{{refundReference}}", refundsFoundByChargeExternalId.getFirst().get("external_id").toString())
+                    .replace("{{amount}}", "100");
+            verifyRequestBodyToWorldpay(expectedRequestBody);
+        }
+
+        @Test
+        @DisplayName("Should create charge entities, send refund requests to Worldpay, update statuses and have accurate refund summary when submitting multiple refunds")
+        void shouldBeAbleToRequestARefund_multiplePartialAmounts_andRefundShouldBeInFullStatus() {
+            int firstRefundAmount = 80;
+            int secondRefundAmount = 20;
+            String externalChargeId = defaultTestCharge.getExternalChargeId();
+            app.getWorldpayMockClient().mockRefundSuccess();
+            
+            // Request first refund
+            var firstResponse = app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", firstRefundAmount,
+                            "refund_amount_available", defaultTestCharge.getAmount()
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
+                    .then().statusCode(202)
+                    .body("refund_id", is(notNullValue()))
+                    .body("amount", is(firstRefundAmount))
+                    .body("status", is("submitted"))
+                    .body("created_date", is(notNullValue()));;
+            String firstRefundId = firstResponse.extract().path("refund_id");
+            
+            // Request second refund
+            var secondResponse = app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", secondRefundAmount,
+                            "refund_amount_available", defaultTestCharge.getAmount() - firstRefundAmount
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
+                    .then().statusCode(202)
+                    .body("refund_id", is(notNullValue()))
+                    .body("amount", is(secondRefundAmount))
+                    .body("status", is("submitted"))
+                    .body("created_date", is(notNullValue()));;
+            String secondRefundId = secondResponse.extract().path("refund_id");
+            
+            // Verify refund entities are created in database
+            List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+            assertThat(refundsFoundByChargeExternalId.size(), is(2));
+            assertThat(refundsFoundByChargeExternalId, hasItems(
+                    aRefundMatching(firstRefundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), firstRefundAmount, "REFUND SUBMITTED"),
+                    aRefundMatching(secondRefundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), secondRefundAmount, "REFUND SUBMITTED")
+            ));
+            
+            // Verify refund summary on charge
+            app.givenSetup()
+                    .get(format("/v1/api/accounts/%s/charges/%s", defaultAccountId, externalChargeId))
+                    .then()
+                    .statusCode(200)
+                    .body("refund_summary.status", is("full"))
+                    .body("refund_summary.amount_available", is(0))
+                    .body("refund_summary.amount_submitted", is(100));
+
+            // Verify requests sent to Worldpay
+            String expectedFirstRequestBody = TestTemplateResourceLoader.load(WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST)
+                    .replace("{{merchantCode}}", "merchant-id")
+                    .replace("{{transactionId}}", "MyUniqueTransactionId!")
+                    .replace("{{refundReference}}", refundsFoundByChargeExternalId.getFirst().get("external_id").toString())
+                    .replace("{{amount}}", "80");
+            String expectedSecondRequestBody = TestTemplateResourceLoader.load(WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST)
+                    .replace("{{merchantCode}}", "merchant-id")
+                    .replace("{{transactionId}}", "MyUniqueTransactionId!")
+                    .replace("{{refundReference}}", refundsFoundByChargeExternalId.get(1).get("external_id").toString())
+                    .replace("{{amount}}", "20");
+
+            app.getWorldpayWireMockServer().verify(2, postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
+            verifyRequestBodyToWorldpay(expectedFirstRequestBody);
+            verifyRequestBodyToWorldpay(expectedSecondRequestBody);
+        }
+
+        @ParameterizedTest
+        @DisplayName("Should return 400, not create a refund entity, and not send refund request to Worldpay when charge is in non-refundable state")
+        @MethodSource("nonRefundableChargeStatuses")
+        void shouldFailRequestingARefund_whenChargeStatusMakesItNotRefundable(ChargeStatus nonRefundableChargeStatus) {
+            DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
+                    .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                    .aTestCharge()
+                    .withAmount(100L)
+                    .withTestAccount(defaultTestAccount)
+                    .withChargeStatus(nonRefundableChargeStatus)
+                    .withPaymentProvider("worldpay")
+                    .withGatewayCredentialId(defaultCredentialsId)
+                    .insert();
+
+            Long refundAmount = 20L;
+
+            app.getWorldpayMockClient().mockRefundSuccess();
+
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", refundAmount,
+                            "refund_amount_available", testCharge.getAmount()
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, testCharge.getExternalChargeId()))
+                    .then().statusCode(BAD_REQUEST.getStatusCode())
+                    .body("message", contains(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())))
+                    .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+            
+            // Verify no refunds are created in the database
+            List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+            assertThat(refundsFoundByChargeExternalId.size(), is(0));
+            
+            // Verify no refund requests are made to Worldpay
+            app.getWorldpayWireMockServer().verify(0, postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
+        }
+        
+        private static Stream<ChargeStatus> nonRefundableChargeStatuses() {
+            return NON_REFUNDABLE_CHARGE_STATUSES.stream();
+        }
+
+        @Test
+        @DisplayName("Should return 400, not create a refund entity, and not send refund request to Worldpay when charge has already been fully refunded")
+        void shouldFailRequestingARefund_whenChargeRefundIsFull() {
+            app.getWorldpayMockClient().mockRefundSuccess();
+            
+            // Issue full refund for charge
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", defaultTestCharge.getAmount(),
+                            "refund_amount_available", defaultTestCharge.getAmount()
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
+                    .then().statusCode(ACCEPTED.getStatusCode());
+
+            // Verify first request to Worldpay
+            app.getWorldpayWireMockServer().verify(1, postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
+
+            // Verify refund entity exists
+            List<Map<String, Object>> firstRefundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+            assertThat(firstRefundsFoundByChargeExternalId.size(), is(1));
+            
+            // Request additional refund
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount", 1,
+                            "refund_amount_available", 0
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
+                    .then().statusCode(BAD_REQUEST.getStatusCode())
+                    .body("reason", is("full"))
+                    .body("message", contains(format("Charge with id [%s] not available for refund.", defaultTestCharge.getExternalChargeId())))
+                    .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+            // Verify no additional requests to Worldpay
+            app.getWorldpayWireMockServer().verify(1, postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
+
+            // Verify only one refund entity exists
+            List<Map<String, Object>> secondRefundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+            assertThat(secondRefundsFoundByChargeExternalId.size(), is(1));
+        }
+        
+        @Test
+        @DisplayName("Should return 400, not create a refund entity, and not send refund request to Worldpay when requested refund is larger than charge amount")
+        void shouldFailRequestingARefund_whenAmountIsBiggerThanChargeAmount() {
+            app.getWorldpayMockClient().mockRefundSuccess();
+
+            // Request refund exceeding charge amount
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount",  defaultTestCharge.getAmount() + 20,
+                            "refund_amount_available", defaultTestCharge.getAmount()
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
+                    .then().statusCode(BAD_REQUEST.getStatusCode())
+                    .body("reason", is("amount_not_available"))
+                    .body("message", contains("Not sufficient amount available for refund"))
+                    .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+            // Verify no requests made to Worldpay
+            app.getWorldpayWireMockServer().verify(0, postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
+            
+            // Verify no refund entity is created
+            List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+            assertThat(refundsFoundByChargeExternalId.size(), is(0));
+        }
+        
+        @Test
+        @DisplayName("Should return 400, not create a refund entity, and not send refund request to Worldpay when requested refund is larger than allowed charge amount")
+        void shouldFailRequestingARefund_whenAmountIsBiggerThanAllowedChargeAmount() {
+            app.getWorldpayMockClient().mockRefundSuccess();
+
+            // Request refund exceeding allowed charge amount
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount",  10000001L,
+                            "refund_amount_available", defaultTestCharge.getAmount()
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
+                    .then().statusCode(BAD_REQUEST.getStatusCode())
+                    .body("reason", is("amount_not_available"))
+                    .body("message", contains("Not sufficient amount available for refund"))
+                    .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+            // Verify no requests made to Worldpay
+            app.getWorldpayWireMockServer().verify(0, postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
+
+            // Verify no refund entity is created
+            List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+            assertThat(refundsFoundByChargeExternalId.size(), is(0));
+        }
+        
+        @Test
+        @DisplayName("Should return 400, not create a refund entity, and not send refund request to Worldpay when requested refund is less than minimum charge amount")
+        void shouldFailRequestingARefund_whenAmountIsLessThanOnePence() {
+            app.getWorldpayMockClient().mockRefundSuccess();
+
+            // Request refund of less than minimum amount
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount",  0,
+                            "refund_amount_available", defaultTestCharge.getAmount()
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
+                    .then().statusCode(BAD_REQUEST.getStatusCode())
+                    .body("reason", is("amount_min_validation"))
+                    .body("message", contains("Validation error for amount. Minimum amount for a refund is 1"))
+                    .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+            // Verify no requests made to Worldpay
+            app.getWorldpayWireMockServer().verify(0, postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
+
+            // Verify no refund entity is created
+            List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+            assertThat(refundsFoundByChargeExternalId.size(), is(0));
+        }
+
+        @Test
+        @DisplayName("Should return 400, not create a refund entity, and not send refund request to Worldpay when a requested partial refund is more than the amount available")
+        void shouldFailRequestingARefund_whenAPartialRefundMakesTotalRefundedAmountBiggerThanChargeAmount() {
+            int firstRefundAmount = 80;
+            int secondRefundAmount = 30; // 10 more than available
+
+            app.getWorldpayMockClient().mockRefundSuccess();
+
+            // Request first partial refund
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount",  firstRefundAmount,
+                            "refund_amount_available", defaultTestCharge.getAmount()
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
+                    .then().statusCode(ACCEPTED.getStatusCode())
+                    .body("amount", is(firstRefundAmount))
+                    .body("status", is("submitted"));
+            
+            // Verify refund entity is created
+            List<Map<String, Object>> firstRefundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+            assertThat(firstRefundsFoundByChargeExternalId.size(), is(1));
+
+            // Verify first request to Worldpay
+            app.getWorldpayWireMockServer().verify(1, postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
+            
+            // Request refund of more than amount remaining available
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount",  secondRefundAmount,
+                            "refund_amount_available", defaultTestCharge.getAmount() - firstRefundAmount
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
+                    .then().statusCode(BAD_REQUEST.getStatusCode())
+                    .body("reason", is("amount_not_available"))
+                    .body("message", contains("Not sufficient amount available for refund"))
+                    .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
+
+            // Verify no additional refund entity is created
+            List<Map<String, Object>> secondRefundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+            assertThat(secondRefundsFoundByChargeExternalId.size(), is(1));
+            
+            // Verify no additional requests made to Worldpay
+            app.getWorldpayWireMockServer().verify(1, postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
+        }
+
+
+        @Test
+        @DisplayName("Should return 500 and create refund entity with status REFUND_ERROR when refund request to Worldpay fails")
+        void shouldFailRequestingARefund_whenGatewayOperationFails() {
+            long refundAmount = defaultTestCharge.getAmount();
+            app.getWorldpayMockClient().mockRefundError();
+
+            app.givenSetup()
+                    .body(toJson(Map.of(
+                            "amount",  refundAmount,
+                            "refund_amount_available", defaultTestCharge.getAmount()
+                    )))
+                    .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
+                    .then().statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
+                    .body("message", contains("Worldpay refund response (error code: 2, error: Something went wrong.)"))
+                    .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+
+            java.util.List<Map<String, Object>> refundsFoundByChargeExternalId = (app.getDatabaseTestHelper()).getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
+            assertThat(refundsFoundByChargeExternalId.size(), is(1));
+            assertThat(refundsFoundByChargeExternalId, contains(
+                    allOf(
+                            hasEntry("amount", (Object) refundAmount),
+                            hasEntry("status", RefundStatus.REFUND_ERROR.getValue()),
+                            hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId())
+                    )));
         }
     }
 
@@ -470,9 +862,9 @@ public class WorldpayRefundSubmitResourceIT {
         return refundId;
     }
 
-    private void verifyRequestBodyToWorldpay(String path, String body) {
+    private void verifyRequestBodyToWorldpay(String body) {
         app.getWorldpayWireMockServer().verify(
-                postRequestedFor(urlPathEqualTo(path))
+                postRequestedFor(urlPathEqualTo(WORLDPAY_URL))
                         .withHeader("Content-Type", equalTo("application/xml"))
                         .withHeader("Authorization", equalTo("Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ="))
                         .withRequestBody(equalToXml(body)));

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundSubmitResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundSubmitResourceIT.java
@@ -75,8 +75,6 @@ public class WorldpayRefundSubmitResourceIT {
                     CREDENTIALS_PASSWORD, "test-password")
     );
     
-    private static final List<ChargeStatus> NON_REFUNDABLE_CHARGE_STATUSES = Arrays.stream(ChargeStatus.values()).filter(chargeStatus -> !chargeStatus.equals(CAPTURED)).toList();
-
     @BeforeEach
     void setUpCharge() {
         defaultAccountId = randomLong();
@@ -635,9 +633,11 @@ public class WorldpayRefundSubmitResourceIT {
             // Verify no refund requests are made to Worldpay
             app.getWorldpayWireMockServer().verify(0, postRequestedFor(urlPathEqualTo(WORLDPAY_URL)));
         }
-        
+
+
+        private static final Stream<ChargeStatus> NON_REFUNDABLE_CHARGE_STATUSES = Arrays.stream(ChargeStatus.values()).filter(chargeStatus -> !chargeStatus.equals(CAPTURED));
         private static Stream<ChargeStatus> nonRefundableChargeStatuses() {
-            return NON_REFUNDABLE_CHARGE_STATUSES.stream();
+            return NON_REFUNDABLE_CHARGE_STATUSES;
         }
 
         @Test


### PR DESCRIPTION
## WHAT YOU DID
 - Add integration tests for `POST /v1/api/service/{serviceId}/account/{accountType}/charges/{chargeId}/refunds` for Worldpay

## How to test
 - Run tests
