### PR TITLE
PP-13420 Log message for Splunk Alert on REFUND_ERROR

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -87,8 +87,11 @@ public class RefundNotificationProcessor {
             userNotificationService.sendRefundIssuedEmail(refundEntity, charge, gatewayAccountEntity);
         }
 
-        logger.info("Notification received for refund. Updating refund - charge_external_id={}, refund_reference={}, transaction_id={}, status={}, "
+        String stateTransitionMessage = newStatus == REFUND_ERROR ? "Refund request record set as failed (REFUND_ERROR)" : "Refund request record set as successful (REFUNDED)";
+
+        logger.info("Notification received for refund. Updating refund: {} - charge_external_id={}, refund_reference={}, transaction_id={}, status={}, "
                         + "status_to={}, account_id={}, provider={}, provider_type={}",
+                stateTransitionMessage,
                 refundEntity.getChargeExternalId(),
                 gatewayTransactionId,
                 transactionId,

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
@@ -113,6 +113,19 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
+    void shouldLogFailedRefund_WhenRefundStatusWasSetAsRefundError() {
+        Optional<RefundEntity> optionalRefundEntity = Optional.of(refundEntity);
+        when(refundService.findByChargeExternalIdAndGatewayTransactionId(charge.getExternalId(), refundGatewayTransactionId)).thenReturn(optionalRefundEntity);
+
+        refundNotificationProcessor.invoke(paymentGatewayName, RefundStatus.REFUND_ERROR, gatewayAccountEntity, refundGatewayTransactionId, transactionId, charge);
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
+        String expectedLogMessageForSplunkAlert = "Refund request record set as failed (REFUND_ERROR)";
+        assertThat(logStatement.get(0).getFormattedMessage(), containsString(expectedLogMessageForSplunkAlert));
+    }
+
+    @Test
     void shouldLogIllegalStateTransition_IfRefundedWhenRefundStatusWasSetAsRefundError() {
         refundEntity.setStatus(RefundStatus.REFUND_ERROR);
         Optional<RefundEntity> optionalRefundEntity = Optional.of(refundEntity);


### PR DESCRIPTION
With this change, we are updating the log in the Refund Notification Processor
in Connector, so that a specific message is written when we receive a
notification from Worldpay informing us that a refund request has failed.

This specific message will be used to trigger a Splunk Alert[1], creating a
new support request in Zendesk.

Further information in Jira[2].

[1]
https://github.com/alphagov/cyber-security-splunk-apps/pull/972

[2]
https://payments-platform.atlassian.net/browse/PP-13420


