### PR TITLE
PP-13062 handle exception

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayStatus.java
@@ -13,7 +13,9 @@ public enum WorldpayStatus {
     CANCELLED("CANCELLED", ChargeStatus.AUTHORISATION_CANCELLED),
     CAPTURED("CAPTURED", ChargeStatus.CAPTURED),
     ERROR("ERROR", ChargeStatus.AUTHORISATION_ERROR),
-    REFUSED("REFUSED", ChargeStatus.AUTHORISATION_REJECTED);
+    REFUSED("REFUSED", ChargeStatus.AUTHORISATION_REJECTED),
+    NULL("null", ChargeStatus.AUTHORISATION_ERROR);
+
 
     private final String worldpayStatus;
     private final ChargeStatus payStatus;


### PR DESCRIPTION
## WHAT YOU DID

An unhandled case on our side: we do not anticipate the response to an order inquiry request will give us a lastEvent for an authorisation error payment but we need to because we could query the order inquiry endpoint if there was a timeout.

Handle <lastEvent>null</lastEvent> Worldpay response case.
