### PR TITLE
PP-13003 encode gateway transaction ids in path parameters

### DIFF
--- a/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
@@ -17,6 +17,8 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -61,9 +63,9 @@ public class LedgerService {
                                                                                         String gatewayTransactionId) {
         var uri = UriBuilder
                 .fromPath(ledgerUrl)
-                .path(format("/v1/transaction/gateway-transaction/%s", gatewayTransactionId))
+                .path(format("/v1/transaction/gateway-transaction/%s", URLEncoder.encode(gatewayTransactionId, StandardCharsets.UTF_8)))
                 .queryParam("payment_provider", paymentGatewayName);
-
+        
         return getTransactionFromLedger(uri);
     }
 
@@ -147,5 +149,4 @@ public class LedgerService {
                 .request()
                 .get();
     }
-
 }


### PR DESCRIPTION
## WHAT YOU DID

- encode gateway transaction ids to prevent possible slashes in the id being interpreted as path segments by ledger
