### PR TITLE
PP-13051 Add CORPORATE back to Exemption3dsType

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Exemption3dsType.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Exemption3dsType.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 public enum Exemption3dsType {
-    OPTIMISED
+    OPTIMISED,
+    CORPORATE
 }


### PR DESCRIPTION
Between commit dcedf7d17a1cf024a961a79a5e4cabd9fb0a4e15 (which added `CORPORATE` to the `Exemption3dsType` enum) and commit 7d4a04e2b24cd80043e954bed91182cadec87617 (which removed it), some `CORPORATE` values were persisted to the `exemption_3ds_requested` column of the `charges` table in the database.

Add back `CORPORATE` to `Exemption3dsType` so these charges can be successfully read from the database in the application.