### PR TITLE
Introduce new reference attribute in Worldpay Notification: `refundAuthorisationReference`

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -787,7 +787,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 123
+        "line_number": 125
       }
     ],
     "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayAuthRequestBuilder.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-22T15:39:59Z"
+  "generated_at": "2025-01-23T09:12:11Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotification.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotification.java
@@ -16,7 +16,7 @@ public class WorldpayNotification implements ChargeStatusRequest {
     public WorldpayNotification() {
     }
 
-    public WorldpayNotification(String merchantCode, String status, int dayOfMonth, int month, int year, String transactionId, String reference) {
+    public WorldpayNotification(String merchantCode, String status, int dayOfMonth, int month, int year, String transactionId, String reference, String refundAuthorisationReference) {
         this.merchantCode = merchantCode;
         this.status = status;
         this.dayOfMonth = dayOfMonth;
@@ -24,6 +24,7 @@ public class WorldpayNotification implements ChargeStatusRequest {
         this.year = year;
         this.transactionId = transactionId;
         this.reference = reference;
+        this.refundAuthorisationReference = refundAuthorisationReference;
     }
 
     @XmlPath("@merchantCode")
@@ -43,6 +44,9 @@ public class WorldpayNotification implements ChargeStatusRequest {
 
     @XmlPath("notify/orderStatusEvent/@orderCode")
     private String transactionId;
+
+    @XmlPath("notify/orderStatusEvent/journal/journalReference[@type='refund_authorisation']/@reference")
+    private String refundAuthorisationReference;
 
     @XmlPath("notify/orderStatusEvent/journal/journalReference/@reference")
     private String reference;
@@ -79,6 +83,10 @@ public class WorldpayNotification implements ChargeStatusRequest {
         return reference;
     }
 
+    public String getRefundAuthorisationReference() {
+        return refundAuthorisationReference;
+    }
+
     public LocalDate getBookingDate() {
         return LocalDate.of(year, month, dayOfMonth);
     }
@@ -93,6 +101,8 @@ public class WorldpayNotification implements ChargeStatusRequest {
                 ", year=" + year +
                 ", transactionId='" + transactionId + '\'' +
                 ", reference='" + reference + '\'' +
+                ", captureReference='" + reference + '\'' +
+                ", refundAuthorisationReference='" + refundAuthorisationReference + '\'' +
                 ", chargeStatus=" + chargeStatus +
                 '}';
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -52,6 +52,7 @@ class WorldpayNotificationServiceTest {
 
     private final String ipAddress = "1.1.1.1";
     private final String referenceId = "refund-reference";
+    private final String refundAuthorisationReference = "refund-authorisation-reference";
     private final String transactionId = "transaction-reference";
 
     @BeforeEach
@@ -72,6 +73,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
+                "",
                 "CAPTURED",
                 "10",
                 "03",
@@ -87,7 +89,8 @@ class WorldpayNotificationServiceTest {
                 3,
                 2017,
                 transactionId,
-                referenceId
+                referenceId,
+                ""
         );
         verify(mockChargeNotificationProcessor).invoke(expectedNotification.getTransactionId(), charge, CAPTURED, expectedNotification.getGatewayEventDate());
     }
@@ -103,6 +106,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
+                "",
                 "CAPTURED",
                 "10",
                 "03",
@@ -126,7 +130,7 @@ class WorldpayNotificationServiceTest {
 
         for (String status : refundSuccessStatuses) {
             final String payload = sampleWorldpayNotification(
-                    transactionId, referenceId, status,
+                    transactionId, referenceId, "", status,
                     "10", "03", "2017");
 
             final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
@@ -143,7 +147,7 @@ class WorldpayNotificationServiceTest {
         setUpChargeServiceToReturnCharge(Optional.of(charge));
         setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
         final String payload = sampleWorldpayNotification(
-                transactionId, referenceId, "REFUND_FAILED",
+                transactionId, referenceId, "", "REFUND_FAILED",
                 "10", "03", "2017");
 
         final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
@@ -160,6 +164,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
+                "",
                 "CHARGED",
                 "10",
                 "03",
@@ -176,7 +181,7 @@ class WorldpayNotificationServiceTest {
     void ifChargeNotFound_shouldIgnoreForNonTelephonePaymentAccount() {
         when(mockGatewayAccountService.isATelephonePaymentNotificationAccount("MERCHANTCODE")).thenReturn(false);
         final String payload = sampleWorldpayNotification(
-                transactionId, referenceId, "CHARGED", "10", "03", "2017");
+                transactionId, referenceId, "", "CHARGED", "10", "03", "2017");
         setUpChargeServiceToReturnCharge(Optional.empty());
 
         final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
@@ -192,6 +197,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
+                "",
                 "CHARGED",
                 "10",
                 "03",
@@ -209,6 +215,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 "",
                 referenceId,
+                "",
                 "CHARGED",
                 "10",
                 "03",
@@ -238,6 +245,7 @@ class WorldpayNotificationServiceTest {
             final String payload = sampleWorldpayNotification(
                     transactionId,
                     referenceId,
+                    refundAuthorisationReference,
                     status);
 
             assertTrue(notificationService.handleNotificationFor(ipAddress, payload));
@@ -254,7 +262,7 @@ class WorldpayNotificationServiceTest {
         setUpChargeServiceToReturnCharge(Optional.of(charge));
         setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(mockGatewayAccountEntity));
 
-        final String payload = sampleWorldpayNotification(transactionId, referenceId, "ERROR");
+        final String payload = sampleWorldpayNotification(transactionId, referenceId, "", "ERROR");
 
         assertTrue(notificationService.handleNotificationFor(ipAddress, payload));
         verify(mockGatewayAccountEntity, times(1)).isLive();
@@ -267,6 +275,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
+                "",
                 "CAPTURED",
                 "10",
                 "03",
@@ -296,6 +305,7 @@ class WorldpayNotificationServiceTest {
     private static String sampleWorldpayNotification(
             String transactionId,
             String referenceId,
+            String refundAuthorisationReference,
             String status,
             String bookingDateDay,
             String bookingDateMonth,
@@ -303,6 +313,7 @@ class WorldpayNotificationServiceTest {
         return TestTemplateResourceLoader.load(WORLDPAY_NOTIFICATION)
                 .replace("{{transactionId}}", transactionId)
                 .replace("{{refund-ref}}", referenceId)
+                .replace("{{refund-authorisation-reference}}", refundAuthorisationReference)
                 .replace("{{status}}", status)
                 .replace("{{bookingDateDay}}", bookingDateDay)
                 .replace("{{bookingDateMonth}}", bookingDateMonth)
@@ -312,8 +323,9 @@ class WorldpayNotificationServiceTest {
     private static String sampleWorldpayNotification(
             String transactionId,
             String referenceId,
+            String refundAuthorisationReference,
             String status) {
-        return sampleWorldpayNotification(transactionId, referenceId, status, "2017", "10", "22");
+        return sampleWorldpayNotification(transactionId, referenceId, refundAuthorisationReference, status, "2017", "10", "22");
     }
 
     private void setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional<GatewayAccountEntity> gatewayAccountEntity) {

--- a/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
@@ -63,6 +63,7 @@ class WorldpayXMLUnmarshallerTest {
                 .replace("{{transactionId}}", transactionId)
                 .replace("{{status}}", status)
                 .replace("{{refund-ref}}", "REFUND-REF")
+                .replace("{{refund-authorisation-reference}}", "REFUND-AUTHORISATION-REFERENCE")
                 .replace("{{bookingDateDay}}", "10")
                 .replace("{{bookingDateMonth}}", "01")
                 .replace("{{bookingDateYear}}", "2017");
@@ -71,6 +72,7 @@ class WorldpayXMLUnmarshallerTest {
         assertThat(response.getTransactionId(), is(transactionId));
         assertThat(response.getMerchantCode(), is("MERCHANTCODE"));
         assertThat(response.getReference(), is("REFUND-REF"));
+        assertThat(response.getRefundAuthorisationReference(), is("REFUND-AUTHORISATION-REFERENCE"));
         assertThat(response.getBookingDate(), is(LocalDate.parse("2017-01-10")));
     }
 

--- a/src/test/resources/templates/worldpay/notification.xml
+++ b/src/test/resources/templates/worldpay/notification.xml
@@ -30,6 +30,7 @@
                     <amount value="5000" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
                 </accountTx>
                 <journalReference type="capture" reference="{{refund-ref}}"/>
+                <journalReference type="refund_authorisation" reference="{{refund-authorisation-reference}}"/>
             </journal>
         </orderStatusEvent>
     </notify>


### PR DESCRIPTION
With this change, we are introducing a new reference attribute in the Worldpay
notification, i.e. in our representation of the notification we receive from
Worldpay: refundAuthorisationReference.

This is parsed from the XML element `journalReference` with type
`refund_authorisation`.

We have already been parsing an other reference attribute, parsing it from the
XML element `journalReference` with type `capture`.

An example for the first is:

```
<journalReference type="capture" reference="7500jujg0e8hjap4m9885f8ska"/>
```
 An example for the second is:
 
 ```
 <journalReference type="refund_authorisation" reference="987654"/>
```

This change makes sure that we avoid parsing the wrong reference values, now
that Worldpay will start sending the new reference attribute for successful
refunds.

In the future, it might be good to rename our first internal `reference`
attribute to `captureReference`, to make it clearer that it is parsed from
the journalReference XML element with type `capture`, however we are keeping
it named as `reference`, for now, to limit the scope of this change.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-13419


