### PR TITLE
PP-12413: Prevent creation of duplicate Stripe test accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/MultipleStripeTestGatewayAccountsException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/MultipleStripeTestGatewayAccountsException.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.connector.gatewayaccount.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.util.ResponseUtil.conflictErrorResponse;
+
+public class MultipleStripeTestGatewayAccountsException extends WebApplicationException {
+    
+    public MultipleStripeTestGatewayAccountsException(String serviceId, 
+                                                      String gatewayAccountExternalId, 
+                                                      String gatewayAccountCredentialExternalId) {
+        super(conflictErrorResponse(format("Service '%s' already has an active Stripe gateway account with external id " +
+                "'%s' with gateway account credential is '%s' ", serviceId, gatewayAccountExternalId, gatewayAccountCredentialExternalId)));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -141,7 +141,9 @@ public class GatewayAccountService {
             throw MultipleLiveGatewayAccountsException.liveGatewayAccountAlreadyExists(gatewayAccountEntity.getServiceId());
         }
         
-        throwIfRequestIsForStripeTestAccountButItAlreadyExists(gatewayAccountEntity, gatewayAccountRequest.getServiceId());
+        if (!gatewayAccountEntity.isLive() && gatewayAccountRequest.getPaymentProvider().equalsIgnoreCase("stripe")) {
+            throwIfStripeTestAccountAlreadyExists(gatewayAccountRequest.getServiceId());
+        }
 
         LOGGER.info("Setting the new account to accept all card types by default");
 
@@ -159,9 +161,9 @@ public class GatewayAccountService {
         return GatewayAccountObjectConverter.createResponseFrom(gatewayAccountEntity, uriInfo);
     }
 
-    private void throwIfRequestIsForStripeTestAccountButItAlreadyExists(GatewayAccountEntity gatewayAccountEntity, String serviceId) {
+    private void throwIfStripeTestAccountAlreadyExists(String serviceId) {
         var maybeGatewayAccount = getGatewayAccountByServiceIdAndAccountType(serviceId, TEST);
-        if (maybeGatewayAccount.isPresent() && !gatewayAccountEntity.isLive() && 
+        if (maybeGatewayAccount.isPresent() && 
                 maybeGatewayAccount.get().getCurrentOrActiveGatewayAccountCredential().isPresent() &&
                 maybeGatewayAccount.get().getCurrentOrActiveGatewayAccountCredential().get().getPaymentProvider().equalsIgnoreCase("stripe")) {
             GatewayAccountEntity stripeGatewayAccount = maybeGatewayAccount.get();


### PR DESCRIPTION
Because there is a possibility of concurrent requests to `POST /v1/service/{serviceId}/request-stripe-test-account`, do a check to prevent a duplicate test Stripe gateway account from being created.
