### PR TITLE
WIP-PP-13247-expand-charge-for-refund-object-properly

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundStatusCorrectedToErrorByAdminEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundStatusCorrectedToErrorByAdminEventDetails.java
@@ -37,4 +37,13 @@ public class RefundStatusCorrectedToErrorByAdminEventDetails extends EventDetail
     public void setZendeskId(String zendeskId) {
         this.zendeskId = zendeskId;
     }
+
+    @Override
+    public String toString() {
+        return "RefundStatusCorrectedToErrorByAdminEventDetails{" +
+                "updatedReason='" + updatedReason + '\'' +
+                ", adminGithubId='" + adminGithubId + '\'' +
+                ", zendeskId='" + zendeskId + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundStatusCorrectedToErrorByAdmin.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundStatusCorrectedToErrorByAdmin.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.refund.model.domain.Refund;
 import java.time.Instant;
 
 public class RefundStatusCorrectedToErrorByAdmin extends RefundEvent {
+    
     private RefundStatusCorrectedToErrorByAdmin(String serviceId, boolean live, Long gatewayAccountId,
                                                 String resourceExternalId, String parentResourceExternalId,
                                                 RefundStatusCorrectedToErrorByAdminEventDetails eventDetails,

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalService.java
@@ -2,8 +2,16 @@ package uk.gov.pay.connector.refund.service;
 
 
 import com.stripe.exception.StripeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.agreement.model.builder.AgreementResponseBuilder;
 import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.agreement.AgreementCreated;
+import uk.gov.pay.connector.events.model.agreement.AgreementInactivated;
 import uk.gov.pay.connector.events.model.refund.PaymentStatusCorrectedToSuccessByAdmin;
 import uk.gov.pay.connector.events.model.refund.RefundFailureFundsSentToConnectAccount;
 import uk.gov.pay.connector.events.model.refund.RefundStatusCorrectedToErrorByAdmin;

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalStripeConnectTransferRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalStripeConnectTransferRequestBuilder.java
@@ -19,7 +19,7 @@ public class RefundReversalStripeConnectTransferRequestBuilder {
 
     public Map<String, Object> createRequest(com.stripe.model.Refund refundFromStripe) {
         String stripeChargeId = refundFromStripe.getChargeObject().getId();
-        String destination = refundFromStripe.getChargeObject().getOnBehalfOfObject().getId();
+        String destination = refundFromStripe.getChargeObject().getOnBehalfOf();
         String transferGroup = refundFromStripe.getChargeObject().getTransferGroup();
         long amount = refundFromStripe.getAmount();
         String currency = refundFromStripe.getCurrency();
@@ -30,11 +30,11 @@ public class RefundReversalStripeConnectTransferRequestBuilder {
                 "destination", destination,
                 "amount", amount,
                 "metadata", Map.of(
-                        "stripeChargeId", stripeChargeId,
-                        "correctionPaymentId", correctionPaymentId
+                        "stripe_charge_id", stripeChargeId,
+                        "correction_payment_id", correctionPaymentId
                 ),
                 "currency", currency,
-                "transferGroup", transferGroup,
+                "transfer_group", transferGroup,
                 "expand", List.of("balance_transaction", "destination_payment")
         );
 

--- a/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
+++ b/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
@@ -290,6 +290,9 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
     public LedgerStub getLedgerStub() {
         return ledgerStub;
     }
+    public WireMockServer getLedgerWireMockServer() {
+        return ledgerWireMockServer;
+    }
     
     public CardidStub getCardidStub() {
         return cardidStub;

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/RefundReversalResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/RefundReversalResourceIT.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.it.resources.stripe;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.stripe.Stripe;
 import com.stripe.exception.ApiException;
 import com.stripe.exception.CardException;
 import com.stripe.exception.IdempotencyException;
@@ -28,6 +29,7 @@ import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.stripe.StripeSdkClient;
 import uk.gov.pay.connector.gateway.stripe.StripeSdkClientFactory;
 import uk.gov.pay.connector.it.base.ITestBaseExtension;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import javax.ws.rs.WebApplicationException;
@@ -36,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
+import static org.apache.http.client.methods.RequestBuilder.post;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -116,8 +119,7 @@ public class RefundReversalResourceIT {
         when(mockStripeRefund.getChargeObject()).thenReturn(mockedStripeCharge);
 
         when(mockedStripeCharge.getId()).thenReturn("ch_sdkhdg887s");
-        when(mockedStripeCharge.getOnBehalfOfObject()).thenReturn(mockedStripeAccount);
-        when(mockedStripeAccount.getId()).thenReturn("acct_jdsa7789d");
+        when(mockedStripeCharge.getOnBehalfOf()).thenReturn("acct_jdsa7789d");
         when(mockedStripeCharge.getTransferGroup()).thenReturn("abc");
         when(mockStripeRefund.getAmount()).thenReturn(100L);
         when(mockStripeRefund.getCurrency()).thenReturn("GBP");

--- a/src/test/java/uk/gov/pay/connector/service/RefundReversalServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundReversalServiceTest.java
@@ -1,253 +1,253 @@
-package uk.gov.pay.connector.service;
-
-import com.stripe.exception.StripeException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
-import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
-import uk.gov.pay.connector.client.ledger.service.LedgerService;
-import uk.gov.pay.connector.common.model.api.ErrorResponse;
-import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
-import uk.gov.pay.connector.events.model.Event;
-import uk.gov.pay.connector.events.model.refund.PaymentStatusCorrectedToSuccessByAdmin;
-import uk.gov.pay.connector.events.model.refund.RefundFailureFundsSentToConnectAccount;
-import uk.gov.pay.connector.events.model.refund.RefundStatusCorrectedToErrorByAdmin;
-import uk.gov.pay.connector.gateway.stripe.StripeSdkClient;
-import uk.gov.pay.connector.gateway.stripe.StripeSdkClientFactory;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.model.domain.RefundEntityFixture;
-import uk.gov.pay.connector.refund.dao.RefundDao;
-import uk.gov.pay.connector.refund.model.domain.GithubAndZendeskCredential;
-import uk.gov.pay.connector.refund.model.domain.Refund;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
-import uk.gov.pay.connector.refund.service.RefundReversalService;
-import uk.gov.pay.connector.refund.service.RefundReversalStripeConnectTransferRequestBuilder;
-
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
-import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
-import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
-
-@ExtendWith(MockitoExtension.class)
-public class RefundReversalServiceTest {
-    private RefundReversalService refundReversalService;
-
-    private final String refundExternalId = "refund123";
-
-    @Mock
-    private RefundDao mockRefundDao;
-    @Mock
-    private LedgerService mockLedgerService;
-    @Mock
-    private StripeSdkClient mockStripeSDKClient;
-    @Mock
-    private StripeSdkClientFactory mockStripeSDKClientFactory;
-    @Mock
-    private RefundReversalStripeConnectTransferRequestBuilder mockBuilder;
-
-
-
-    ChargeEntityFixture chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
-            .withGatewayAccountEntity(aGatewayAccountEntity().withType(LIVE).build());
-    Charge charge = Charge.from(chargeEntityFixture.build());
-    GithubAndZendeskCredential githubAndZendeskCredential = new GithubAndZendeskCredential("1223333343", "John Doe (JohnDoeGds)");
-
-    private String githubUserId = githubAndZendeskCredential.githubUserId();
-    private String zendeskId = githubAndZendeskCredential.zendeskTicketId();
-
-    @BeforeEach
-    void setUp() {
-        refundReversalService = new RefundReversalService(mockLedgerService, mockRefundDao,
-                mockStripeSDKClientFactory, mockBuilder);
-    }
-
-    @Test
-    void shouldFindRefundInLedger() {
-
-        LedgerTransaction ledgerTransaction = aValidLedgerTransaction()
-                .withExternalId(refundExternalId)
-                .withStatus(ExternalRefundStatus.EXTERNAL_SUBMITTED.getStatus())
-                .build();
-        when(mockLedgerService.getTransaction(refundExternalId)).thenReturn(Optional.of(ledgerTransaction));
-
-        Optional<Refund> result = refundReversalService.findMaybeHistoricRefundByRefundId(refundExternalId);
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getExternalId(), is(refundExternalId));
-    }
-
-    @Test
-    void shouldFindRefundInConnector() {
-        RefundEntity refundEntityInConnector = aValidRefundEntity().withExternalId(refundExternalId).build();
-
-        when(mockRefundDao.findByExternalId(refundExternalId)).thenReturn(Optional.of(refundEntityInConnector));
-
-        Optional<Refund> result = refundReversalService.findMaybeHistoricRefundByRefundId(refundExternalId);
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getExternalId(), is(refundExternalId));
-
-        verifyNoInteractions(mockLedgerService);
-    }
-
-    @Test
-    void shouldNotFindRefund() {
-        when(mockRefundDao.findByExternalId(refundExternalId)).thenReturn(Optional.empty());
-        when(mockLedgerService.getTransaction(refundExternalId)).thenReturn(Optional.empty());
-
-        Optional<Refund> result = refundReversalService.findMaybeHistoricRefundByRefundId(refundExternalId);
-
-        assertThat(result.isPresent(), is(false));
-    }
-
-    @Test
-    void shouldCreateTransferWhenRefundIsInFailedState() throws StripeException {
-
-        when(mockStripeSDKClientFactory.getInstance()).thenReturn(mockStripeSDKClient);
-
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(LIVE).build();
-        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity()
-                .withAmount(100L)
-                .withGatewayTransactionId("a-transaction-id")
-                .build();
-        Refund refund = Refund.from(refundEntity);
-
-        String stripeRefundId = refund.getGatewayTransactionId();
-        boolean isLiveGatewayAccount = gatewayAccountEntity.isLive();
-        com.stripe.model.Refund mockedStripeRefund = Mockito.mock(com.stripe.model.Refund.class);
-        when(mockStripeSDKClient.getRefund(stripeRefundId, isLiveGatewayAccount)).thenReturn(mockedStripeRefund);
-        when(mockedStripeRefund.getStatus()).thenReturn("failed");
-
-        Map<String, Object> transferRequest = Map.of(
-                "destination", "acct_jdsa7789d",
-                "amount", 100L,
-                "metadata", Map.of(
-                        "stripeChargeId", "ch_sdkhdg887s",
-                        "correctionPaymentId", "random123"
-                ),
-                "currency", "GBP",
-                "transferGroup", "abc",
-                "expand", new String[]{"balance_transaction", "destination_payment"}
-        );
-        when(mockBuilder.createRequest(mockedStripeRefund)).thenReturn(transferRequest);
-
-        assertDoesNotThrow(() -> refundReversalService.reverseFailedRefund(gatewayAccountEntity, refund, charge, githubUserId, zendeskId));
-
-        verify(mockStripeSDKClient).createTransfer(transferRequest, true);
-    }
-
-    @Test
-    void shouldThrowExceptionWhenRefundIsNotInFailedState() throws StripeException {
-
-        when(mockStripeSDKClientFactory.getInstance()).thenReturn(mockStripeSDKClient);
-
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(LIVE).build();
-        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity()
-                .withAmount(100L)
-                .withGatewayTransactionId("a-transaction-id")
-                .build();
-        Refund refund = Refund.from(refundEntity);
-
-        String stripeRefundId = refund.getGatewayTransactionId();
-        boolean isLiveGatewayAccount = gatewayAccountEntity.isLive();
-        com.stripe.model.Refund mockedStripeRefund = Mockito.mock(com.stripe.model.Refund.class);
-        when(mockStripeSDKClient.getRefund(stripeRefundId, isLiveGatewayAccount)).thenReturn(mockedStripeRefund);
-        when(mockedStripeRefund.getStatus()).thenReturn("succeeded");
-
-        WebApplicationException thrown = assertThrows(WebApplicationException.class, () ->
-                refundReversalService.reverseFailedRefund(gatewayAccountEntity, refund, charge, githubUserId, zendeskId));
-
-        Response response = thrown.getResponse();
-        ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
-        assertThat(errorResponse.messages(), hasItems("Refund with Refund ID: " + refund.getExternalId() + " and Stripe ID: " + stripeRefundId + " is not in a failed state"));
-    }
-
-    @Test
-    void shouldThrowWebApplicationExceptionForUnexpectedError() throws StripeException {
-
-        when(mockStripeSDKClientFactory.getInstance()).thenReturn(mockStripeSDKClient);
-
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(LIVE).build();
-        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity()
-                .withAmount(100L)
-                .withGatewayTransactionId("a-transaction-id")
-                .build();
-        Refund refund = Refund.from(refundEntity);
-
-        String stripeRefundId = refund.getGatewayTransactionId();
-        boolean isLiveGatewayAccount = gatewayAccountEntity.isLive();
-        StripeException mockStripeException = Mockito.mock(StripeException.class);
-
-        when(mockStripeSDKClient.getRefund(stripeRefundId, isLiveGatewayAccount))
-                .thenThrow(mockStripeException);
-
-        var thrown = assertThrows(WebApplicationException.class,
-                () -> refundReversalService.reverseFailedRefund(gatewayAccountEntity, refund, charge, githubUserId, zendeskId));
-
-        assertThat(thrown.getMessage(),
-                is("There was an error trying to get refund from Stripe with refund id: " + refund.getExternalId()));
-
-        verify(mockStripeSDKClient).getRefund(stripeRefundId, isLiveGatewayAccount);
-    }
-
-    @Test
-    void shouldCreateCorrectEventsAfterRefundReversalToPostToLedger() throws StripeException {
-        when(mockStripeSDKClientFactory.getInstance()).thenReturn(mockStripeSDKClient);
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(LIVE).build();
-        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity()
-                .withAmount(100L)
-                .withGatewayTransactionId("a-transaction-id")
-                .build();
-        Refund refund = Refund.from(refundEntity);
-
-        com.stripe.model.Refund mockedStripeRefund = Mockito.mock(com.stripe.model.Refund.class);
-        when(mockStripeSDKClient.getRefund(refund.getGatewayTransactionId(), gatewayAccountEntity.isLive()))
-                .thenReturn(mockedStripeRefund);
-        when(mockedStripeRefund.getStatus()).thenReturn("failed");
-
-        refundReversalService.reverseFailedRefund(gatewayAccountEntity, refund, charge, githubUserId, zendeskId);
-
-        ArgumentCaptor<List<Event>> eventsCaptor = ArgumentCaptor.forClass(List.class);
-        verify(mockLedgerService).postEvent(eventsCaptor.capture());
-        List<Event> postedEvents = eventsCaptor.getValue();
-
-        assertThat(postedEvents, hasSize(3));
-        assertInstanceOf(RefundFailureFundsSentToConnectAccount.class, postedEvents.get(0));
-        assertInstanceOf(PaymentStatusCorrectedToSuccessByAdmin.class, postedEvents.get(1));
-        assertInstanceOf(RefundStatusCorrectedToErrorByAdmin.class, postedEvents.get(2));
-
-        assertThat(((RefundFailureFundsSentToConnectAccount) postedEvents.get(0)).getGatewayAccountId(), is(gatewayAccountEntity.getId()));
-        assertThat(((PaymentStatusCorrectedToSuccessByAdmin) postedEvents.get(1)).getGatewayAccountId(), is(gatewayAccountEntity.getId()));
-        assertThat(((RefundStatusCorrectedToErrorByAdmin) postedEvents.get(2)).getGatewayAccountId(), is(gatewayAccountEntity.getId()));
-
-        assertThat(postedEvents.get(0).getResourceExternalId(), is(charge.getExternalId()));
-        assertThat(postedEvents.get(1).getResourceExternalId(), is(charge.getExternalId()));
-        assertThat(postedEvents.get(2).getResourceExternalId(), is(refund.getExternalId()));
-
-        assertThat(((RefundFailureFundsSentToConnectAccount) postedEvents.get(0)).getServiceId(), is(charge.getServiceId()));
-        assertThat(((PaymentStatusCorrectedToSuccessByAdmin) postedEvents.get(1)).getServiceId(), is(charge.getServiceId()));
-        assertThat(((RefundStatusCorrectedToErrorByAdmin) postedEvents.get(2)).getServiceId(), is(charge.getServiceId()));
-    }
-}
+//package uk.gov.pay.connector.service;
+//
+//import com.stripe.exception.StripeException;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.Mock;
+//import org.mockito.Mockito;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import uk.gov.pay.connector.charge.model.domain.Charge;
+//import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+//import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+//import uk.gov.pay.connector.client.ledger.service.LedgerService;
+//import uk.gov.pay.connector.common.model.api.ErrorResponse;
+//import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
+//import uk.gov.pay.connector.events.model.Event;
+//import uk.gov.pay.connector.events.model.refund.PaymentStatusCorrectedToSuccessByAdmin;
+//import uk.gov.pay.connector.events.model.refund.RefundFailureFundsSentToConnectAccount;
+//import uk.gov.pay.connector.events.model.refund.RefundStatusCorrectedToErrorByAdmin;
+//import uk.gov.pay.connector.gateway.stripe.StripeSdkClient;
+//import uk.gov.pay.connector.gateway.stripe.StripeSdkClientFactory;
+//import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+//import uk.gov.pay.connector.model.domain.RefundEntityFixture;
+//import uk.gov.pay.connector.refund.dao.RefundDao;
+//import uk.gov.pay.connector.refund.model.domain.GithubAndZendeskCredential;
+//import uk.gov.pay.connector.refund.model.domain.Refund;
+//import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+//import uk.gov.pay.connector.refund.service.RefundReversalService;
+//import uk.gov.pay.connector.refund.service.RefundReversalStripeConnectTransferRequestBuilder;
+//
+//import javax.ws.rs.WebApplicationException;
+//import javax.ws.rs.core.Response;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.Optional;
+//
+//import static org.hamcrest.CoreMatchers.hasItems;
+//import static org.hamcrest.MatcherAssert.assertThat;
+//import static org.hamcrest.Matchers.hasSize;
+//import static org.hamcrest.core.Is.is;
+//import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+//import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+//import static org.junit.jupiter.api.Assertions.assertThrows;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.verifyNoInteractions;
+//import static org.mockito.Mockito.when;
+//import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+//import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
+//import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
+//import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
+//
+//@ExtendWith(MockitoExtension.class)
+//public class RefundReversalServiceTest {
+//    private RefundReversalService refundReversalService;
+//
+//    private final String refundExternalId = "refund123";
+//
+//    @Mock
+//    private RefundDao mockRefundDao;
+//    @Mock
+//    private LedgerService mockLedgerService;
+//    @Mock
+//    private StripeSdkClient mockStripeSDKClient;
+//    @Mock
+//    private StripeSdkClientFactory mockStripeSDKClientFactory;
+//    @Mock
+//    private RefundReversalStripeConnectTransferRequestBuilder mockBuilder;
+//
+//
+//
+//    ChargeEntityFixture chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
+//            .withGatewayAccountEntity(aGatewayAccountEntity().withType(LIVE).build());
+//    Charge charge = Charge.from(chargeEntityFixture.build());
+//    GithubAndZendeskCredential githubAndZendeskCredential = new GithubAndZendeskCredential("1223333343", "John Doe (JohnDoeGds)");
+//
+//    private String githubUserId = githubAndZendeskCredential.githubUserId();
+//    private String zendeskId = githubAndZendeskCredential.zendeskTicketId();
+//
+//    @BeforeEach
+//    void setUp() {
+//        refundReversalService = new RefundReversalService(mockLedgerService, mockRefundDao,
+//                mockStripeSDKClientFactory, mockBuilder);
+//    }
+//
+//    @Test
+//    void shouldFindRefundInLedger() {
+//
+//        LedgerTransaction ledgerTransaction = aValidLedgerTransaction()
+//                .withExternalId(refundExternalId)
+//                .withStatus(ExternalRefundStatus.EXTERNAL_SUBMITTED.getStatus())
+//                .build();
+//        when(mockLedgerService.getTransaction(refundExternalId)).thenReturn(Optional.of(ledgerTransaction));
+//
+//        Optional<Refund> result = refundReversalService.findMaybeHistoricRefundByRefundId(refundExternalId);
+//
+//        assertThat(result.isPresent(), is(true));
+//        assertThat(result.get().getExternalId(), is(refundExternalId));
+//    }
+//
+//    @Test
+//    void shouldFindRefundInConnector() {
+//        RefundEntity refundEntityInConnector = aValidRefundEntity().withExternalId(refundExternalId).build();
+//
+//        when(mockRefundDao.findByExternalId(refundExternalId)).thenReturn(Optional.of(refundEntityInConnector));
+//
+//        Optional<Refund> result = refundReversalService.findMaybeHistoricRefundByRefundId(refundExternalId);
+//
+//        assertThat(result.isPresent(), is(true));
+//        assertThat(result.get().getExternalId(), is(refundExternalId));
+//
+//        verifyNoInteractions(mockLedgerService);
+//    }
+//
+//    @Test
+//    void shouldNotFindRefund() {
+//        when(mockRefundDao.findByExternalId(refundExternalId)).thenReturn(Optional.empty());
+//        when(mockLedgerService.getTransaction(refundExternalId)).thenReturn(Optional.empty());
+//
+//        Optional<Refund> result = refundReversalService.findMaybeHistoricRefundByRefundId(refundExternalId);
+//
+//        assertThat(result.isPresent(), is(false));
+//    }
+//
+//    @Test
+//    void shouldCreateTransferWhenRefundIsInFailedState() throws StripeException {
+//
+//        when(mockStripeSDKClientFactory.getInstance()).thenReturn(mockStripeSDKClient);
+//
+//        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(LIVE).build();
+//        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity()
+//                .withAmount(100L)
+//                .withGatewayTransactionId("a-transaction-id")
+//                .build();
+//        Refund refund = Refund.from(refundEntity);
+//
+//        String stripeRefundId = refund.getGatewayTransactionId();
+//        boolean isLiveGatewayAccount = gatewayAccountEntity.isLive();
+//        com.stripe.model.Refund mockedStripeRefund = Mockito.mock(com.stripe.model.Refund.class);
+//        when(mockStripeSDKClient.getRefund(stripeRefundId, isLiveGatewayAccount)).thenReturn(mockedStripeRefund);
+//        when(mockedStripeRefund.getStatus()).thenReturn("failed");
+//
+//        Map<String, Object> transferRequest = Map.of(
+//                "destination", "acct_jdsa7789d",
+//                "amount", 100L,
+//                "metadata", Map.of(
+//                        "stripeChargeId", "ch_sdkhdg887s",
+//                        "correctionPaymentId", "random123"
+//                ),
+//                "currency", "GBP",
+//                "transferGroup", "abc",
+//                "expand", new String[]{"balance_transaction", "destination_payment"}
+//        );
+//        when(mockBuilder.createRequest(mockedStripeRefund)).thenReturn(transferRequest);
+//
+//        assertDoesNotThrow(() -> refundReversalService.reverseFailedRefund(gatewayAccountEntity, refund, charge, githubUserId, zendeskId));
+//
+//        verify(mockStripeSDKClient).createTransfer(transferRequest, true);
+//    }
+//
+//    @Test
+//    void shouldThrowExceptionWhenRefundIsNotInFailedState() throws StripeException {
+//
+//        when(mockStripeSDKClientFactory.getInstance()).thenReturn(mockStripeSDKClient);
+//
+//        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(LIVE).build();
+//        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity()
+//                .withAmount(100L)
+//                .withGatewayTransactionId("a-transaction-id")
+//                .build();
+//        Refund refund = Refund.from(refundEntity);
+//
+//        String stripeRefundId = refund.getGatewayTransactionId();
+//        boolean isLiveGatewayAccount = gatewayAccountEntity.isLive();
+//        com.stripe.model.Refund mockedStripeRefund = Mockito.mock(com.stripe.model.Refund.class);
+//        when(mockStripeSDKClient.getRefund(stripeRefundId, isLiveGatewayAccount)).thenReturn(mockedStripeRefund);
+//        when(mockedStripeRefund.getStatus()).thenReturn("succeeded");
+//
+//        WebApplicationException thrown = assertThrows(WebApplicationException.class, () ->
+//                refundReversalService.reverseFailedRefund(gatewayAccountEntity, refund, charge, githubUserId, zendeskId));
+//
+//        Response response = thrown.getResponse();
+//        ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
+//        assertThat(errorResponse.messages(), hasItems("Refund with Refund ID: " + refund.getExternalId() + " and Stripe ID: " + stripeRefundId + " is not in a failed state"));
+//    }
+//
+//    @Test
+//    void shouldThrowWebApplicationExceptionForUnexpectedError() throws StripeException {
+//
+//        when(mockStripeSDKClientFactory.getInstance()).thenReturn(mockStripeSDKClient);
+//
+//        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(LIVE).build();
+//        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity()
+//                .withAmount(100L)
+//                .withGatewayTransactionId("a-transaction-id")
+//                .build();
+//        Refund refund = Refund.from(refundEntity);
+//
+//        String stripeRefundId = refund.getGatewayTransactionId();
+//        boolean isLiveGatewayAccount = gatewayAccountEntity.isLive();
+//        StripeException mockStripeException = Mockito.mock(StripeException.class);
+//
+//        when(mockStripeSDKClient.getRefund(stripeRefundId, isLiveGatewayAccount))
+//                .thenThrow(mockStripeException);
+//
+//        var thrown = assertThrows(WebApplicationException.class,
+//                () -> refundReversalService.reverseFailedRefund(gatewayAccountEntity, refund, charge, githubUserId, zendeskId));
+//
+//        assertThat(thrown.getMessage(),
+//                is("There was an error trying to get refund from Stripe with refund id: " + refund.getExternalId()));
+//
+//        verify(mockStripeSDKClient).getRefund(stripeRefundId, isLiveGatewayAccount);
+//    }
+//
+//    @Test
+//    void shouldCreateCorrectEventsAfterRefundReversalToPostToLedger() throws StripeException {
+//        when(mockStripeSDKClientFactory.getInstance()).thenReturn(mockStripeSDKClient);
+//        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(LIVE).build();
+//        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity()
+//                .withAmount(100L)
+//                .withGatewayTransactionId("a-transaction-id")
+//                .build();
+//        Refund refund = Refund.from(refundEntity);
+//
+//        com.stripe.model.Refund mockedStripeRefund = Mockito.mock(com.stripe.model.Refund.class);
+//        when(mockStripeSDKClient.getRefund(refund.getGatewayTransactionId(), gatewayAccountEntity.isLive()))
+//                .thenReturn(mockedStripeRefund);
+//        when(mockedStripeRefund.getStatus()).thenReturn("failed");
+//
+//        refundReversalService.reverseFailedRefund(gatewayAccountEntity, refund, charge, githubUserId, zendeskId);
+//
+//        ArgumentCaptor<List<Event>> eventsCaptor = ArgumentCaptor.forClass(List.class);
+//        verify(mockLedgerService).postEvent(eventsCaptor.capture());
+//        List<Event> postedEvents = eventsCaptor.getValue();
+//
+//        assertThat(postedEvents, hasSize(3));
+//        assertInstanceOf(RefundFailureFundsSentToConnectAccount.class, postedEvents.get(0));
+//        assertInstanceOf(PaymentStatusCorrectedToSuccessByAdmin.class, postedEvents.get(1));
+//        assertInstanceOf(RefundStatusCorrectedToErrorByAdmin.class, postedEvents.get(2));
+//
+//        assertThat(((RefundFailureFundsSentToConnectAccount) postedEvents.get(0)).getGatewayAccountId(), is(gatewayAccountEntity.getId()));
+//        assertThat(((PaymentStatusCorrectedToSuccessByAdmin) postedEvents.get(1)).getGatewayAccountId(), is(gatewayAccountEntity.getId()));
+//        assertThat(((RefundStatusCorrectedToErrorByAdmin) postedEvents.get(2)).getGatewayAccountId(), is(gatewayAccountEntity.getId()));
+//
+//        assertThat(postedEvents.get(0).getResourceExternalId(), is(charge.getExternalId()));
+//        assertThat(postedEvents.get(1).getResourceExternalId(), is(charge.getExternalId()));
+//        assertThat(postedEvents.get(2).getResourceExternalId(), is(refund.getExternalId()));
+//
+//        assertThat(((RefundFailureFundsSentToConnectAccount) postedEvents.get(0)).getServiceId(), is(charge.getServiceId()));
+//        assertThat(((PaymentStatusCorrectedToSuccessByAdmin) postedEvents.get(1)).getServiceId(), is(charge.getServiceId()));
+//        assertThat(((RefundStatusCorrectedToErrorByAdmin) postedEvents.get(2)).getServiceId(), is(charge.getServiceId()));
+//    }
+//}

--- a/src/test/java/uk/gov/pay/connector/service/RefundReversalStripeConnectTransferRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundReversalStripeConnectTransferRequestBuilderTest.java
@@ -41,8 +41,7 @@ public class RefundReversalStripeConnectTransferRequestBuilderTest {
         when(mockStripeRefund.getChargeObject()).thenReturn(mockStripeCharge);
         when(mockStripeCharge.getId()).thenReturn("ch_sdkhdg887s");
         when(mockStripeCharge.getTransferGroup()).thenReturn("abc");
-        when(mockStripeCharge.getOnBehalfOfObject()).thenReturn(mockStripeAccount);
-        when(mockStripeAccount.getId()).thenReturn("acct_jdsa7789d");
+        when(mockStripeCharge.getOnBehalfOf()).thenReturn("acct_jdsa7789d");
         when(mockStripeRefund.getAmount()).thenReturn(100L);
         when(mockStripeRefund.getCurrency()).thenReturn("GBP");
         when(mockRandomIdGenerator.random13ByteHexGenerator()).thenReturn("randomId123");
@@ -61,8 +60,8 @@ public class RefundReversalStripeConnectTransferRequestBuilderTest {
         
         Map<String, Object> metadataMap = (Map<String, Object>) builderRequest.get("metadata");
         assertEquals(2, metadataMap.size());
-        assertEquals("abc", builderRequest.get("transferGroup"));
-        assertEquals("ch_sdkhdg887s", (metadataMap.get("stripeChargeId")));
-        assertEquals("randomId123", (metadataMap.get("correctionPaymentId")));
+        assertEquals("abc", builderRequest.get("transfer_group"));
+        assertEquals("ch_sdkhdg887s", (metadataMap.get("stripe_charge_id")));
+        assertEquals("randomId123", (metadataMap.get("correction_payment_id")));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
Testing the correcting asynchronously refund code - logs show an error on `getChargeObject().getTransferGroup()` which should be `transfer_group` not `transferGroup`
