### PR TITLE
PP-13029 log reason of exemption result

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -542,7 +542,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 845
+        "line_number": 888
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-16T09:15:31Z"
+  "generated_at": "2024-08-19T15:17:01Z"
 }


### PR DESCRIPTION
## WHAT YOU DID

When requesting a 3ds exemption, log the `reason` attribute of the `exemptionResponse` if exemption was requested and reason is available.

If no exemption was requested log should be as is.

Add tests.
