### PR TITLE
PP-13220 Use Instant instead of ZonedDateTime in payout code

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/payout/PayoutCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/payout/PayoutCreatedEventDetails.java
@@ -1,20 +1,20 @@
 package uk.gov.pay.connector.events.eventdetails.payout;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
+import uk.gov.service.payments.commons.api.json.IsoInstantMicrosecondSerializer;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PayoutCreatedEventDetails extends PayoutEventWithGatewayStatusDetails {
 
     private Long gatewayAccountId;
     private Long amount;
-    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
-    private ZonedDateTime estimatedArrivalDateInBank;
+    @JsonSerialize(using = IsoInstantMicrosecondSerializer.class)
+    private Instant estimatedArrivalDateInBank;
     private String destinationType;
     private String statementDescriptor;
 
-    public PayoutCreatedEventDetails(Long gatewayAccountId, Long amount, ZonedDateTime estimatedArrivalDateInBank, String gatewayStatus, String destinationType, String statementDescriptor) {
+    public PayoutCreatedEventDetails(Long gatewayAccountId, Long amount, Instant estimatedArrivalDateInBank, String gatewayStatus, String destinationType, String statementDescriptor) {
         super(gatewayStatus);
         this.gatewayAccountId = gatewayAccountId;
         this.amount = amount;
@@ -31,7 +31,7 @@ public class PayoutCreatedEventDetails extends PayoutEventWithGatewayStatusDetai
         return amount;
     }
 
-    public ZonedDateTime getEstimatedArrivalDateInBank() {
+    public Instant getEstimatedArrivalDateInBank() {
         return estimatedArrivalDateInBank;
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/payout/PayoutPaidEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/payout/PayoutPaidEventDetails.java
@@ -1,21 +1,21 @@
 package uk.gov.pay.connector.events.eventdetails.payout;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
+import uk.gov.service.payments.commons.api.json.IsoInstantMicrosecondSerializer;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PayoutPaidEventDetails extends PayoutEventWithGatewayStatusDetails {
 
-    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
-    private ZonedDateTime paidOutDate;
+    @JsonSerialize(using = IsoInstantMicrosecondSerializer.class)
+    private Instant paidOutDate;
 
-    public PayoutPaidEventDetails(ZonedDateTime paidOutDate, String gatewayStatus) {
+    public PayoutPaidEventDetails(Instant paidOutDate, String gatewayStatus) {
         super(gatewayStatus);
         this.paidOutDate = paidOutDate;
     }
 
-    public ZonedDateTime getPaidOutDate() {
+    public Instant getPaidOutDate() {
         return paidOutDate;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutCreated.java
@@ -21,6 +21,6 @@ public class PayoutCreated extends PayoutEvent {
                         payout.getStatus(),
                         payout.getType(),
                         payout.getStatementDescriptor()),
-                payout.getCreated().toInstant());
+                        payout.getCreated());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayout.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayout.java
@@ -5,10 +5,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.stripe.model.Payout;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Objects;
-
-import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -65,12 +63,12 @@ public class StripePayout {
         return amount;
     }
 
-    public ZonedDateTime getCreated() {
-        return toUTCZonedDateTime(created);
+    public Instant getCreated() {
+        return Instant.ofEpochSecond(created);
     }
 
-    public ZonedDateTime getArrivalDate() {
-        return toUTCZonedDateTime(arrivalDate);
+    public Instant getArrivalDate() {
+        return Instant.ofEpochSecond(arrivalDate);
     }
 
     public String getStatus() {

--- a/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
@@ -132,7 +132,7 @@ public class PayoutReconcileProcess {
         Payout payoutObject = (Payout) balanceTransaction.getSourceObject();
         StripePayout stripePayout = StripePayout.from(payoutObject);
 
-        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, stripePayout.getCreated().toInstant(),
+        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, stripePayout.getCreated(),
                 payoutReconcileMessage.getConnectAccountId(), stripePayout);
 
         emitTerminalPayoutEvent(payoutReconcileMessage.getConnectAccountId(), stripePayout);
@@ -149,7 +149,7 @@ public class PayoutReconcileProcess {
         if (stripePayoutStatus.isTerminal()) {
             Optional<Class<? extends PayoutEvent>> mayBeEventClass = stripePayoutStatus.getEventClass();
             mayBeEventClass.ifPresentOrElse(
-                    eventClass -> payoutEmitterService.emitPayoutEvent(eventClass, stripePayout.getCreated().toInstant(),
+                    eventClass -> payoutEmitterService.emitPayoutEvent(eventClass, stripePayout.getCreated(),
                             connectAccountId, stripePayout),
                     () -> LOGGER.warn("Event class is not available for a payout in terminal status. " +
                                     "gateway_payout_id [{}], connect_account_id [{}], status [{}]",
@@ -199,7 +199,7 @@ public class PayoutReconcileProcess {
     private void emitPaymentEvent(PayoutReconcileMessage payoutReconcileMessage, String paymentExternalId) {
         var paymentEvent = new PaymentIncludedInPayout(paymentExternalId,
                 payoutReconcileMessage.getGatewayPayoutId(),
-                payoutReconcileMessage.getCreatedDate().toInstant());
+                payoutReconcileMessage.getCreatedDate());
         emitEvent(paymentEvent, payoutReconcileMessage, paymentExternalId);
 
         LOGGER.info(format("Emitted event for payment [%s] included in payout [%s]",
@@ -211,7 +211,7 @@ public class PayoutReconcileProcess {
     private void emitRefundEvent(PayoutReconcileMessage payoutReconcileMessage, String refundExternalId) {
         var refundEvent = new RefundIncludedInPayout(refundExternalId,
                 payoutReconcileMessage.getGatewayPayoutId(),
-                payoutReconcileMessage.getCreatedDate().toInstant());
+                payoutReconcileMessage.getCreatedDate());
         emitEvent(refundEvent, payoutReconcileMessage, refundExternalId);
 
         LOGGER.info(format("Emitted event for refund [%s] included in payout [%s]",
@@ -223,7 +223,7 @@ public class PayoutReconcileProcess {
     private void emitDisputeEvent(PayoutReconcileMessage payoutReconcileMessage, String disputeExternalId) {
         var disputeEvent = new DisputeIncludedInPayout(disputeExternalId,
                 payoutReconcileMessage.getGatewayPayoutId(),
-                payoutReconcileMessage.getCreatedDate().toInstant());
+                payoutReconcileMessage.getCreatedDate());
         emitEvent(disputeEvent, payoutReconcileMessage, disputeExternalId);
 
         LOGGER.info(format("Emitted event for dispute [%s] included in payout [%s]",

--- a/src/main/java/uk/gov/pay/connector/queue/payout/Payout.java
+++ b/src/main/java/uk/gov/pay/connector/queue/payout/Payout.java
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeDeserializer;
-import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
+import uk.gov.service.payments.commons.api.json.IsoInstantMicrosecondDeserializer;
+import uk.gov.service.payments.commons.api.json.IsoInstantMicrosecondSerializer;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -17,14 +17,14 @@ public class Payout {
     private String gatewayPayoutId;
     private String connectAccountId;
 
-    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
-    @JsonDeserialize(using = MicrosecondPrecisionDateTimeDeserializer.class)
-    private ZonedDateTime createdDate;
+    @JsonSerialize(using = IsoInstantMicrosecondSerializer.class)
+    @JsonDeserialize(using = IsoInstantMicrosecondDeserializer.class)
+    private Instant createdDate;
 
     public Payout() {
     }
 
-    public Payout(String gatewayPayoutId, String connectAccountId, ZonedDateTime createdDate) {
+    public Payout(String gatewayPayoutId, String connectAccountId, Instant createdDate) {
         this.gatewayPayoutId = gatewayPayoutId;
         this.connectAccountId = connectAccountId;
         this.createdDate = createdDate;
@@ -38,7 +38,7 @@ public class Payout {
         return connectAccountId;
     }
 
-    public ZonedDateTime getCreatedDate() {
+    public Instant getCreatedDate() {
         return createdDate;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/payout/PayoutReconcileMessage.java
+++ b/src/main/java/uk/gov/pay/connector/queue/payout/PayoutReconcileMessage.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.queue.payout;
 
 import uk.gov.service.payments.commons.queue.model.QueueMessage;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class PayoutReconcileMessage {
     private Payout payout;
@@ -25,7 +25,9 @@ public class PayoutReconcileMessage {
         return payout.getConnectAccountId();
     }
     
-    public ZonedDateTime getCreatedDate() { return payout.getCreatedDate(); }
+    public Instant getCreatedDate() {
+        return payout.getCreatedDate();
+    }
 
     public String getQueueMessageReceiptHandle() {
         return queueMessage.getReceiptHandle();
@@ -38,4 +40,5 @@ public class PayoutReconcileMessage {
     public QueueMessage getQueueMessage() {
         return queueMessage;
     }
+
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
@@ -300,7 +300,7 @@ class StripeNotificationServiceTest {
         Payout payout = payoutArgumentCaptor.getValue();
         assertThat(payout.getGatewayPayoutId(), is("po_aaaaaaaaaaaaaaaaaaaaa"));
         assertThat(payout.getConnectAccountId(), is("connect_account_id"));
-        assertThat(payout.getCreatedDate(), is(ZonedDateTime.parse("2020-03-24T01:30:46Z")));
+        assertThat(payout.getCreatedDate(), is(Instant.parse("2020-03-24T01:30:46Z")));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/queue/payout/PayoutReconcileQueueTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/payout/PayoutReconcileQueueTest.java
@@ -15,7 +15,7 @@ import uk.gov.service.payments.commons.queue.exception.QueueException;
 import uk.gov.service.payments.commons.queue.model.QueueMessage;
 import uk.gov.service.payments.commons.queue.sqs.SqsQueueService;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
@@ -63,12 +63,12 @@ class PayoutReconcileQueueTest {
         assertNotNull(payoutReconcileMessages);
         assertEquals("payout-id", payoutReconcileMessages.get(0).getGatewayPayoutId());
         assertEquals("connect-accnt-id", payoutReconcileMessages.get(0).getConnectAccountId());
-        assertEquals(ZonedDateTime.parse("2020-05-01T10:30:00.000Z"), payoutReconcileMessages.get(0).getCreatedDate());
+        assertEquals(Instant.parse("2020-05-01T10:30:00.000Z"), payoutReconcileMessages.get(0).getCreatedDate());
     }
 
     @Test
     void shouldSendValidSerialisedPayoutToQueue() throws QueueException, JsonProcessingException {
-        Payout payout = new Payout("payout-id", "connect-accnt-id", ZonedDateTime.parse("2020-05-01T10:30:00.000Z"));
+        Payout payout = new Payout("payout-id", "connect-accnt-id", Instant.parse("2020-05-01T10:30:00.000Z"));
         when(sqsQueueService.sendMessage(anyString(), anyString())).thenReturn(mock(QueueMessage.class));
 
         payoutReconcileQueue.sendPayout(payout);


### PR DESCRIPTION
Use `Instant` instead of `ZonedDateTime` in the (Stripe) payout code because they’re only used as timestamps and time zone support is unnecessary.

This introduces a small behaviour change in that the code will no longer tolerate the `"arrival_date"` or `"created"` properties in the Stripe Payout object being null. However, [Stripe’s docs](https://docs.stripe.com/api/payouts/object) say they should never be null so let’s hope they’re telling the truth.