### PR TITLE
PP-13584 Remove payload inspection needed for testing

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -81,9 +81,6 @@ public class WorldpayNotificationService {
             logger.debug("Payload: {}", payload);
             notification = XMLUnmarshaller.unmarshall(payload, WorldpayNotification.class);
             logger.info("Parsed {} notification: {}", PAYMENT_GATEWAY_NAME, notification);
-            if (isTemporaryLoggingRequiredOnTestOnly(notification)) {
-                logger.info("{} notification {} is being inspected (on test only) for PP-13416. Payload: {}", PAYMENT_GATEWAY_NAME, notification, payload);
-            }
         } catch (XMLUnmarshallerException e) {
             logger.error("{} notification parsing failed: {}", PAYMENT_GATEWAY_NAME, e);
             return true;
@@ -169,13 +166,6 @@ public class WorldpayNotificationService {
 
     private boolean isErrorNotification(WorldpayNotification notification) {
         return "ERROR".equals(notification.getStatus());
-    }
-
-    // TODO: Remove temporary logging for PP-13416 (by June 2025)
-    private boolean isTemporaryLoggingRequiredOnTestOnly(WorldpayNotification notification) {
-        return ("REFUND_FAILED".equals(notification.getStatus()) ||
-        "SENT_FOR_REFUND".equals(notification.getStatus()))
-        && "GBSRECABOFFGDSGBPTEST".equals(notification.getMerchantCode());
     }
 
     private RefundStatus newRefundStatus(WorldpayNotification notification) {


### PR DESCRIPTION
With this commit, we are removing some temporary logging that we put in place to inspect the full payload sent by Worldpay in the refund notifications.

We are now parsing additional properties from the full payload into our notification object, so there is no longer any need to keep this temporary logging.

Further information in Jira.

https://payments-platform.atlassian.net/browse/PP-13584

