### PR TITLE
PP-13419 Handle new successful refund notification

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -38,10 +38,9 @@ public class WorldpayNotificationService {
             "REFUSED",
             "REFUSED_BY_BANK",
             "SETTLED",
-            "SETTLED_BY_MERCHANT",
-            "SENT_FOR_REFUND"
+            "SETTLED_BY_MERCHANT"
     );
-    private static final List<String> REFUND_STATUSES = ImmutableList.of("REFUNDED", "REFUNDED_BY_MERCHANT", "REFUND_FAILED");
+    private static final List<String> REFUND_STATUSES = ImmutableList.of("REFUNDED", "REFUNDED_BY_MERCHANT", "REFUND_FAILED", "SENT_FOR_REFUND");
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final ChargeService chargeService;
@@ -146,8 +145,13 @@ public class WorldpayNotificationService {
             }
             chargeNotificationProcessor.invoke(notification.getTransactionId(), charge, CAPTURED, notification.getGatewayEventDate());
         } else if (isRefundNotification(notification)) {
-            refundNotificationProcessor.invoke(PaymentGatewayName.WORLDPAY, newRefundStatus(notification), gatewayAccountEntity,
-                    notification.getReference(), notification.getTransactionId(), charge);
+            if(isOfflineRefund(notification)){
+                logger.info("{} notification {} ignored (SENT_FOR_REFUND without refund authorisation code)", PAYMENT_GATEWAY_NAME, notification);
+                return true;
+            } else {
+                refundNotificationProcessor.invoke(PaymentGatewayName.WORLDPAY, newRefundStatus(notification), gatewayAccountEntity,
+                notification.getReference(), notification.getTransactionId(), charge);
+            }
         } else if (isErrorNotification(notification)) {
             if (gatewayAccountEntity.isLive()) {
                 logger.error("{} error notification received for live account {}", PAYMENT_GATEWAY_NAME, notification);
@@ -164,7 +168,7 @@ public class WorldpayNotificationService {
         return "ERROR".equals(notification.getStatus());
     }
 
-    // TODO: Temporary logging for PP-13416
+    // TODO: Remove temporary logging for PP-13416 (by June 2025)
     private boolean isTemporaryLoggingRequiredOnTestOnly(WorldpayNotification notification) {
         return ("REFUND_FAILED".equals(notification.getStatus()) ||
         "SENT_FOR_REFUND".equals(notification.getStatus()))
@@ -193,6 +197,21 @@ public class WorldpayNotificationService {
 
     private boolean isIgnored(WorldpayNotification notification) {
         return IGNORED_STATUSES.contains(notification.getStatus());
+    }
+
+    private boolean isOfflineRefund(WorldpayNotification notification) {
+        if (!"SENT_FOR_REFUND".equals(notification.getStatus())) {
+            return false;
+        }
+
+        boolean hasRefundAuthorisationCode = false;
+        try {
+            Integer.parseInt(notification.getRefundAuthorisationReference());
+            hasRefundAuthorisationCode = true;
+        } catch (NumberFormatException e) {
+            hasRefundAuthorisationCode = false;
+        }
+        return !hasRefundAuthorisationCode;
     }
 
     public String notificationDomain() {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -145,13 +145,7 @@ public class WorldpayNotificationService {
             }
             chargeNotificationProcessor.invoke(notification.getTransactionId(), charge, CAPTURED, notification.getGatewayEventDate());
         } else if (isRefundNotification(notification)) {
-            if(isOfflineRefund(notification)){
-                logger.info("{} notification {} ignored (SENT_FOR_REFUND without refund authorisation code)", PAYMENT_GATEWAY_NAME, notification);
-                return true;
-            } else {
-                refundNotificationProcessor.invoke(PaymentGatewayName.WORLDPAY, newRefundStatus(notification), gatewayAccountEntity,
-                notification.getReference(), notification.getTransactionId(), charge);
-            }
+            processRefundNotification(notification, charge, gatewayAccountEntity);
         } else if (isErrorNotification(notification)) {
             if (gatewayAccountEntity.isLive()) {
                 logger.error("{} error notification received for live account {}", PAYMENT_GATEWAY_NAME, notification);
@@ -162,6 +156,15 @@ public class WorldpayNotificationService {
             logger.error("{} notification {} unknown", PAYMENT_GATEWAY_NAME, notification);
         }
         return true;
+    }
+
+    private void processRefundNotification(WorldpayNotification notification, Charge charge, GatewayAccountEntity gatewayAccountEntity) {
+        if(isOfflineRefund(notification)) {
+            logger.info("{} notification {} ignored (SENT_FOR_REFUND without refund authorisation code)", PAYMENT_GATEWAY_NAME, notification);
+        } else {
+            refundNotificationProcessor.invoke(PaymentGatewayName.WORLDPAY, newRefundStatus(notification), gatewayAccountEntity,
+                notification.getReference(), notification.getTransactionId(), charge);
+        }
     }
 
     private boolean isErrorNotification(WorldpayNotification notification) {

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
@@ -92,6 +92,26 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
+    void shouldNotInvokeSendEmailNotifications_WhenRefundStatusWasAlreadySetAsRefunded() {
+        refundEntity.setStatus(RefundStatus.REFUNDED);
+        Optional<RefundEntity> optionalRefundEntity = Optional.of(refundEntity);
+        when(refundService.findByChargeExternalIdAndGatewayTransactionId(charge.getExternalId(), refundGatewayTransactionId)).thenReturn(optionalRefundEntity);
+
+        refundNotificationProcessor.invoke(paymentGatewayName, RefundStatus.REFUNDED, gatewayAccountEntity, refundGatewayTransactionId, transactionId, charge);
+        verify(userNotificationService, never()).sendRefundIssuedEmail(refundEntity, charge, gatewayAccountEntity);
+    }
+
+    @Test
+    void shouldNotInvokeSendEmailNotifications_WhenRefundStatusWasSetAsRefundError() {
+        refundEntity.setStatus(RefundStatus.REFUND_ERROR);
+        Optional<RefundEntity> optionalRefundEntity = Optional.of(refundEntity);
+        when(refundService.findByChargeExternalIdAndGatewayTransactionId(charge.getExternalId(), refundGatewayTransactionId)).thenReturn(optionalRefundEntity);
+
+        refundNotificationProcessor.invoke(paymentGatewayName, RefundStatus.REFUNDED, gatewayAccountEntity, refundGatewayTransactionId, transactionId, charge);
+        verify(userNotificationService, never()).sendRefundIssuedEmail(refundEntity, charge, gatewayAccountEntity);
+    }
+
+    @Test
      void shouldLogError_whenRefundGatewayTransactionIdIsNotAvailable() {
         refundNotificationProcessor.invoke(paymentGatewayName, RefundStatus.REFUND_ERROR, gatewayAccountEntity, null, transactionId, charge);
 


### PR DESCRIPTION
With this change, we are no longer ignoring the SENT_FOR_REFUND notification sent by Worldpay after a refund submission.

The notification is now included in the REFUND_STATUSES and examined: if it contains a RefundAuthorisationReference, then it means that the refund submission was successful, otherwise the notification is ignored.

Since we are now processing different types of notifications arriving after a successful refund, we are also introducing a check in the Refund Notification Processor, to avoid setting a refund as successful multiple times, also avoiding multiple emails to the end user.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-13419


