### PR TITLE
PP-13217 Expunge 0p payments in capture submitted state

### DIFF
--- a/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
@@ -61,6 +61,8 @@ public class ChargeExpungeService {
             SYSTEM_CANCEL_SUBMITTED,
             USER_CANCEL_SUBMITTED);
 
+    private final List<ChargeStatus> terminalStatesFor0pPayments = List.of(CAPTURE_SUBMITTED);
+
     @Inject
     public ChargeExpungeService(ChargeDao chargeDao, ConnectorConfiguration connectorConfiguration,
                                 ParityCheckService parityCheckService,
@@ -76,6 +78,10 @@ public class ChargeExpungeService {
         long ageInDays = ChronoUnit.DAYS.between(chargeEntity.getCreatedDate(), ZonedDateTime.now());
         boolean chargeIsHistoric = ageInDays > expungeConfig.getMinimumAgeForHistoricChargeExceptions();
         ChargeStatus status = ChargeStatus.fromString(chargeEntity.getStatus());
+
+        if(chargeEntity.getAmount() == 0 && terminalStatesFor0pPayments.contains(status)){
+            return true;
+        }
         if (chargeIsHistoric && historicChargeExceptionStatuses.contains(status)) {
             return true;
         }


### PR DESCRIPTION
## WHAT YOU DID
- For `0p` payments we don't get CAPTURED notifications from Worldpay as payments are never captured. So these charges stay in the connector and are expunged after 90 days which isn't necessary.

  Expunge 0p payments in CAPTURED_SUBMITTED state (after a day) along with other terminal payments.

