### PR TITLE
PP-13202 fix json include

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -725,6 +725,7 @@ public class ChargeResponse {
             private boolean required;
 
             @JsonProperty("version")
+            @JsonInclude(Include.NON_EMPTY)
             @Schema(description = "3DS version used to authorise payment", example = "2.1.0")
             private String version;
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -290,6 +290,55 @@ public class ChargesApiResourceIT {
         }
 
         @Test
+        void shouldReturnAuthorisationSummary_whenChargeIsAuthorisedWith3dsAndVersionIsNotPresent() {
+            long chargeId = nextInt();
+            String externalChargeId = RandomIdGenerator.newId();
+
+            databaseTestHelper.addCharge(anAddChargeParams()
+                    .withChargeId(chargeId)
+                    .withExternalChargeId(externalChargeId)
+                    .withGatewayAccountId(accountId)
+                    .withAmount(AMOUNT)
+                    .withStatus(AUTHORISATION_SUCCESS)
+                    .build());
+            databaseTestHelper.updateCharge3dsFlexChallengeDetails(chargeId, "acsUrl", "transactionId", "payload", null);
+            databaseTestHelper.addToken(chargeId, "tokenId");
+
+            testBaseExtension.getConnectorRestApiClient()
+                    .withAccountId(accountId)
+                    .withChargeId(externalChargeId)
+                    .getCharge()
+                    .statusCode(OK.getStatusCode())
+                    .contentType(JSON)
+                    .body("authorisation_summary.three_d_secure.required", is(true))
+                    .body("authorisation_summary.three_d_secure", not(hasKey("version")));
+        }
+
+        @Test
+        void shouldReturnAuthorisationSummary_whenChargeIsAuthorisedWithOut3dsAndVersionIsNotPresent() {
+            long chargeId = nextInt();
+            String externalChargeId = RandomIdGenerator.newId();
+
+            databaseTestHelper.addCharge(anAddChargeParams()
+                    .withChargeId(chargeId)
+                    .withExternalChargeId(externalChargeId)
+                    .withGatewayAccountId(accountId)
+                    .withAmount(AMOUNT)
+                    .withStatus(AUTHORISATION_SUCCESS)
+                    .build());
+            databaseTestHelper.addToken(chargeId, "tokenId");
+
+            testBaseExtension.getConnectorRestApiClient()
+                    .withAccountId(accountId)
+                    .withChargeId(externalChargeId)
+                    .getCharge()
+                    .statusCode(OK.getStatusCode())
+                    .contentType(JSON)
+                    .body("authorisation_summary.three_d_secure.required", is(false))
+                    .body("authorisation_summary.three_d_secure", not(hasKey("version")));
+        }
+
+        @Test
         void shouldReturnEmptyCardBrandLabel_whenChargeIsAuthorisedAndBrandUnknown() {
             long chargeId = nextInt();
             String externalChargeId = RandomIdGenerator.newId();


### PR DESCRIPTION
## WHAT YOU DID

`AuthorisationSummary`'s @JsonInclude(Include.NON_NULL) does not exclude version from the JSON object when it's null.
- add @JsonInclude(Include.NON_EMPTY) on variable level.
