### PR TITLE
PP-13052 Add instant source to WorldpayPaymentProvider

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -521,28 +521,28 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 143
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "fd9f851472586dc75f7a60ee311842ec64ecf527",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 146
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "9367c8305bd1afe815ffc0cc3ebf95af9cb6d157",
         "is_verified": false,
-        "line_number": 146
+        "line_number": 149
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 987
+        "line_number": 993
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-28T11:36:24Z"
+  "generated_at": "2024-11-01T12:13:15Z"
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -57,6 +57,8 @@ import javax.ws.rs.WebApplicationException;
 import java.net.HttpCookie;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.InstantSource;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -78,6 +80,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -144,6 +147,7 @@ class WorldpayPaymentProviderTest {
     public static final String MIT_MERCHANT_CODE = "mit-merchant-code";
     public static final String MIT_USERNAME = "mit-username";
     public static final String MIT_PASSWORD = "mit-password";
+    private static final String INSTANT_EXPECTED = "2024-11-01T14:13:47Z";
 
     @Mock
     private GatewayClient authoriseClient;
@@ -178,6 +182,7 @@ class WorldpayPaymentProviderTest {
 
     @BeforeEach
     void setup() {
+        InstantSource instantSource = InstantSource.fixed(Instant.parse(INSTANT_EXPECTED));
         worldpayPaymentProvider = new WorldpayPaymentProvider(
                 GATEWAY_URL_MAP,
                 authoriseClient,
@@ -191,7 +196,8 @@ class WorldpayPaymentProviderTest {
                 new AuthorisationService(mock(CardExecutorService.class), mock(Environment.class), mock(ConnectorConfiguration.class)),
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
                 chargeDao,
-                eventService);
+                eventService,
+                instantSource);
 
         gatewayAccountEntity = aGatewayAccount();
         chargeEntityFixture = aValidChargeEntity()

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -56,6 +56,8 @@ import javax.ws.rs.client.ClientBuilder;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.time.Clock;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -106,6 +108,7 @@ class WorldpayPaymentProviderTest {
     private static final String MAGIC_CARDHOLDER_NAME_FOR_3DS_FLEX_CHALLENGE_REQUIRED_RESPONSE = "3DS_V2_CHALLENGE_IDENTIFIED";
 
     private static final String VISA_CARD_NUMBER = "4444333322221111";
+    private InstantSource instantSource = Clock.systemUTC();
 
     private GatewayAccountEntity validGatewayAccount;
     private GatewayAccountEntity validGatewayAccountFor3ds;
@@ -659,7 +662,8 @@ class WorldpayPaymentProviderTest {
                 new AuthorisationService(mockCardExecutorService, mockEnvironment, mockConnectorConfiguration),
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
                 mock(ChargeDao.class),
-                mock(EventService.class));
+                mock(EventService.class),
+                instantSource);
     }
 
     private Map<String, URI> gatewayUrlMap() {


### PR DESCRIPTION
With this change, we are adding InstantSource to WorldpayPaymentProvider to disambiguate events emitted based on time.

Further information in a previous PR review[1] and in Jira[2].

[1]
https://github.com/alphagov/pay-connector/pull/5616#discussion_r1820736340

[2]
https://payments-platform.atlassian.net/browse/PP-13052

