### PR TITLE
fix order in sending async refund and clean up

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdmin.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdmin.java
@@ -29,7 +29,7 @@ public class PaymentStatusCorrectedToSuccessByAdmin extends PaymentEvent {
                         refund.getAmount(),
                         timestamp,
                         ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE.getStatus(),
-                        "A refund failed and we returned the recovered funds to the service",
+                        "A refund failed and we returned the recovered funds to the service - Zendesk ticket " + zendeskId,
                         githubId,
                         charge.getGatewayAccountId(),
                         timestamp,

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccount.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccount.java
@@ -28,9 +28,9 @@ public class RefundFailureFundsSentToConnectAccount extends PaymentEvent {
                 new RefundFailureFundsSentToConnectAccountEventDetails(
                         refund.getAmount(),
                         charge.getReference(),
-                        "Failed refund correction for payment.",
+                        "Failed refund correction for payment " + charge.getExternalId() + ". Returning funds from GOV.UK Pay platform.",
                         githubUserId,
-                        "A refund failed and we returned the recovered funds to the service",
+                        "A refund failed and we returned the recovered funds to the service - Zendesk ticket " + zendeskId,
                         charge.getPaymentGatewayName(),
                         charge.getGatewayAccountId(),
                         gatewayTransactionId,

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundStatusCorrectedToErrorByAdmin.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundStatusCorrectedToErrorByAdmin.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.events.model.refund;
 
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundStatusCorrectedToErrorByAdminEventDetails;
-import uk.gov.pay.connector.refund.model.domain.GithubAndZendeskCredential;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 
 import java.time.Instant;
@@ -23,7 +22,7 @@ public class RefundStatusCorrectedToErrorByAdmin extends RefundEvent {
                 refund.getExternalId(),
                 refund.getChargeExternalId(),
                 new RefundStatusCorrectedToErrorByAdminEventDetails(
-                        "Correct refund status to match Stripe",
+                        "Correct refund status to match Stripe - Zendesk ticket " + zendeskId,
                         githubId,
                         zendeskId
                 ),

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundReversalService.java
@@ -102,9 +102,9 @@ public class RefundReversalService {
 
         try {
             ledgerService.postEvent(List.of(
-                            PaymentStatusCorrectedToSuccessByAdmin.from(correctionPaymentId, refund, charge, Instant.now(), githubUserId, zendeskUserId),
-                            RefundFailureFundsSentToConnectAccount.from(correctionPaymentId, refund, charge, githubUserId, zendeskUserId, transferId),
-                            RefundStatusCorrectedToErrorByAdmin.from(refund, charge, githubUserId, zendeskUserId)
+                    RefundFailureFundsSentToConnectAccount.from(correctionPaymentId, refund, charge, githubUserId, zendeskUserId, transferId),
+                    PaymentStatusCorrectedToSuccessByAdmin.from(correctionPaymentId, refund, charge, Instant.now(), githubUserId, zendeskUserId),
+                    RefundStatusCorrectedToErrorByAdmin.from(refund, charge, githubUserId, zendeskUserId)
                     )
             );
             return Response.ok().build();

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdminTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/PaymentStatusCorrectedToSuccessByAdminTest.java
@@ -49,7 +49,7 @@ class PaymentStatusCorrectedToSuccessByAdminTest {
         assertThat(details.getFee(), is(0L));
         assertThat(details.getAdminGithubId(), is("John Doe (JohnDoeGds)"));
         assertThat(details.getZendeskId(), is("1223333343"));
-        assertThat(details.getUpdatedReason(), is("A refund failed and we returned the recovered funds to the service"));
+        assertThat(details.getUpdatedReason(), is("A refund failed and we returned the recovered funds to the service - Zendesk ticket " + zendeskId));
         assertThat(details.getCapturedDate(), is(fixedTimestamp));
         assertThat(details.getNetAmount(), is(charge.getAmount()));
         assertThat(details.getRefundAmountAvailable(), is(0L));

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccountTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundFailureFundsSentToConnectAccountTest.java
@@ -49,11 +49,11 @@ class RefundFailureFundsSentToConnectAccountTest {
         assertThat(details.getAmount(), is(refund.getAmount()));
         assertThat(details.getAdminGithubId(), is("John Doe (JohnDoeGds)"));
         assertThat(details.getZendeskId(), is("1223333343"));
-        assertThat(details.getUpdatedReason(), is("A refund failed and we returned the recovered funds to the service"));
+        assertThat(details.getUpdatedReason(), is("A refund failed and we returned the recovered funds to the service - Zendesk ticket " + zendeskId));
         assertThat(details.getGatewayAccountId(), is(charge.getGatewayAccountId()));
         assertThat(details.getPaymentProvider(), is(charge.getPaymentGatewayName()));
         assertThat(details.getReference(), is(charge.getReference()));
-        assertThat(details.getDescription(), is("Failed refund correction for payment."));
+        assertThat(details.getDescription(), is("Failed refund correction for payment " + charge.getExternalId() + ". Returning funds from GOV.UK Pay platform."));
         assertThat(details.getGatewayTransactionId(), is(transferIdFromStripe));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundStatusCorrectedToErrorByAdminTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundStatusCorrectedToErrorByAdminTest.java
@@ -46,7 +46,7 @@ class RefundStatusCorrectedToErrorByAdminTest {
         RefundStatusCorrectedToErrorByAdminEventDetails details = (RefundStatusCorrectedToErrorByAdminEventDetails)
                 refundStatusCorrectedToErrorByAdmin.getEventDetails();
 
-        assertThat(details.getUpdatedReason(), is("Correct refund status to match Stripe"));
+        assertThat(details.getUpdatedReason(), is("Correct refund status to match Stripe - Zendesk ticket " + zendeskId));
         assertThat(details.getAdminGithubId(), is("John Doe (JohnDoeGds)"));
         assertThat(details.getZendeskId(), is("1223333343"));
     }


### PR DESCRIPTION


## WHAT YOU DID

- Correct the order the refund events are sent in accordance with the `handle_failed_refund` script (https://github.com/alphagov/pay-scripts/blob/master/ad-hoc-scripts/stripe/handle_failed_refund.js)
- Added a few Id's including `zendeskId` and `GOV.UK Pay ID` for descriptions of refund events