### PR TITLE
PP-13247 Set idempotency key for async failed refund fix and other improvements

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/PaymentStatusCorrectedToSuccessByAdminEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/PaymentStatusCorrectedToSuccessByAdminEventDetails.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.events.eventdetails.refund;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.service.payments.commons.api.json.IsoInstantMicrosecondSerializer;
 
@@ -12,7 +11,7 @@ public class PaymentStatusCorrectedToSuccessByAdminEventDetails extends EventDet
     private final long netAmount;
     @JsonSerialize(using = IsoInstantMicrosecondSerializer.class)
     private final Instant capturedDate;
-    private final ExternalRefundStatus refundStatus;
+    private final String refundStatus;
     private final String updatedReason;
     private final String adminGithubId;
     private final long gatewayAccountId;
@@ -27,7 +26,7 @@ public class PaymentStatusCorrectedToSuccessByAdminEventDetails extends EventDet
             long fee,
             long netAmount,
             Instant capturedDate,
-            ExternalRefundStatus refundStatus,
+            String refundStatus,
             String updatedReason,
             String adminGithubId,
             long gatewayAccountId,
@@ -62,7 +61,7 @@ public class PaymentStatusCorrectedToSuccessByAdminEventDetails extends EventDet
         return capturedDate;
     }
 
-    public ExternalRefundStatus getRefundStatus() {
+    public String getRefundStatus() {
         return refundStatus;
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdmin.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdmin.java
@@ -1,13 +1,12 @@
 package uk.gov.pay.connector.events.model.refund;
 
 import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.events.eventdetails.refund.PaymentStatusCorrectedToSuccessByAdminEventDetails;
 import uk.gov.pay.connector.events.model.charge.PaymentEvent;
-import uk.gov.pay.connector.refund.model.domain.GithubAndZendeskCredential;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 
 import java.time.Instant;
-import java.time.ZonedDateTime;
 
 public class PaymentStatusCorrectedToSuccessByAdmin extends PaymentEvent {
     private PaymentStatusCorrectedToSuccessByAdmin(String serviceId, boolean live, Long gatewayAccountId,
@@ -17,18 +16,19 @@ public class PaymentStatusCorrectedToSuccessByAdmin extends PaymentEvent {
         super(serviceId, live, gatewayAccountId, resourceExternalId, eventDetails, timestamp);
     }
 
-    public static PaymentStatusCorrectedToSuccessByAdmin from(Refund refund, Charge charge, Instant timestamp, String githubId, String zendeskId) {
+    public static PaymentStatusCorrectedToSuccessByAdmin from(String correctionPaymentId,  Refund refund,
+                                                              Charge charge, Instant timestamp, String githubId, String zendeskId) {
 
         return new PaymentStatusCorrectedToSuccessByAdmin(
                 charge.getServiceId(),
                 charge.isLive(),
                 charge.getGatewayAccountId(),
-                charge.getExternalId(),
+                correctionPaymentId,
                 new PaymentStatusCorrectedToSuccessByAdminEventDetails(
                         0L,
-                        charge.getAmount(),
+                        refund.getAmount(),
                         timestamp,
-                        refund.getExternalStatus(),
+                        ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE.getStatus(),
                         "A refund failed and we returned the recovered funds to the service",
                         githubId,
                         charge.getGatewayAccountId(),

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccount.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccount.java
@@ -17,12 +17,12 @@ public class RefundFailureFundsSentToConnectAccount extends PaymentEvent {
     }
 
 
-    public static RefundFailureFundsSentToConnectAccount from(Refund refund, Charge charge, String githubUserId, String zendeskId) {
+    public static RefundFailureFundsSentToConnectAccount from(String correctionPaymentId, Refund refund, Charge charge, String githubUserId, String zendeskId) {
         return new RefundFailureFundsSentToConnectAccount(
                 charge.getServiceId(),
                 charge.isLive(),
                 charge.getGatewayAccountId(),
-                charge.getExternalId(),
+                correctionPaymentId,
                 new RefundFailureFundsSentToConnectAccountEventDetails(
                         refund.getAmount(),
                         charge.getReference(),
@@ -31,7 +31,7 @@ public class RefundFailureFundsSentToConnectAccount extends PaymentEvent {
                         "A refund failed and we returned the recovered funds to the service",
                         charge.getPaymentGatewayName(),
                         charge.getGatewayAccountId(),
-                        charge.getGatewayTransactionId(),
+                        charge.getGatewayTransactionId(), //todo: should be new transfer ID
                         zendeskId
                 ),
                 Instant.now()

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClient.java
@@ -5,11 +5,14 @@ import com.stripe.model.BalanceTransaction;
 import com.stripe.model.Refund;
 import com.stripe.net.RequestOptions;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.yaml.snakeyaml.nodes.Tag.STR;
 
 public class StripeSdkClient {
 
@@ -62,9 +65,14 @@ public class StripeSdkClient {
         return stripeSDKWrapper.getRefund(stripeRefundId, params, requestOptions);
     }
 
-    public void createTransfer(Map<String, Object> transferRequest, boolean live) throws StripeException {
+    public void createTransfer(Map<String, Object> transferRequest,
+                               boolean live, String refundId) throws StripeException {
         String apiKey = getStripeApiKey(live);
+
+        String idempotencyKey = String.format("correction_payment_for_%s", refundId);
+
         RequestOptions requestOptions = RequestOptions.builder()
+                .setIdempotencyKey(idempotencyKey)
                 .setApiKey(apiKey)
                 .build();
         stripeSDKWrapper.createTransfer(transferRequest, requestOptions);

--- a/src/main/java/uk/gov/pay/connector/refund/resource/RefundReversalResource.java
+++ b/src/main/java/uk/gov/pay/connector/refund/resource/RefundReversalResource.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.refund.resource;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -95,10 +94,10 @@ public class RefundReversalResource {
         if (!refund.getChargeExternalId().equals(chargeExternalId)) {
             throw new RefundNotFoundForChargeException(refundExternalId, chargeExternalId, gatewayAccountId);
         }
-            
+
         String githubUserId = githubAndZendeskCredential.githubUserId();
         String zendeskUserId = githubAndZendeskCredential.zendeskTicketId();
-        refundReversalService.reverseFailedRefund(gatewayAccount, refund, charge, githubUserId, zendeskUserId);
-        return Response.ok().build();
+        return refundReversalService.reverseFailedRefund(gatewayAccount, refund, charge, githubUserId, zendeskUserId);
+
     }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalService.java
@@ -2,8 +2,12 @@ package uk.gov.pay.connector.refund.service;
 
 
 import com.stripe.exception.StripeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.client.ledger.exception.LedgerException;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.events.model.refund.PaymentStatusCorrectedToSuccessByAdmin;
 import uk.gov.pay.connector.events.model.refund.RefundFailureFundsSentToConnectAccount;
 import uk.gov.pay.connector.events.model.refund.RefundStatusCorrectedToErrorByAdmin;
@@ -11,18 +15,21 @@ import uk.gov.pay.connector.gateway.stripe.StripeSdkClient;
 import uk.gov.pay.connector.gateway.stripe.StripeSdkClientFactory;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.dao.RefundDao;
-import uk.gov.pay.connector.refund.model.domain.GithubAndZendeskCredential;
 import uk.gov.pay.connector.refund.model.domain.Refund;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
 
 
@@ -31,6 +38,8 @@ public class RefundReversalService {
     private final RefundDao refundDao;
     private final StripeSdkClientFactory stripeSdkClientFactory;
     private final RefundReversalStripeConnectTransferRequestBuilder refundRequest;
+    private final Logger logger = LoggerFactory.getLogger(LedgerService.class);
+
 
     @Inject
     public RefundReversalService(LedgerService ledgerService, RefundDao refundDao, StripeSdkClientFactory stripeSdkClientFactory,
@@ -48,8 +57,10 @@ public class RefundReversalService {
     }
 
 
-    public void reverseFailedRefund(GatewayAccountEntity gatewayAccount, Refund refund, Charge charge, String githubUserId, String zendeskUserId) {
+    public Response reverseFailedRefund(GatewayAccountEntity gatewayAccount, Refund refund, Charge charge, String githubUserId, String zendeskUserId) {
 
+        RandomIdGenerator randomIdGenerator = new RandomIdGenerator();
+        String correctionPaymentId = randomIdGenerator.random13ByteHexGenerator();
         String stripeRefundId = refund.getGatewayTransactionId();
         boolean isLiveGatewayAccount = gatewayAccount.isLive();
         String refundExternalId = refund.getExternalId();
@@ -72,10 +83,11 @@ public class RefundReversalService {
                     format("Refund with Refund ID: %s and Stripe ID: %s is not in a failed state", refundExternalId, stripeRefundId)));
         }
 
-        Map<String, Object> refundRequestBody = refundRequest.createRequest(refundFromStripe);
+        Map<String, Object> refundRequestBody = refundRequest.createRequest(correctionPaymentId, refundFromStripe);
 
         try {
-            stripeClient.createTransfer(refundRequestBody, isLiveGatewayAccount);
+
+            stripeClient.createTransfer(refundRequestBody, isLiveGatewayAccount, refundExternalId);
         } catch (StripeException e) {
             if (e.getStripeError() != null && "insufficient_funds".equals(e.getStripeError().getDeclineCode())) {
                 throw new WebApplicationException(badRequestResponse(
@@ -88,11 +100,26 @@ public class RefundReversalService {
             }
         }
 
-        ledgerService.postEvent(List.of(
-                        RefundFailureFundsSentToConnectAccount.from(refund, charge, githubUserId, zendeskUserId),
-                        PaymentStatusCorrectedToSuccessByAdmin.from(refund, charge, Instant.now(), githubUserId, zendeskUserId),
-                        RefundStatusCorrectedToErrorByAdmin.from(refund, charge, githubUserId, zendeskUserId)
-                )
-        );
+        try {
+            ledgerService.postEvent(List.of(
+                            PaymentStatusCorrectedToSuccessByAdmin.from(correctionPaymentId, refund, charge, Instant.now(), githubUserId, zendeskUserId),
+                            RefundFailureFundsSentToConnectAccount.from(correctionPaymentId, refund, charge, githubUserId, zendeskUserId),
+                            RefundStatusCorrectedToErrorByAdmin.from(refund, charge, githubUserId, zendeskUserId)
+                    )
+            );
+            return Response.ok().build();
+        } catch (LedgerException e) {
+            logger.info(e.getMessage(),
+                    kv("refundExternalId", refundExternalId),
+                    kv("gatewayTransactionId", stripeRefundId));
+
+            ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC,
+                    "Stripe transfer successful but error updating payment and refunds");
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(errorResponse)
+                    .type(APPLICATION_JSON)
+                    .build();
+        }
+
     }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalStripeConnectTransferRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalStripeConnectTransferRequestBuilder.java
@@ -10,31 +10,27 @@ import java.util.Map;
 
 @Singleton
 public class RefundReversalStripeConnectTransferRequestBuilder {
-    private final RandomIdGenerator randomIdGenerator;
 
     @Inject
-    public RefundReversalStripeConnectTransferRequestBuilder(RandomIdGenerator randomIdGenerator) {
-        this.randomIdGenerator = randomIdGenerator;
+    public RefundReversalStripeConnectTransferRequestBuilder() {
     }
 
-    public Map<String, Object> createRequest(com.stripe.model.Refund refundFromStripe) {
+    public Map<String, Object> createRequest(String correctionPaymentId, com.stripe.model.Refund refundFromStripe) {
         String stripeChargeId = refundFromStripe.getChargeObject().getId();
-        String destination = refundFromStripe.getChargeObject().getOnBehalfOfObject().getId();
+        String destination = refundFromStripe.getChargeObject().getOnBehalfOf();
         String transferGroup = refundFromStripe.getChargeObject().getTransferGroup();
         long amount = refundFromStripe.getAmount();
         String currency = refundFromStripe.getCurrency();
-        String correctionPaymentId = randomIdGenerator.random13ByteHexGenerator();
-
 
         return Map.of(
                 "destination", destination,
                 "amount", amount,
                 "metadata", Map.of(
-                        "stripeChargeId", stripeChargeId,
-                        "correctionPaymentId", correctionPaymentId
+                        "stripe_charge_id", stripeChargeId,
+                        "govuk_pay_transaction_external_id", correctionPaymentId
                 ),
                 "currency", currency,
-                "transferGroup", transferGroup,
+                "transfer_group", transferGroup,
                 "expand", List.of("balance_transaction", "destination_payment")
         );
 

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdminTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdminTest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.events.model.refund;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.events.eventdetails.refund.PaymentStatusCorrectedToSuccessByAdminEventDetails;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.GithubAndZendeskCredential;
@@ -20,7 +21,7 @@ class PaymentStatusCorrectedToSuccessByAdminTest {
     void shouldCreatePaymentStatusCorrectedToSuccessByAdminEventFromRefundAndCharge() {
 
         Instant fixedTimestamp = Instant.now();
-
+        String correctionPaymentId = "ExampleCorrectionPaymentId123";
         ChargeEntityFixture chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
                 .withServiceId("service-id")
                 .withGatewayAccountEntity(aGatewayAccountEntity().withType(LIVE).build());
@@ -37,11 +38,11 @@ class PaymentStatusCorrectedToSuccessByAdminTest {
         String zendeskId = githubAndZendeskCredential.zendeskTicketId();
 
         PaymentStatusCorrectedToSuccessByAdmin paymentStatusCorrectedToSuccessByAdmin = PaymentStatusCorrectedToSuccessByAdmin
-                .from(refund, charge, fixedTimestamp, githubUserId, zendeskId);
+                .from(correctionPaymentId, refund, charge, fixedTimestamp, githubUserId, zendeskId);
 
         assertThat(paymentStatusCorrectedToSuccessByAdmin.isLive(), is(true));
         assertThat(paymentStatusCorrectedToSuccessByAdmin.getGatewayAccountId(), is(charge.getGatewayAccountId()));
-        assertThat(paymentStatusCorrectedToSuccessByAdmin.getResourceExternalId(), is(charge.getExternalId()));
+        assertThat(paymentStatusCorrectedToSuccessByAdmin.getResourceExternalId(), is(correctionPaymentId));
 
         PaymentStatusCorrectedToSuccessByAdminEventDetails details = (PaymentStatusCorrectedToSuccessByAdminEventDetails) paymentStatusCorrectedToSuccessByAdmin.getEventDetails();
 
@@ -53,7 +54,7 @@ class PaymentStatusCorrectedToSuccessByAdminTest {
         assertThat(details.getNetAmount(), is(charge.getAmount()));
         assertThat(details.getRefundAmountAvailable(), is(0L));
         assertThat(details.getRefundAmountRefunded(), is(0L));
-        assertThat(details.getRefundStatus(), is(refund.getExternalStatus()));
+        assertThat(details.getRefundStatus(), is(ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE.getStatus()));
         assertThat(details.getGatewayAccountId(), is(charge.getGatewayAccountId()));
         assertThat(details.getCaptureSubmittedDate(), is(fixedTimestamp));
         assertThat(details.getReference(), is(charge.getReference()));

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccountTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccountTest.java
@@ -23,7 +23,6 @@ class RefundFailureFundsSentToConnectAccountTest {
                 .withServiceId("service-id")
                 .withGatewayAccountEntity(aGatewayAccountEntity().withType(LIVE).build());
 
-
         Charge charge = Charge.from(chargeEntityFixture.withPaymentProvider(STRIPE.getName()).build());
 
         Refund refund = Refund.from(RefundEntityFixture.aValidRefundEntity()
@@ -35,14 +34,15 @@ class RefundFailureFundsSentToConnectAccountTest {
 
         String githubUserId = githubAndZendeskCredential.githubUserId();
         String zendeskId = githubAndZendeskCredential.zendeskTicketId();
+        String correctionPaymentId = "ExampleCorrectionPaymentId123";
+
 
         RefundFailureFundsSentToConnectAccount refundFailureFundsSentToConnectAccount = RefundFailureFundsSentToConnectAccount
-                .from(refund, charge, githubUserId, zendeskId);
+                .from(correctionPaymentId, refund, charge, githubUserId, zendeskId);
 
-        assertThat(refundFailureFundsSentToConnectAccount.getResourceExternalId(), is(charge.getExternalId()));
+        assertThat(refundFailureFundsSentToConnectAccount.getResourceExternalId(), is(correctionPaymentId));
         assertThat(refundFailureFundsSentToConnectAccount.isLive(), is(true));
         assertThat(refundFailureFundsSentToConnectAccount.getGatewayAccountId(), is(charge.getGatewayAccountId()));
-        assertThat(refundFailureFundsSentToConnectAccount.getResourceExternalId(), is(refund.getChargeExternalId()));
 
         RefundFailureFundsSentToConnectAccountEventDetails details = (RefundFailureFundsSentToConnectAccountEventDetails) refundFailureFundsSentToConnectAccount.getEventDetails();
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClientTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClientTest.java
@@ -135,12 +135,14 @@ class StripeSdkClientTest {
     @Test
     void createTransfer_shouldUseLiveAPIKey() throws Exception {
         when(stripeAuthTokens.getLive()).thenReturn(LIVE_API_KEY);
+        String expectedIdempotencyKey = String.format("correction_payment_for_%s", STRIPE_REFUND_ID);
 
-        stripeSDKClient.createTransfer(transferRequest, true);
+        stripeSDKClient.createTransfer(transferRequest, true, STRIPE_REFUND_ID);
 
         verify(stripeSDKWrapper).createTransfer(paramsArgumentCaptor.capture(), requestOptionsArgumentCaptor.capture());
 
         assertThat(requestOptionsArgumentCaptor.getValue().getApiKey(), is(LIVE_API_KEY));
+        assertThat(requestOptionsArgumentCaptor.getValue().getIdempotencyKey(), is(expectedIdempotencyKey));
         assertThat(paramsArgumentCaptor.getValue(), is(transferRequest));
 
     }
@@ -149,7 +151,7 @@ class StripeSdkClientTest {
     void createTransfer_shouldUseTestAPIKey() throws Exception {
         when(stripeAuthTokens.getTest()).thenReturn(TEST_API_KEY);
 
-        stripeSDKClient.createTransfer(transferRequest, false);
+        stripeSDKClient.createTransfer(transferRequest, false, STRIPE_REFUND_ID);
 
         verify(stripeSDKWrapper).createTransfer(paramsArgumentCaptor.capture(), requestOptionsArgumentCaptor.capture());
 

--- a/src/test/java/uk/gov/pay/connector/refund/resource/RefundReversalResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/refund/resource/RefundReversalResourceTest.java
@@ -44,36 +44,7 @@ class RefundReversalResourceTest {
     public static final ResourceExtension resources = ResourceExtension.builder()
             .addResource(new RefundReversalResource(mockChargeService, mockGatewayAccountDao, mockRefundReversalService))
             .build();
-
-
-    @Test
-    void shouldReturn200WhenRefundExistsAndProviderIsStripe() {
-
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withId(gatewayAccountId).build();
-        when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(gatewayAccountEntity));
-
-        RefundEntity refundEntity = aValidRefundEntity()
-                .withExternalId(refundExternalId)
-                .withChargeExternalId(externalChargeId)
-                .build();
-        Refund refund = Refund.from(refundEntity);
-        when(mockRefundReversalService.findMaybeHistoricRefundByRefundId(refundExternalId)).thenReturn(Optional.of(refund));
-
-        ChargeEntity chargeEntity = aValidChargeEntity()
-                .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
-                .withExternalId(externalChargeId)
-                .withGatewayAccountEntity(gatewayAccountEntity)
-                .build();
-        Charge charge = Charge.from(chargeEntity);
-        when(mockChargeService.findCharge(externalChargeId)).thenReturn(Optional.of(charge));
-
-        Response response = resources
-                .target("/v1/api/accounts/1234/charges/a-charge-id/refunds/a-refund-id/reverse-failed")
-                .request()
-                .post(Entity.json(Map.of("zendesk_ticket_id", "1223333343", "github_user_id", "87")));
-
-        assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
-    }
+    
 
     @Test
     void shouldReturn400ErrorWhenPaymentProviderIsNotStripe() {

--- a/src/test/java/uk/gov/pay/connector/service/RefundReversalStripeConnectTransferRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundReversalStripeConnectTransferRequestBuilderTest.java
@@ -32,7 +32,7 @@ public class RefundReversalStripeConnectTransferRequestBuilderTest {
 
     @BeforeEach
     public void setUp() {
-        builder = new RefundReversalStripeConnectTransferRequestBuilder(mockRandomIdGenerator);
+        builder = new RefundReversalStripeConnectTransferRequestBuilder();
     }
 
     @Test
@@ -41,14 +41,12 @@ public class RefundReversalStripeConnectTransferRequestBuilderTest {
         when(mockStripeRefund.getChargeObject()).thenReturn(mockStripeCharge);
         when(mockStripeCharge.getId()).thenReturn("ch_sdkhdg887s");
         when(mockStripeCharge.getTransferGroup()).thenReturn("abc");
-        when(mockStripeCharge.getOnBehalfOfObject()).thenReturn(mockStripeAccount);
-        when(mockStripeAccount.getId()).thenReturn("acct_jdsa7789d");
+        when(mockStripeCharge.getOnBehalfOf()).thenReturn("acct_jdsa7789d");
         when(mockStripeRefund.getAmount()).thenReturn(100L);
         when(mockStripeRefund.getCurrency()).thenReturn("GBP");
-        when(mockRandomIdGenerator.random13ByteHexGenerator()).thenReturn("randomId123");
 
-        Map<String, Object> builderRequest = builder.createRequest(mockStripeRefund);
-        
+        Map<String, Object> builderRequest = builder.createRequest("randomId123", mockStripeRefund);
+
         List expandList = (List) builderRequest.get("expand");
         assertEquals(2, expandList.size());
         assertEquals("balance_transaction", expandList.get(0));
@@ -58,11 +56,11 @@ public class RefundReversalStripeConnectTransferRequestBuilderTest {
         assertEquals("acct_jdsa7789d", builderRequest.get("destination"));
         assertEquals(100L, builderRequest.get("amount"));
         assertEquals("GBP", builderRequest.get("currency"));
-        
+
         Map<String, Object> metadataMap = (Map<String, Object>) builderRequest.get("metadata");
         assertEquals(2, metadataMap.size());
-        assertEquals("abc", builderRequest.get("transferGroup"));
-        assertEquals("ch_sdkhdg887s", (metadataMap.get("stripeChargeId")));
-        assertEquals("randomId123", (metadataMap.get("correctionPaymentId")));
+        assertEquals("abc", builderRequest.get("transfer_group"));
+        assertEquals("ch_sdkhdg887s", (metadataMap.get("stripe_charge_id")));
+        assertEquals("randomId123", (metadataMap.get("govuk_pay_transaction_external_id")));
     }
 }


### PR DESCRIPTION
## Background

- A Stripe refund succeeded initially but later failed asynchronously. We do not handle this failure case automatically
Funds for a refund are taken from our Stripe platform account as soon as the request to make the refund succeeds. We then make a transfer from the service’s connect account to our platform account. If the refund later fails, Stripe returns the money to our platform account.
- To correct this, we need to make a new transfer from our platform account to the connect account.
We then add a new payment into Pay with required details


## WHAT YOU DID
 - Set the idempotency key for each request to correct async failed refund
 - Added try-catch to catch exceptions if new payment and refund events can't be posted to Ledger
 - Added loggging for posting refunds and new payment events to Ledger

