### PR TITLE
PP-13145: Accept BIND_HOST env var and default to localhost

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -813,28 +813,28 @@
         "filename": "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 31
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 31
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml",
         "hashed_secret": "ab85666a760f1a3fa02b3ac84953be727ce3dbfa",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 32
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 123
+        "line_number": 125
       }
     ],
     "src/test/resources/config/client-factory-test-config.yaml": [
@@ -843,28 +843,28 @@
         "filename": "src/test/resources/config/client-factory-test-config.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 31
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/resources/config/client-factory-test-config.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 31
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/resources/config/client-factory-test-config.yaml",
         "hashed_secret": "ab85666a760f1a3fa02b3ac84953be727ce3dbfa",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 32
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/resources/config/client-factory-test-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 115
       }
     ],
     "src/test/resources/config/test-config.yaml": [
@@ -873,28 +873,28 @@
         "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 34
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 34
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "ab85666a760f1a3fa02b3ac84953be727ce3dbfa",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 35
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 124
       }
     ],
     "src/test/resources/config/test-it-config.yaml": [
@@ -903,28 +903,28 @@
         "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 32
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 32
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "ab85666a760f1a3fa02b3ac84953be727ce3dbfa",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 33
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 118
+        "line_number": 120
       }
     ],
     "src/test/resources/googlepay/auth-request-with-empty-last-digits-card-number.json": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-27T14:01:06Z"
+  "generated_at": "2024-09-06T12:14:52Z"
 }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Alternatively, docs can be generated using [Pay API Docs generator](https://gith
 | `DISABLE_INTERNAL_HTTPS` | false | disable secure connection for calls to internal APIs |
 | `DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS` | 7200 | Sets the default duration in seconds for events (emitted by parity checker worker) until which the emitted events sweeper ignores to re-emit. Value can be overridden by passing `do_not_retry_emit_until` query parameter to parity checker worker or historical event emitter tasks |
 | `EMIT_PAYOUT_EVENTS` | false | enable or disable emitting payout specific events to payment queue |
+| `BIND_HOST` | `127.0.0.1` | The IP address for the application to bind to |
 
 
 ### Queues

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -1,9 +1,11 @@
 server:
   applicationConnectors:
     - type: http
+      bindHost: ${BIND_HOST:-127.0.0.1}
       port: ${PORT:-0}
   adminConnectors:
     - type: http
+      bindHost: ${BIND_HOST:-127.0.0.1}
       port: ${ADMIN_PORT:-0}
   registerDefaultExceptionMappers: false
   requestLog:

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -1,9 +1,11 @@
 server:
   applicationConnectors:
     - type: http
+      bindHost: ${BIND_HOST:-127.0.0.1}
       port: 0
   adminConnectors:
     - type: http
+      bindHost: ${BIND_HOST:-127.0.0.1}
       port: 0
   registerDefaultExceptionMappers: false
 

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -1,9 +1,11 @@
 server:
   applicationConnectors:
     - type: http
+      bindHost: ${BIND_HOST:-127.0.0.1}
       port: 0
   adminConnectors:
     - type: http
+      bindHost: ${BIND_HOST:-127.0.0.1}
       port: 0
   registerDefaultExceptionMappers: false
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -1,9 +1,11 @@
 server:
   applicationConnectors:
     - type: http
+      bindHost: ${BIND_HOST:-127.0.0.1}
       port: 0
   adminConnectors:
     - type: http
+      bindHost: ${BIND_HOST:-127.0.0.1}
       port: 0
   registerDefaultExceptionMappers: false
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -1,9 +1,11 @@
 server:
   applicationConnectors:
     - type: http
+      bindHost: ${BIND_HOST:-127.0.0.1}
       port: 0
   adminConnectors:
     - type: http
+      bindHost: ${BIND_HOST:-127.0.0.1}
       port: 0
   registerDefaultExceptionMappers: false
   requestLog:


### PR DESCRIPTION
## WHAT YOU DID
Bind to 127.0.0.1 by default instead of 0.0.0.0

## How to test

I tested this with pay local (which has BIND_HOST set to 0.0.0.0 by default).

`pay local up --local connector`

The startup logs that it's listening on 0.0.0.0
```
$ docker logs connector | grep 'Opened a'
{"@timestamp":"2024-09-06T12:34:28.563594172Z","@version":"1","message":"Opened application@533494ad{HTTP/1.1, (http/1.1)}{0.0.0.0:9300}","logger_name":"org.eclipse.jetty.setuid.SetUIDListener","thread_name":"main","level":"INFO","level_value":20000,"container":"connector","environment":"${ENVIRONMENT}"}
{"@timestamp":"2024-09-06T12:34:28.563782047Z","@version":"1","message":"Opened admin@4fb4bffa{HTTP/1.1, (http/1.1)}{0.0.0.0:9301}","logger_name":"org.eclipse.jetty.setuid.SetUIDListener","thread_name":"main","level":"INFO","level_value":20000,"container":"connector","environment":"${ENVIRONMENT}"}
```

If I edit the `all.yaml` file that was created by pay local and delete the `BIND_HOST` env var for connector then `docker compose -f all.yaml down connector && docker compose -f all.yaml up connector` you can see the logs change to bind to 127.0.0.1
```
{"@timestamp":"2024-09-06T12:39:11.076399178Z","@version":"1","message":"Opened application@7fbe92c6{HTTP/1.1, (http/1.1)}{127.0.0.1:9300}","logger_name":"org.eclipse.jetty.setuid.SetUIDListener","thread_name":"main","level":"INFO","level_value":20000,"container":"connector","environment":"${ENVIRONMENT}"}
{"@timestamp":"2024-09-06T12:39:11.076496636Z","@version":"1","message":"Opened admin@3aa9762a{HTTP/1.1, (http/1.1)}{127.0.0.1:9301}","logger_name":"org.eclipse.jetty.setuid.SetUIDListener","thread_name":"main","level":"INFO","level_value":20000,"container":"connector","environment":"${ENVIRONMENT}"}
```

Finally if I set BIND_HOST to be something that wont work (say 192.168.0.111 which doesn't work on my home network) the app fails to startup correctly
```
connector  | java.lang.RuntimeException: java.io.IOException: Failed to bind to /192.168.0.111:9300
```