### PR TITLE
PP-13153 Add DAO method to get earliest capture ready charge date

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -929,6 +929,10 @@ public class DatabaseFixtures {
             return createdDate;
         }
 
+        public Instant getUpdatedDate() {
+            return updatedDate;
+        }
+
         public String getDescription() {
             return description;
         }


### PR DESCRIPTION
## WHAT YOU DID
- Added DAO method to get the earliest updated date of capture-ready charges. This date is to be used to emit a metric of the duration (longest) of charges in the approved state. Metric can be used to alert if any charges are stuck in the approved state for longer than necessary.
- Also included the `CAPTURE_QUEUED` state in the query which is a capture-ready state (for RCP - user not present payments)

- `TimeZone.setDefault` has been set to UTC as `Timestamp` returns datetime in the local time zone which is BST when tests are run locally.
