### PR TITLE
PP-11559 fix how RefundFailureFundsSentToConnectAccount is instantiated

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccount.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccount.java
@@ -17,7 +17,9 @@ public class RefundFailureFundsSentToConnectAccount extends PaymentEvent {
     }
 
 
-    public static RefundFailureFundsSentToConnectAccount from(String correctionPaymentId, Refund refund, Charge charge, String githubUserId, String zendeskId) {
+    public static RefundFailureFundsSentToConnectAccount from(String correctionPaymentId, Refund refund,
+                                                              Charge charge, String githubUserId,
+                                                              String zendeskId, String gatewayTransactionId) {
         return new RefundFailureFundsSentToConnectAccount(
                 charge.getServiceId(),
                 charge.isLive(),
@@ -31,7 +33,7 @@ public class RefundFailureFundsSentToConnectAccount extends PaymentEvent {
                         "A refund failed and we returned the recovered funds to the service",
                         charge.getPaymentGatewayName(),
                         charge.getGatewayAccountId(),
-                        charge.getGatewayTransactionId(), //todo: should be new transfer ID
+                        gatewayTransactionId,
                         zendeskId
                 ),
                 Instant.now()

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeSdkClient.java
@@ -65,7 +65,7 @@ public class StripeSdkClient {
         return stripeSDKWrapper.getRefund(stripeRefundId, params, requestOptions);
     }
 
-    public void createTransfer(Map<String, Object> transferRequest,
+    public String createTransfer(Map<String, Object> transferRequest,
                                boolean live, String refundId) throws StripeException {
         String apiKey = getStripeApiKey(live);
 
@@ -75,6 +75,6 @@ public class StripeSdkClient {
                 .setIdempotencyKey(idempotencyKey)
                 .setApiKey(apiKey)
                 .build();
-        stripeSDKWrapper.createTransfer(transferRequest, requestOptions);
+        return stripeSDKWrapper.createTransfer(transferRequest, requestOptions);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeSdkWrapper.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeSdkWrapper.java
@@ -28,7 +28,7 @@ public class StripeSdkWrapper {
         return Refund.retrieve(stripeRefundId, params, requestOptions);
     }
 
-    void createTransfer(Map<String, Object> params, RequestOptions requestOptions) throws StripeException {
-        Transfer.create(params, requestOptions);
+    String createTransfer(Map<String, Object> params, RequestOptions requestOptions) throws StripeException {
+        return Transfer.create(params, requestOptions).getId();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalService.java
@@ -84,10 +84,10 @@ public class RefundReversalService {
         }
 
         Map<String, Object> refundRequestBody = refundRequest.createRequest(correctionPaymentId, refundFromStripe);
-
+        String transferId;
         try {
 
-            stripeClient.createTransfer(refundRequestBody, isLiveGatewayAccount, refundExternalId);
+            transferId = stripeClient.createTransfer(refundRequestBody, isLiveGatewayAccount, refundExternalId);
         } catch (StripeException e) {
             if (e.getStripeError() != null && "insufficient_funds".equals(e.getStripeError().getDeclineCode())) {
                 throw new WebApplicationException(badRequestResponse(
@@ -103,7 +103,7 @@ public class RefundReversalService {
         try {
             ledgerService.postEvent(List.of(
                             PaymentStatusCorrectedToSuccessByAdmin.from(correctionPaymentId, refund, charge, Instant.now(), githubUserId, zendeskUserId),
-                            RefundFailureFundsSentToConnectAccount.from(correctionPaymentId, refund, charge, githubUserId, zendeskUserId),
+                            RefundFailureFundsSentToConnectAccount.from(correctionPaymentId, refund, charge, githubUserId, zendeskUserId, transferId),
                             RefundStatusCorrectedToErrorByAdmin.from(refund, charge, githubUserId, zendeskUserId)
                     )
             );

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccountTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccountTest.java
@@ -35,10 +35,10 @@ class RefundFailureFundsSentToConnectAccountTest {
         String githubUserId = githubAndZendeskCredential.githubUserId();
         String zendeskId = githubAndZendeskCredential.zendeskTicketId();
         String correctionPaymentId = "ExampleCorrectionPaymentId123";
-
+        String transferIdFromStripe = "a-transfer-id-123";
 
         RefundFailureFundsSentToConnectAccount refundFailureFundsSentToConnectAccount = RefundFailureFundsSentToConnectAccount
-                .from(correctionPaymentId, refund, charge, githubUserId, zendeskId);
+                .from(correctionPaymentId, refund, charge, githubUserId, zendeskId, transferIdFromStripe);
 
         assertThat(refundFailureFundsSentToConnectAccount.getResourceExternalId(), is(correctionPaymentId));
         assertThat(refundFailureFundsSentToConnectAccount.isLive(), is(true));
@@ -54,6 +54,6 @@ class RefundFailureFundsSentToConnectAccountTest {
         assertThat(details.getPaymentProvider(), is(charge.getPaymentGatewayName()));
         assertThat(details.getReference(), is(charge.getReference()));
         assertThat(details.getDescription(), is("Failed refund correction for payment."));
-        assertThat(details.getGatewayTransactionId(), is(charge.getGatewayTransactionId()));
+        assertThat(details.getGatewayTransactionId(), is(transferIdFromStripe));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/RefundReversalResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/RefundReversalResourceIT.java
@@ -8,10 +8,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.model.Refund;
 import com.stripe.model.StripeError;
 import io.dropwizard.core.setup.Environment;
-import io.restassured.RestAssured;
-import io.restassured.parsing.Parser;
 import io.restassured.http.ContentType;
-import io.restassured.parsing.Parser;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -98,9 +95,6 @@ public class RefundReversalResourceIT {
                 .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
                 .withGatewayTransactionId(STRIPE_REFUND_ID)
                 .build();
-
-//        when(mockRandomIdGenerator.random13ByteHexGenerator()).thenReturn("random123");
-
     }
 
     @AfterEach
@@ -126,8 +120,6 @@ public class RefundReversalResourceIT {
         when(mockStripeRefund.getAmount()).thenReturn(100L);
         when(mockStripeRefund.getCurrency()).thenReturn("GBP");
 
-//        when(mockRandomIdGenerator.random13ByteHexGenerator()).thenReturn("random123");
-        
         ValidatableResponse response = given().port(app.getLocalPort())
                 .accept(ContentType.JSON)
                 .contentType(ContentType.JSON)
@@ -264,7 +256,6 @@ public class RefundReversalResourceIT {
                 .body("message[0]", is("Transfer failed due to insufficient funds for refund with " + REFUND_EXTERNAL_ID + " error with stripe because of insufficient funds; code: insufficient_funds_error; request-id: req_12345"))
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode());
     }
-
 
     @Test
     void shouldReturnErrorWhenDuplicateIdepmpotencyKeys() throws JsonProcessingException, StripeException {


### PR DESCRIPTION
## WHAT YOU DID

`RefundFailureFundsSentToConnectAccount` should have the new id.

- refactor TODO to use `correctionPaymentId`
- clean up `RefundReversalResourceIT`
