### PR TITLE
PP-13497 Log for Worldpay Refund illegal state transitions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -76,7 +76,7 @@ public class RefundNotificationProcessor {
         }
 
         if (isRefundTransitionIllegal(oldStatus, newStatus)) {
-            logger.error("Notification received for refund [{}] is unexpected and therefore ignored because it would cause an illegal state transition to [{}] as refund is already in state [{}]",
+            logger.info("Notification received for refund would cause an illegal state transition: refund [{}] cannot be set as [{}] because it is already in state [{}].",
                     refundEntity.getExternalId(), newStatus, oldStatus);
             return;
         }


### PR DESCRIPTION
With this change, we are improving the message that will be logged in case of illegal state transitions for Worldpay refunds to make it clearer.

We are also adding tests to prevent accidental removal or change, given that this log message is linked to a Splunk Alert.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-13497


