### PR TITLE
PP-13051 Send corporate exemption with Worldpay authorisation request for corporate cards if enabled

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -512,7 +512,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java",
         "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 86
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java": [
@@ -521,28 +521,28 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 143
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "fd9f851472586dc75f7a60ee311842ec64ecf527",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 146
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "9367c8305bd1afe815ffc0cc3ebf95af9cb6d157",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 149
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 888
+        "line_number": 960
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-27T14:01:06Z"
+  "generated_at": "2024-09-04T11:00:26Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -512,7 +512,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java",
         "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 86
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java": [
@@ -521,28 +521,28 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 143
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "fd9f851472586dc75f7a60ee311842ec64ecf527",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 146
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "9367c8305bd1afe815ffc0cc3ebf95af9cb6d157",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 149
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 888
+        "line_number": 960
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Exemption3dsType.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Exemption3dsType.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 public enum Exemption3dsType {
-    OPTIMISED
+    OPTIMISED,
+    CORPORATE
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.util.AuthUtil;
+import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 import uk.gov.pay.connector.util.AcceptLanguageHeaderParser;
 
 import java.util.Optional;
@@ -43,10 +44,16 @@ public interface WorldpayOrderBuilder {
 
         boolean is3dsRequired = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
                 request.getGatewayAccount().isRequires3ds();
+        
+        boolean isCorporateExemptionEnabled = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
+                request.getGatewayAccount().getWorldpay3dsFlexCredentials().map(Worldpay3dsFlexCredentials::isCorporateExemptionsEnabled)
+                        .orElse(false);
+        
 
         return (WorldpayOrderRequestBuilder) builder
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getGovUkPayPaymentId()))
                 .with3dsRequired(is3dsRequired)
+                .withCorporateExemptionEnabled(isCorporateExemptionEnabled)
                 .withSavePaymentInstrumentToAgreement(request.isSavePaymentInstrumentToAgreement())
                 .withAgreementId(request.getAgreement().map(AgreementEntity::getExternalId).orElse(null))
                 .withTransactionId(request.getTransactionId().orElse(""))

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -31,6 +31,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         private String acceptHeader;
         private String userAgentHeader;
         private boolean requires3ds;
+        private boolean corporateExemptionEnabled;
         private String paResponse3ds;
         private String payerIpAddress;
         private String payerEmail;
@@ -106,11 +107,17 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         public boolean isRequires3ds() {
             return requires3ds;
         }
+        
+        public boolean isCorporateExemptionEnabled() { return corporateExemptionEnabled; }
 
         public void setRequires3ds(boolean requires3ds) {
             this.requires3ds = requires3ds;
         }
 
+        public void setCorporateExemptionEnabled(boolean corporateExemptionEnabled) {
+            this.corporateExemptionEnabled = corporateExemptionEnabled;
+        }
+        
         public Optional<String> getPaResponse3ds() {
             return Optional.ofNullable(paResponse3ds);
         }
@@ -293,6 +300,12 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     public WorldpayOrderRequestBuilder with3dsRequired(boolean requires3ds) {
         logger.info("3DS requirement is: " + requires3ds + " for " + worldpayTemplateData.sessionId);
         worldpayTemplateData.setRequires3ds(requires3ds);
+        return this;
+    }
+    
+    public WorldpayOrderRequestBuilder withCorporateExemptionEnabled(boolean corporateExemptionEnabled) {
+        logger.info("Corporate Exemption is: " + corporateExemptionEnabled + " for " + worldpayTemplateData.sessionId);
+        worldpayTemplateData.setCorporateExemptionEnabled(corporateExemptionEnabled);
         return this;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.model.domain.Exemption3dsType;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.model.charge.Requested3dsExemption;
@@ -62,6 +63,7 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
+import static uk.gov.pay.connector.charge.model.domain.Exemption3dsType.CORPORATE;
 import static uk.gov.pay.connector.charge.model.domain.Exemption3dsType.OPTIMISED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.util.AuthUtil.getWorldpayAuthHeader;
@@ -208,14 +210,20 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     public GatewayResponse<WorldpayOrderStatusResponse> authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) {
 
         boolean exemptionEngineEnabled = isExemptionEngineEnabled(request);
+        boolean corporateExemptionsEnabled = isCorporateExemptionsEnabled(request);
+        boolean cardIsCorporate = isCorporateCard(request);
+        
         GatewayResponse<WorldpayOrderStatusResponse> response;
+        Exemption3dsType exemptionType = corporateExemptionsEnabled && cardIsCorporate ? CORPORATE : OPTIMISED;
 
-        if (!exemptionEngineEnabled) {
-            response = worldpayAuthoriseHandler.authoriseWithoutExemption(request);
-        } else {
-            charge = updateChargeWithRequested3dsExemption(charge);
-            response = worldpayAuthoriseHandler.authoriseWithExemption(request);
+        if (exemptionEngineEnabled || corporateExemptionsEnabled) {
+            charge = updateChargeWithRequested3dsExemption(charge, exemptionType);
         }
+        
+        response = exemptionEngineEnabled
+                ? worldpayAuthoriseHandler.authoriseWithExemption(request)
+                : worldpayAuthoriseHandler.authoriseWithoutExemption(request);
+        
 
         calculateAndStoreExemption(exemptionEngineEnabled, charge, response);
 
@@ -292,9 +300,9 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     }
 
     @Transactional
-    public ChargeEntity updateChargeWithRequested3dsExemption(ChargeEntity chargeEntity) {
-        chargeEntity.setExemption3dsRequested(OPTIMISED);
-        LOGGER.info("Requesting {} exemption - charge_external_id={}", "OPTIMISED", chargeEntity.getExternalId());
+    public ChargeEntity updateChargeWithRequested3dsExemption(ChargeEntity chargeEntity, Exemption3dsType exemption3dsType) {
+        chargeEntity.setExemption3dsRequested(exemption3dsType);
+        LOGGER.info("Requesting {} exemption - charge_external_id={}", exemption3dsType, chargeEntity.getExternalId());
         eventService.emitAndRecordEvent(Requested3dsExemption.from(chargeEntity, Instant.now()));
 
         return chargeDao.merge(chargeEntity);
@@ -305,6 +313,18 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
         return gatewayAccount.isRequires3ds() && gatewayAccount.getWorldpay3dsFlexCredentials()
                 .map(Worldpay3dsFlexCredentials::isExemptionEngineEnabled)
                 .orElse(false);
+    }
+    
+    private boolean isCorporateExemptionsEnabled(CardAuthorisationGatewayRequest request) {
+        GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
+        return gatewayAccount.isRequires3ds() && gatewayAccount.getWorldpay3dsFlexCredentials()
+                .map(Worldpay3dsFlexCredentials::isCorporateExemptionsEnabled)
+                .orElse(false);
+    }
+    
+    private boolean isCorporateCard(CardAuthorisationGatewayRequest request) {
+        AuthCardDetails authCardDetails = request.getAuthCardDetails();
+        return authCardDetails.isCorporateCard();
     }
 
     @Override

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -80,10 +80,16 @@
                 challengeWindowSize="390x400" challengePreference="noPreference"
             />
             </#if>
-            <#if exemptionEngineEnabled>
+            <#if authCardDetails.corporateCard>
+            <#if (corporateExemptionEnabled && !exemptionEngineEnabled) || (corporateExemptionEnabled && exemptionEngineEnabled)>
+            <exemption type="CP" placement="AUTHORISATION"/>
+            <#elseif !corporateExemptionEnabled && exemptionEngineEnabled>
             <exemption type="OP" placement="OPTIMISED"/>
             </#if>
+            <#elseif !authCardDetails.corporateCard && corporateExemptionEnabled && exemptionEngineEnabled>
+            <exemption type="OP" placement="OPTIMISED"/>
             </#if>
+        </#if>
         </order>
     </submit>
 </paymentService>

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -6,6 +6,9 @@ import com.codahale.metrics.MetricRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -51,6 +54,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -59,6 +63,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -215,8 +220,14 @@ class WorldpayAuthoriseHandlerTest {
                 gatewayOrderArgumentCaptor.getValue().getPayload());
     }
 
-    @Test
-    void should_include_exemption_element_if_account_has_exemption_engine_set_to_true() throws Exception {
+    @ParameterizedTest
+    @MethodSource("exemptionValues")
+    void should_include_exemption_element_if_account_has_exemption_engine_set_to_true(
+            boolean corporateExemption,
+            String exemptionType,
+            String exemptionPlacement,
+            boolean corporateCard
+    ) throws Exception {
 
         when(authorisationSuccessResponse.getEntity()).thenReturn(load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
@@ -224,7 +235,10 @@ class WorldpayAuthoriseHandlerTest {
 
         gatewayAccountEntity.setRequires3ds(true);
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
-        worldpayAuthoriseHandler.authoriseWithExemption(new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), getValidTestCard()));
+
+        AuthCardDetails authCardDetails = getValidTestCard(UUID.randomUUID().toString());
+        authCardDetails.setCorporateCard(corporateCard);
+        worldpayAuthoriseHandler.authoriseWithExemption(new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), authCardDetails));
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
 
@@ -236,10 +250,17 @@ class WorldpayAuthoriseHandlerTest {
 
         Document document = XPathUtils.getDocumentXmlString(gatewayOrderArgumentCaptor.getValue().getPayload());
         XPath xPath = XPathFactory.newInstance().newXPath();
-        assertThat(xPath.evaluate("/paymentService/submit/order/exemption/@type", document), is("OP"));
-        assertThat(xPath.evaluate("/paymentService/submit/order/exemption/@placement", document), is("OPTIMISED"));
+        assertThat(xPath.evaluate("/paymentService/submit/order/exemption/@type", document), is(exemptionType));
+        assertThat(xPath.evaluate("/paymentService/submit/order/exemption/@placement", document), is(exemptionPlacement));
     }
 
+    private static Stream<Arguments> exemptionValues() {
+        return Stream.of(
+                arguments(true, "CP", "AUTHORISATION", true),
+                arguments(true, "OP", "OPTIMISED", false)
+        );
+    }
+    
     @Test
     void should_not_include_exemption_element() throws Exception {
 

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -53,6 +53,8 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-with-ip-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-with-email.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_REQUEST_3DS_FLEX_NON_JS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-3ds-flex-non-js.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_3DS_REQUEST_EXEMPTION_OPTIMISED = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-exemption-optimised.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_3DS_REQUEST_EXEMPTION_AUTHORISATION = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-exemption-authorisation.xml";
 
     public static final String WORLDPAY_3DS_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-response.xml";
     public static final String WORLDPAY_3DS_FLEX_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-flex-response.xml";

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-3ds-request-exemption-authorisation.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-3ds-request-exemption-authorisation.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <CARD-SSL>
+                    <cardNumber>4111111111111111</cardNumber>
+                    <expiryDate>
+                        <date month="12" year="2015"/>
+                    </expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cvc>123</cvc>
+                    <cardAddress>
+                        <address>
+                            <address1>123 My Street</address1>
+                            <postalCode>SW8URR</postalCode>
+                            <city>London</city>
+                            <countryCode>GB</countryCode>
+                        </address>
+                    </cardAddress>
+                </CARD-SSL>
+                <session id="uniqueSessionId"/>
+            </paymentDetails>
+            <shopper>
+                <browser>
+                    <acceptHeader>text/html</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0</userAgentHeader>
+                </browser>
+            </shopper>
+            <exemption type="CP" placement="AUTHORISATION"/>
+        </order>
+    </submit>
+</paymentService>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-3ds-request-exemption-optimised.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-3ds-request-exemption-optimised.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <CARD-SSL>
+                    <cardNumber>4111111111111111</cardNumber>
+                    <expiryDate>
+                        <date month="12" year="2015"/>
+                    </expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cvc>123</cvc>
+                    <cardAddress>
+                        <address>
+                            <address1>123 My Street</address1>
+                            <postalCode>SW8URR</postalCode>
+                            <city>London</city>
+                            <countryCode>GB</countryCode>
+                        </address>
+                    </cardAddress>
+                </CARD-SSL>
+                <session id="uniqueSessionId"/>
+            </paymentDetails>
+            <shopper>
+                <browser>
+                    <acceptHeader>text/html</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0</userAgentHeader>
+                </browser>
+            </shopper>
+            <exemption type="OP" placement="OPTIMISED"/>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
## WHAT YOU DID
Ensure that if corporate exemptions are enabled and a corporate card is used, then the charges tabel of the connector database is updatd to the value of optimised and the authorisation request to Worldpay includs `<exemption type="OP" placement="OPTIMISED"/>` element inside the order element

## How to test

- How should it be reviewed? 
    - Check the code.
- What feedback do you need? 
    - I've made the test on Line 223 of `src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java` a parameterised test for readability but realise this may be better as two separate tests?
    - I have read the ticket as 3D secure enabled meaning the `requires_3ds` column of the `gateway_accounts` table.
    - I suspect there's a better way of structuring my changes in [WorldpayAuthoriseOrderTemplate.xml](https://github.com/alphagov/pay-connector/pull/5535/files#diff-a18066368d3d8d932d82af7fd4458986a47b0d41cf495b7432c8497767664976)
    - I'm not sure if the naming of the tests in [WorldpayPaymentProviderTest.java](https://github.com/alphagov/pay-connector/pull/5535/files#diff-d64f06829c2303c7615e41d361e4db01df11be2bc86524770d875079b99d79fd) could be made more explicit.
 
- Steps to test
    - Checkout this branch as well as `pp-13038-toggle-corporate-exemptions-button` pay-toolbox branch (this may not be needed if this branch has been merged by the time of writing). 
    - In `pay-connector` you will need to change the test Worldpay URLs and test threeDsFlexDdcUrls in `config.yaml` to the worldpay test urls. You can find theses in `pay-magic-urls` in pay-infra.
    - Run connector from local branch:
       `pay local launch --cluster endtoend --local connector`
    - Create a user:
       `pay local user`
    - Run toolbox locally and go to the gateway account for the service just created.
    - Go to ‘Manage PSP’ and switch to Worldpay.
    - This will create a worldpay credentials record (in gateway_account_credentials) but the status needs to be changed 
    to `ACTIVE` so you can use APIs or a SQL update. Don't forget to add a`active_start_date`. Alternatively you can run the following query `update gateway_account_credentials set state = 'ACTIVE', active_start_date = now()  where id = 2;`. 
    - Remember to set `requires_3ds` to true in the DB on the gateway account.
    - Now set the `worldpay_3ds_flex_credentials` using the following query `insert into worldpay_3ds_flex_credentials(id, gateway_account_id, issuer, organisational_unit_id, jwt_mac_key, version, exemption_engine, corporate_exemptions) values (1,1, 'issuer', 'organisational_unit_id', 'jwt_mac_key', 1,  false, false);` . The correct values can be found on the Worldpay developer docs.
    - Now if you `select * from worldpay_3ds_flex_credentials` you can toggle the exemption_engine and corporate_exemption properties as necessary. 
    - Now set your account credentials using the selfservice UI by going first to _setttings_ and then to _Your PSP - Worldpay_ menu. You will need to obtain these from someone with access to pay-low-pass. 
    - Now create a new payment link in order to make some test transactions.
    - You can check if `CORPORATE` or `OPTIMISED` has been set if you `select * from charges`
    - You can use the mock card numbers in the card numbers tech docs to test corporate/non-corporate cards https://docs.payments.service.gov.uk/testing_govuk_pay/#mock-card-numbers
    - You should also check that each transaction has a `REQUESTED_3DS_EXEMPTION` event that is either set to `OPTIMISED` or `CORPORATE` dependant upon how you set `exemption_enging` , `corporate_exemptions` and whether you use a corporate card or not.

