### PR TITLE
Temporarily log message to test Splunk Alert

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -83,6 +83,10 @@ public class WorldpayNotificationService {
             logger.info("Parsed {} notification: {}", PAYMENT_GATEWAY_NAME, notification);
             if (isTemporaryLoggingRequiredOnTestOnly(notification)) {
                 logger.info("{} notification {} is being inspected (on test only) for PP-13416. Payload: {}", PAYMENT_GATEWAY_NAME, notification, payload);
+                //TODO: Remove - Needed for PP-13497
+                if (isOfflineRefund(notification)) {
+                    logger.info("{} notification {} PP-13497 TEST: Notification received for refund would cause an illegal state transition ", PAYMENT_GATEWAY_NAME, notification);
+                }
             }
         } catch (XMLUnmarshallerException e) {
             logger.error("{} notification parsing failed: {}", PAYMENT_GATEWAY_NAME, e);


### PR DESCRIPTION
With this change, we are temporarily adding a log message that will be written only for the Worldpay Test account and only for the SENT_FOR_REFUND notifications without the refund authorisation reference.

This is needed to test the alert which will be triggered in case of illegal state transitions.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-13497

## Test

This can be tested in the Worldpay test account by refunding a payment with the specific payment amount causing the simulated refund to happen offline.

