### PR TITLE
PP-13154 Stop sending DDC result for samsung browsers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -551,7 +551,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 91
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
@@ -936,6 +936,15 @@
         "line_number": 9
       }
     ],
+    "src/test/resources/googlepay/example-3ds-auth-request-with-ddc-samsung-browser.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/googlepay/example-3ds-auth-request-with-ddc-samsung-browser.json",
+        "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
     "src/test/resources/googlepay/example-3ds-auth-request-with-ddc.json": [
       {
         "type": "Base64 High Entropy String",
@@ -1086,5 +1095,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-27T14:01:06Z"
+  "generated_at": "2024-09-03T12:35:01Z"
 }

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml
@@ -34,10 +34,18 @@
             </shopper>
             </#if>
             <#if googlePayPaymentData.paymentInfo.worldpay3dsFlexDdcResult.isPresent()>
+                <#if userAgentHeader?contains("SamsungBrowser/26")>
+                        <additional3DSData
+                        dfReferenceId=""
+                        javaScriptEnabled="false"
+                        challengeWindowSize="390x400" challengePreference="noPreference"
+                        />
+                <#else>
             <additional3DSData
                 dfReferenceId="${googlePayPaymentData.paymentInfo.worldpay3dsFlexDdcResult.get()?xml}"
                 challengeWindowSize="390x400" challengePreference="noPreference"
             />
+                </#if>
             </#if>
         </order>
     </submit>

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -68,10 +68,18 @@
             </#if>
             <#if requires3ds>
             <#if authCardDetails.worldpay3dsFlexDdcResult.isPresent()>
-            <additional3DSData
-                dfReferenceId="${authCardDetails.worldpay3dsFlexDdcResult.get()?xml}"
-                challengeWindowSize="390x400" challengePreference="noPreference"
-            />
+                <#if authCardDetails.userAgentHeader?contains("SamsungBrowser/26")>
+                    <additional3DSData
+                    dfReferenceId=""
+                    javaScriptEnabled="false"
+                    challengeWindowSize="390x400" challengePreference="noPreference"
+                    />
+                <#else>
+                    <additional3DSData
+                    dfReferenceId="${authCardDetails.worldpay3dsFlexDdcResult.get()?xml}"
+                    challengeWindowSize="390x400" challengePreference="noPreference"
+                    />
+                </#if>
             </#if>
             <#if authCardDetails.worldpay3dsFlexDdcResult.isEmpty() && integrationVersion3ds == 2>
             <additional3DSData

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -334,6 +334,50 @@ class WorldpayAuthoriseHandlerTest {
     }
 
     @Test
+    void should_not_include_3DS2_ddc_data_and_use_default_3ds_data_for_samsung_browsers() throws Exception {
+        when(authorisationSuccessResponse.getEntity()).thenReturn(load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
+
+        ChargeEntity chargeEntity = chargeEntityFixture
+                .withExternalId("uniqueSessionId")
+                .withAmount(500L)
+                .withDescription("This is a description")
+                .withReference(ServicePaymentReference.of("service-payment-reference"))
+                .withTransactionId("transaction-id")
+                .build();
+
+        gatewayAccountEntity.setIntegrationVersion3ds(2);
+        gatewayAccountEntity.setRequires3ds(true);
+
+        when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
+                .thenReturn(authorisationSuccessResponse);
+
+        AuthCardDetails authCardDetails = getValidTestCard(UUID.randomUUID().toString());
+        authCardDetails.setUserAgentHeader("SamsungBrowser/26.0 Chrome/122.0.0.0");
+        authCardDetails.setAcceptLanguageHeader("en-GB,en-US;q=0.9,en;q=0.8");
+
+        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), authCardDetails);
+        worldpayAuthoriseHandler.authoriseWithoutExemption(cardAuthorisationGatewayRequest);        
+
+        ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
+        verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
+
+        Document document = XPathUtils.getDocumentXmlString(gatewayOrderArgumentCaptor.getValue().getPayload());
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        assertThat(xPath.evaluate("/paymentService/submit/order/additional3DSData/@dfReferenceId", document),
+                is(""));
+        assertThat(xPath.evaluate("/paymentService/submit/order/additional3DSData/@challengeWindowSize", document),
+                is("390x400"));
+        assertThat(xPath.evaluate("/paymentService/submit/order/additional3DSData/@challengePreference", document),
+                is("noPreference"));
+        assertThat(xPath.evaluate("/paymentService/submit/order/paymentDetails/session/@id", document),
+                not(emptyString()));
+        assertThat(xPath.evaluate("/paymentService/submit/order/shopper/browser/acceptHeader", document),
+                not(emptyString()));
+        assertThat(xPath.evaluate("/paymentService/submit/order/shopper/browser/userAgentHeader", document),
+                not(emptyString()));
+    }
+
+    @Test
     void should_include_email_when_present_and_send_email_to_gateway_enabled_and_3ds_disabled() throws Exception {
         when(authorisationSuccessResponse.getEntity()).thenReturn(load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -8,6 +8,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.w3c.dom.Document;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.gateway.GatewayClient;
@@ -16,15 +17,18 @@ import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
-import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
-import uk.gov.pay.connector.wallets.applepay.api.ApplePayPaymentInfo;
-import uk.gov.pay.connector.wallets.googlepay.GooglePayAuthorisationGatewayRequest;
+import uk.gov.pay.connector.util.XPathUtils;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
+import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.applepay.ApplePayDecrypter;
 import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
+import uk.gov.pay.connector.wallets.applepay.api.ApplePayPaymentInfo;
+import uk.gov.pay.connector.wallets.googlepay.GooglePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
 import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
 
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -34,7 +38,9 @@ import java.util.List;
 import java.util.Map;
 
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -246,6 +252,40 @@ class WorldpayWalletAuthorisationHandlerTest {
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
+        }
+    }
+
+    @Test
+    void shouldSendGooglePay3dsRequestWithDefault3DSDataForSamsungBrowsers() throws Exception {
+        try {
+
+            String fixturePath = "googlepay/example-3ds-auth-request-with-ddc-samsung-browser.json";
+            GooglePayAuthRequest googlePayAuthRequest = Jackson.getObjectMapper().readValue(
+                    load(fixturePath), GooglePayAuthRequest.class);
+            chargeEntity.getGatewayAccount().setRequires3ds(true);
+            chargeEntity.getGatewayAccount().setSendPayerIpAddressToGateway(false);
+            chargeEntity.setExternalId(GOOGLE_PAY_3DS_WITHOUT_IP_ADDRESS);
+            GooglePayAuthorisationGatewayRequest googlePayAuthorisationGatewayRequest
+                    = new GooglePayAuthorisationGatewayRequest(chargeEntity, googlePayAuthRequest);
+
+            worldpayWalletAuthorisationHandler.authoriseGooglePay(googlePayAuthorisationGatewayRequest);
+        } catch (GatewayErrorException e) {
+            verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
+
+            Document document = XPathUtils.getDocumentXmlString(gatewayOrderArgumentCaptor.getValue().getPayload());
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            assertThat(xPath.evaluate("/paymentService/submit/order/additional3DSData/@dfReferenceId", document),
+                    is(""));
+            assertThat(xPath.evaluate("/paymentService/submit/order/additional3DSData/@challengeWindowSize", document),
+                    is("390x400"));
+            assertThat(xPath.evaluate("/paymentService/submit/order/additional3DSData/@challengePreference", document),
+                    is("noPreference"));
+            assertThat(xPath.evaluate("/paymentService/submit/order/paymentDetails/session/@id", document),
+                    not(emptyString()));
+            assertThat(xPath.evaluate("/paymentService/submit/order/shopper/browser/acceptHeader", document),
+                    not(emptyString()));
+            assertThat(xPath.evaluate("/paymentService/submit/order/shopper/browser/userAgentHeader", document),
+                    not(emptyString()));
         }
     }
 

--- a/src/test/resources/googlepay/example-3ds-auth-request-with-ddc-samsung-browser.json
+++ b/src/test/resources/googlepay/example-3ds-auth-request-with-ddc-samsung-browser.json
@@ -1,0 +1,16 @@
+{
+  "payment_info": {
+    "last_digits_card_number": "4242",
+    "brand": "visa",
+    "cardholder_name": "Example Name",
+    "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,/;q=0.8",
+    "user_agent_header": "SamsungBrowser/26.0 Chrome/122.0.0.0",
+    "ip_address": "8.8.8.8",
+    "worldpay_3ds_flex_ddc_result": "1f1154b7-620d-4654-801b-893b5bb22db1"
+  },
+  "encrypted_payment_data": {
+    "signature": "MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl",
+    "protocol_version": "ECv1",
+    "signed_message": "aSignedMessage"
+  }
+}


### PR DESCRIPTION
## WHAT YOU DID
- Temporary fix to not send Worldpay 3DS Flex device data collection result when a user is using Samsung Internet 26

