### PR TITLE
PP-13220 Use Instant instead of ZonedDateTime in EventDetails

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CaptureConfirmedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CaptureConfirmedEventDetails.java
@@ -1,22 +1,23 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.service.payments.commons.api.json.IsoInstantMicrosecondSerializer;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 public class CaptureConfirmedEventDetails extends EventDetails {
-    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
-    private final ZonedDateTime gatewayEventDate;
-    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
-    private final ZonedDateTime capturedDate;
+    @JsonSerialize(using = IsoInstantMicrosecondSerializer.class)
+    private final Instant gatewayEventDate;
+    @JsonSerialize(using = IsoInstantMicrosecondSerializer.class)
+    private final Instant capturedDate;
     private final Long fee;
     private final Long netAmount;
 
 
-    public CaptureConfirmedEventDetails(ZonedDateTime gatewayEventDate, ZonedDateTime capturedDate, Long fee, Long netAmount) {
+    public CaptureConfirmedEventDetails(Instant gatewayEventDate, Instant capturedDate, Long fee, Long netAmount) {
         this.gatewayEventDate = gatewayEventDate;
         this.capturedDate = capturedDate;
         this.fee = fee;
@@ -26,25 +27,25 @@ public class CaptureConfirmedEventDetails extends EventDetails {
     public static CaptureConfirmedEventDetails from(ChargeEventEntity chargeEvent) {
         if (chargeEvent.getChargeEntity().getFees().size() > 1) {
             return new CaptureConfirmedEventDetails(
-                    chargeEvent.getGatewayEventDate().orElse(null),
-                    chargeEvent.getUpdated(),
+                    chargeEvent.getGatewayEventDate().map(ZonedDateTime::toInstant).orElse(null),
+                    chargeEvent.getUpdated().toInstant(),
                     null,
                     null
             );
         }
         return new CaptureConfirmedEventDetails(
-                chargeEvent.getGatewayEventDate().orElse(null),
-                chargeEvent.getUpdated(),
+                chargeEvent.getGatewayEventDate().map(ZonedDateTime::toInstant).orElse(null),
+                chargeEvent.getUpdated().toInstant(),
                 chargeEvent.getChargeEntity().getFeeAmount().orElse(null),
                 chargeEvent.getChargeEntity().getNetAmount().orElse(null)
         );
     }
 
-    public ZonedDateTime getCapturedDate() {
+    public Instant getCapturedDate() {
         return capturedDate;
     }
 
-    public ZonedDateTime getGatewayEventDate() {
+    public Instant getGatewayEventDate() {
         return gatewayEventDate;
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CaptureSubmittedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CaptureSubmittedEventDetails.java
@@ -1,25 +1,25 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.service.payments.commons.api.json.IsoInstantMicrosecondSerializer;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 public class CaptureSubmittedEventDetails extends EventDetails {
-    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
-    private final ZonedDateTime captureSubmittedDate;
+    @JsonSerialize(using = IsoInstantMicrosecondSerializer.class)
+    private final Instant captureSubmittedDate;
 
-    private CaptureSubmittedEventDetails(ZonedDateTime captureSubmittedDate) {
+    private CaptureSubmittedEventDetails(Instant captureSubmittedDate) {
         this.captureSubmittedDate = captureSubmittedDate;
     }
 
     public static CaptureSubmittedEventDetails from(ChargeEventEntity chargeEvent) {
-        return new CaptureSubmittedEventDetails(chargeEvent.getUpdated());
+        return new CaptureSubmittedEventDetails(chargeEvent.getUpdated().toInstant());
     }
 
-    public ZonedDateTime getCaptureSubmittedDate() {
+    public Instant getCaptureSubmittedDate() {
         return captureSubmittedDate;
     }
 }


### PR DESCRIPTION
Use `Instant` instead of `ZonedDateTime` in the `EventDetails` subclasses because they’re only used as timestamps and time zone support is unnecessary.