### PR TITLE
PP-12863 Parity check - ignore refund_summary for disputed transactions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
@@ -87,7 +87,9 @@ public class ChargeParityChecker {
             fieldsMatch = fieldsMatch && matchGatewayAccountFields(chargeEntity.getGatewayAccount(), transaction);
             fieldsMatch = fieldsMatch && matchFeatureSpecificFields(chargeEntity, transaction);
             fieldsMatch = fieldsMatch && matchCaptureFields(chargeEntity, transaction);
-            fieldsMatch = fieldsMatch && matchRefundSummary(chargeEntity, transaction);
+            if (!transaction.isDisputed()) {
+                fieldsMatch = fieldsMatch && matchRefundSummary(chargeEntity, transaction);
+            }
             fieldsMatch = fieldsMatch && matchAuthorisationSummary(chargeEntity, transaction);
 
             if (fieldsMatch) {

--- a/src/test/java/uk/gov/pay/connector/tasks/service/ChargeParityCheckerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/service/ChargeParityCheckerTest.java
@@ -81,7 +81,7 @@ class ChargeParityCheckerTest {
     
     private ChargeEntity chargeEntity;
     private ChargeEntity chargeEntityWith3ds;
-    private List<RefundEntity> refundEntities = List.of();
+    private final List<RefundEntity> refundEntities = List.of();
     
     @BeforeEach
     void setUp() {
@@ -254,11 +254,24 @@ class ChargeParityCheckerTest {
 
         LedgerTransaction transaction = from(chargeEntity, refundEntities)
                 .withRefundSummary(null)
+                .withDisputed(false)
                 .build();
 
         ParityCheckStatus parityCheckStatus = chargeParityChecker.checkParity(chargeEntity, transaction);
 
         assertThat(parityCheckStatus, is(DATA_MISMATCH));
+    }
+
+    @Test
+    void parityCheck_shouldIgnoreRefundSummaryMismatchIfLedgerTransactionIsDisputed() {
+        LedgerTransaction transaction = from(chargeEntity, refundEntities)
+                .withRefundSummary(null)
+                .withDisputed(true)
+                .build();
+
+        ParityCheckStatus parityCheckStatus = chargeParityChecker.checkParity(chargeEntity, transaction);
+
+        assertThat(parityCheckStatus, is(EXISTS_IN_LEDGER));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- For disputed payment, Ledger returns `refund_summary.status` as `unavailable`. But if the charge is not expunged, Connector returns `refund_summary.status` as `available` as the connector doesn't know about disputes and is causing parity check failures.
- So removed checking refund_summary for disputed payments.
