### PR TITLE
PP-12876 Reimplement mandatory serviceId for creating accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -35,6 +35,7 @@ public class GatewayAccountRequest {
     private String serviceName;
 
     @JsonIgnore
+    @NotBlank(message = "Field [service_id] cannot be blank or missing")
     private final String serviceId;
 
     @JsonIgnore

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
@@ -41,7 +41,22 @@ class GatewayAccountResourceValidationTest {
 
         assertThat(response.getStatus(), is(422));
     }
-    
+
+    @Test
+    void shouldReturn422_whenServiceIdIsMissing() {
+        Map<String, Object> payload = Map.of("provider", "sandbox", "type", "invalid");
+
+        Response response = resources.client()
+                .target("/v1/api/accounts")
+                .request()
+                .post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(422));
+
+        List<String> errorResponseMessages = response.readEntity(ErrorResponse.class).messages();
+        assertTrue(errorResponseMessages.contains("Field [service_id] cannot be blank or missing"));
+    }
+
     @Test
     void shouldReturn422_whenProviderAccountTypeIsInvalid() {
 


### PR DESCRIPTION
Context: In a [previous PR](https://github.com/alphagov/pay-connector/actions/runs/10367862946) we made serviceId mandatory for creating accounts, but then [reverted the change](https://github.com/alphagov/pay-connector/pull/5501) in order to check that selfservice and toolbox are already sending serviceId in POST requests to the connector endpoint `v1/api/accounts`. Selfservice calls the endpoint when a user adds a new service, Toolbox calls the endpoint when the Pay team user is creating a new test account or completing the go-live process, and in each of these cases serviceId is sent in the request.

- Make serviceId mandatory when creating a gateway account