### PR TITLE
PP-12876 Make serviceId mandatory when creating accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -35,6 +35,7 @@ public class GatewayAccountRequest {
     private String serviceName;
 
     @JsonIgnore
+    @NotBlank
     private final String serviceId;
 
     @JsonIgnore

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -35,7 +35,7 @@ public class GatewayAccountRequest {
     private String serviceName;
 
     @JsonIgnore
-    @NotBlank
+    @NotBlank(message = "Field [service_id] cannot be blank or missing")
     private final String serviceId;
 
     @JsonIgnore

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
@@ -58,7 +58,7 @@ class GatewayAccountResourceValidationTest {
     @Test
     void shouldReturn422_whenPaymentProviderIsInvalid() {
 
-        Map<String, Object> payload = Map.of("payment_provider", "blockchain");
+        Map<String, Object> payload = Map.of("service_id", "a-valid-service-id", "payment_provider", "blockchain");
 
         Response response = resources.client()
                 .target("/v1/api/accounts")

--- a/src/test/java/uk/gov/pay/connector/it/resources/AgreementsApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/AgreementsApiResourceIT.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
 import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
 import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
@@ -38,7 +38,7 @@ public class AgreementsApiResourceIT {
     
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions(app.getLocalPort());
+    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
     
     public static final String VALID_SERVICE_ID = "a-valid-service-id";
     private static final String REFERENCE_ID = "1234";
@@ -187,7 +187,7 @@ public class AgreementsApiResourceIT {
             
             @BeforeEach
             void setUp() {
-                gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                gatewayAccountId = testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder()
                         .withServiceId(VALID_SERVICE_ID)
                         .build());
@@ -321,7 +321,7 @@ public class AgreementsApiResourceIT {
             
             @Test
             void shouldReturn204AndCancelAgreement() {
-                String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                String gatewayAccountId = testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder()
                                 .withServiceId(VALID_SERVICE_ID)
                                 .build());

--- a/src/test/java/uk/gov/pay/connector/it/resources/AgreementsApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/AgreementsApiResourceIT.java
@@ -180,18 +180,18 @@ public class AgreementsApiResourceIT {
 
     @Nested
     class ByServiceIdAndAccountType {
+        private String gatewayAccountId;
 
+        @BeforeEach
+        void setUp() {
+            gatewayAccountId = testHelpers.createGatewayAccount(
+                    aCreateGatewayAccountPayloadBuilder()
+                            .withServiceId(VALID_SERVICE_ID)
+                            .build());
+        }
+        
         @Nested
         class CreateAgreement {
-            private String gatewayAccountId;
-            
-            @BeforeEach
-            void setUp() {
-                gatewayAccountId = testHelpers.createGatewayAccount(
-                        aCreateGatewayAccountPayloadBuilder()
-                        .withServiceId(VALID_SERVICE_ID)
-                        .build());
-            }
             
             @Test
             void shouldCreateAgreement_forValidRequest() {
@@ -321,10 +321,6 @@ public class AgreementsApiResourceIT {
             
             @Test
             void shouldReturn204AndCancelAgreement() {
-                String gatewayAccountId = testHelpers.createGatewayAccount(
-                        aCreateGatewayAccountPayloadBuilder()
-                                .withServiceId(VALID_SERVICE_ID)
-                                .build());
                 testHelpers.updateGatewayAccount(gatewayAccountId, "recurring_enabled", true);
 
                 String createAgreementPayload = toJson(Map.of(

--- a/src/test/java/uk/gov/pay/connector/it/resources/AgreementsApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/AgreementsApiResourceIT.java
@@ -38,7 +38,7 @@ public class AgreementsApiResourceIT {
     
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
+    public static GatewayAccountResourceITHelpers testHelpers = new GatewayAccountResourceITHelpers(app.getLocalPort());
     
     public static final String VALID_SERVICE_ID = "a-valid-service-id";
     private static final String REFERENCE_ID = "1234";
@@ -187,7 +187,7 @@ public class AgreementsApiResourceIT {
             
             @BeforeEach
             void setUp() {
-                gatewayAccountId = testBaseExtension.createGatewayAccount(
+                gatewayAccountId = testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder()
                         .withServiceId(VALID_SERVICE_ID)
                         .build());
@@ -195,7 +195,7 @@ public class AgreementsApiResourceIT {
             
             @Test
             void shouldCreateAgreement_forValidRequest() {
-                testBaseExtension.updateGatewayAccount(gatewayAccountId, "recurring_enabled", true);
+                testHelpers.updateGatewayAccount(gatewayAccountId, "recurring_enabled", true);
 
                 String createAgreementPayload = toJson(Map.of(
                         "reference", REFERENCE_ID,
@@ -321,11 +321,11 @@ public class AgreementsApiResourceIT {
             
             @Test
             void shouldReturn204AndCancelAgreement() {
-                String gatewayAccountId = testBaseExtension.createGatewayAccount(
+                String gatewayAccountId = testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder()
                                 .withServiceId(VALID_SERVICE_ID)
                                 .build());
-                testBaseExtension.updateGatewayAccount(gatewayAccountId, "recurring_enabled", true);
+                testHelpers.updateGatewayAccount(gatewayAccountId, "recurring_enabled", true);
 
                 String createAgreementPayload = toJson(Map.of(
                         "reference", REFERENCE_ID,

--- a/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_API_URL;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class EmailNotificationResourceIT {

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -43,17 +43,17 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_FRONTEND_URL;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNT_FRONTEND_EXTERNAL_ID_URL;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_API_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_FRONTEND_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNT_FRONTEND_EXTERNAL_ID_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountFrontendResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     
-    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions(app.getLocalPort());
+    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
     private static final String ACCOUNTS_CARD_TYPE_FRONTEND_URL = "v1/frontend/accounts/{accountId}/card-types";
     private static final String ACCOUNTS_CARD_TYPE_BY_SERVICE_ID_AND_ACCOUNT_TYPE_FRONTEND_URL = "v1/frontend/service/{serviceId}/account/{accountType}/card-types";
 
@@ -136,7 +136,7 @@ public class GatewayAccountFrontendResourceIT {
 
     @Test
     void shouldAcceptAllCardTypesNotRequiring3DSForNewlyCreatedAccountAs3dsIsDisabledByDefault() {
-        String accountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+        String accountId = testBaseExtension.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build());
         String frontendCardTypeUrl = ACCOUNTS_CARD_TYPE_FRONTEND_URL.replace("{accountId}", accountId);
         ValidatableResponse response = app.givenSetup().accept(JSON)
@@ -157,7 +157,7 @@ public class GatewayAccountFrontendResourceIT {
 
     @Test
     void shouldGetCardTypesByServiceIdAndAccountType() {
-        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().withServiceId("a-service-id").build());
+        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withServiceId("a-service-id").build());
         String frontendCardTypeByServiceIdAndAccountTypeUrl = ACCOUNTS_CARD_TYPE_BY_SERVICE_ID_AND_ACCOUNT_TYPE_FRONTEND_URL
                 .replace("{serviceId}", "a-service-id")
                 .replace("{accountType}", GatewayAccountType.TEST.name());
@@ -271,7 +271,7 @@ public class GatewayAccountFrontendResourceIT {
     class UpdateServiceNameByAccountId {
         @Test
         void updateServiceName_shouldUpdateGatewayAccountServiceNameSuccessfully() {
-            String accountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+            String accountId = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
             String newServiceName = "A Brand New Service Name";
 
@@ -287,7 +287,7 @@ public class GatewayAccountFrontendResourceIT {
 
         @Test
         void updateServiceName_shouldNotUpdateGatewayAccountServiceNameIfMissingServiceName() {
-            String accountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+            String accountId = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
             app.givenSetup().accept(JSON)
                     .body(Map.of())
@@ -300,7 +300,7 @@ public class GatewayAccountFrontendResourceIT {
 
         @Test
         void updateServiceName_shouldFailUpdatingIfInvalidServiceNameLength() {
-            String accountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+            String accountId = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
             String tooLongServiceName = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 
             app.givenSetup().accept(JSON)
@@ -326,7 +326,7 @@ public class GatewayAccountFrontendResourceIT {
         
         @Test
         void updateServiceName_shouldNotUpdateGatewayAccountServiceNameIfAccountIdDoesNotExist() {
-            testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+            testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
             String nonExistentAccountId = "111111111";
 
             app.givenSetup().accept(JSON)
@@ -388,7 +388,7 @@ public class GatewayAccountFrontendResourceIT {
             CardTypeEntity visaCredit = getCardTypes(CardType.CREDIT, "visa");
 
             String serviceId = "my-service-id";
-            testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+            testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                     .withProvider("worldpay")
                     .withServiceId(serviceId)
                     .build());
@@ -438,7 +438,7 @@ public class GatewayAccountFrontendResourceIT {
         @Test
         void updateAcceptedCardTypes_shouldUpdateGatewayAccountToAcceptNoCardTypes() {
             String serviceId = "another-service-id";
-            testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+            testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                     .withProvider("worldpay")
                     .withServiceId(serviceId)
                     .build());

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -52,8 +52,8 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 public class GatewayAccountFrontendResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static GatewayAccountResourceITHelpers testHelpers = new GatewayAccountResourceITHelpers(app.getLocalPort());
     
-    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
     private static final String ACCOUNTS_CARD_TYPE_FRONTEND_URL = "v1/frontend/accounts/{accountId}/card-types";
     private static final String ACCOUNTS_CARD_TYPE_BY_SERVICE_ID_AND_ACCOUNT_TYPE_FRONTEND_URL = "v1/frontend/service/{serviceId}/account/{accountType}/card-types";
 
@@ -136,7 +136,7 @@ public class GatewayAccountFrontendResourceIT {
 
     @Test
     void shouldAcceptAllCardTypesNotRequiring3DSForNewlyCreatedAccountAs3dsIsDisabledByDefault() {
-        String accountId = testBaseExtension.createGatewayAccount(
+        String accountId = testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build());
         String frontendCardTypeUrl = ACCOUNTS_CARD_TYPE_FRONTEND_URL.replace("{accountId}", accountId);
         ValidatableResponse response = app.givenSetup().accept(JSON)
@@ -157,7 +157,7 @@ public class GatewayAccountFrontendResourceIT {
 
     @Test
     void shouldGetCardTypesByServiceIdAndAccountType() {
-        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withServiceId("a-service-id").build());
+        testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withServiceId("a-service-id").build());
         String frontendCardTypeByServiceIdAndAccountTypeUrl = ACCOUNTS_CARD_TYPE_BY_SERVICE_ID_AND_ACCOUNT_TYPE_FRONTEND_URL
                 .replace("{serviceId}", "a-service-id")
                 .replace("{accountType}", GatewayAccountType.TEST.name());
@@ -271,7 +271,7 @@ public class GatewayAccountFrontendResourceIT {
     class UpdateServiceNameByAccountId {
         @Test
         void updateServiceName_shouldUpdateGatewayAccountServiceNameSuccessfully() {
-            String accountId = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+            String accountId = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
             String newServiceName = "A Brand New Service Name";
 
@@ -287,7 +287,7 @@ public class GatewayAccountFrontendResourceIT {
 
         @Test
         void updateServiceName_shouldNotUpdateGatewayAccountServiceNameIfMissingServiceName() {
-            String accountId = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+            String accountId = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
             app.givenSetup().accept(JSON)
                     .body(Map.of())
@@ -300,7 +300,7 @@ public class GatewayAccountFrontendResourceIT {
 
         @Test
         void updateServiceName_shouldFailUpdatingIfInvalidServiceNameLength() {
-            String accountId = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+            String accountId = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
             String tooLongServiceName = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 
             app.givenSetup().accept(JSON)
@@ -326,7 +326,7 @@ public class GatewayAccountFrontendResourceIT {
         
         @Test
         void updateServiceName_shouldNotUpdateGatewayAccountServiceNameIfAccountIdDoesNotExist() {
-            testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+            testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
             String nonExistentAccountId = "111111111";
 
             app.givenSetup().accept(JSON)
@@ -388,7 +388,7 @@ public class GatewayAccountFrontendResourceIT {
             CardTypeEntity visaCredit = getCardTypes(CardType.CREDIT, "visa");
 
             String serviceId = "my-service-id";
-            testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+            testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                     .withProvider("worldpay")
                     .withServiceId(serviceId)
                     .build());
@@ -438,7 +438,7 @@ public class GatewayAccountFrontendResourceIT {
         @Test
         void updateAcceptedCardTypes_shouldUpdateGatewayAccountToAcceptNoCardTypes() {
             String serviceId = "another-service-id";
-            testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+            testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                     .withProvider("worldpay")
                     .withServiceId(serviceId)
                     .build());

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -46,15 +46,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_FRONTEND_URL;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNT_FRONTEND_EXTERNAL_ID_URL;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.GatewayAccountPayload.createDefault;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.createAGatewayAccountRequestSpecificationFor;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountFrontendResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     
-    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions("sandbox", app.getLocalPort());
+    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions(app.getLocalPort());
     private static final String ACCOUNTS_CARD_TYPE_FRONTEND_URL = "v1/frontend/accounts/{accountId}/card-types";
     private static final String ACCOUNTS_CARD_TYPE_BY_SERVICE_ID_AND_ACCOUNT_TYPE_FRONTEND_URL = "v1/frontend/service/{serviceId}/account/{accountType}/card-types";
 
@@ -62,13 +61,15 @@ public class GatewayAccountFrontendResourceIT {
 
     @Test
     void shouldGetGatewayAccountByExternalId() {
-        var gatewayAccountOptions = createDefault();
         DatabaseFixtures.TestAccount gatewayAccount = DatabaseFixtures
                 .withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aTestAccount()
                 .withPaymentProvider("worldpay")
-                .withCredentials(gatewayAccountOptions.getCredentials())
-                .withServiceName(gatewayAccountOptions.getServiceName())
+                .withCredentials(Map.of(
+                        "username", "a-username",
+                        "password", "a-password",
+                        "merchant_id", "a-merchant-id"))
+                .withServiceName("A Service Name")
                 .withCorporateCreditCardSurchargeAmount(250L)
                 .withCorporateDebitCardSurchargeAmount(50L)
                 .withIntegrationVersion3ds(1)
@@ -89,7 +90,7 @@ public class GatewayAccountFrontendResourceIT {
                 .body("email_notifications.REFUND_ISSUED.enabled", is(true))
                 .body("description", is(gatewayAccount.getDescription()))
                 .body("analytics_id", is(gatewayAccount.getAnalyticsId()))
-                .body("service_name", is(gatewayAccountOptions.getServiceName()))
+                .body("service_name", is("A Service Name"))
                 .body("corporate_credit_card_surcharge_amount", is(250))
                 .body("corporate_debit_card_surcharge_amount", is(50))
                 .body("allow_apple_pay", is(false))
@@ -135,7 +136,8 @@ public class GatewayAccountFrontendResourceIT {
 
     @Test
     void shouldAcceptAllCardTypesNotRequiring3DSForNewlyCreatedAccountAs3dsIsDisabledByDefault() {
-        String accountId = testBaseExtension.createAGatewayAccountFor("worldpay");
+        String accountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build());
         String frontendCardTypeUrl = ACCOUNTS_CARD_TYPE_FRONTEND_URL.replace("{accountId}", accountId);
         ValidatableResponse response = app.givenSetup().accept(JSON)
                 .get(frontendCardTypeUrl)
@@ -155,7 +157,7 @@ public class GatewayAccountFrontendResourceIT {
 
     @Test
     void shouldGetCardTypesByServiceIdAndAccountType() {
-        testBaseExtension.createAGatewayAccountWithServiceId("a-service-id");
+        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().withServiceId("a-service-id").build());
         String frontendCardTypeByServiceIdAndAccountTypeUrl = ACCOUNTS_CARD_TYPE_BY_SERVICE_ID_AND_ACCOUNT_TYPE_FRONTEND_URL
                 .replace("{serviceId}", "a-service-id")
                 .replace("{accountType}", GatewayAccountType.TEST.name());
@@ -269,25 +271,27 @@ public class GatewayAccountFrontendResourceIT {
     class UpdateServiceNameByAccountId {
         @Test
         void updateServiceName_shouldUpdateGatewayAccountServiceNameSuccessfully() {
-            String accountId = testBaseExtension.createAGatewayAccountFor("stripe");
+            String accountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
 
-            var gatewayAccountPayload = createDefault();
+            String newServiceName = "A Brand New Service Name";
 
             app.givenSetup().accept(JSON)
-                    .body(gatewayAccountPayload.buildServiceNamePayload())
+                    .body(Map.of("service_name", newServiceName))
                     .patch(ACCOUNTS_FRONTEND_URL + accountId + "/servicename")
                     .then()
                     .statusCode(200);
 
             String currentServiceName = app.getDatabaseTestHelper().getAccountServiceName(Long.valueOf(accountId));
-            assertThat(currentServiceName, is(gatewayAccountPayload.getServiceName()));
+            assertThat(currentServiceName, is(newServiceName));
         }
 
         @Test
         void updateServiceName_shouldNotUpdateGatewayAccountServiceNameIfMissingServiceName() {
-            String accountId = testBaseExtension.createAGatewayAccountFor("worldpay");
+            String accountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
 
-            updateGatewayAccountServiceNameWith(accountId, new HashMap<>())
+            app.givenSetup().accept(JSON)
+                    .body(Map.of())
+                    .patch(ACCOUNTS_FRONTEND_URL + accountId + "/servicename")
                     .then()
                     .statusCode(400)
                     .body("message", contains("Field(s) missing: [service_name]"))
@@ -296,12 +300,12 @@ public class GatewayAccountFrontendResourceIT {
 
         @Test
         void updateServiceName_shouldFailUpdatingIfInvalidServiceNameLength() {
-            String accountId = testBaseExtension.createAGatewayAccountFor("worldpay");
+            String accountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+            String tooLongServiceName = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 
-            var gatewayAccountPayload = createDefault()
-                    .withServiceName("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
-
-            updateGatewayAccountServiceNameWith(accountId, gatewayAccountPayload.buildServiceNamePayload())
+            app.givenSetup().accept(JSON)
+                    .body(Map.of("service_name", tooLongServiceName))
+                    .patch(ACCOUNTS_FRONTEND_URL + accountId + "/servicename")
                     .then()
                     .statusCode(400)
                     .body("message", contains("Field(s) are too big: [service_name]"))
@@ -310,23 +314,26 @@ public class GatewayAccountFrontendResourceIT {
 
         @Test
         void updateServiceName_shouldNotUpdateGatewayAccountServiceNameIfAccountIdIsNotNumeric() {
-            Map<String, String> serviceNamePayload = createDefault().buildServiceNamePayload();
-            updateGatewayAccountServiceNameWith("NO_NUMERIC_ACCOUNT_ID", serviceNamePayload)
+           app.givenSetup().accept(JSON)
+                    .body(Map.of("service_name", "A Brand New Service Name"))
+                    .patch(ACCOUNTS_FRONTEND_URL + "NON_NUMERIC_ACCOUNT_ID" + "/servicename")
                     .then()
                     .contentType(JSON)
                     .statusCode(NOT_FOUND.getStatusCode())
                     .body("code", is(404))
                     .body("message", is("HTTP 404 Not Found"));
         }
-
+        
         @Test
         void updateServiceName_shouldNotUpdateGatewayAccountServiceNameIfAccountIdDoesNotExist() {
-            String nonExistingAccountId = "111111111";
-            testBaseExtension.createAGatewayAccountFor("stripe");
+            testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+            String nonExistentAccountId = "111111111";
 
-            Map<String, String> serviceNamePayload = createDefault().buildServiceNamePayload();
-            updateGatewayAccountServiceNameWith(nonExistingAccountId, serviceNamePayload)
+            app.givenSetup().accept(JSON)
+                    .body(Map.of("service_name", "A Brand New Service Name"))
+                    .patch(ACCOUNTS_FRONTEND_URL + nonExistentAccountId + "/servicename")
                     .then()
+                    .contentType(JSON)
                     .statusCode(404)
                     .body("message", contains("The gateway account id '111111111' does not exist"))
                     .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
@@ -381,13 +388,11 @@ public class GatewayAccountFrontendResourceIT {
             CardTypeEntity visaCredit = getCardTypes(CardType.CREDIT, "visa");
 
             String serviceId = "my-service-id";
-            var createRequest = createAGatewayAccountRequestSpecificationFor(app.getLocalPort(), "worldpay",
-                    "my test service", "analytics", serviceId);
-            createRequest.post(ACCOUNTS_API_URL)
-                    .then()
-                    .statusCode(201)
-                    .contentType(JSON);
-
+            testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+                    .withProvider("worldpay")
+                    .withServiceId(serviceId)
+                    .build());
+            
             String bodyWithJustVisaCredit = buildAcceptedCardTypesBody(visaCredit);
             updateGatewayAccountCardTypesWith(serviceId, GatewayAccountType.TEST, bodyWithJustVisaCredit)
                     .then()
@@ -433,12 +438,10 @@ public class GatewayAccountFrontendResourceIT {
         @Test
         void updateAcceptedCardTypes_shouldUpdateGatewayAccountToAcceptNoCardTypes() {
             String serviceId = "another-service-id";
-            var createRequest = createAGatewayAccountRequestSpecificationFor(app.getLocalPort(), "worldpay",
-                    "my test service", "analytics", serviceId);
-            createRequest.post(ACCOUNTS_API_URL)
-                    .then()
-                    .statusCode(201)
-                    .contentType(JSON);
+            testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+                    .withProvider("worldpay")
+                    .withServiceId(serviceId)
+                    .build());
 
             String bodyWithJustVisaCredit = buildAcceptedCardTypesBody(getCardTypes(CardType.CREDIT, "visa"));
             updateGatewayAccountCardTypesWith(serviceId, GatewayAccountType.TEST, bodyWithJustVisaCredit)
@@ -527,12 +530,6 @@ public class GatewayAccountFrontendResourceIT {
                 app.getDatabaseTestHelper().getAcceptedCardTypesByAccountId(gatewayAccount.getAccountId());
 
         assertEquals(0, acceptedCardTypes.size());
-    }
-
-    private Response updateGatewayAccountServiceNameWith(String accountId, Map<String, String> serviceName) {
-        return app.givenSetup().accept(JSON)
-                .body(serviceName)
-                .patch(ACCOUNTS_FRONTEND_URL + accountId + "/servicename");
     }
 
     private Response updateGatewayAccountCardTypesWith(long accountId, String body) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
@@ -118,7 +118,6 @@ public class GatewayAccountResourceCreateIT {
         
         @Test
         public void createASandboxGatewayAccount() {
-            //ValidatableResponse response = GatewayAccountResourceITBaseExtensions.createAGatewayAccountFor(app.getLocalPort(), "sandbox", "my test service", "analytics");
             Map<String, Object> payload = Map.of("payment_provider", "sandbox", "service_id", "a-valid-service-id", "description","my test service", "analytics_id", "analytics");
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
             GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
@@ -28,9 +28,9 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.assertCorrectCreateResponse;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_API_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.assertCorrectCreateResponse;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountResourceCreateIT {
@@ -121,21 +121,21 @@ public class GatewayAccountResourceCreateIT {
             //ValidatableResponse response = GatewayAccountResourceITBaseExtensions.createAGatewayAccountFor(app.getLocalPort(), "sandbox", "my test service", "analytics");
             Map<String, Object> payload = Map.of("payment_provider", "sandbox", "service_id", "a-valid-service-id", "description","my test service", "analytics_id", "analytics");
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
-            GatewayAccountResourceITBaseExtensions.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
+            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
         }
 
         @Test
         public void createAWorldpaySandboxGatewayAccount() {
             Map<String, Object> payload = Map.of("payment_provider", "worldpay", "service_id", "a-valid-service-id", "description","my test service", "analytics_id", "analytics");
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
-            GatewayAccountResourceITBaseExtensions.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
+            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
         }
 
         @Test
         public void createAWorldpayStripeGatewayAccount() {
             Map<String, Object> payload = Map.of("payment_provider", "stripe", "service_id", "a-valid-service-id", "description","my test service", "analytics_id", "analytics");
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
-            GatewayAccountResourceITBaseExtensions.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
+            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
         }
 
         @Test
@@ -247,7 +247,7 @@ public class GatewayAccountResourceCreateIT {
         }
 
         private void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountType type) {
-            GatewayAccountResourceITBaseExtensions.assertCorrectCreateResponse(response, type, null, null, null);
+            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, type, null, null, null);
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
@@ -29,8 +29,8 @@ import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.assertCorrectCreateResponse;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.createAGatewayAccountRequestSpecificationFor;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountResourceCreateIT {
@@ -48,26 +48,36 @@ public class GatewayAccountResourceCreateIT {
         @Test
         public void shouldNotAllowMultipleGatewayAccountsWhenQueryStringIsIncluded() {
 
-            var createRequest = createAGatewayAccountRequestSpecificationFor(app.getLocalPort(), "worldpay", 
-                    "my test service", "analytics", "my-service-id");
-            var createRequestDuplicate = createAGatewayAccountRequestSpecificationFor(app.getLocalPort(), 
-                    "worldpay", "my test service2", "analytics2", "my-service-id");
-
-            createRequest.queryParam("degatewayification", "true");
-            createRequestDuplicate.queryParam("degatewayification", "true");
-
-            ValidatableResponse responseA = createRequest.post(ACCOUNTS_API_URL)
+            Map<String, String> requestForAccountPayload = aCreateGatewayAccountPayloadBuilder()
+                    .withProvider("worldpay")
+                    .withServiceId("my-service-id")
+                    .withDescription("my test service")
+                    .withAnalyticsId("analytics")
+                    .build();
+            
+            Map<String, String> requestForSecondAccountPayload = aCreateGatewayAccountPayloadBuilder()
+                    .withProvider("worldpay")
+                    .withServiceId("my-service-id")
+                    .withDescription("my extra test service")
+                    .withAnalyticsId("more analytics")
+                    .build();
+            
+            ValidatableResponse response = app.givenSetup()
+                    .body(requestForAccountPayload)
+                    .post(ACCOUNTS_API_URL + "?degatewayification=true")
                     .then()
                     .statusCode(201)
                     .contentType(JSON);
-
-            createRequestDuplicate.post(ACCOUNTS_API_URL)
+            
+            app.givenSetup()
+                    .body(requestForSecondAccountPayload)
+                    .post(ACCOUNTS_API_URL + "?degatewayification=true")
                     .then()
                     .statusCode(409)
                     .contentType(JSON)
                     .body("message", contains("Gateway account with service id my-service-id and account type 'test' already exists."));
-
-            assertCorrectCreateResponse(responseA, TEST, "my test service", "analytics", null);
+            
+            assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
         }
     }
 
@@ -76,16 +86,31 @@ public class GatewayAccountResourceCreateIT {
 
         @Test
         public void shouldAllowMultipleGatewayAccounts() {
-            var createRequest = createAGatewayAccountRequestSpecificationFor(app.getLocalPort(), "sandbox", 
-                    "my test service", "analytics", "my-service-id");
-            createRequest.post(ACCOUNTS_API_URL)
+
+            Map<String, String> requestForAccountPayload = aCreateGatewayAccountPayloadBuilder()
+                    .withProvider("worldpay")
+                    .withServiceId("my-service-id")
+                    .withDescription("my test service")
+                    .withAnalyticsId("analytics")
+                    .build();
+
+            Map<String, String> requestForSecondAccountPayload = aCreateGatewayAccountPayloadBuilder()
+                    .withProvider("worldpay")
+                    .withServiceId("my-service-id")
+                    .withDescription("my extra test service")
+                    .withAnalyticsId("more analytics")
+                    .build();
+
+            app.givenSetup()
+                    .body(requestForAccountPayload)
+                    .post(ACCOUNTS_API_URL)
                     .then()
                     .statusCode(201)
                     .contentType(JSON);
 
-            createRequest = createAGatewayAccountRequestSpecificationFor(app.getLocalPort(), "worldpay", 
-                    "my test service", "analytics", "my-service-id");
-            createRequest.post(ACCOUNTS_API_URL)
+            app.givenSetup()
+                    .body(requestForSecondAccountPayload)
+                    .post(ACCOUNTS_API_URL)
                     .then()
                     .statusCode(201)
                     .contentType(JSON);
@@ -93,19 +118,23 @@ public class GatewayAccountResourceCreateIT {
         
         @Test
         public void createASandboxGatewayAccount() {
-            ValidatableResponse response = GatewayAccountResourceITBaseExtensions.createAGatewayAccountFor(app.getLocalPort(), "sandbox", "my test service", "analytics");
+            //ValidatableResponse response = GatewayAccountResourceITBaseExtensions.createAGatewayAccountFor(app.getLocalPort(), "sandbox", "my test service", "analytics");
+            Map<String, Object> payload = Map.of("payment_provider", "sandbox", "service_id", "a-valid-service-id", "description","my test service", "analytics_id", "analytics");
+            ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
             GatewayAccountResourceITBaseExtensions.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
         }
 
         @Test
         public void createAWorldpaySandboxGatewayAccount() {
-            ValidatableResponse response = GatewayAccountResourceITBaseExtensions.createAGatewayAccountFor(app.getLocalPort(), "worldpay", "my test service", "analytics");
+            Map<String, Object> payload = Map.of("payment_provider", "worldpay", "service_id", "a-valid-service-id", "description","my test service", "analytics_id", "analytics");
+            ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
             GatewayAccountResourceITBaseExtensions.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
         }
 
         @Test
         public void createAWorldpayStripeGatewayAccount() {
-            ValidatableResponse response = GatewayAccountResourceITBaseExtensions.createAGatewayAccountFor(app.getLocalPort(), "stripe", "my test service", "analytics");
+            Map<String, Object> payload = Map.of("payment_provider", "stripe", "service_id", "a-valid-service-id", "description","my test service", "analytics_id", "analytics");
+            ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
             GatewayAccountResourceITBaseExtensions.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
         }
 
@@ -132,7 +161,8 @@ public class GatewayAccountResourceCreateIT {
         Map<String, Object> payload = Map.of(
                 "type", "test",
                 "payment_provider", "stripe",
-                "service_name", "My shiny new stripe service");
+                "service_name", "My shiny new stripe service",
+                "service_id", "a-valid-service-id");
         app.givenSetup()
                 .body(toJson(payload))
                 .post(ACCOUNTS_API_URL)
@@ -155,6 +185,7 @@ public class GatewayAccountResourceCreateIT {
                 "type", "test",
                 "payment_provider", "stripe",
                 "service_name", "My shiny new stripe service",
+                "service_id", "a-valid-service-id",
                 "credentials", Map.of("stripe_account_id", stripeAccountId));
         String gatewayAccountId = app.givenSetup()
                 .body(toJson(payload))
@@ -188,13 +219,22 @@ public class GatewayAccountResourceCreateIT {
 
         @Test
         public void createGatewayAccountWithoutPaymentProviderDefaultsToSandbox() {
-            String payload = toJson(Map.of("name", "test account", "type", "test"));
+            String payload = toJson(Map.of("name", "test account", "type", "test", "service_id", "a-valid-service-id"));
 
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201);
 
             assertCorrectCreateResponse(response, TEST);
-            GatewayAccountResourceITBaseExtensions.assertGettingAccountReturnsProviderName(app.getLocalPort(), response, "sandbox", TEST);
 
+            app.givenSetup()
+                    .contentType(JSON)
+                    .get(response.extract().header("Location").replace("https", "http")) //Scheme on links back are forced to be https
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("payment_provider", is("sandbox"))
+                    .body("gateway_account_id", is(notNullValue()))
+                    .body("type", is("test"));
+            
             String gatewayAccountId = response.extract().body().jsonPath().getString("gateway_account_id");
             Optional<GatewayAccountEntity> gatewayAccount = gatewayAccountDao.findById(Long.valueOf(gatewayAccountId));
             assertThat(gatewayAccount.isPresent(), is(true));

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -58,7 +58,7 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 public class GatewayAccountResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
+    public static GatewayAccountResourceITHelpers testHelpers = new GatewayAccountResourceITHelpers(app.getLocalPort());
     private DatabaseFixtures.TestAccount defaultTestAccount;
 
     @Nested
@@ -382,7 +382,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnDescriptionAndAnalyticsId() {
-            String gatewayAccountId = testBaseExtension.createGatewayAccount(
+            String gatewayAccountId = testHelpers.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withDescription("desc")
                             .withAnalyticsId("id")
@@ -397,7 +397,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnAnalyticsId() {
-            String gatewayAccountId = testBaseExtension.createGatewayAccount(
+            String gatewayAccountId = testHelpers.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withAnalyticsId("id")
                             .build());
@@ -411,7 +411,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnDescription() {
-            String gatewayAccountId = testBaseExtension.createGatewayAccount(
+            String gatewayAccountId = testHelpers.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withDescription("desc")
                             .build());
@@ -427,7 +427,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturn3dsSetting() {
-            String gatewayAccountId = testBaseExtension.createGatewayAccount(
+            String gatewayAccountId = testHelpers.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withProvider("stripe")
                             .withRequires3ds(true)
@@ -650,7 +650,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldNotReturn3dsFlexCredentials_whenGatewayAccountHasNoCreds() {
-            String gatewayAccountId = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+            String gatewayAccountId = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
             app.givenSetup()
                     .get("/v1/api/accounts/" + gatewayAccountId)
                     .then()
@@ -670,9 +670,9 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetAllGatewayAccountsWhenSearchWithNoParams() {
-        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
-        testBaseExtension.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
-        String gatewayAccountId2 = testBaseExtension.createGatewayAccount(
+        String gatewayAccountId1 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        testHelpers.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
+        String gatewayAccountId2 = testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("worldpay")
                         .build());
@@ -767,8 +767,8 @@ public class GatewayAccountResourceIT {
     
     @Test
     public void shouldSetApplePayEnabledByDefaultForSandboxAccount() {
-        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withProvider("sandbox").build());
-        String gatewayAccountId2 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build());
+        String gatewayAccountId1 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withProvider("sandbox").build());
+        String gatewayAccountId2 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build());
 
         app.givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId1)
@@ -783,9 +783,9 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByIds() {
-        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
-        String gatewayAccountId2 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
-        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        String gatewayAccountId1 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        String gatewayAccountId2 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?accountIds=" + gatewayAccountId1 + "," + gatewayAccountId2)
@@ -804,11 +804,11 @@ public class GatewayAccountResourceIT {
         String anotherServiceId = "anotherServiceId";
         String nonExistentServiceId = "nonExistentServiceId";
         
-        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(
+        String gatewayAccountId1 = testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withServiceId(serviceId)
                         .build());
-        testBaseExtension.createGatewayAccount(
+        testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withServiceId(anotherServiceId)
                         .build());
@@ -830,9 +830,9 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByMotoEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
-        testBaseExtension.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
-        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        String gatewayAccountId1 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        testHelpers.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
+        testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?moto_enabled=true")
@@ -844,9 +844,9 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByMotoDisabled() {
-        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
-        testBaseExtension.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
-        String gatewayAccountId2 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        String gatewayAccountId1 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        testHelpers.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
+        String gatewayAccountId2 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?moto_enabled=false")
@@ -858,12 +858,12 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByApplePayEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(
+        String gatewayAccountId1 = testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("worldpay")
                         .withAllowApplePay(true)
                         .build());
-        testBaseExtension.createGatewayAccount(
+        testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("stripe")
                         .build());
@@ -878,12 +878,12 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByGooglePayEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(
+        String gatewayAccountId1 = testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("worldpay")
                         .withAllowGooglePay(true)
                         .build());
-        testBaseExtension.createGatewayAccount(
+        testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("stripe")
                         .build());
@@ -898,11 +898,11 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByType() {
-        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+        String gatewayAccountId1 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                 .withProvider("stripe")
                 .withType(LIVE)
                 .build());
-        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?type=live")
@@ -914,11 +914,11 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByRecurringEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+        String gatewayAccountId1 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                 .withProvider("worldpay")
                 .build());
-        testBaseExtension.updateGatewayAccount(gatewayAccountId1, "recurring_enabled", true);
-        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        testHelpers.updateGatewayAccount(gatewayAccountId1, "recurring_enabled", true);
+        testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?recurring_enabled=true")
@@ -930,10 +930,10 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByProvider() {
-        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+        String gatewayAccountId1 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                 .withProvider("worldpay")
                 .build());
-        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+        testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                 .withProvider("stripe")
                 .build());
 
@@ -1100,7 +1100,7 @@ public class GatewayAccountResourceIT {
         String gatewayAccountId;
         @BeforeEach
         void createGatewayAccount() {
-            gatewayAccountId = testBaseExtension.createGatewayAccount(
+            gatewayAccountId = testHelpers.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withProvider("worldpay")
                             .build());
@@ -1160,7 +1160,7 @@ public class GatewayAccountResourceIT {
     
     @Test
     void shouldReturn3dsFlexCredentials_whenGatewayAccountHasCreds() {
-        String gatewayAccountId = testBaseExtension.createGatewayAccount(
+        String gatewayAccountId = testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("worldpay")
                         .build());
@@ -1180,7 +1180,7 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldReturn3dsFlexCredentials_whenGatewayAccountHasCreds_byServiceIdAndAccountType() {
-        String gatewayAccountId = testBaseExtension.createGatewayAccount(
+        String gatewayAccountId = testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("worldpay")
                         .withServiceId("a-valid-service-id")
@@ -1202,7 +1202,7 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldNotReturn3dsFlexCredentials_whenGatewayIsNotAWorldpayAccount() {
-        String gatewayAccountId = testBaseExtension.createGatewayAccount(
+        String gatewayAccountId = testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("stripe")
                         .build());

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -46,10 +46,10 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator.FIELD_GATEWAY_MERCHANT_ID;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_SERVICE_ID_URL;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_FRONTEND_URL;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_API_SERVICE_ID_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_API_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_FRONTEND_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
@@ -58,7 +58,7 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 public class GatewayAccountResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions(app.getLocalPort());
+    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
     private DatabaseFixtures.TestAccount defaultTestAccount;
 
     @Nested
@@ -382,7 +382,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnDescriptionAndAnalyticsId() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+            String gatewayAccountId = testBaseExtension.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withDescription("desc")
                             .withAnalyticsId("id")
@@ -397,7 +397,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnAnalyticsId() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+            String gatewayAccountId = testBaseExtension.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withAnalyticsId("id")
                             .build());
@@ -411,7 +411,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnDescription() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+            String gatewayAccountId = testBaseExtension.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withDescription("desc")
                             .build());
@@ -427,7 +427,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturn3dsSetting() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+            String gatewayAccountId = testBaseExtension.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withProvider("stripe")
                             .withRequires3ds(true)
@@ -650,7 +650,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldNotReturn3dsFlexCredentials_whenGatewayAccountHasNoCreds() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+            String gatewayAccountId = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
             app.givenSetup()
                     .get("/v1/api/accounts/" + gatewayAccountId)
                     .then()
@@ -670,9 +670,9 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetAllGatewayAccountsWhenSearchWithNoParams() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
         testBaseExtension.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
-        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+        String gatewayAccountId2 = testBaseExtension.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("worldpay")
                         .build());
@@ -767,8 +767,8 @@ public class GatewayAccountResourceIT {
     
     @Test
     public void shouldSetApplePayEnabledByDefaultForSandboxAccount() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().withProvider("sandbox").build());
-        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build());
+        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withProvider("sandbox").build());
+        String gatewayAccountId2 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build());
 
         app.givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId1)
@@ -783,9 +783,9 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByIds() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
-        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
-        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        String gatewayAccountId2 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?accountIds=" + gatewayAccountId1 + "," + gatewayAccountId2)
@@ -804,11 +804,11 @@ public class GatewayAccountResourceIT {
         String anotherServiceId = "anotherServiceId";
         String nonExistentServiceId = "nonExistentServiceId";
         
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withServiceId(serviceId)
                         .build());
-        testBaseExtension.createAGatewayAccountAndExtractAccountId(
+        testBaseExtension.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withServiceId(anotherServiceId)
                         .build());
@@ -830,9 +830,9 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByMotoEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
         testBaseExtension.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
-        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?moto_enabled=true")
@@ -844,9 +844,9 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByMotoDisabled() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
         testBaseExtension.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
-        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+        String gatewayAccountId2 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?moto_enabled=false")
@@ -858,12 +858,12 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByApplePayEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("worldpay")
                         .withAllowApplePay(true)
                         .build());
-        testBaseExtension.createAGatewayAccount(
+        testBaseExtension.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("stripe")
                         .build());
@@ -878,12 +878,12 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByGooglePayEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("worldpay")
                         .withAllowGooglePay(true)
                         .build());
-        testBaseExtension.createAGatewayAccount(
+        testBaseExtension.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("stripe")
                         .build());
@@ -898,11 +898,11 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByType() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder()
+        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                 .withProvider("stripe")
                 .withType(LIVE)
                 .build());
-        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?type=live")
@@ -914,11 +914,11 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByRecurringEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder()
+        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                 .withProvider("worldpay")
                 .build());
         testBaseExtension.updateGatewayAccount(gatewayAccountId1, "recurring_enabled", true);
-        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?recurring_enabled=true")
@@ -930,10 +930,10 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByProvider() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder()
+        String gatewayAccountId1 = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                 .withProvider("worldpay")
                 .build());
-        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+        testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder()
                 .withProvider("stripe")
                 .build());
 
@@ -1100,7 +1100,7 @@ public class GatewayAccountResourceIT {
         String gatewayAccountId;
         @BeforeEach
         void createGatewayAccount() {
-            gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+            gatewayAccountId = testBaseExtension.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withProvider("worldpay")
                             .build());
@@ -1160,7 +1160,7 @@ public class GatewayAccountResourceIT {
     
     @Test
     void shouldReturn3dsFlexCredentials_whenGatewayAccountHasCreds() {
-        String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+        String gatewayAccountId = testBaseExtension.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("worldpay")
                         .build());
@@ -1180,7 +1180,7 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldReturn3dsFlexCredentials_whenGatewayAccountHasCreds_byServiceIdAndAccountType() {
-        String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+        String gatewayAccountId = testBaseExtension.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("worldpay")
                         .withServiceId("a-valid-service-id")
@@ -1202,7 +1202,7 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldNotReturn3dsFlexCredentials_whenGatewayIsNotAWorldpayAccount() {
-        String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+        String gatewayAccountId = testBaseExtension.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("stripe")
                         .build());

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -49,6 +49,7 @@ import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAcc
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_SERVICE_ID_URL;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_FRONTEND_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
@@ -57,7 +58,7 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 public class GatewayAccountResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions("sandbox", app.getLocalPort());
+    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions(app.getLocalPort());
     private DatabaseFixtures.TestAccount defaultTestAccount;
 
     @Nested
@@ -381,7 +382,11 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnDescriptionAndAnalyticsId() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "desc", "id");
+            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                    aCreateGatewayAccountPayloadBuilder()
+                            .withDescription("desc")
+                            .withAnalyticsId("id")
+                                    .build());
             app.givenSetup()
                     .get(ACCOUNTS_API_URL + gatewayAccountId)
                     .then()
@@ -392,7 +397,10 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnAnalyticsId() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", null, "id");
+            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                    aCreateGatewayAccountPayloadBuilder()
+                            .withAnalyticsId("id")
+                            .build());
             app.givenSetup()
                     .get(ACCOUNTS_API_URL + gatewayAccountId)
                     .then()
@@ -403,7 +411,11 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnDescription() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "desc", null);
+            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                    aCreateGatewayAccountPayloadBuilder()
+                            .withDescription("desc")
+                            .build());
+            
             app.givenSetup()
                     .get(ACCOUNTS_API_URL + gatewayAccountId)
                     .then()
@@ -415,7 +427,12 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturn3dsSetting() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("stripe", "desc", "id", "true", "test");
+            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                    aCreateGatewayAccountPayloadBuilder()
+                            .withProvider("stripe")
+                            .withRequires3ds(true)
+                            .build());
+
             app.givenSetup()
                     .get(ACCOUNTS_API_URL + gatewayAccountId)
                     .then()
@@ -633,7 +650,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldNotReturn3dsFlexCredentials_whenGatewayAccountHasNoCreds() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
+            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
             app.givenSetup()
                     .get("/v1/api/accounts/" + gatewayAccountId)
                     .then()
@@ -653,9 +670,13 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetAllGatewayAccountsWhenSearchWithNoParams() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountFor("sandbox");
+        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
         testBaseExtension.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
-        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
+        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                aCreateGatewayAccountPayloadBuilder()
+                        .withProvider("worldpay")
+                        .build());
+        
         app.getDatabaseTestHelper().insertWorldpay3dsFlexCredential(
                 Long.valueOf(gatewayAccountId2),
                 "macKey",
@@ -746,8 +767,8 @@ public class GatewayAccountResourceIT {
     
     @Test
     public void shouldSetApplePayEnabledByDefaultForSandboxAccount() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountFor("sandbox");
-        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
+        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().withProvider("sandbox").build());
+        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build());
 
         app.givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId1)
@@ -762,9 +783,9 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByIds() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountFor("sandbox");
-        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountFor("sandbox");
-        testBaseExtension.createAGatewayAccountFor("sandbox");
+        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?accountIds=" + gatewayAccountId1 + "," + gatewayAccountId2)
@@ -779,15 +800,21 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldFilterGetGatewayAccountForExistingAccountByServiceId() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountFor("sandbox");
-        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountFor("sandbox");
-        String serviceId = "someexternalserviceid";
-
-        app.getDatabaseTestHelper().updateServiceIdFor(Long.parseLong(gatewayAccountId1), serviceId);
-        app.getDatabaseTestHelper().updateServiceIdFor(Long.parseLong(gatewayAccountId2), "notsearchedforserviceid");
-
+        String serviceId = "aValidServiceId";
+        String anotherServiceId = "anotherServiceId";
+        String nonExistentServiceId = "nonExistentServiceId";
+        
+        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                aCreateGatewayAccountPayloadBuilder()
+                        .withServiceId(serviceId)
+                        .build());
+        testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                aCreateGatewayAccountPayloadBuilder()
+                        .withServiceId(anotherServiceId)
+                        .build());
+        
         app.givenSetup().accept(JSON)
-                .get("/v1/api/accounts?serviceIds=somemissingserviceid,anotherserviceid," + serviceId)
+                .get(format("/v1/api/accounts?serviceIds=%s,%s", nonExistentServiceId, serviceId))
                 .then()
                 .statusCode(200)
                 .body("accounts", hasSize(1))
@@ -795,7 +822,7 @@ public class GatewayAccountResourceIT {
                 .body("accounts[0].service_id", is(serviceId));
 
         app.givenSetup().accept(JSON)
-                .get("/v1/api/accounts?serviceIds=nonexistingserviceid")
+                .get(format("/v1/api/accounts?serviceIds=%s", nonExistentServiceId))
                 .then()
                 .statusCode(200)
                 .body("accounts", hasSize(0));
@@ -803,9 +830,9 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByMotoEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountFor("sandbox");
+        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
         testBaseExtension.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
-        testBaseExtension.createAGatewayAccountFor("sandbox");
+        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?moto_enabled=true")
@@ -817,9 +844,9 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByMotoDisabled() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountFor("sandbox");
+        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
         testBaseExtension.updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
-        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountFor("sandbox");
+        String gatewayAccountId2 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?moto_enabled=false")
@@ -831,9 +858,15 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByApplePayEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountFor("worldpay");
-        testBaseExtension.updateGatewayAccount(gatewayAccountId1, "allow_apple_pay", true);
-        testBaseExtension.createAGatewayAccountFor("stripe");
+        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                aCreateGatewayAccountPayloadBuilder()
+                        .withProvider("worldpay")
+                        .withAllowApplePay(true)
+                        .build());
+        testBaseExtension.createAGatewayAccount(
+                aCreateGatewayAccountPayloadBuilder()
+                        .withProvider("stripe")
+                        .build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?apple_pay_enabled=true")
@@ -845,9 +878,15 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByGooglePayEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountFor("worldpay");
-        testBaseExtension.updateGatewayAccount(gatewayAccountId1, "allow_google_pay", true);
-        testBaseExtension.createAGatewayAccountFor("sandbox");
+        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                aCreateGatewayAccountPayloadBuilder()
+                        .withProvider("worldpay")
+                        .withAllowGooglePay(true)
+                        .build());
+        testBaseExtension.createAGatewayAccount(
+                aCreateGatewayAccountPayloadBuilder()
+                        .withProvider("stripe")
+                        .build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?google_pay_enabled=true")
@@ -859,8 +898,11 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByType() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountFor("worldpay", "descr", "analytics", "true", "live");
-        testBaseExtension.createAGatewayAccountFor("sandbox");
+        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder()
+                .withProvider("stripe")
+                .withType(LIVE)
+                .build());
+        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?type=live")
@@ -872,9 +914,11 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByRecurringEnabled() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountFor("worldpay");
+        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder()
+                .withProvider("worldpay")
+                .build());
         testBaseExtension.updateGatewayAccount(gatewayAccountId1, "recurring_enabled", true);
-        testBaseExtension.createAGatewayAccountFor("sandbox");
+        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?recurring_enabled=true")
@@ -886,8 +930,12 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldGetGatewayAccountsByProvider() {
-        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountFor("worldpay");
-        testBaseExtension.createAGatewayAccountFor("sandbox");
+        String gatewayAccountId1 = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder()
+                .withProvider("worldpay")
+                .build());
+        testBaseExtension.createAGatewayAccount(aCreateGatewayAccountPayloadBuilder()
+                .withProvider("stripe")
+                .build());
 
         app.givenSetup()
                 .get("/v1/api/accounts?payment_provider=worldpay")
@@ -1049,10 +1097,17 @@ public class GatewayAccountResourceIT {
     
     @Nested
     class Update3dsToggleByGatewayAccountId {
-
+        String gatewayAccountId;
+        @BeforeEach
+        void createGatewayAccount() {
+            gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                    aCreateGatewayAccountPayloadBuilder()
+                            .withProvider("worldpay")
+                            .build());
+        }
+        
         @Test
         void shouldToggle3dsToTrue() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "old-desc", "old-id");
             app.givenSetup()
                     .body(toJson(Map.of("toggle_3ds", true)))
                     .patch("/v1/frontend/accounts/" + gatewayAccountId + "/3ds-toggle")
@@ -1067,7 +1122,6 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldToggle3dsToFalse() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "old-desc", "old-id");
             app.givenSetup()
                     .body(toJson(Map.of("toggle_3ds", false)))
                     .patch("/v1/frontend/accounts/" + gatewayAccountId + "/3ds-toggle")
@@ -1082,7 +1136,6 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturn409Conflict_Toggling3dsToFalse_WhenA3dsCardTypeIsAccepted() {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "desc", "id");
             String maestroCardTypeId = app.getDatabaseTestHelper().getCardTypeId("maestro", "DEBIT");
 
             app.givenSetup()
@@ -1107,7 +1160,10 @@ public class GatewayAccountResourceIT {
     
     @Test
     void shouldReturn3dsFlexCredentials_whenGatewayAccountHasCreds() {
-        String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
+        String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                aCreateGatewayAccountPayloadBuilder()
+                        .withProvider("worldpay")
+                        .build());
         app.getDatabaseTestHelper().insertWorldpay3dsFlexCredential(Long.valueOf(gatewayAccountId), "macKey", "issuer", "org_unit_id", 2L);
         app.givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId)
@@ -1124,8 +1180,11 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldReturn3dsFlexCredentials_whenGatewayAccountHasCreds_byServiceIdAndAccountType() {
-        String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
-        app.getDatabaseTestHelper().updateServiceIdFor(Long.parseLong(gatewayAccountId), "a-valid-service-id");
+        String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                aCreateGatewayAccountPayloadBuilder()
+                        .withProvider("worldpay")
+                        .withServiceId("a-valid-service-id")
+                        .build());
         app.getDatabaseTestHelper().insertWorldpay3dsFlexCredential(Long.valueOf(gatewayAccountId), "macKey", "issuer", "org_unit_id", 2L);
         String url = ACCOUNTS_API_SERVICE_ID_URL.replace("{serviceId}", "a-valid-service-id").replace("{accountType}", GatewayAccountType.TEST.name());
         app.givenSetup()
@@ -1143,7 +1202,10 @@ public class GatewayAccountResourceIT {
 
     @Test
     void shouldNotReturn3dsFlexCredentials_whenGatewayIsNotAWorldpayAccount() {
-        String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("stripe", "a-description", "analytics-id");
+        String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                aCreateGatewayAccountPayloadBuilder()
+                        .withProvider("stripe")
+                        .build());
         app.givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId)
                 .then()

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITHelpers.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITHelpers.java
@@ -10,19 +10,19 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.util.Map.entry;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
-public class GatewayAccountResourceITBaseExtensions {
+public class GatewayAccountResourceITHelpers {
+     
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     private final int appLocalPort;
 
-    public GatewayAccountResourceITBaseExtensions(int appLocalPort) {
+    public GatewayAccountResourceITHelpers(int appLocalPort) {
         this.appLocalPort = appLocalPort;
     }
 
@@ -30,17 +30,13 @@ public class GatewayAccountResourceITBaseExtensions {
     public static final String ACCOUNTS_API_SERVICE_ID_URL = "/v1/api/service/{serviceId}/account/{accountType}";
     public static final String ACCOUNTS_FRONTEND_URL = "/v1/frontend/accounts/";
     public static final String ACCOUNT_FRONTEND_EXTERNAL_ID_URL = "/v1/frontend/accounts/external-id/";
-
     
-    protected ValidatableResponse createAGatewayAccount(Map<String, String> createGatewayAccountPayload) {
+    protected String createGatewayAccount(Map<String, String> createGatewayAccountPayload) {
         return app.givenSetup()
                 .body(toJson(createGatewayAccountPayload))
                 .post(ACCOUNTS_API_URL)
-                .then();
-    }
-    
-    protected String createAGatewayAccountAndExtractAccountId(Map<String, String> createGatewayAccountPayload) {
-        return createAGatewayAccount(createGatewayAccountPayload).extract().path("gateway_account_id");
+                .then()
+                .extract().path("gateway_account_id");
     }
     
     void updateGatewayAccount(String gatewayAccountId, String path, Object value) {
@@ -74,17 +70,18 @@ public class GatewayAccountResourceITBaseExtensions {
     }
     
     public static class CreateGatewayAccountPayloadBuilder {
-        Map<String, String> payload = new HashMap<String, String> (Map.ofEntries(
-                entry("payment_provider", "sandbox"),
-                entry("service_id", "a-valid-service-id")
-        ));
+        private Map<String, String> payload = new HashMap<String, String> (
+                Map.of(
+                "payment_provider", "sandbox",
+                "service_id", "a-valid-service-id")
+        );
         
         public static CreateGatewayAccountPayloadBuilder aCreateGatewayAccountPayloadBuilder() {
             return new CreateGatewayAccountPayloadBuilder();
         }
         
         public Map<String, String> build() {
-            return payload;
+            return Map.copyOf(payload);
         }
 
         public CreateGatewayAccountPayloadBuilder withServiceId(String serviceId) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITHelpers.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITHelpers.java
@@ -27,7 +27,7 @@ public class GatewayAccountResourceITHelpers {
     public static final String ACCOUNTS_FRONTEND_URL = "/v1/frontend/accounts/";
     public static final String ACCOUNT_FRONTEND_EXTERNAL_ID_URL = "/v1/frontend/accounts/external-id/";
     
-    protected String createGatewayAccount(Map<String, String> createGatewayAccountPayload) {
+    public String createGatewayAccount(Map<String, String> createGatewayAccountPayload) {
         return given()
                 .port(appLocalPort)
                 .contentType(JSON)
@@ -37,7 +37,7 @@ public class GatewayAccountResourceITHelpers {
                 .extract().path("gateway_account_id");
     }
     
-    void updateGatewayAccount(String gatewayAccountId, String path, Object value) {
+    public void updateGatewayAccount(String gatewayAccountId, String path, Object value) {
         given()
                 .port(appLocalPort)
                 .contentType(JSON)

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITHelpers.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITHelpers.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.connector.it.resources;
 
 import io.restassured.response.ValidatableResponse;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 
 import java.util.HashMap;
@@ -18,8 +16,6 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountResourceITHelpers {
      
-    @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     private final int appLocalPort;
 
     public GatewayAccountResourceITHelpers(int appLocalPort) {
@@ -32,7 +28,9 @@ public class GatewayAccountResourceITHelpers {
     public static final String ACCOUNT_FRONTEND_EXTERNAL_ID_URL = "/v1/frontend/accounts/external-id/";
     
     protected String createGatewayAccount(Map<String, String> createGatewayAccountPayload) {
-        return app.givenSetup()
+        return given()
+                .port(appLocalPort)
+                .contentType(JSON)
                 .body(toJson(createGatewayAccountPayload))
                 .post(ACCOUNTS_API_URL)
                 .then()

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.VERIFIED_WITH_LIVE_PAYMENT;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_API_URL;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceUpdateIT.java
@@ -28,7 +28,7 @@ public class GatewayAccountResourceUpdateIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
 
-    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
+    public static GatewayAccountResourceITHelpers testHelpers = new GatewayAccountResourceITHelpers(app.getLocalPort());
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
     
@@ -392,7 +392,7 @@ public class GatewayAccountResourceUpdateIT {
         @BeforeEach
         void createGatewayAccount() {
             Map<String, String> createAccountPayload = aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build();
-            gatewayAccountId = testBaseExtension.createGatewayAccount(createAccountPayload);
+            gatewayAccountId = testHelpers.createGatewayAccount(createAccountPayload);
         }
         
         @Test
@@ -565,7 +565,7 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void patchGatewayAccount_forCorporateDebitCardSurcharge() throws JsonProcessingException {
-            String gatewayAccountId = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
+            String gatewayAccountId = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
             app.givenSetup()
                     .get("/v1/api/accounts/" + gatewayAccountId)
                     .then()

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceUpdateIT.java
@@ -18,9 +18,9 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountResourceUpdateIT {
@@ -28,7 +28,7 @@ public class GatewayAccountResourceUpdateIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
 
-    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions("sandbox", app.getLocalPort());
+    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions(app.getLocalPort());
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
     
@@ -387,9 +387,16 @@ public class GatewayAccountResourceUpdateIT {
 
     @Nested
     class PatchByGatewayAccountId {
+        private String gatewayAccountId;
+        
+        @BeforeEach
+        void createGatewayAccount() {
+            Map<String, String> createAccountPayload = aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build();
+            gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(createAccountPayload);
+        }
+        
         @Test
         void shouldReturn200WhenWorldpayExemptionEngineEnabledIsUpdated() throws JsonProcessingException {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor(WORLDPAY.getName(), "a-description", "analytics-id");
             app.getDatabaseTestHelper().insertWorldpay3dsFlexCredential(
                     Long.valueOf(gatewayAccountId),
                     "macKey",
@@ -416,7 +423,6 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void shouldReturn200_whenNotifySettingsIsUpdated() throws Exception {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay");
             String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                     "path", "notify_settings",
                     "value", Map.of("api_token", "anapitoken",
@@ -431,7 +437,6 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void shouldReturn400_whenNotifySettingsIsUpdated_withWrongOp() throws Exception {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay");
             String payload = objectMapper.writeValueAsString(Map.of("op", "insert",
                     "path", "notify_settings",
                     "value", Map.of("api_token", "anapitoken",
@@ -445,7 +450,6 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void shouldReturn200_whenBlockPrepaidCardsIsUpdated() throws Exception {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay");
             String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                     "path", "block_prepaid_cards",
                     "value", true));
@@ -464,7 +468,6 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void shouldReturn200_whenEmailCollectionModeIsUpdated() throws Exception {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay");
             String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                     "path", "email_collection_mode",
                     "value", "OFF"));
@@ -477,7 +480,6 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void shouldReturn400_whenEmailCollectionModeIsUpdated_withWrongValue() throws Exception {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay");
             String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                     "path", "email_collection_mode",
                     "value", "nope"));
@@ -490,7 +492,7 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void shouldReturn404ForNotifySettings_whenGatewayAccountIsNonExistent() throws Exception {
-            String gatewayAccountId = "1000023";
+            String nonExistentGatewayAccountId = "1000023";
             String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                     "path", "notify_settings",
                     "value", Map.of("api_token", "anapitoken",
@@ -498,14 +500,13 @@ public class GatewayAccountResourceUpdateIT {
                             "refund_issued_template_id", "anothertemplate")));
             app.givenSetup()
                     .body(payload)
-                    .patch("/v1/api/accounts/" + gatewayAccountId)
+                    .patch("/v1/api/accounts/" + nonExistentGatewayAccountId)
                     .then()
                     .statusCode(NOT_FOUND.getStatusCode());
         }
 
         @Test
         void shouldReturn200_whenNotifySettingsIsRemoved() throws Exception {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay");
             String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                     "path", "notify_settings",
                     "value", Map.of("api_token", "anapitoken",
@@ -529,7 +530,6 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void shouldReturn400_whenNotifySettingsIsRemoved_withWrongPath() throws Exception {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay");
             String payload = objectMapper.writeValueAsString(Map.of("op", "insert",
                     "path", "notify_setting"));
             app.givenSetup()
@@ -541,7 +541,6 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void patchGatewayAccount_forCorporateCreditCardSurcharge() throws JsonProcessingException {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
             app.givenSetup()
                     .get("/v1/api/accounts/" + gatewayAccountId)
                     .then()
@@ -566,7 +565,7 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void patchGatewayAccount_forCorporateDebitCardSurcharge() throws JsonProcessingException {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
+            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
             app.givenSetup()
                     .get("/v1/api/accounts/" + gatewayAccountId)
                     .then()
@@ -591,7 +590,6 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void patchGatewayAccount_forCorporatePrepaidDebitCardSurcharge() throws JsonProcessingException {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
             app.givenSetup()
                     .get("/v1/api/accounts/" + gatewayAccountId)
                     .then()
@@ -616,7 +614,6 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void patchGatewayAccount_forAllowTelephonePaymentNotifications() throws JsonProcessingException {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("sandbox", "a-description", "analytics-id");
             app.givenSetup()
                     .get("/v1/api/accounts/" + gatewayAccountId)
                     .then()
@@ -637,20 +634,19 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void shouldReturn404ForCorporateSurcharge_whenGatewayAccountIsNonExistent() throws Exception {
-            String gatewayAccountId = "1000023";
+            String nonExistentGatewayAccountId = "1000023";
             String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                     "path", "corporate_credit_card_surcharge_amount",
                     "value", 100));
             app.givenSetup()
                     .body(payload)
-                    .patch("/v1/api/accounts/" + gatewayAccountId)
+                    .patch("/v1/api/accounts/" + nonExistentGatewayAccountId)
                     .then()
                     .statusCode(NOT_FOUND.getStatusCode());
         }
 
         @Test
         void patchGatewayAccount_setDisabledToFalse_shouldClearDisabledReason() throws JsonProcessingException {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountFor("sandbox", "a-description", "analytics-id");
             long gatewayAccountIdAsLong = Long.parseLong(gatewayAccountId);
             app.getDatabaseTestHelper().setDisabled(gatewayAccountIdAsLong);
             String disabledReason = "Because reasons";

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceUpdateIT.java
@@ -19,8 +19,8 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.ACCOUNTS_API_URL;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_API_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountResourceUpdateIT {
@@ -28,7 +28,7 @@ public class GatewayAccountResourceUpdateIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
 
-    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions(app.getLocalPort());
+    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
     
@@ -392,7 +392,7 @@ public class GatewayAccountResourceUpdateIT {
         @BeforeEach
         void createGatewayAccount() {
             Map<String, String> createAccountPayload = aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build();
-            gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(createAccountPayload);
+            gatewayAccountId = testBaseExtension.createGatewayAccount(createAccountPayload);
         }
         
         @Test
@@ -565,7 +565,7 @@ public class GatewayAccountResourceUpdateIT {
 
         @Test
         void patchGatewayAccount_forCorporateDebitCardSurcharge() throws JsonProcessingException {
-            String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(aCreateGatewayAccountPayloadBuilder().build());
+            String gatewayAccountId = testBaseExtension.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().build());
             app.givenSetup()
                     .get("/v1/api/accounts/" + gatewayAccountId)
                     .then()

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
@@ -199,6 +199,7 @@ public class StripeAccountResourceIT {
             String accountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
                     aCreateGatewayAccountPayloadBuilder()
                             .withServiceId("a-valid-service-id")
+                            .withProvider("stripe")
                             .build());
             Map<String, String> credentials = Map.of("stripe_account_id", STRIPE_ACCOUNT_ID);
             app.givenSetup()

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
@@ -29,7 +29,7 @@ public class StripeAccountResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     
-    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
+    public static GatewayAccountResourceITHelpers testHelpers = new GatewayAccountResourceITHelpers(app.getLocalPort());
 
     private static final String STRIPE_ACCOUNT_ID = "acct_123example123";
     
@@ -196,7 +196,7 @@ public class StripeAccountResourceIT {
     class GetStripeAccountByServiceIdAndAccountType {
         @Test
         void returnsSuccessfulResponse() {
-            String accountId = testBaseExtension.createGatewayAccount(
+            String accountId = testHelpers.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withServiceId("a-valid-service-id")
                             .withProvider("stripe")
@@ -226,7 +226,7 @@ public class StripeAccountResourceIT {
 
         @Test
         void returnsNotFoundResponseWhenNoStripeAccountExistsForService() {
-            testBaseExtension.createGatewayAccount(
+            testHelpers.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withServiceId("a-valid-service-id")
                             .withProvider("sandbox")
@@ -241,7 +241,7 @@ public class StripeAccountResourceIT {
 
         @Test
         void returnsNotFoundResponseWhenGatewayAccountCredentialsAreEmpty() {
-            testBaseExtension.createGatewayAccount(
+            testHelpers.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withServiceId("a-valid-service-id")
                             .withProvider("stripe")

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceIT.java
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class StripeAccountResourceIT {
@@ -29,7 +29,7 @@ public class StripeAccountResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     
-    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions(app.getLocalPort());
+    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
 
     private static final String STRIPE_ACCOUNT_ID = "acct_123example123";
     
@@ -196,7 +196,7 @@ public class StripeAccountResourceIT {
     class GetStripeAccountByServiceIdAndAccountType {
         @Test
         void returnsSuccessfulResponse() {
-            String accountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+            String accountId = testBaseExtension.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withServiceId("a-valid-service-id")
                             .withProvider("stripe")
@@ -226,7 +226,7 @@ public class StripeAccountResourceIT {
 
         @Test
         void returnsNotFoundResponseWhenNoStripeAccountExistsForService() {
-            testBaseExtension.createAGatewayAccount(
+            testBaseExtension.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withServiceId("a-valid-service-id")
                             .withProvider("sandbox")
@@ -241,7 +241,7 @@ public class StripeAccountResourceIT {
 
         @Test
         void returnsNotFoundResponseWhenGatewayAccountCredentialsAreEmpty() {
-            testBaseExtension.createAGatewayAccount(
+            testBaseExtension.createGatewayAccount(
                     aCreateGatewayAccountPayloadBuilder()
                             .withServiceId("a-valid-service-id")
                             .withProvider("stripe")

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
@@ -15,13 +15,13 @@ import static java.lang.String.format;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITBaseExtensions.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.CreateGatewayAccountPayloadBuilder.aCreateGatewayAccountPayloadBuilder;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class StripeAccountSetupResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-    public static GatewayAccountResourceITBaseExtensions testBaseExtension = new GatewayAccountResourceITBaseExtensions(app.getLocalPort());
+    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
 
     @Nested
     class ByAccountId {
@@ -29,7 +29,7 @@ public class StripeAccountSetupResourceIT {
         class GetStripeSetup {
             @Test
             void withNoTasksCompletedReturnsFalseFlags() {
-                String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                String gatewayAccountId = testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
 
                 app.givenSetup()
@@ -47,7 +47,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void withSomeTasksCompletedReturnsAppropriateFlags() {
-                String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                String gatewayAccountId = testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
 
                 addCompletedTask(gatewayAccountId, StripeAccountSetupTask.BANK_ACCOUNT);
@@ -78,7 +78,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void returnsSuccessfulResponseWhenGatewayAccountIsNotAStripeAccount() {
-                String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                String gatewayAccountId = testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build());
                 app.givenSetup()
                         .get("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
@@ -92,7 +92,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void withSingleUpdate_shouldUpdateSetup() {
-                String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                String gatewayAccountId = testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
                 app.givenSetup()
                         .body(toJson(Collections.singletonList(Map.of(
@@ -117,7 +117,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void withMultipleUpdates_shouldUpdateSetup() {
-                String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                String gatewayAccountId = testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
                 app.givenSetup()
                         .body(toJson(Arrays.asList(
@@ -169,7 +169,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void forInvalidOperation_shouldReturn422_withValidationError() {
-                String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                String gatewayAccountId = testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
                 app.givenSetup()
                         .body(toJson(Collections.singletonList(Map.of(
@@ -197,7 +197,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void forGatewayAccountNotStripe_shouldReturn200() {
-                String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                String gatewayAccountId = testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
                 app.givenSetup()
                         .body(toJson(Collections.singletonList(Map.of(
@@ -211,7 +211,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void forPatchDirectorWithFalse_shouldUpdateSetup() {
-                String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                String gatewayAccountId = testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
                 addCompletedTask(gatewayAccountId, StripeAccountSetupTask.DIRECTOR);
 
@@ -249,7 +249,7 @@ public class StripeAccountSetupResourceIT {
         class GetStripeSetup {
             @Test
             void withNoTasksCompletedReturnsFalseFlags() {
-                testBaseExtension.createAGatewayAccount(
+                testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder()
                                 .withServiceId("a-valid-service-id")
                                 .withProvider("stripe")
@@ -270,7 +270,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void withSomeTasksCompletedReturnsAppropriateFlags() {
-                String gatewayAccountId = testBaseExtension.createAGatewayAccountAndExtractAccountId(
+                String gatewayAccountId = testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder()
                                 .withServiceId("a-valid-service-id")
                                 .withProvider("stripe")
@@ -318,7 +318,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void returnsSuccessfulResponseWhenGatewayAccountIsNotAStripeAccount() {
-                testBaseExtension.createAGatewayAccount(
+                testBaseExtension.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder()
                                 .withServiceId("a-valid-service-id")
                                 .withProvider("worldpay")

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
@@ -21,7 +21,7 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 public class StripeAccountSetupResourceIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-    public static GatewayAccountResourceITHelpers testBaseExtension = new GatewayAccountResourceITHelpers(app.getLocalPort());
+    public static GatewayAccountResourceITHelpers testHelpers = new GatewayAccountResourceITHelpers(app.getLocalPort());
 
     @Nested
     class ByAccountId {
@@ -29,7 +29,7 @@ public class StripeAccountSetupResourceIT {
         class GetStripeSetup {
             @Test
             void withNoTasksCompletedReturnsFalseFlags() {
-                String gatewayAccountId = testBaseExtension.createGatewayAccount(
+                String gatewayAccountId = testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
 
                 app.givenSetup()
@@ -47,7 +47,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void withSomeTasksCompletedReturnsAppropriateFlags() {
-                String gatewayAccountId = testBaseExtension.createGatewayAccount(
+                String gatewayAccountId = testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
 
                 addCompletedTask(gatewayAccountId, StripeAccountSetupTask.BANK_ACCOUNT);
@@ -78,7 +78,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void returnsSuccessfulResponseWhenGatewayAccountIsNotAStripeAccount() {
-                String gatewayAccountId = testBaseExtension.createGatewayAccount(
+                String gatewayAccountId = testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build());
                 app.givenSetup()
                         .get("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
@@ -92,7 +92,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void withSingleUpdate_shouldUpdateSetup() {
-                String gatewayAccountId = testBaseExtension.createGatewayAccount(
+                String gatewayAccountId = testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
                 app.givenSetup()
                         .body(toJson(Collections.singletonList(Map.of(
@@ -117,7 +117,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void withMultipleUpdates_shouldUpdateSetup() {
-                String gatewayAccountId = testBaseExtension.createGatewayAccount(
+                String gatewayAccountId = testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
                 app.givenSetup()
                         .body(toJson(Arrays.asList(
@@ -169,7 +169,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void forInvalidOperation_shouldReturn422_withValidationError() {
-                String gatewayAccountId = testBaseExtension.createGatewayAccount(
+                String gatewayAccountId = testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
                 app.givenSetup()
                         .body(toJson(Collections.singletonList(Map.of(
@@ -197,7 +197,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void forGatewayAccountNotStripe_shouldReturn200() {
-                String gatewayAccountId = testBaseExtension.createGatewayAccount(
+                String gatewayAccountId = testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
                 app.givenSetup()
                         .body(toJson(Collections.singletonList(Map.of(
@@ -211,7 +211,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void forPatchDirectorWithFalse_shouldUpdateSetup() {
-                String gatewayAccountId = testBaseExtension.createGatewayAccount(
+                String gatewayAccountId = testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder().withProvider("stripe").build());
                 addCompletedTask(gatewayAccountId, StripeAccountSetupTask.DIRECTOR);
 
@@ -249,7 +249,7 @@ public class StripeAccountSetupResourceIT {
         class GetStripeSetup {
             @Test
             void withNoTasksCompletedReturnsFalseFlags() {
-                testBaseExtension.createGatewayAccount(
+                testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder()
                                 .withServiceId("a-valid-service-id")
                                 .withProvider("stripe")
@@ -270,7 +270,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void withSomeTasksCompletedReturnsAppropriateFlags() {
-                String gatewayAccountId = testBaseExtension.createGatewayAccount(
+                String gatewayAccountId = testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder()
                                 .withServiceId("a-valid-service-id")
                                 .withProvider("stripe")
@@ -318,7 +318,7 @@ public class StripeAccountSetupResourceIT {
 
             @Test
             void returnsSuccessfulResponseWhenGatewayAccountIsNotAStripeAccount() {
-                testBaseExtension.createGatewayAccount(
+                testHelpers.createGatewayAccount(
                         aCreateGatewayAccountPayloadBuilder()
                                 .withServiceId("a-valid-service-id")
                                 .withProvider("worldpay")


### PR DESCRIPTION
- Ensure serviceId cannot be null or blank in a GatewayAccountRequest
- Update tests to meet this requirement
- GatewayAccountResourceITBaseExtensions has a lot of helper methods to create gateway accounts, so many that it undermines their usefulness and the class is quite cluttered. I've created a CreateGatewayAccountRequestBuilder to provide flexibility for creating the request payload with different parameters, a method for creating an account using this class, and I've refactored the tests to use that method and deleted the old helper methods.