### PR TITLE
PP-13497 - Revert "Temporarily log message to test Splunk Alert"

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -83,10 +83,6 @@ public class WorldpayNotificationService {
             logger.info("Parsed {} notification: {}", PAYMENT_GATEWAY_NAME, notification);
             if (isTemporaryLoggingRequiredOnTestOnly(notification)) {
                 logger.info("{} notification {} is being inspected (on test only) for PP-13416. Payload: {}", PAYMENT_GATEWAY_NAME, notification, payload);
-                //TODO: Remove - Needed for PP-13497
-                if (isOfflineRefund(notification)) {
-                    logger.info("{} notification {} PP-13497 TEST: Notification received for refund would cause an illegal state transition ", PAYMENT_GATEWAY_NAME, notification);
-                }
             }
         } catch (XMLUnmarshallerException e) {
             logger.error("{} notification parsing failed: {}", PAYMENT_GATEWAY_NAME, e);


### PR DESCRIPTION
Reverts alphagov/pay-connector#5703

Now that [PP-13497](https://payments-platform.atlassian.net/browse/PP-13497) has been verified, we can remove the temporary logging.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-13497

[PP-13497]: https://payments-platform.atlassian.net/browse/PP-13497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ