### PR TITLE
PP-12876 Revert mandatory serviceId for creating account

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -35,7 +35,6 @@ public class GatewayAccountRequest {
     private String serviceName;
 
     @JsonIgnore
-    @NotBlank(message = "Field [service_id] cannot be blank or missing")
     private final String serviceId;
 
     @JsonIgnore

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
@@ -41,22 +41,7 @@ class GatewayAccountResourceValidationTest {
 
         assertThat(response.getStatus(), is(422));
     }
-
-    @Test
-    void shouldReturn422_whenServiceIdIsMissing() {
-        Map<String, Object> payload = Map.of("provider", "sandbox", "type", "invalid");
-        
-        Response response = resources.client()
-                .target("/v1/api/accounts")
-                .request()
-                .post(Entity.json(payload));
-
-        assertThat(response.getStatus(), is(422));
-
-        List<String> errorResponseMessages = response.readEntity(ErrorResponse.class).messages();
-        assertTrue(errorResponseMessages.contains("Field [service_id] cannot be blank or missing"));
-    }
-
+    
     @Test
     void shouldReturn422_whenProviderAccountTypeIsInvalid() {
 


### PR DESCRIPTION
Context: A [previous PR](https://github.com/alphagov/pay-connector/actions/runs/10367862946) made serviceId mandatory for creating a gateway account. Shortly after deploying, we identified that the PACT test covering this scenario had not been enabled.

- Out of an abundance of caution, make serviceId optional again, so that we can make sure that the consumers are already sending serviceId, and get the PACT test coverage in place, before implementing mandatory serviceId.