### PR TITLE
PP-PP-13237 set requires_3ds to true

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -496,6 +496,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     public void set3dsRequiredDetails(Auth3dsRequiredEntity auth3dsRequiredDetails) {
         this.auth3dsRequiredDetails = auth3dsRequiredDetails;
+        this.requires3ds = true;
     }
 
     public SupportedLanguage getLanguage() {

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -170,12 +170,15 @@ public class ChargeEntityFixture {
         chargeEntity.setCorporateSurcharge(corporateSurcharge);
         chargeEntity.getEvents().addAll(events);
         chargeEntity.setProviderSessionId(providerSessionId);
-        chargeEntity.set3dsRequiredDetails(auth3DsRequiredEntity);
         chargeEntity.setWalletType(walletType);
         chargeEntity.setExemption3ds(exemption3ds);
         chargeEntity.setExemption3dsRequested(exemption3dsRequested);
         chargeEntity.setPaymentInstrument(paymentInstrument);
         chargeEntity.setUpdatedDate(updatedDate);
+
+        if (this.auth3DsRequiredEntity != null) {
+            chargeEntity.set3dsRequiredDetails(auth3DsRequiredEntity);
+        }
 
         if (this.fees != null) {
             fees.stream().forEach(partialFee -> {

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -450,6 +450,8 @@ class ChargeServiceTest {
         verify(chargeSpy).setGatewayTransactionId("transaction-id");
         verify(chargeSpy).setStatus(AUTHORISATION_SUCCESS);
         verify(mockedChargeEventDao).persistChargeEventOf(eq(chargeSpy), isNull());
+
+        assertThat(chargeSpy.getRequires3ds(), is(nullValue()));
     }
 
     @Test
@@ -472,6 +474,8 @@ class ChargeServiceTest {
         verify(chargeSpy).setProviderSessionId("provider-session-identifier");
         verify(mockedChargeEventDao).persistChargeEventOf(eq(chargeSpy), isNull());
         verify(mockEventService).emitAndRecordEvent(any(Gateway3dsInfoObtained.class));
+
+        assertThat(chargeSpy.getRequires3ds(), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -184,8 +184,9 @@ public class ChargeDaoIT {
                 .withId(null)
                 .withGatewayAccountEntity(gatewayAccount)
                 .withGatewayAccountCredentialsEntity(gatewayAccountCredentialsEntity)
-                .withAuth3dsDetailsEntity(auth3dsDetailsEntity)
                 .build();
+
+        chargeEntity.set3dsRequiredDetails(auth3dsDetailsEntity);
 
         assertThat(chargeEntity.getId(), is(nullValue()));
 
@@ -201,6 +202,7 @@ public class ChargeDaoIT {
         assertThat(charge.get().get3dsRequiredDetails().getWorldpayChallengeTransactionId(), is(worldpayChallengeTransactionId));
         assertThat(charge.get().get3dsRequiredDetails().getWorldpayChallengePayload(), is(worldpayChallengePayload));
         assertThat(charge.get().get3dsRequiredDetails().getThreeDsVersion(), is(threeDsVersion));
+        assertThat(charge.get().getRequires3ds(), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityTest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.model.domain;
 
 
 import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.FeeType;
@@ -15,6 +16,7 @@ import java.util.Optional;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -219,5 +221,17 @@ class ChargeEntityTest {
                 kv(AGREEMENT_EXTERNAL_ID, agreementExternalId)
         ));
     }
-     
+
+    @Test
+    void shouldSetRequires3dsToTrueWhenSettingAuth3dsRequiredEntity() {
+        Auth3dsRequiredEntity auth3dsRequiredEntity = new Auth3dsRequiredEntity();
+        auth3dsRequiredEntity.setThreeDsVersion("2.1");
+        ChargeEntity chargeEntity = aValidChargeEntity().build();
+
+        assertThat(chargeEntity.getRequires3ds(), is(nullValue()));
+
+        chargeEntity.set3dsRequiredDetails(auth3dsRequiredEntity);
+
+        assertTrue(chargeEntity.getRequires3ds());
+    }
 }


### PR DESCRIPTION
## WHAT YOU DID

When connector emits a GATEWAY_REQUIRES_3DS_AUTHORISATION event then the requires_3ds column for that payment in the charges table of the connector table has its value set to true
