### PR TITLE
Add temporary debug logging for refund notifications on test merchant

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -82,6 +82,9 @@ public class WorldpayNotificationService {
             logger.debug("Payload: {}", payload);
             notification = XMLUnmarshaller.unmarshall(payload, WorldpayNotification.class);
             logger.info("Parsed {} notification: {}", PAYMENT_GATEWAY_NAME, notification);
+            if (isTemporaryLoggingRequiredOnTestOnly(notification)) {
+                logger.info("{} notification {} is being inspected (on test only) for PP-13416. Payload: {}", PAYMENT_GATEWAY_NAME, notification, payload);
+            }
         } catch (XMLUnmarshallerException e) {
             logger.error("{} notification parsing failed: {}", PAYMENT_GATEWAY_NAME, e);
             return true;
@@ -159,6 +162,13 @@ public class WorldpayNotificationService {
 
     private boolean isErrorNotification(WorldpayNotification notification) {
         return "ERROR".equals(notification.getStatus());
+    }
+
+    // TODO: Temporary logging for PP-13416
+    private boolean isTemporaryLoggingRequiredOnTestOnly(WorldpayNotification notification) {
+        return ("REFUND_FAILED".equals(notification.getStatus()) ||
+        "SENT_FOR_REFUND".equals(notification.getStatus()))
+        && "GBSRECABOFFGDSGBPTEST".equals(notification.getMerchantCode());
     }
 
     private RefundStatus newRefundStatus(WorldpayNotification notification) {


### PR DESCRIPTION
This change adds additional logging to inspect the complete notification payload from Worldpay specifically for refund notifications (REFUND_FAILED and SENT_FOR_REFUND statuses) on the test merchant account (GBSRECABOFFGDSGBPTEST).

The extra logging will help investigate where Worldpay includes the refund request ID in their notifications, since we discovered that the 'reference' field is being used for:
- authorization code (for successful refunds)
- failure reason (for failed refunds)

The logging is strictly limited to the test merchant to avoid exposing PII in production environments.

Further information in JIRA.

https://payments-platform.atlassian.net/browse/PP-13416
