### PR TITLE
Parse Worldpay notification reference attributes univocally

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -787,7 +787,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 127
       }
     ],
     "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayAuthRequestBuilder.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-23T09:12:11Z"
+  "generated_at": "2025-01-23T15:53:00Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotification.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotification.java
@@ -16,7 +16,7 @@ public class WorldpayNotification implements ChargeStatusRequest {
     public WorldpayNotification() {
     }
 
-    public WorldpayNotification(String merchantCode, String status, int dayOfMonth, int month, int year, String transactionId, String reference, String refundAuthorisationReference) {
+    public WorldpayNotification(String merchantCode, String status, int dayOfMonth, int month, int year, String transactionId, String reference, String refundAuthorisationReference, String refundResponseReference) {
         this.merchantCode = merchantCode;
         this.status = status;
         this.dayOfMonth = dayOfMonth;
@@ -25,6 +25,7 @@ public class WorldpayNotification implements ChargeStatusRequest {
         this.transactionId = transactionId;
         this.reference = reference;
         this.refundAuthorisationReference = refundAuthorisationReference;
+        this.refundResponseReference = refundResponseReference;
     }
 
     @XmlPath("@merchantCode")
@@ -48,8 +49,11 @@ public class WorldpayNotification implements ChargeStatusRequest {
     @XmlPath("notify/orderStatusEvent/journal/journalReference[@type='refund_authorisation']/@reference")
     private String refundAuthorisationReference;
 
-    @XmlPath("notify/orderStatusEvent/journal/journalReference/@reference")
+    @XmlPath("notify/orderStatusEvent/journal/journalReference[@type='capture']/@reference")
     private String reference;
+
+    @XmlPath("notify/orderStatusEvent/journal/journalReference[@type='refund_response']/@reference")
+    private String refundResponseReference;
 
     private Optional<ChargeStatus> chargeStatus = Optional.empty();
 
@@ -87,6 +91,10 @@ public class WorldpayNotification implements ChargeStatusRequest {
         return refundAuthorisationReference;
     }
 
+    public String getRefundResponseReference() {
+        return refundResponseReference;
+    }
+
     public LocalDate getBookingDate() {
         return LocalDate.of(year, month, dayOfMonth);
     }
@@ -103,6 +111,7 @@ public class WorldpayNotification implements ChargeStatusRequest {
                 ", reference='" + reference + '\'' +
                 ", captureReference='" + reference + '\'' +
                 ", refundAuthorisationReference='" + refundAuthorisationReference + '\'' +
+                ", refundResponseReference='" + refundResponseReference + '\'' +
                 ", chargeStatus=" + chargeStatus +
                 '}';
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -53,6 +53,7 @@ class WorldpayNotificationServiceTest {
     private final String ipAddress = "1.1.1.1";
     private final String referenceId = "refund-reference";
     private final String refundAuthorisationReference = "refund-authorisation-reference";
+    private final String refundResponseReference = "refund-response-reference";
     private final String transactionId = "transaction-reference";
 
     @BeforeEach
@@ -74,6 +75,7 @@ class WorldpayNotificationServiceTest {
                 transactionId,
                 referenceId,
                 "",
+                "",
                 "CAPTURED",
                 "10",
                 "03",
@@ -90,6 +92,7 @@ class WorldpayNotificationServiceTest {
                 2017,
                 transactionId,
                 referenceId,
+                "",
                 ""
         );
         verify(mockChargeNotificationProcessor).invoke(expectedNotification.getTransactionId(), charge, CAPTURED, expectedNotification.getGatewayEventDate());
@@ -106,6 +109,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
+                "",
                 "",
                 "CAPTURED",
                 "10",
@@ -130,7 +134,7 @@ class WorldpayNotificationServiceTest {
 
         for (String status : refundSuccessStatuses) {
             final String payload = sampleWorldpayNotification(
-                    transactionId, referenceId, "", status,
+                    transactionId, referenceId, "", "", status,
                     "10", "03", "2017");
 
             final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
@@ -147,7 +151,7 @@ class WorldpayNotificationServiceTest {
         setUpChargeServiceToReturnCharge(Optional.of(charge));
         setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
         final String payload = sampleWorldpayNotification(
-                transactionId, referenceId, "", "REFUND_FAILED",
+                transactionId, referenceId, "", refundResponseReference, "REFUND_FAILED",
                 "10", "03", "2017");
 
         final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
@@ -165,6 +169,7 @@ class WorldpayNotificationServiceTest {
                 transactionId,
                 referenceId,
                 "",
+                "",
                 "CHARGED",
                 "10",
                 "03",
@@ -181,7 +186,7 @@ class WorldpayNotificationServiceTest {
     void ifChargeNotFound_shouldIgnoreForNonTelephonePaymentAccount() {
         when(mockGatewayAccountService.isATelephonePaymentNotificationAccount("MERCHANTCODE")).thenReturn(false);
         final String payload = sampleWorldpayNotification(
-                transactionId, referenceId, "", "CHARGED", "10", "03", "2017");
+                transactionId, referenceId, "", "", "CHARGED", "10", "03", "2017");
         setUpChargeServiceToReturnCharge(Optional.empty());
 
         final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
@@ -197,6 +202,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
+                "",
                 "",
                 "CHARGED",
                 "10",
@@ -215,6 +221,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 "",
                 referenceId,
+                "",
                 "",
                 "CHARGED",
                 "10",
@@ -246,6 +253,7 @@ class WorldpayNotificationServiceTest {
                     transactionId,
                     referenceId,
                     refundAuthorisationReference,
+                    refundResponseReference,
                     status);
 
             assertTrue(notificationService.handleNotificationFor(ipAddress, payload));
@@ -262,7 +270,7 @@ class WorldpayNotificationServiceTest {
         setUpChargeServiceToReturnCharge(Optional.of(charge));
         setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(mockGatewayAccountEntity));
 
-        final String payload = sampleWorldpayNotification(transactionId, referenceId, "", "ERROR");
+        final String payload = sampleWorldpayNotification(transactionId, referenceId, "", "", "ERROR");
 
         assertTrue(notificationService.handleNotificationFor(ipAddress, payload));
         verify(mockGatewayAccountEntity, times(1)).isLive();
@@ -275,6 +283,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
+                "",
                 "",
                 "CAPTURED",
                 "10",
@@ -306,6 +315,7 @@ class WorldpayNotificationServiceTest {
             String transactionId,
             String referenceId,
             String refundAuthorisationReference,
+            String refundResponseReference,
             String status,
             String bookingDateDay,
             String bookingDateMonth,
@@ -314,6 +324,7 @@ class WorldpayNotificationServiceTest {
                 .replace("{{transactionId}}", transactionId)
                 .replace("{{refund-ref}}", referenceId)
                 .replace("{{refund-authorisation-reference}}", refundAuthorisationReference)
+                .replace("{{refund-response-reference}}", refundResponseReference)
                 .replace("{{status}}", status)
                 .replace("{{bookingDateDay}}", bookingDateDay)
                 .replace("{{bookingDateMonth}}", bookingDateMonth)
@@ -324,8 +335,9 @@ class WorldpayNotificationServiceTest {
             String transactionId,
             String referenceId,
             String refundAuthorisationReference,
+            String refundResponseReference,
             String status) {
-        return sampleWorldpayNotification(transactionId, referenceId, refundAuthorisationReference, status, "2017", "10", "22");
+        return sampleWorldpayNotification(transactionId, referenceId, refundAuthorisationReference, refundResponseReference, status, "2017", "10", "22");
     }
 
     private void setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional<GatewayAccountEntity> gatewayAccountEntity) {

--- a/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
@@ -64,6 +64,7 @@ class WorldpayXMLUnmarshallerTest {
                 .replace("{{status}}", status)
                 .replace("{{refund-ref}}", "REFUND-REF")
                 .replace("{{refund-authorisation-reference}}", "REFUND-AUTHORISATION-REFERENCE")
+                .replace("{{refund-response-reference}}", "REFUND-RESPONSE-REFERENCE")
                 .replace("{{bookingDateDay}}", "10")
                 .replace("{{bookingDateMonth}}", "01")
                 .replace("{{bookingDateYear}}", "2017");
@@ -73,6 +74,7 @@ class WorldpayXMLUnmarshallerTest {
         assertThat(response.getMerchantCode(), is("MERCHANTCODE"));
         assertThat(response.getReference(), is("REFUND-REF"));
         assertThat(response.getRefundAuthorisationReference(), is("REFUND-AUTHORISATION-REFERENCE"));
+        assertThat(response.getRefundResponseReference(), is("REFUND-RESPONSE-REFERENCE"));
         assertThat(response.getBookingDate(), is(LocalDate.parse("2017-01-10")));
     }
 

--- a/src/test/resources/templates/worldpay/notification.xml
+++ b/src/test/resources/templates/worldpay/notification.xml
@@ -31,6 +31,7 @@
                 </accountTx>
                 <journalReference type="capture" reference="{{refund-ref}}"/>
                 <journalReference type="refund_authorisation" reference="{{refund-authorisation-reference}}"/>
+                <journalReference type="refund_response" reference="{{refund-response-reference}}"/>
             </journal>
         </orderStatusEvent>
     </notify>


### PR DESCRIPTION
With this change, we are updating our code responsible for parsing the Worldpay notifications in order to avoid assigning incorrect values to our `reference` attribute.

Before recent changes, the parsing would use the first value contained in a reference attribute of the Worldpay notification assigning it to our reference property.

With a previous PR[1], we made sure we would be assigning the refund authorisation reference to a dedicated property first, and then we left the reference property to be populated with the first value contained in a reference attribute excluding the refund authorisation reference.

This was not enough, however, because the REFUND_FAILED notification contains yet another XML element with an attribute named `reference`, which would then incorrectly be parsed into our `reference` attribute.

With this change we are now univocally assigning the correct reference value, i.e. using only the value contained in the XML element journalReference with type `capture` if available.

Additionally, we are parsing the above mentioned reference attribute within the REFUND_FAILED notification, calling it refundResponseReference.

Note that we have considered using the WrappedStringValue type instead of String, to enhance type safety, however this cannot be used in this case, since our values are optional and could be null, which is not an option for the WrappedStringValue type.

Further information in JIRA[2].

[1]
https://github.com/alphagov/pay-connector/pull/5697

[2]
https://payments-platform.atlassian.net/browse/PP-13419

## Payload examples and the corresponding parsed notifications, BEFORE THIS CHANGE

### SENT_FOR_REFUND with auth code

Payload: 
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
                                "http://dtd.worldpay.com/paymentService_v1.dtd">
<paymentService version="1.4" merchantCode="GBSRECABOFFGDSGBPTEST"><notify><orderStatusEvent orderCode="c83eafea-a716-403a-a761-c790026503fa">
<payment><paymentMethod>VISA_CREDIT-SSL</paymentMethod><amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/><lastEvent>SENT_FOR_REFUND</lastEvent><reference>1c4ejcu8p0jufp4lpii7terr0a</reference><CVCResultCode description="NOT SENT TO ACQUIRER"/><AVSResultCode description="NOT SENT TO ACQUIRER"/><cardHolderName><![CDATA[Mr Someone]]></cardHolderName><issuerCountryCode>N/</issuerCountryCode></payment>
<journal journalType="SENT_FOR_REFUND">
<bookingDate><date dayOfMonth="23" month="01" year="2025"/></bookingDate><accountTx accountType="IN_PROCESS_CAPTURED" batchId="102"><amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="debit"/></accountTx><journalReference type="capture" reference="1c4ejcu8p0jufp4lpii7terr0a"/>
<journalReference type="refund_authorisation" reference="987654"/>
</journal>
</orderStatusEvent></notify></paymentService>
```
Parsed notification: 

```
{merchantCode='GBSRECABOFFGDSGBPTEST', status='SENT_FOR_REFUND', dayOfMonth=23, month=1, year=2025, transactionId='c83eafea-a716-403a-a761-c790026503fa', reference='1c4ejcu8p0jufp4lpii7terr0a', captureReference='1c4ejcu8p0jufp4lpii7terr0a', refundAuthorisationReference='987654', chargeStatus=Optional.empty}
```

### SENT_FOR_REFUND without auth code

Payload: 
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
                                "http://dtd.worldpay.com/paymentService_v1.dtd">
<paymentService version="1.4" merchantCode="GBSRECABOFFGDSGBPTEST"><notify><orderStatusEvent orderCode="1c94db70-d2e9-46f2-91c9-4ead4e919b03">
<payment><paymentMethod>VISA_CREDIT-SSL</paymentMethod><amount value="330" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/><lastEvent>SENT_FOR_REFUND</lastEvent><reference>b2742hs3i7tar8174roje7vf5k</reference><CVCResultCode description="NOT SENT TO ACQUIRER"/><AVSResultCode description="NOT SENT TO ACQUIRER"/><cardHolderName><![CDATA[Mr Someone]]></cardHolderName><issuerCountryCode>N/</issuerCountryCode></payment>
<journal journalType="SENT_FOR_REFUND" description="No response from Acquirer">
<bookingDate><date dayOfMonth="23" month="01" year="2025"/></bookingDate><accountTx accountType="IN_PROCESS_CAPTURED" batchId="102"><amount value="330" currencyCode="GBP" exponent="2" debitCreditIndicator="debit"/></accountTx><journalReference type="capture" reference="b2742hs3i7tar8174roje7vf5k"/>
</journal>
</orderStatusEvent></notify></paymentService>
```
Parsed notification: 

```
{merchantCode='GBSRECABOFFGDSGBPTEST', status='SENT_FOR_REFUND', dayOfMonth=23, month=1, year=2025, transactionId='1c94db70-d2e9-46f2-91c9-4ead4e919b03', reference='b2742hs3i7tar8174roje7vf5k', captureReference='b2742hs3i7tar8174roje7vf5k', refundAuthorisationReference='null', chargeStatus=Optional.empty}
```

### REFUND_FAILED

Payload: 
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
                                "http://dtd.worldpay.com/paymentService_v1.dtd">
<paymentService version="1.4" merchantCode="GBSRECABOFFGDSGBPTEST"><notify><orderStatusEvent orderCode="51665c70-e071-4e21-b6c7-5815c6de279f">
<payment><paymentMethod>VISA_CREDIT-SSL</paymentMethod><amount value="220" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/><lastEvent>REFUND_FAILED</lastEvent><CVCResultCode description="NOT SENT TO ACQUIRER"/><AVSResultCode description="NOT SENT TO ACQUIRER"/><cardHolderName><![CDATA[Mr Someone]]></cardHolderName><issuerCountryCode>N/</issuerCountryCode><balance accountType="IN_PROCESS_CAPTURED"><amount value="220" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/></balance></payment>
<journal journalType="REFUND_FAILED" description="Do not honor">
<bookingDate><date dayOfMonth="23" month="01" year="2025"/></bookingDate><amount value="220" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/><journalReference type="refund_response" reference="5"/>
</journal>
</orderStatusEvent></notify></paymentService>
```

**Incorrectly** parsed notification **before** this change: 

```
{merchantCode='GBSRECABOFFGDSGBPTEST', status='REFUND_FAILED', dayOfMonth=23, month=1, year=2025, transactionId='51665c70-e071-4e21-b6c7-5815c6de279f', reference='5', captureReference='5', refundAuthorisationReference='null', chargeStatus=Optional.empty}
```