### PR TITLE
PP-13038 Support toggling corporate exemptions on Connector via REST

### DIFF
--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1279,8 +1279,8 @@ paths:
         \ corporate_prepaid_debit_card_surcharge_amount, allow_zero_amount, allow_moto,\
         \ moto_mask_card_number_input, moto_mask_card_security_code_input, allow_telephone_payment_notifications,\
         \ send_payer_ip_address_to_gateway, send_payer_email_to_gateway, integration_version_3ds,\
-        \ send_reference_to_gateway, allow_authorisation_api or worldpay_exemption_engine_enabled\
-        \ using a JSON Patch-esque message body."
+        \ send_reference_to_gateway, allow_authorisation_api, worldpay_corporate_exemptions_enabled\
+        \ or worldpay_exemption_engine_enabled using a JSON Patch-esque message body."
       operationId: patchGatewayAccountByServiceIdAndType
       parameters:
       - description: Service ID

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -95,43 +95,21 @@ public class GatewayAccountRequestValidator {
             throw new ValidationException(Collections.singletonList(format("Operation [%s] not supported for path [%s]", FIELD_OPERATION, path)));
 
         switch (path) {
-            case FIELD_NOTIFY_SETTINGS:
-                validateNotifySettingsRequest(payload);
-                break;
-            case FIELD_EMAIL_COLLECTION_MODE:
-                validateEmailCollectionMode(payload);
-                break;
-            case FIELD_ALLOW_GOOGLE_PAY:
-            case FIELD_BLOCK_PREPAID_CARDS:
-            case FIELD_ALLOW_ZERO_AMOUNT:
-            case FIELD_ALLOW_APPLE_PAY:
-            case FIELD_ALLOW_MOTO:
-            case FIELD_MOTO_MASK_CARD_NUMBER_INPUT:
-            case FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT:
-            case FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS:
-            case FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED:
-            case FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED:
-            case FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY:
-            case FIELD_SEND_PAYER_EMAIL_TO_GATEWAY:
-            case FIELD_PROVIDER_SWITCH_ENABLED:
-            case FIELD_SEND_REFERENCE_TO_GATEWAY:
-            case FIELD_ALLOW_AUTHORISATION_API:
-            case FIELD_RECURRING_ENABLED:
-            case FIELD_DISABLED:
-                validateReplaceBooleanValue(payload);
-                break;
-            case FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT:
-            case FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT:
-            case FIELD_CORPORATE_PREPAID_CREDIT_CARD_SURCHARGE_AMOUNT:
-            case FIELD_CORPORATE_PREPAID_DEBIT_CARD_SURCHARGE_AMOUNT:
-                validateCorporateCardSurchargePayload(payload);
-                break;
-            case FIELD_INTEGRATION_VERSION_3DS:
-                validateIntegrationVersion3ds(payload);
-                break;
-            case FIELD_DISABLED_REASON:
-                validateReplaceString(payload);
-                break;
+            case FIELD_NOTIFY_SETTINGS -> validateNotifySettingsRequest(payload);
+            case FIELD_EMAIL_COLLECTION_MODE -> validateEmailCollectionMode(payload);
+            case FIELD_ALLOW_GOOGLE_PAY, FIELD_BLOCK_PREPAID_CARDS, FIELD_ALLOW_ZERO_AMOUNT,
+                 FIELD_ALLOW_APPLE_PAY, FIELD_ALLOW_MOTO, FIELD_MOTO_MASK_CARD_NUMBER_INPUT,
+                 FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT, FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS,
+                 FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED, FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED,
+                 FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY, FIELD_SEND_PAYER_EMAIL_TO_GATEWAY,
+                 FIELD_PROVIDER_SWITCH_ENABLED, FIELD_SEND_REFERENCE_TO_GATEWAY,
+                 FIELD_ALLOW_AUTHORISATION_API, FIELD_RECURRING_ENABLED, FIELD_DISABLED
+                    -> validateReplaceBooleanValue(payload);
+            case FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT, FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT,
+                 FIELD_CORPORATE_PREPAID_CREDIT_CARD_SURCHARGE_AMOUNT, FIELD_CORPORATE_PREPAID_DEBIT_CARD_SURCHARGE_AMOUNT
+                    -> validateCorporateCardSurchargePayload(payload);
+            case FIELD_INTEGRATION_VERSION_3DS -> validateIntegrationVersion3ds(payload);
+            case FIELD_DISABLED_REASON -> validateReplaceString(payload);
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -40,6 +40,7 @@ public class GatewayAccountRequestValidator {
     public static final String FIELD_MOTO_MASK_CARD_NUMBER_INPUT = "moto_mask_card_number_input";
     public static final String FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT = "moto_mask_card_security_code_input";
     public static final String FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS = "allow_telephone_payment_notifications";
+    public static final String FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED = "worldpay_corporate_exemptions_enabled";
     public static final String FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED = "worldpay_exemption_engine_enabled";
     public static final String FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY = "send_payer_ip_address_to_gateway";
     public static final String FIELD_SEND_PAYER_EMAIL_TO_GATEWAY = "send_payer_email_to_gateway";
@@ -66,6 +67,7 @@ public class GatewayAccountRequestValidator {
             FIELD_MOTO_MASK_CARD_NUMBER_INPUT,
             FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT,
             FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS,
+            FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED,
             FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED,
             FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY,
             FIELD_SEND_PAYER_EMAIL_TO_GATEWAY,
@@ -107,6 +109,7 @@ public class GatewayAccountRequestValidator {
             case FIELD_MOTO_MASK_CARD_NUMBER_INPUT:
             case FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT:
             case FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS:
+            case FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED:
             case FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED:
             case FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY:
             case FIELD_SEND_PAYER_EMAIL_TO_GATEWAY:

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -305,7 +305,7 @@ public class GatewayAccountResource {
                     "email_collection_mode, corporate_credit_card_surcharge_amount, corporate_debit_card_surcharge_amount, " +
                     "corporate_prepaid_debit_card_surcharge_amount, allow_zero_amount, allow_moto, moto_mask_card_number_input, " +
                     "moto_mask_card_security_code_input, allow_telephone_payment_notifications, send_payer_ip_address_to_gateway, send_payer_email_to_gateway, " +
-                    "integration_version_3ds, send_reference_to_gateway, allow_authorisation_api or worldpay_exemption_engine_enabled using a JSON Patch-esque message body.",
+                    "integration_version_3ds, send_reference_to_gateway, allow_authorisation_api, worldpay_corporate_exemptions_enabled or worldpay_exemption_engine_enabled using a JSON Patch-esque message body.",
             tags = {"Gateway accounts"},
             requestBody = @RequestBody(content = @Content(schema = @Schema(example = "{" +
                     "    \"op\":\"replace\", \"path\":\"allow_apple_pay\", \"value\": true" +

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -64,6 +64,7 @@ import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequest
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_PAYER_EMAIL_TO_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_REFERENCE_TO_GATEWAY;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
@@ -265,6 +266,15 @@ public class GatewayAccountService {
             entry(
                     FIELD_SEND_REFERENCE_TO_GATEWAY,
                     (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setSendReferenceToGateway(gatewayAccountRequest.valueAsBoolean())
+            ),
+            entry(
+                    FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED,
+                    (gatewayAccountRequest, gatewayAccountEntity) -> {
+                        throwIfGatewayAccountIsNotWorldpay(gatewayAccountEntity, FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED);
+                        var worldpay3dsFlexCredentialsEntity = gatewayAccountEntity.getWorldpay3dsFlexCredentialsEntity()
+                                .orElseThrow(() -> new MissingWorldpay3dsFlexCredentialsEntityException(gatewayAccountEntity.getId(), FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED));
+                        worldpay3dsFlexCredentialsEntity.setCorporateExemptionEnabled(gatewayAccountRequest.valueAsBoolean());
+                    }
             ),
             entry(
                     FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED,

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -52,6 +52,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_DISABLED;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_DISABLED_REASON;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_RECURRING_ENABLED;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
@@ -586,6 +587,43 @@ class GatewayAccountServiceTest {
         Optional<GatewayAccountEntity> gatewayAccountEntity = gatewayAccountService.getGatewayAccountByExternal(externalId);
 
         assertThat(gatewayAccountEntity.get(), is(this.mockGatewayAccountEntity));
+    }
+
+
+    @Test
+    void shouldUpdateWorldpayCorporateExemptionsEnabledToFalse() {
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
+                "op", "replace",
+                "path", FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED,
+                "value", false)));
+        when(mockGatewayAccountEntity.getGatewayName()).thenReturn(WORLDPAY.getName());
+        when(mockGatewayAccountEntity.getWorldpay3dsFlexCredentialsEntity()).thenReturn(Optional.of(mockWorldpay3dsFlexCredentialsEntity));
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+
+        InOrder inOrder = inOrder(mockWorldpay3dsFlexCredentialsEntity, mockGatewayAccountDao);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        inOrder.verify(mockWorldpay3dsFlexCredentialsEntity).setCorporateExemptionEnabled(false);
+        inOrder.verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+
+    @Test
+    void shouldUpdateWorldpayCorporateExemptionsEnabledToTrue() {
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
+                "op", "replace",
+                "path", FIELD_WORLDPAY_CORPORATE_EXEMPTIONS_ENABLED,
+                "value", true)));
+        when(mockGatewayAccountEntity.getGatewayName()).thenReturn(WORLDPAY.getName());
+        when(mockGatewayAccountEntity.getWorldpay3dsFlexCredentialsEntity()).thenReturn(Optional.of(mockWorldpay3dsFlexCredentialsEntity));
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+
+        InOrder inOrder = inOrder(mockWorldpay3dsFlexCredentialsEntity, mockGatewayAccountDao);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        inOrder.verify(mockWorldpay3dsFlexCredentialsEntity).setCorporateExemptionEnabled(true);
+        inOrder.verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
     }
 
     @Test


### PR DESCRIPTION
With this change, we are introducing the ability to toggle corporate exemptions for Worldpay accounts in Connector via REST patch requests.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-13038

## How to test

How should it be reviewed?  What feedback do you need? 

- The new implementation should be very similar to the way we toggle the Worldpay exemption engine flag.
- The second commit refactors a switch statement in order to use the new style with arrow syntax.

## Code review checklist

### Logging

No changes to logs as we are re-using an existing Patch method.

- [X] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [X] Updated README.md for any of the following ? NO

* Introduced any new environment variables / removed existing environment variable --> NO
* Added new API / updated existing API definition --> NO
