### PR TITLE
PP-12413: Return new ids to selfservice

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,56 +139,56 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 3356
+        "line_number": 3357
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 3400
+        "line_number": 3401
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3867
+        "line_number": 3868
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4256
+        "line_number": 4257
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4292
+        "line_number": 4293
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 5220
+        "line_number": 5221
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5703
+        "line_number": 5704
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5714
+        "line_number": 5715
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -317,7 +317,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 65
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java": [
@@ -1079,5 +1079,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-30T13:30:36Z"
+  "generated_at": "2024-08-02T16:09:36Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3005,8 +3005,9 @@ paths:
         "409":
           description: "Stripe Connect Account already exists, or existing test account\
             \ is not a Sandbox one"
-      summary: 1) Create a Stripe Connect Account 2) Create gateway account in connector
-        3) Disables the old sandbox account
+      summary: 1) Creates a Stripe Connect Account 2) Creates a gateway account in
+        connector and links this with the Stripe Connect Account id 3) Disables the
+        old sandbox account
       tags:
       - Gateway accounts
   /v1/tasks/emitted-events-sweep:

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
@@ -48,7 +48,12 @@ public class StripeAccountResourceIT {
         var createGatewayAccountResponse = setupSandboxGatewayAccount(serviceId, "Ollivander's wand shop");
 
         app.givenSetup().post(format("/v1/service/%s/request-stripe-test-account", serviceId))
-                .then().statusCode(200);
+                .then().statusCode(200).log().body()
+                .body("stripe_connect_account_id", is("acct_123"))
+                .body("gateway_account_id", is(notNullValue()))
+                .body("gateway_account_id", not(createGatewayAccountResponse.gatewayAccountId()))
+                .body("gateway_account_external_id", is(notNullValue()))
+                .body("gateway_account_id", not(createGatewayAccountResponse.externalId()));
         
         // Assert API calls to Stripe
         app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/accounts")));

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
@@ -48,7 +48,7 @@ public class StripeAccountResourceIT {
         var createGatewayAccountResponse = setupSandboxGatewayAccount(serviceId, "Ollivander's wand shop");
 
         app.givenSetup().post(format("/v1/service/%s/request-stripe-test-account", serviceId))
-                .then().statusCode(200).log().body()
+                .then().statusCode(200)
                 .body("stripe_connect_account_id", is("acct_123"))
                 .body("gateway_account_id", is(notNullValue()))
                 .body("gateway_account_id", not(createGatewayAccountResponse.gatewayAccountId()))


### PR DESCRIPTION
Selfservice calls `POST /v1/service/{serviceId}/request-stripe-test-account` and it would useful for it to have the stripe connect account id and gateway account id for logging purposes (for e.g. for selfservice to log `Stripe account acct_XXXX was created; gateway account with id XXXX was created`) and to be able to redirect the user back to the newly created gateway account page.
