### PR TITLE
PP-13029 log reason of exemption result

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -542,7 +542,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 845
+        "line_number": 888
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-16T09:15:31Z"
+  "generated_at": "2024-08-19T15:17:01Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayExemptionResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayExemptionResponse.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import java.util.Objects;
+
+public record WorldpayExemptionResponse(String result, String reason) {
+
+    public WorldpayExemptionResponse {
+        Objects.requireNonNull(result);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
@@ -143,6 +143,11 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
         return exemptionResponseReason;
     }
 
+    public Optional<WorldpayExemptionResponse> getExemptionResponse() {
+        return Optional.ofNullable(exemptionResponseResult)
+                .map(result -> new WorldpayExemptionResponse(result, exemptionResponseReason));
+    }
+
     public String getPaRequest() {
         return paRequest;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -264,28 +264,29 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     }
 
     private void calculateAndStoreExemption(ChargeEntity charge, GatewayResponse<WorldpayOrderStatusResponse> response) {
-        response.getBaseResponse().flatMap(WorldpayOrderStatusResponse::getExemptionResponseResult).ifPresent(exemption3ds -> {
-            switch (exemption3ds) {
-                case "HONOURED":
-                    updateChargeWithExemption3ds(EXEMPTION_HONOURED, charge);
-                    break;
-                case "REJECTED":
-                    updateChargeWithExemption3ds(EXEMPTION_REJECTED, charge);
-                    break;
-                case "OUT_OF_SCOPE":
-                    updateChargeWithExemption3ds(EXEMPTION_OUT_OF_SCOPE, charge);
-                    break;
-                default:
-                    LOGGER.warn("Received unrecognised exemption 3ds response result {} from Worldpay - " +
-                            "charge_external_id={}", exemption3ds, charge.getExternalId());
+        response.getBaseResponse().flatMap(WorldpayOrderStatusResponse::getExemptionResponse).ifPresent(exemptionResponse -> {
+            switch (exemptionResponse.result()) {
+                case "HONOURED" ->  updateChargeWithExemption3ds(EXEMPTION_HONOURED, charge, exemptionResponse.reason());
+                case "REJECTED" -> updateChargeWithExemption3ds(EXEMPTION_REJECTED, charge, exemptionResponse.reason());
+                case "OUT_OF_SCOPE" -> updateChargeWithExemption3ds(EXEMPTION_OUT_OF_SCOPE, charge, exemptionResponse.reason());
+                default -> LOGGER.warn("Received unrecognised exemption 3ds response result {} from Worldpay - " +
+                            "charge_external_id={}", exemptionResponse, charge.getExternalId());
             }
         });
     }
 
-    @Transactional
     public void updateChargeWithExemption3ds(Exemption3ds exemption3ds, ChargeEntity charge) {
+       updateChargeWithExemption3ds(exemption3ds, charge, null);
+    }
+
+    @Transactional
+    public void updateChargeWithExemption3ds(Exemption3ds exemption3ds, ChargeEntity charge, String reason) {
         charge.setExemption3ds(exemption3ds);
-        LOGGER.info("Updated exemption_3ds of charge to {} - charge_external_id={}", exemption3ds, charge.getExternalId());
+        if (reason == null) {
+            LOGGER.info("Updated exemption_3ds of charge to {} - charge_external_id={}", exemption3ds, charge.getExternalId());
+        } else {
+            LOGGER.info("Updated exemption_3ds of charge to {} (reason {}) - charge_external_id={}", exemption3ds.name(), reason, charge.getExternalId());
+        }
         chargeDao.merge(charge);
         eventService.emitAndRecordEvent(Gateway3dsExemptionResultObtained.from(charge, Instant.now()));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -245,6 +245,7 @@ class WorldpayPaymentProviderTest {
         assertThat(chargeEntity.getExemption3dsRequested(), is(nullValue()));
 
         verifyChargeUpdatedWith(EXEMPTION_NOT_REQUESTED);
+        verifyLoggingWithOutExemptionReason(EXEMPTION_NOT_REQUESTED, chargeEntity.getExternalId(), 1);
         verifyEventEmitted(chargeEntity, EXEMPTION_NOT_REQUESTED);
     }
 
@@ -261,6 +262,26 @@ class WorldpayPaymentProviderTest {
         List<ChargeEntity> mergedCharges = chargeDaoArgumentCaptor.getAllValues();
         assertThat(mergedCharges.get(0).getExemption3dsRequested(), is(OPTIMISED));
         assertThat(mergedCharges.get(1).getExemption3ds(), is(exemption3ds));
+    }
+
+    private void verifyLoggingWithExemptionReason(Exemption3ds exemption3ds, String reason, String externalId, int timesLoggingCalled) {
+        ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(mockAppender, times(timesLoggingCalled)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logs = loggingEventArgumentCaptor.getAllValues();
+        assertTrue(logs.stream().anyMatch(loggingEvent -> {
+            String log = format("Updated exemption_3ds of charge to %s (reason %s) - charge_external_id=%s", exemption3ds.name(), reason, externalId);
+            return loggingEvent.getFormattedMessage().contains(log);
+        }));
+    }
+
+    private void verifyLoggingWithOutExemptionReason(Exemption3ds exemption3ds, String externalId, int timesLoggingCalled) {
+        ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(mockAppender, times(timesLoggingCalled)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logs = loggingEventArgumentCaptor.getAllValues();
+        assertTrue(logs.stream().anyMatch(loggingEvent -> {
+            String log = format("Updated exemption_3ds of charge to %s - charge_external_id=%s", exemption3ds.name(), externalId);
+            return loggingEvent.getFormattedMessage().contains(log);
+        }));
     }
 
     @Test
@@ -283,6 +304,7 @@ class WorldpayPaymentProviderTest {
         assertThat(chargeEntity.getExemption3dsRequested(), is(nullValue()));
 
         verifyChargeUpdatedWith(EXEMPTION_NOT_REQUESTED);
+        verifyLoggingWithOutExemptionReason(EXEMPTION_NOT_REQUESTED, chargeEntity.getExternalId(), 1);
         verifyEventEmitted(chargeEntity, EXEMPTION_NOT_REQUESTED);
     }
 
@@ -305,6 +327,7 @@ class WorldpayPaymentProviderTest {
         assertThat(chargeEntity.getExemption3dsRequested(), is(nullValue()));
 
         verifyChargeUpdatedWith(EXEMPTION_NOT_REQUESTED);
+        verifyLoggingWithOutExemptionReason(EXEMPTION_NOT_REQUESTED, chargeEntity.getExternalId(), 1);
         verifyEventEmitted(chargeEntity, EXEMPTION_NOT_REQUESTED);
     }
 
@@ -333,6 +356,7 @@ class WorldpayPaymentProviderTest {
         assertThat(secondRequest.getTransactionId(), not(nullValue()));
         assertThat(secondRequest.getTransactionId(), not(chargeEntity.getGatewayTransactionId()));
         verifyChargeUpdatedWith3dsAndExemptionRequested(EXEMPTION_REJECTED);
+        verifyLoggingWithExemptionReason(EXEMPTION_REJECTED, "HIGH_RISK", chargeEntity.getExternalId(), 3);
         verify3dsExemptionEventsEmitted(chargeEntity, EXEMPTION_REJECTED, OPTIMISED);
     }
 
@@ -360,6 +384,7 @@ class WorldpayPaymentProviderTest {
         assertThat(secondRequest.getTransactionId(), not(nullValue()));
         assertThat(secondRequest.getTransactionId(), not(chargeEntity.getGatewayTransactionId()));
         verifyChargeUpdatedWith3dsAndExemptionRequested(EXEMPTION_OUT_OF_SCOPE);
+        verifyLoggingWithExemptionReason(EXEMPTION_OUT_OF_SCOPE, "HIGH_RISK", chargeEntity.getExternalId(), 3);
         verify3dsExemptionEventsEmitted(chargeEntity, EXEMPTION_OUT_OF_SCOPE, OPTIMISED);
     }
 
@@ -423,6 +448,7 @@ class WorldpayPaymentProviderTest {
         assertThat(chargeEntity.getExemption3dsRequested(), is(OPTIMISED));
 
         verifyChargeUpdatedWith3dsAndExemptionRequested(EXEMPTION_HONOURED);
+        verifyLoggingWithExemptionReason(EXEMPTION_HONOURED, "ISSUER_HONOURED", chargeEntity.getExternalId(), 2);
         verify3dsExemptionEventsEmitted(chargeEntity, EXEMPTION_HONOURED, OPTIMISED);
     }
 
@@ -503,6 +529,23 @@ class WorldpayPaymentProviderTest {
         worldpayPaymentProvider.authorise3dsResponse(get3dsResponseGatewayRequest(chargeEntity));
 
         verifyChargeUpdatedWith(EXEMPTION_REJECTED);
+        verifyLoggingWithExemptionReason(EXEMPTION_REJECTED, "HIGH_RISK", chargeEntity.getExternalId(), 2);
+        verifyEventEmitted(chargeEntity, EXEMPTION_REJECTED);
+
+    }
+
+    @Test
+    void should_log_exemption_3ds_for_charge_during_3ds_authorisation_without_reason() throws Exception {
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+
+        when(response.getEntity()).thenReturn(load(WORLDPAY_EXEMPTION_REQUEST_REJECTED_AUTHORISED_RESPONSE).replace("reason=\"HIGH_RISK\"", ""));
+        when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyList(), anyMap()))
+                .thenReturn(response);
+
+        worldpayPaymentProvider.authorise3dsResponse(get3dsResponseGatewayRequest(chargeEntity));
+
+        verifyChargeUpdatedWith(EXEMPTION_REJECTED);
+        verifyLoggingWithOutExemptionReason(EXEMPTION_REJECTED, chargeEntity.getExternalId(), 2);
         verifyEventEmitted(chargeEntity, EXEMPTION_REJECTED);
     }
 


### PR DESCRIPTION
When requesting a 3ds exemption, log the `reason` attribute of the `exemptionResponse` if exemption was requested and reason is available.

If no exemption was requested log should be as is.

Add tests.

with @alexbishop1