### PR TITLE
PP-13052 Test charge update and logging for soft decline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -557,7 +557,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 1181
+        "line_number": 1184
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-11T15:32:37Z"
+  "generated_at": "2024-11-11T16:37:23Z"
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -502,6 +502,9 @@ class WorldpayPaymentProviderTest {
         verify(worldpayAuthoriseHandler).authorise(cardAuthRequest, SEND_CORPORATE_EXEMPTION_REQUEST);
         verifyNoMoreInteractions(worldpayAuthoriseHandler);
 
+        verifyChargeUpdatedWith3dsAndExemptionRequested(EXEMPTION_REJECTED, CORPORATE);
+        verifyLoggingWithExemptionReason(EXEMPTION_REJECTED, "HIGH_RISK", chargeEntity.getExternalId(), 3);
+
         var exemptionRejectedEvent = new Gateway3dsExemptionResultObtained(
                 chargeEntity.getServiceId(), 
                 chargeEntity.getGatewayAccount().isLive(), 


### PR DESCRIPTION
With previous work[1], we have handled the Worldpay authorisation response for requests with corporate exemptions, with several tests for all the scenarios.

However, the test for the scenario describing the interaction when the corporate exemption is soft-declined was not testing that the charge was being updated and that the logging was taking place.

This change introduces the missing verifications.

Further information in JIRA[2].

[1]
https://github.com/alphagov/pay-connector/pull/5616

[2]
https://payments-platform.atlassian.net/browse/PP-13052?focusedCommentId=58545

