### PR TITLE
PP-13240 fix optimistic lock exception

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -221,7 +221,7 @@ public class CardAuthoriseService {
                 mayBeCanRetry.orElse(null),
                 mayBeRejectedReason.orElse(null));
 
-        updatedCharge = chargeService.updateRequires3dsPostAuthorisation(updatedCharge.getExternalId());
+        updatedCharge = chargeService.updateRequires3dsPostAuthorisationAndEmitEvent(updatedCharge.getExternalId());
 
         var authorisationRequestSummary = generateAuthorisationRequestSummary(charge, authCardDetails);
 

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -184,7 +184,7 @@ public class WalletAuthoriseService {
                 walletAuthorisationRequest.getPaymentInfo().getEmail(),
                 auth3dsRequiredDetails);
 
-        updatedCharge = chargeService.updateRequires3dsPostAuthorisation(updatedCharge.getExternalId());
+        updatedCharge = chargeService.updateRequires3dsPostAuthorisationAndEmitEvent(updatedCharge.getExternalId());
 
         metricRegistry.counter(String.format(
                 "gateway-operations.%s.%s.%s.authorise.result.%s",

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
@@ -140,7 +140,7 @@ class WalletAuthoriseServiceForGooglePay3dsTest {
         WorldpayOrderStatusResponse worldpayOrderStatusResponse = XMLUnmarshaller.unmarshall(successPayload, WorldpayOrderStatusResponse.class);
         providerRequestsFor3dsAuthorisation(worldpayOrderStatusResponse);
 
-        when(chargeService.updateRequires3dsPostAuthorisation(chargeEntity.getExternalId())).thenReturn(chargeEntity);
+        when(chargeService.updateRequires3dsPostAuthorisationAndEmitEvent(chargeEntity.getExternalId())).thenReturn(chargeEntity);
 
         GooglePayAuthRequest authorisationData =
                 Jackson.getObjectMapper().readValue(load("googlepay/example-auth-request.json"), GooglePayAuthRequest.class);


### PR DESCRIPTION
## WHAT YOU DID

Merging charge by updateRequires3dsPostAuthorisation when marked as `@Transactional` is delayed by waiting to emit an event. Move the merging (when required) to a separate `@Transactional` method.
