### PR TITLE
PP-13220 Use Instant instead of ZonedDateTime in dispute code

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/dispute/DisputeCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/dispute/DisputeCreatedEventDetails.java
@@ -1,19 +1,19 @@
 package uk.gov.pay.connector.events.eventdetails.dispute;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
+import uk.gov.service.payments.commons.api.json.IsoInstantMicrosecondSerializer;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Objects;
 
 public class DisputeCreatedEventDetails extends DisputeEventDetails {
-    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
-    private final ZonedDateTime evidenceDueDate;
+    @JsonSerialize(using = IsoInstantMicrosecondSerializer.class)
+    private final Instant evidenceDueDate;
     private final Long amount;
     private final String reason;
     private final String gatewayTransactionId;
 
-    public DisputeCreatedEventDetails(ZonedDateTime evidenceDueDate, String gatewayAccountId, Long amount,
+    public DisputeCreatedEventDetails(Instant evidenceDueDate, String gatewayAccountId, Long amount,
                                       String reason, String gatewayTransactionId) {
         super(gatewayAccountId);
         this.evidenceDueDate = evidenceDueDate;
@@ -22,7 +22,7 @@ public class DisputeCreatedEventDetails extends DisputeEventDetails {
         this.gatewayTransactionId = gatewayTransactionId;
     }
 
-    public ZonedDateTime getEvidenceDueDate() {
+    public Instant getEvidenceDueDate() {
         return evidenceDueDate;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeDisputeData.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeDisputeData.java
@@ -6,10 +6,8 @@ import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 import uk.gov.pay.connector.queue.tasks.dispute.Evidence;
 import uk.gov.pay.connector.queue.tasks.dispute.EvidenceDetails;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
-
-import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StripeDisputeData {
@@ -80,8 +78,8 @@ public class StripeDisputeData {
         return reason;
     }
 
-    public ZonedDateTime getDisputeCreated() {
-        return toUTCZonedDateTime(created);
+    public Instant getDisputeCreated() {
+        return Instant.ofEpochSecond(created);
     }
 
     public List<BalanceTransaction> getBalanceTransactionList() {

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/EvidenceDetails.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/dispute/EvidenceDetails.java
@@ -3,9 +3,7 @@ package uk.gov.pay.connector.queue.tasks.dispute;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.ZonedDateTime;
-
-import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
+import java.time.Instant;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EvidenceDetails {
@@ -20,7 +18,8 @@ public class EvidenceDetails {
         this.dueByTimestamp = dueByTimestamp;
     }
 
-    public ZonedDateTime getEvidenceDueByDate() {
-        return toUTCZonedDateTime(dueByTimestamp);
+    public Instant getEvidenceDueByDate() {
+        return dueByTimestamp != null ? Instant.ofEpochSecond(dueByTimestamp) : null;
     }
+
 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
@@ -121,9 +121,9 @@ public class StripeWebhookTaskHandler {
                 switch (stripeNotificationType) {
                     case DISPUTE_CREATED:
                         DisputeCreated disputeCreatedEvent = DisputeCreated.from(disputeExternalId, stripeDisputeData, transaction,
-                                stripeDisputeData.getDisputeCreated().toInstant());
+                                stripeDisputeData.getDisputeCreated());
                         emitEvent(disputeCreatedEvent);
-                        PaymentDisputed paymentDisputedEvent = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated().toInstant());
+                        PaymentDisputed paymentDisputedEvent = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated());
                         emitEvent(paymentDisputedEvent);
                         // NOTE: we update the refund availability in ledger - but for connector it is calculated separately.
                         // So this status update will block a refund attempt made VIA the API is made if the charge has been
@@ -206,8 +206,8 @@ public class StripeWebhookTaskHandler {
     }
 
     private boolean shouldRechargeDispute(StripeDisputeData stripeDisputeData, LedgerTransaction transaction) {
-        return (transaction.getLive() && stripeDisputeData.getDisputeCreated().toInstant().isAfter(stripeGatewayConfig.getRechargeServicesForLivePaymentDisputesFromDate())) ||
-                (!transaction.getLive() && stripeDisputeData.getDisputeCreated().toInstant().isAfter(stripeGatewayConfig.getRechargeServicesForTestPaymentDisputesFromDate()));
+        return (transaction.getLive() && stripeDisputeData.getDisputeCreated().isAfter(stripeGatewayConfig.getRechargeServicesForLivePaymentDisputesFromDate())) ||
+                (!transaction.getLive() && stripeDisputeData.getDisputeCreated().isAfter(stripeGatewayConfig.getRechargeServicesForTestPaymentDisputesFromDate()));
     }
 
     private void submitEvidenceForTestAccount(StripeDisputeData stripeDisputeData, LedgerTransaction transaction) {

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -68,7 +68,6 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
-import static java.time.ZonedDateTime.parse;
 import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.defaultCardDetails;
@@ -458,7 +457,7 @@ public class QueueMessageContractTest {
     @PactVerifyProvider("a dispute created event")
     public String verifyDisputeCreatedEvent() throws JsonProcessingException {
         DisputeCreatedEventDetails eventDetails =
-                new DisputeCreatedEventDetails(parse("2022-02-14T23:59:59.000Z"), "a-gateway-account-id",
+                new DisputeCreatedEventDetails(Instant.parse("2022-02-14T23:59:59.000Z"), "a-gateway-account-id",
                         6500L, "duplicate", "du_1LIaq8Dv3CZEaFO2MNQJK333");
         DisputeCreated disputeCreated =
                 new DisputeCreated("resource-external-id", "external-id", "service-id",

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/StripeWebhookTaskHandlerTest.java
@@ -136,8 +136,8 @@ public class StripeWebhookTaskHandlerTest {
 
         String resourceExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeData.getId());
         var disputeCreated = DisputeCreated.from(resourceExternalId, stripeDisputeData, transaction,
-                stripeDisputeData.getDisputeCreated().toInstant());
-        var paymentDisputed = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated().toInstant());
+                stripeDisputeData.getDisputeCreated());
+        var paymentDisputed = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated());
         var refundAvailabilityUpdated = RefundAvailabilityUpdated.from(
                 transaction, ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE, Instant.parse(fixedDateTime));
 
@@ -614,8 +614,8 @@ public class StripeWebhookTaskHandlerTest {
 
         String resourceExternalId = RandomIdGenerator.idFromExternalId(stripeDisputeData.getId());
         var disputeCreated = DisputeCreated.from(resourceExternalId, stripeDisputeData, transaction,
-                stripeDisputeData.getDisputeCreated().toInstant());
-        var paymentDisputed = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated().toInstant());
+                stripeDisputeData.getDisputeCreated());
+        var paymentDisputed = PaymentDisputed.from(transaction, stripeDisputeData.getDisputeCreated());
         var refundAvailabilityUpdated = RefundAvailabilityUpdated.from(
                 transaction, ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE, Instant.parse(fixedDateTime));
 


### PR DESCRIPTION
Use `Instant` instead of `ZonedDateTime` in the (Stripe) dispute code because they’re only used as timestamps and time zone support is unnecessary.

According to [Stripe’s docs](https://docs.stripe.com/api/disputes/object#dispute_object-evidence_details), `dispute.evidence_details.due_by` can be null so continue to handle this when converting to an `Instant` in `getEvidenceDueByDate()` in `EvidenceDetails` (as we did when we converted to a `ZonedDateTime`).