### PR TITLE
PP-13051 Introduce missing test combinations

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -536,28 +536,28 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 145
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "fd9f851472586dc75f7a60ee311842ec64ecf527",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 148
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "9367c8305bd1afe815ffc0cc3ebf95af9cb6d157",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 151
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 1079
+        "line_number": 1181
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-06T16:49:19Z"
+  "generated_at": "2024-11-11T15:32:37Z"
 }


### PR DESCRIPTION
With previous work, we have introduced corporate exemptions and tests to ensure the correct behaviour depending on:

- exemption engine being ON or OFF
- corporate exemptions being ON or OFF
- cards being CORPORATE or NON CORPORATE

With this change, we are adding three new tests for the three missing combinations as follows:

- exemption engine ON, corporate exemptions ON, NON corporate card --> OPTIMISED REQUESTED
- exemption engine OFF, corporate exemptions ON, corporate card --> CORPORATE REQUESTED
- exemption engine OFF, corporate exemptions ON, NON corporate card --> NOT REQUESTED

Further information in the JIRA ticket.

https://payments-platform.atlassian.net/browse/PP-13051

# TEST COMBINATIONS

![test combinations](https://github.com/user-attachments/assets/a639c395-44a8-4628-bb34-cb95b446ef47)

Exemption engine | Corporate Exemptions | Corporate card | Result | Status | Name
-- | -- | -- | -- | -- | --
TRUE | TRUE | TRUE | CORPORATE REQUESTED | existing | should_send_corporate_exemption_with_worldpay_authorisation_if_corporate_exemption_enabled_and_exemption_engine_enabled_and_corporate_card_used
TRUE | TRUE | FALSE | OPTIMISED REQUESTED | new | should_send_optimised_exemption_with_worldpay_authorisation_if_corporate_exemption_enabled_and_exemption_engine_enabled_and_non_corporate_card_used
TRUE | FALSE | TRUE | OPTIMISED REQUESTED | existing | should_send_optimised_exemption_with_worldpay_authorisation_if_corporate_exemption_is_not_enabled_and_exemption_engine_enabled_and_corporate_card_used
TRUE | FALSE | FALSE | OPTIMISED REQUESTED | existing | should_include_exemption_if_account_has_exemption_engine_set_to_true
FALSE | TRUE | TRUE | CORPORATE REQUESTED | new | should_send_corporate_exemption_with_worldpay_authorisation_if_corporate_exemption_enabled_and_exemption_engine_disabled_and_corporate_card_used
FALSE | TRUE | FALSE | NOT REQUESTED | new | should_not_request_exemption_if_exemption_engine_disabled_and_corporate_exemptions_enabled_and_non_corporate_card_used
FALSE | FALSE | TRUE | NOT REQUESTED | existing | should_not_send_corporate_exemption_with_worldpay_authorisation_if_corporate_exemptions_false_and_corporate_card_is_used
FALSE | FALSE | FALSE | NOT REQUESTED | existing | should_not_include_exemption_if_account_has_exemption_engine_set_to_false


