### PR TITLE
PP-13343 fix description for wallet payments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -566,7 +566,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 87
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-20T11:53:42Z"
+  "generated_at": "2024-11-21T11:14:16Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
@@ -100,6 +100,7 @@ public class WorldpayWalletAuthorisationHandler implements WorldpayGatewayRespon
 
     private GatewayOrder buildWalletAuthoriseOrder(AuthorisationGatewayRequest request, WalletPaymentInfo walletPaymentInfo, WorldpayOrderRequestBuilder builder) {
         boolean isSendPayerEmailToGateway = request.getGatewayAccount().isSendPayerEmailToGateway();
+        boolean isSendReferenceToGateway = request.getGatewayAccount().isSendReferenceToGateway();
 
         if (isSendPayerEmailToGateway) {
             Optional.ofNullable(walletPaymentInfo.getEmail()).ifPresent(builder::withPayerEmail);
@@ -109,7 +110,7 @@ public class WorldpayWalletAuthorisationHandler implements WorldpayGatewayRespon
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getGovUkPayPaymentId()))
                 .withTransactionId(request.getTransactionId().orElse(""))
                 .withMerchantCode(AuthUtil.getWorldpayMerchantCode(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()))
-                .withDescription(request.getDescription())
+                .withDescription(isSendReferenceToGateway ? request.getReference().toString() : request.getDescription())
                 .withAmount(request.getAmount())
                 .build();
     }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -46,6 +46,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-with-email.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-with-reference-as-description.xml";
 
     public static final String WORLDPAY_VALID_AUTHORISE_GOOGLE_PAY_3DS_REQUEST_WITH_DDC_RESULT = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-with-ddc.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-with-email.xml";
@@ -55,6 +56,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_REQUEST_3DS_FLEX_NON_JS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-3ds-flex-non-js.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_3DS_REQUEST_EXEMPTION_OPTIMISED = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-exemption-optimised.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_3DS_REQUEST_CORPORATE_EXEMPTION_AUTHORISATION = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-corporate-exemption-authorisation.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-with-reference-as-description.xml";
 
     public static final String WORLDPAY_3DS_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-response.xml";
     public static final String WORLDPAY_3DS_FLEX_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-flex-response.xml";

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-apple-pay-with-reference-as-description.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-apple-pay-with-reference-as-description.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!" shopperLanguageCode="en">
+            <description>This is a reference</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <EMVCO_TOKEN-SSL type="APPLEPAY">
+                    <tokenNumber>4818528840010767</tokenNumber>
+                    <expiryDate><date month="12" year="2023"/></expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cryptogram>Ao/fzpIAFvp1eB9y8WVDMAACAAA=</cryptogram>
+                    <eciIndicator>07</eciIndicator>
+                </EMVCO_TOKEN-SSL>
+            </paymentDetails>
+        </order>
+    </submit>
+</paymentService>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-with-reference-as-description.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-with-reference-as-description.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!" shopperLanguageCode="en">
+            <description>This is a reference</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <PAYWITHGOOGLE-SSL>
+                    <protocolVersion>ECv1</protocolVersion>
+                    <signature>MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl</signature>
+                    <signedMessage>aSignedMessage</signedMessage>
+                </PAYWITHGOOGLE-SSL>
+            </paymentDetails>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
## WHAT YOU DID

For Worldpay accounts, we have a flag to enable payment references to be sent in the Worldpay order description field instead of the payment description.

However, we are not sending the reference for wallet payments even when the flag is enabled.

For Wallet payments - payment reference should be set in the Worldpay order description if the send_reference_to_gateway flag is enabled.

