### PR TITLE
PP-11559 after async refund transfer send events to ledger

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/PaymentStatusCorrectedToSuccessByAdminEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/PaymentStatusCorrectedToSuccessByAdminEventDetails.java
@@ -1,0 +1,101 @@
+package uk.gov.pay.connector.events.eventdetails.refund;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.service.payments.commons.api.json.IsoInstantMicrosecondSerializer;
+
+import java.time.Instant;
+
+public class PaymentStatusCorrectedToSuccessByAdminEventDetails extends EventDetails {
+    private final long fee;
+    private final long netAmount;
+    @JsonSerialize(using = IsoInstantMicrosecondSerializer.class)
+    private final Instant capturedDate;
+    private final ExternalRefundStatus refundStatus;
+    private final String updatedReason;
+    private final String adminGithubId;
+    private final long gatewayAccountId;
+    @JsonSerialize(using = IsoInstantMicrosecondSerializer.class)
+    private final Instant captureSubmittedDate;
+    private final long refundAmountRefunded;
+    private final long refundAmountAvailable;
+    private final String reference;
+    private final String zendeskId;
+
+    public PaymentStatusCorrectedToSuccessByAdminEventDetails(
+            long fee,
+            long netAmount,
+            Instant capturedDate,
+            ExternalRefundStatus refundStatus,
+            String updatedReason,
+            String adminGithubId,
+            long gatewayAccountId,
+            Instant captureSubmittedDate,
+            long refundAmountRefunded,
+            long refundAmountAvailable,
+            String reference,
+            String zendeskId) {
+        this.fee = fee;  
+        this.netAmount = netAmount;
+        this.capturedDate = capturedDate;
+        this.refundStatus = refundStatus;
+        this.updatedReason = updatedReason;
+        this.adminGithubId = adminGithubId;
+        this.gatewayAccountId = gatewayAccountId;
+        this.captureSubmittedDate = captureSubmittedDate;
+        this.refundAmountRefunded = refundAmountRefunded;
+        this.refundAmountAvailable = refundAmountAvailable;
+        this.reference = reference;
+        this.zendeskId = zendeskId;
+    }
+
+    public long getFee() {
+        return fee;
+    }
+
+    public long getNetAmount() {
+        return netAmount;
+    }
+
+    public Instant getCapturedDate() {
+        return capturedDate;
+    }
+
+    public ExternalRefundStatus getRefundStatus() {
+        return refundStatus;
+    }
+
+    public String getUpdatedReason() {
+        return updatedReason;
+    }
+
+    public String getAdminGithubId() {
+        return adminGithubId;
+    }
+
+    public long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public Instant getCaptureSubmittedDate() {
+        return captureSubmittedDate;
+    }
+
+    public long getRefundAmountRefunded() {
+        return refundAmountRefunded;
+    }
+
+    public long getRefundAmountAvailable() {
+        return refundAmountAvailable;
+    }
+
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getZendeskId() {
+        return zendeskId;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundFailureFundsSentToConnectAccountEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundFailureFundsSentToConnectAccountEventDetails.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.events.eventdetails.refund;
+
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+public class RefundFailureFundsSentToConnectAccountEventDetails extends EventDetails {
+
+    private final long amount;
+    private final String reference;
+    private final String description;
+    private final String adminGithubId;
+    private final String updatedReason;
+    private final String paymentProvider;
+    private final long gatewayAccountId;
+    private final String gatewayTransactionId;
+    private final String zendeskId;
+
+
+    public RefundFailureFundsSentToConnectAccountEventDetails(
+            long amount,
+            String reference,
+            String description,
+            String adminGithubId,
+            String updatedReason,
+            String paymentProvider,
+            long gatewayAccountId,
+            String gatewayTransactionId,
+            String zendeskId) {
+        this.amount = amount;
+        this.reference = reference;
+        this.description = description;
+        this.adminGithubId = adminGithubId;
+        this.updatedReason = updatedReason;
+        this.paymentProvider = paymentProvider;
+        this.gatewayAccountId = gatewayAccountId;
+        this.gatewayTransactionId = gatewayTransactionId;
+        this.zendeskId = zendeskId;
+    }
+
+    public long getAmount() {
+        return amount;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getAdminGithubId() {
+        return adminGithubId;
+    }
+
+    public String getUpdatedReason() {
+        return updatedReason;
+    }
+
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+
+    public long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public String getZendeskId() {
+        return zendeskId;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundStatusCorrectedToErrorByAdminEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundStatusCorrectedToErrorByAdminEventDetails.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.connector.events.eventdetails.refund;
+
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+public class RefundStatusCorrectedToErrorByAdminEventDetails extends EventDetails {
+    
+    String updatedReason;
+    String adminGithubId;
+    String zendeskId;
+
+    public RefundStatusCorrectedToErrorByAdminEventDetails( String updatedReason, String adminGithubId, String zendeskId) {
+        this.updatedReason = updatedReason;
+        this.adminGithubId = adminGithubId;
+        this.zendeskId = zendeskId;
+    }
+
+    public String getUpdatedReason() {
+        return updatedReason;
+    }
+
+    public void setUpdatedReason(String updatedReason) {
+        this.updatedReason = updatedReason;
+    }
+
+    public String getAdminGithubId() {
+        return adminGithubId;
+    }
+
+    public void setAdminGithubId(String adminGithubId) {
+        this.adminGithubId = adminGithubId;
+    }
+
+    public String getZendeskId() {
+        return zendeskId;
+    }
+
+    public void setZendeskId(String zendeskId) {
+        this.zendeskId = zendeskId;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdmin.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdmin.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.events.eventdetails.refund.PaymentStatusCorrectedToSuccessByAdminEventDetails;
+import uk.gov.pay.connector.events.model.charge.PaymentEvent;
+import uk.gov.pay.connector.refund.model.domain.GithubAndZendeskCredential;
+import uk.gov.pay.connector.refund.model.domain.Refund;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+
+public class PaymentStatusCorrectedToSuccessByAdmin extends PaymentEvent {
+    private PaymentStatusCorrectedToSuccessByAdmin(String serviceId, boolean live, Long gatewayAccountId,
+                                                   String resourceExternalId,
+                                                   PaymentStatusCorrectedToSuccessByAdminEventDetails eventDetails,
+                                                   Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static PaymentStatusCorrectedToSuccessByAdmin from(Refund refund, Charge charge, Instant timestamp, String githubId, String zendeskId) {
+
+        return new PaymentStatusCorrectedToSuccessByAdmin(
+                charge.getServiceId(),
+                charge.isLive(),
+                charge.getGatewayAccountId(),
+                charge.getExternalId(),
+                new PaymentStatusCorrectedToSuccessByAdminEventDetails(
+                        0L,
+                        charge.getAmount(),
+                        timestamp,
+                        refund.getExternalStatus(),
+                        "A refund failed and we returned the recovered funds to the service",
+                        githubId,
+                        charge.getGatewayAccountId(),
+                        timestamp,
+                        0L,
+                        0L,
+                        charge.getReference(),
+                        zendeskId
+                ),
+                Instant.now()
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccount.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccount.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.events.eventdetails.refund.RefundFailureFundsSentToConnectAccountEventDetails;
+import uk.gov.pay.connector.events.model.charge.PaymentEvent;
+import uk.gov.pay.connector.refund.model.domain.Refund;
+
+import java.time.Instant;
+
+public class RefundFailureFundsSentToConnectAccount extends PaymentEvent {
+    private RefundFailureFundsSentToConnectAccount(String serviceId, boolean live, Long gatewayAccountId,
+                                                   String resourceExternalId,
+                                                   RefundFailureFundsSentToConnectAccountEventDetails eventDetails,
+                                                   Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
+
+    }
+
+
+    public static RefundFailureFundsSentToConnectAccount from(Refund refund, Charge charge, String githubUserId, String zendeskId) {
+        return new RefundFailureFundsSentToConnectAccount(
+                charge.getServiceId(),
+                charge.isLive(),
+                charge.getGatewayAccountId(),
+                charge.getExternalId(),
+                new RefundFailureFundsSentToConnectAccountEventDetails(
+                        refund.getAmount(),
+                        charge.getReference(),
+                        "Failed refund correction for payment.",
+                        githubUserId,
+                        "A refund failed and we returned the recovered funds to the service",
+                        charge.getPaymentGatewayName(),
+                        charge.getGatewayAccountId(),
+                        charge.getGatewayTransactionId(),
+                        zendeskId
+                ),
+                Instant.now()
+        );
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundStatusCorrectedToErrorByAdmin.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundStatusCorrectedToErrorByAdmin.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.events.eventdetails.refund.RefundStatusCorrectedToErrorByAdminEventDetails;
+import uk.gov.pay.connector.refund.model.domain.GithubAndZendeskCredential;
+import uk.gov.pay.connector.refund.model.domain.Refund;
+
+import java.time.Instant;
+
+public class RefundStatusCorrectedToErrorByAdmin extends RefundEvent {
+    private RefundStatusCorrectedToErrorByAdmin(String serviceId, boolean live, Long gatewayAccountId,
+                                                String resourceExternalId, String parentResourceExternalId,
+                                                RefundStatusCorrectedToErrorByAdminEventDetails eventDetails,
+                                                Instant timestamp) {
+        super(serviceId, live, gatewayAccountId, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
+    }
+
+    public static RefundStatusCorrectedToErrorByAdmin from(Refund refund, Charge charge, String githubId, String zendeskId) {
+        return new RefundStatusCorrectedToErrorByAdmin(
+                charge.getServiceId(),
+                charge.isLive(),
+                charge.getGatewayAccountId(),
+                refund.getExternalId(),
+                refund.getChargeExternalId(),
+                new RefundStatusCorrectedToErrorByAdminEventDetails(
+                        "Correct refund status to match Stripe",
+                        githubId,
+                        zendeskId
+                ),
+                Instant.now()
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/GithubAndZendeskCredential.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/GithubAndZendeskCredential.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.connector.refund.model.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GithubAndZendeskCredential(@JsonProperty("zendesk_ticket_id") String zendeskTicketId,
+                                         @JsonProperty("github_user_id") String githubUserId) {
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdminTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdminTest.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.events.eventdetails.refund.PaymentStatusCorrectedToSuccessByAdminEventDetails;
+import uk.gov.pay.connector.model.domain.RefundEntityFixture;
+import uk.gov.pay.connector.refund.model.domain.GithubAndZendeskCredential;
+import uk.gov.pay.connector.refund.model.domain.Refund;
+
+import java.time.Instant;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
+
+class PaymentStatusCorrectedToSuccessByAdminTest {
+    @Test
+    void shouldCreatePaymentStatusCorrectedToSuccessByAdminEventFromRefundAndCharge() {
+
+        Instant fixedTimestamp = Instant.now();
+
+        ChargeEntityFixture chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
+                .withServiceId("service-id")
+                .withGatewayAccountEntity(aGatewayAccountEntity().withType(LIVE).build());
+
+        Charge charge = Charge.from(chargeEntityFixture.build());
+
+        Refund refund = Refund.from(RefundEntityFixture.aValidRefundEntity()
+                .withChargeExternalId(charge.getExternalId())
+                .withGatewayTransactionId("gateway-transaction-id")
+                .build());
+        GithubAndZendeskCredential githubAndZendeskCredential = new GithubAndZendeskCredential("1223333343", "John Doe (JohnDoeGds)");
+
+        String githubUserId = githubAndZendeskCredential.githubUserId();
+        String zendeskId = githubAndZendeskCredential.zendeskTicketId();
+
+        PaymentStatusCorrectedToSuccessByAdmin paymentStatusCorrectedToSuccessByAdmin = PaymentStatusCorrectedToSuccessByAdmin
+                .from(refund, charge, fixedTimestamp, githubUserId, zendeskId);
+
+        assertThat(paymentStatusCorrectedToSuccessByAdmin.isLive(), is(true));
+        assertThat(paymentStatusCorrectedToSuccessByAdmin.getGatewayAccountId(), is(charge.getGatewayAccountId()));
+        assertThat(paymentStatusCorrectedToSuccessByAdmin.getResourceExternalId(), is(charge.getExternalId()));
+
+        PaymentStatusCorrectedToSuccessByAdminEventDetails details = (PaymentStatusCorrectedToSuccessByAdminEventDetails) paymentStatusCorrectedToSuccessByAdmin.getEventDetails();
+
+        assertThat(details.getFee(), is(0L));
+        assertThat(details.getAdminGithubId(), is("John Doe (JohnDoeGds)"));
+        assertThat(details.getZendeskId(), is("1223333343"));
+        assertThat(details.getUpdatedReason(), is("A refund failed and we returned the recovered funds to the service"));
+        assertThat(details.getCapturedDate(), is(fixedTimestamp));
+        assertThat(details.getNetAmount(), is(charge.getAmount()));
+        assertThat(details.getRefundAmountAvailable(), is(0L));
+        assertThat(details.getRefundAmountRefunded(), is(0L));
+        assertThat(details.getRefundStatus(), is(refund.getExternalStatus()));
+        assertThat(details.getGatewayAccountId(), is(charge.getGatewayAccountId()));
+        assertThat(details.getCaptureSubmittedDate(), is(fixedTimestamp));
+        assertThat(details.getReference(), is(charge.getReference()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccountTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccountTest.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.events.eventdetails.refund.RefundFailureFundsSentToConnectAccountEventDetails;
+import uk.gov.pay.connector.model.domain.RefundEntityFixture;
+import uk.gov.pay.connector.refund.model.domain.GithubAndZendeskCredential;
+import uk.gov.pay.connector.refund.model.domain.Refund;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
+
+class RefundFailureFundsSentToConnectAccountTest {
+
+    @Test
+    void shouldCreateRefundFailureFundsSentToConnectAccountEventFromRefundAndCharge() {
+
+        ChargeEntityFixture chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
+                .withServiceId("service-id")
+                .withGatewayAccountEntity(aGatewayAccountEntity().withType(LIVE).build());
+
+
+        Charge charge = Charge.from(chargeEntityFixture.withPaymentProvider(STRIPE.getName()).build());
+
+        Refund refund = Refund.from(RefundEntityFixture.aValidRefundEntity()
+                .withChargeExternalId(charge.getExternalId())
+                .withGatewayTransactionId("gateway-transaction-id")
+                .build());
+
+        GithubAndZendeskCredential githubAndZendeskCredential = new GithubAndZendeskCredential("1223333343", "John Doe (JohnDoeGds)");
+
+        String githubUserId = githubAndZendeskCredential.githubUserId();
+        String zendeskId = githubAndZendeskCredential.zendeskTicketId();
+
+        RefundFailureFundsSentToConnectAccount refundFailureFundsSentToConnectAccount = RefundFailureFundsSentToConnectAccount
+                .from(refund, charge, githubUserId, zendeskId);
+
+        assertThat(refundFailureFundsSentToConnectAccount.getResourceExternalId(), is(charge.getExternalId()));
+        assertThat(refundFailureFundsSentToConnectAccount.isLive(), is(true));
+        assertThat(refundFailureFundsSentToConnectAccount.getGatewayAccountId(), is(charge.getGatewayAccountId()));
+        assertThat(refundFailureFundsSentToConnectAccount.getResourceExternalId(), is(refund.getChargeExternalId()));
+
+        RefundFailureFundsSentToConnectAccountEventDetails details = (RefundFailureFundsSentToConnectAccountEventDetails) refundFailureFundsSentToConnectAccount.getEventDetails();
+
+        assertThat(details.getAmount(), is(refund.getAmount()));
+        assertThat(details.getAdminGithubId(), is("John Doe (JohnDoeGds)"));
+        assertThat(details.getZendeskId(), is("1223333343"));
+        assertThat(details.getUpdatedReason(), is("A refund failed and we returned the recovered funds to the service"));
+        assertThat(details.getGatewayAccountId(), is(charge.getGatewayAccountId()));
+        assertThat(details.getPaymentProvider(), is(charge.getPaymentGatewayName()));
+        assertThat(details.getReference(), is(charge.getReference()));
+        assertThat(details.getDescription(), is("Failed refund correction for payment."));
+        assertThat(details.getGatewayTransactionId(), is(charge.getGatewayTransactionId()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundStatusCorrectedToErrorByAdminTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundStatusCorrectedToErrorByAdminTest.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.events.eventdetails.refund.RefundStatusCorrectedToErrorByAdminEventDetails;
+import uk.gov.pay.connector.model.domain.RefundEntityFixture;
+import uk.gov.pay.connector.refund.model.domain.GithubAndZendeskCredential;
+import uk.gov.pay.connector.refund.model.domain.Refund;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
+
+class RefundStatusCorrectedToErrorByAdminTest {
+    @Test
+    void shouldCreateRefundStatusCorrectedToErrorByAdminEventFromRefundAndCharge() {
+
+        ChargeEntityFixture chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
+                .withServiceId("service-id")
+                .withGatewayAccountEntity(aGatewayAccountEntity().withType(LIVE).build());
+
+
+        Charge charge = Charge.from(chargeEntityFixture.build());
+
+        Refund refund = Refund.from(RefundEntityFixture.aValidRefundEntity()
+                .withChargeExternalId(charge.getExternalId())
+                .withGatewayTransactionId("gateway-transaction-id")
+                .build());
+
+        GithubAndZendeskCredential githubAndZendeskCredential = new GithubAndZendeskCredential("1223333343", "John Doe (JohnDoeGds)");
+
+        String githubUserId = githubAndZendeskCredential.githubUserId();
+        String zendeskId = githubAndZendeskCredential.zendeskTicketId();
+
+        RefundStatusCorrectedToErrorByAdmin refundStatusCorrectedToErrorByAdmin = RefundStatusCorrectedToErrorByAdmin
+                .from(refund, charge, githubUserId, zendeskId);
+
+        assertThat(refundStatusCorrectedToErrorByAdmin.getParentResourceExternalId(), is(charge.getExternalId()));
+        assertThat(refundStatusCorrectedToErrorByAdmin.isLive(), is(true));
+        assertThat(refundStatusCorrectedToErrorByAdmin.getGatewayAccountId(), is(charge.getGatewayAccountId()));
+        assertThat(refundStatusCorrectedToErrorByAdmin.getResourceExternalId(), is(refund.getExternalId()));
+        assertThat(refundStatusCorrectedToErrorByAdmin.getParentResourceExternalId(), is(refund.getChargeExternalId()));
+
+        RefundStatusCorrectedToErrorByAdminEventDetails details = (RefundStatusCorrectedToErrorByAdminEventDetails)
+                refundStatusCorrectedToErrorByAdmin.getEventDetails();
+
+        assertThat(details.getUpdatedReason(), is("Correct refund status to match Stripe"));
+        assertThat(details.getAdminGithubId(), is("John Doe (JohnDoeGds)"));
+        assertThat(details.getZendeskId(), is("1223333343"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/RefundReversalResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/RefundReversalResourceIT.java
@@ -47,7 +47,7 @@ import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidL
 
 public class RefundReversalResourceIT {
     private static final StripeSdkClientFactory mockStripeSdkClientFactory = mock(StripeSdkClientFactory.class);
-    private static RandomIdGenerator mockRandomIdGenerator = mock(RandomIdGenerator.class);
+    private static final RandomIdGenerator mockRandomIdGenerator = mock(RandomIdGenerator.class);
 
     // App must be instantiated after mock is set
     @RegisterExtension
@@ -85,6 +85,7 @@ public class RefundReversalResourceIT {
                 .build();
 
         refund = aValidLedgerTransaction()
+                .withAmount(50L)
                 .withExternalId(REFUND_EXTERNAL_ID)
                 .withGatewayAccountId(Long.parseLong(testBaseExtension.getAccountId()))
                 .withParentTransactionId(CHARGE_EXTERNAL_ID)
@@ -124,6 +125,11 @@ public class RefundReversalResourceIT {
         ValidatableResponse response = given().port(app.getLocalPort())
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
+                .body("""
+                 {
+                        "zendesk_ticket_id": "1223333343",
+                        "github_user_id": "John Doe"
+                 }""")
                 .post("/v1/api/accounts/{gatewayAccountId}/charges/{chargeId}/refunds/{refundId}/reverse-failed"
                         .replace("{gatewayAccountId}", testBaseExtension.getAccountId())
                         .replace("{chargeId}", CHARGE_EXTERNAL_ID)
@@ -131,7 +137,7 @@ public class RefundReversalResourceIT {
                 .then();
         response.statusCode(Response.Status.OK.getStatusCode());
     }
-    
+
     @Test
     void shouldReturnInternalErrorWhenRefundNotFoundFromStripe() throws JsonProcessingException, StripeException {
         app.getLedgerStub().returnLedgerTransaction(CHARGE_EXTERNAL_ID, charge);
@@ -186,6 +192,11 @@ public class RefundReversalResourceIT {
         given().port(app.getLocalPort())
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
+                .body("""
+                 {
+                        "zendesk_ticket_id": "1223333343",
+                        "github_user_id": "John Doe"
+                 }""")
                 .post("/v1/api/accounts/{gatewayAccountId}/charges/{chargeId}/refunds/{refundId}/reverse-failed"
                         .replace("{gatewayAccountId}", testBaseExtension.getAccountId())
                         .replace("{chargeId}", CHARGE_EXTERNAL_ID)
@@ -195,7 +206,7 @@ public class RefundReversalResourceIT {
                 .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()
                 );
     }
-    
+
     @Test
     void shouldReturnErrorWhenInsufficientFunds() throws JsonProcessingException, StripeException {
         app.getLedgerStub().returnLedgerTransaction(CHARGE_EXTERNAL_ID, charge);
@@ -246,6 +257,11 @@ public class RefundReversalResourceIT {
         given().port(app.getLocalPort())
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
+                .body("""
+                 {
+                        "zendesk_ticket_id": "1223333343",
+                        "github_user_id": "John Doe"
+                 }""")
                 .post("/v1/api/accounts/{gatewayAccountId}/charges/{chargeId}/refunds/{refundId}/reverse-failed"
                         .replace("{gatewayAccountId}", testBaseExtension.getAccountId())
                         .replace("{chargeId}", CHARGE_EXTERNAL_ID)
@@ -304,6 +320,11 @@ public class RefundReversalResourceIT {
         given().port(app.getLocalPort())
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
+                .body("""
+                 {
+                        "zendesk_ticket_id": "1223333343",
+                        "github_user_id": "John Doe"
+                 }""")
                 .post("/v1/api/accounts/{gatewayAccountId}/charges/{chargeId}/refunds/{refundId}/reverse-failed"
                         .replace("{gatewayAccountId}", testBaseExtension.getAccountId())
                         .replace("{chargeId}", CHARGE_EXTERNAL_ID)


### PR DESCRIPTION
## Background
- A Stripe refund succeeded initially but later failed asynchronously. We do not handle this failure case automatically
- Funds for a refund are taken from our Stripe platform account as soon as the request to make the refund succeeds. We then make a transfer from the service’s connect account to our platform account. If the refund later fails, Stripe returns the money to our platform account.
- To correct this, we need to make a new transfer from our platform account to the connect account.
- We then add a new payment into Pay with required details

## WHAT YOU DID
- Added events for `RefundFailureFundsSentToConnectAccount`, `RefundStatusCorrectedToErrorByAdmin` and `PaymentStatusCorrectedToSuccessByAdmin` 
- Called these events in `RefundReversalService` to be posted to Ledger
