### PR TITLE
PP-13445 Parse the reason for a refund failure from the notification

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -787,7 +787,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 130
       }
     ],
     "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayAuthRequestBuilder.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-23T15:53:00Z"
+  "generated_at": "2025-02-03T15:39:00Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotification.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotification.java
@@ -16,7 +16,9 @@ public class WorldpayNotification implements ChargeStatusRequest {
     public WorldpayNotification() {
     }
 
-    public WorldpayNotification(String merchantCode, String status, int dayOfMonth, int month, int year, String transactionId, String reference, String refundAuthorisationReference, String refundResponseReference) {
+    public WorldpayNotification(String merchantCode, String status, int dayOfMonth, int month, int year,
+            String transactionId, String reference, String refundAuthorisationReference,
+            String refundResponseReference, String description) {
         this.merchantCode = merchantCode;
         this.status = status;
         this.dayOfMonth = dayOfMonth;
@@ -26,6 +28,7 @@ public class WorldpayNotification implements ChargeStatusRequest {
         this.reference = reference;
         this.refundAuthorisationReference = refundAuthorisationReference;
         this.refundResponseReference = refundResponseReference;
+        this.description = description;
     }
 
     @XmlPath("@merchantCode")
@@ -33,6 +36,13 @@ public class WorldpayNotification implements ChargeStatusRequest {
 
     @XmlPath("notify/orderStatusEvent/journal/@journalType")
     private String status;
+
+    @XmlPath("notify/orderStatusEvent/journal/@description")
+    private String description;
+
+    public String getRefundFailedDescription() {
+        return "REFUND_FAILED".equals(status) ? description : null;
+    }
 
     @XmlPath("notify/orderStatusEvent/journal/bookingDate/date/@dayOfMonth")
     private int dayOfMonth;
@@ -95,6 +105,10 @@ public class WorldpayNotification implements ChargeStatusRequest {
         return refundResponseReference;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
     public LocalDate getBookingDate() {
         return LocalDate.of(year, month, dayOfMonth);
     }
@@ -104,6 +118,7 @@ public class WorldpayNotification implements ChargeStatusRequest {
         return "WorldpayNotification{" +
                 "merchantCode='" + merchantCode + '\'' +
                 ", status='" + status + '\'' +
+                ", description='" + description + '\'' +
                 ", dayOfMonth=" + dayOfMonth +
                 ", month=" + month +
                 ", year=" + year +
@@ -112,6 +127,7 @@ public class WorldpayNotification implements ChargeStatusRequest {
                 ", captureReference='" + reference + '\'' +
                 ", refundAuthorisationReference='" + refundAuthorisationReference + '\'' +
                 ", refundResponseReference='" + refundResponseReference + '\'' +
+                ", refundFailedDescription='" + getRefundFailedDescription() + '\'' +
                 ", chargeStatus=" + chargeStatus +
                 '}';
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -55,6 +55,7 @@ class WorldpayNotificationServiceTest {
     private final String refundAuthorisationReference = "refund-authorisation-reference";
     private final String refundResponseReference = "refund-response-reference";
     private final String transactionId = "transaction-reference";
+    private final String description = "description";
 
     @BeforeEach
     void setup() {
@@ -76,6 +77,7 @@ class WorldpayNotificationServiceTest {
                 referenceId,
                 "",
                 "",
+                "",
                 "CAPTURED",
                 "10",
                 "03",
@@ -93,6 +95,7 @@ class WorldpayNotificationServiceTest {
                 transactionId,
                 referenceId,
                 "",
+                "",
                 ""
         );
         verify(mockChargeNotificationProcessor).invoke(expectedNotification.getTransactionId(), charge, CAPTURED, expectedNotification.getGatewayEventDate());
@@ -109,6 +112,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
+                "",
                 "",
                 "",
                 "CAPTURED",
@@ -134,7 +138,7 @@ class WorldpayNotificationServiceTest {
 
         for (String status : refundSuccessStatuses) {
             final String payload = sampleWorldpayNotification(
-                    transactionId, referenceId, "", "", status,
+                    transactionId, referenceId, "", "", "", status,
                     "10", "03", "2017");
 
             final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
@@ -151,7 +155,7 @@ class WorldpayNotificationServiceTest {
         setUpChargeServiceToReturnCharge(Optional.of(charge));
         setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
         final String payload = sampleWorldpayNotification(
-                transactionId, referenceId, "", refundResponseReference, "REFUND_FAILED",
+                transactionId, referenceId, "", refundResponseReference, description, "REFUND_FAILED",
                 "10", "03", "2017");
 
         final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
@@ -170,6 +174,7 @@ class WorldpayNotificationServiceTest {
                 referenceId,
                 "",
                 "",
+                "",
                 "CHARGED",
                 "10",
                 "03",
@@ -186,7 +191,7 @@ class WorldpayNotificationServiceTest {
     void ifChargeNotFound_shouldIgnoreForNonTelephonePaymentAccount() {
         when(mockGatewayAccountService.isATelephonePaymentNotificationAccount("MERCHANTCODE")).thenReturn(false);
         final String payload = sampleWorldpayNotification(
-                transactionId, referenceId, "", "", "CHARGED", "10", "03", "2017");
+                transactionId, referenceId, "", "", "", "CHARGED", "10", "03", "2017");
         setUpChargeServiceToReturnCharge(Optional.empty());
 
         final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
@@ -202,6 +207,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
+                "",
                 "",
                 "",
                 "CHARGED",
@@ -221,6 +227,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 "",
                 referenceId,
+                "",
                 "",
                 "",
                 "CHARGED",
@@ -253,6 +260,7 @@ class WorldpayNotificationServiceTest {
                     referenceId,
                     refundAuthorisationReference,
                     refundResponseReference,
+                    description,
                     status);
 
             assertTrue(notificationService.handleNotificationFor(ipAddress, payload));
@@ -269,7 +277,7 @@ class WorldpayNotificationServiceTest {
         String status = "SENT_FOR_REFUND";
         String refundAuthorisationCode = "";
         final String payload = sampleWorldpayNotification(
-                transactionId, referenceId, refundAuthorisationCode, "", status,
+                transactionId, referenceId, refundAuthorisationCode, "", "", status,
                 "10", "03", "2017");
 
         assertTrue(notificationService.handleNotificationFor(ipAddress, payload));
@@ -285,7 +293,7 @@ class WorldpayNotificationServiceTest {
         setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
         String status = "SENT_FOR_REFUND";
         final String payload = sampleWorldpayNotification(
-                transactionId, referenceId, refundAuthorisationCode, "", status,
+                transactionId, referenceId, refundAuthorisationCode, "", "", status,
                 "10", "03", "2017");
 
         assertTrue(notificationService.handleNotificationFor(ipAddress, payload));
@@ -302,7 +310,7 @@ class WorldpayNotificationServiceTest {
         setUpChargeServiceToReturnCharge(Optional.of(charge));
         setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(mockGatewayAccountEntity));
 
-        final String payload = sampleWorldpayNotification(transactionId, referenceId, "", "", "ERROR");
+        final String payload = sampleWorldpayNotification(transactionId, referenceId, "", "", "", "ERROR");
 
         assertTrue(notificationService.handleNotificationFor(ipAddress, payload));
         verify(mockGatewayAccountEntity, times(1)).isLive();
@@ -315,6 +323,7 @@ class WorldpayNotificationServiceTest {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
+                "",
                 "",
                 "",
                 "CAPTURED",
@@ -348,6 +357,7 @@ class WorldpayNotificationServiceTest {
             String referenceId,
             String refundAuthorisationReference,
             String refundResponseReference,
+            String description,
             String status,
             String bookingDateDay,
             String bookingDateMonth,
@@ -360,7 +370,8 @@ class WorldpayNotificationServiceTest {
                 .replace("{{status}}", status)
                 .replace("{{bookingDateDay}}", bookingDateDay)
                 .replace("{{bookingDateMonth}}", bookingDateMonth)
-                .replace("{{bookingDateYear}}", bookingDateYear);
+                .replace("{{bookingDateYear}}", bookingDateYear)
+                .replace("{{description}}", description);
     }
 
     private static String sampleWorldpayNotification(
@@ -368,8 +379,9 @@ class WorldpayNotificationServiceTest {
             String referenceId,
             String refundAuthorisationReference,
             String refundResponseReference,
+            String description,
             String status) {
-        return sampleWorldpayNotification(transactionId, referenceId, refundAuthorisationReference, refundResponseReference, status, "2017", "10", "22");
+        return sampleWorldpayNotification(transactionId, referenceId, refundAuthorisationReference, refundResponseReference, description, status, "2017", "10", "22");
     }
 
     private void setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional<GatewayAccountEntity> gatewayAccountEntity) {

--- a/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
@@ -59,9 +59,11 @@ class WorldpayXMLUnmarshallerTest {
     void shouldUnmarshallANotification() throws Exception {
         String transactionId = "MyUniqueTransactionId!";
         String status = "CAPTURED";
+        String description = "CAPTURED DESCRIPTION";
         String successPayload = TestTemplateResourceLoader.load(WORLDPAY_NOTIFICATION)
                 .replace("{{transactionId}}", transactionId)
                 .replace("{{status}}", status)
+                .replace("{{description}}", description)
                 .replace("{{refund-ref}}", "REFUND-REF")
                 .replace("{{refund-authorisation-reference}}", "REFUND-AUTHORISATION-REFERENCE")
                 .replace("{{refund-response-reference}}", "REFUND-RESPONSE-REFERENCE")
@@ -70,6 +72,7 @@ class WorldpayXMLUnmarshallerTest {
                 .replace("{{bookingDateYear}}", "2017");
         WorldpayNotification response = XMLUnmarshaller.unmarshall(successPayload, WorldpayNotification.class);
         assertThat(response.getStatus(), is(status));
+        assertThat(response.getDescription(), is(description));
         assertThat(response.getTransactionId(), is(transactionId));
         assertThat(response.getMerchantCode(), is("MERCHANTCODE"));
         assertThat(response.getReference(), is("REFUND-REF"));

--- a/src/test/resources/templates/worldpay/notification.xml
+++ b/src/test/resources/templates/worldpay/notification.xml
@@ -19,7 +19,7 @@
                 </balance>
                 <riskScore value="66"/>
             </payment>
-            <journal journalType="{{status}}">
+            <journal journalType="{{status}}" description="{{description}}">
                 <bookingDate>
                     <date dayOfMonth="{{bookingDateDay}}" month="{{bookingDateMonth}}" year="{{bookingDateYear}}"/>
                 </bookingDate>


### PR DESCRIPTION
With this change, we are adding the definition for a new attribute in the
Worldpay Notification class in order to use it for the reason for a refund
failure which is included in the journal XML element with journalType
`REFUND_FAILED`.

The attribute is actually the description for notifications for any
journalType.

For this reason, we are introducing the attribute as `description` and then
also adding a dedicated getter than returns the refund failed description for
notifications of type REFUND_FAILED.

This will be logged and then used by the engineer on Support to determine what
to do when a refund request fails.

We will start informing the Support team with a Splunk Alert[1] linked to the
parsed notification.

Depending on the reason for the failure, the Support Team will be able to ask
the Service Admins to either retry the refund (for example for a payment
older than two years) or to find an alternative method outside of Pay
(for example if the credit card had expired).

Further information in Jira[2].

[1]
https://payments-platform.atlassian.net/browse/PP-13497

[2]
https://payments-platform.atlassian.net/browse/PP-13445

