### PR TITLE
PP-12413: Set up pact provider state

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -702,7 +702,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/pact/ContractTest.java",
         "hashed_secret": "d5662d7353c6257f68cab2a3b0f758cc79b1ac5e",
         "is_verified": false,
-        "line_number": 348
+        "line_number": 373
       }
     ],
     "src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java": [
@@ -1079,5 +1079,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-02T16:09:36Z"
+  "generated_at": "2024-08-05T14:37:59Z"
 }


### PR DESCRIPTION
Sets up the [state from this PR](https://github.com/alphagov/pay-selfservice/pull/4244/files#diff-25be690c9966a02113560ca2ba8e5acd2b14c4d209657eb9231d9f59ca93112bR48).

Unfortunately setting up two separate states - one for the gateway account and one of the stripe mocking - is not possible. They all need to be in one state 😢 