### PR TITLE
PP-13264 Only require service ID in degatewayed updateServiceName endpoint 

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,56 +139,56 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 3415
+        "line_number": 3405
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 3459
+        "line_number": 3449
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3926
+        "line_number": 3916
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4315
+        "line_number": 4305
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4351
+        "line_number": 4341
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 5279
+        "line_number": 5269
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5765
+        "line_number": 5755
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5776
+        "line_number": 5766
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-02T15:14:04Z"
+  "generated_at": "2024-10-18T10:41:20Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -308,7 +308,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 136
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-18T10:41:20Z"
+  "generated_at": "2024-10-18T12:57:33Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -2967,7 +2967,7 @@ paths:
       summary: Update accepted card types for a gateway account
       tags:
       - Gateway accounts
-  /v1/frontend/service/{serviceId}/account/{accountType}/servicename:
+  /v1/frontend/service/{serviceId}/servicename:
     patch:
       operationId: updateGatewayAccountServiceNameByServiceId
       parameters:
@@ -2978,16 +2978,6 @@ paths:
         required: true
         schema:
           type: string
-      - description: Account type
-        example: test
-        in: path
-        name: accountType
-        required: true
-        schema:
-          type: string
-          enum:
-          - test
-          - live
       requestBody:
         content:
           application/json:
@@ -3008,7 +2998,7 @@ paths:
           description: Bad request
         "404":
           description: Not found
-      summary: Update service name of a gateway account
+      summary: Update service name of Test and Live (if existent) accounts for service
       tags:
       - Gateway accounts
   /v1/frontend/tokens/{chargeTokenId}:


### PR DESCRIPTION
## WHAT YOU DID
 - Change `PATCH /v1/frontend/service/{serviceId}/account/{accountType}/servicename` endpoint to `PATCH /v1/frontend/service/{serviceId}/servicename`
 - Endpoint will change service name in both Test and Live accounts (if a live account exists)
 - Will 404 if no test account exists, will do nothing if no live account exists

## How to test
 - Run tests
