### PR TITLE
PP-13623 Set transaction ID for Worldpay refunds on creation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -536,28 +536,28 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 146
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "fd9f851472586dc75f7a60ee311842ec64ecf527",
         "is_verified": false,
-        "line_number": 148
+        "line_number": 149
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "9367c8305bd1afe815ffc0cc3ebf95af9cb6d157",
         "is_verified": false,
-        "line_number": 151
+        "line_number": 152
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 1184
+        "line_number": 1188
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-11T17:08:01Z"
+  "generated_at": "2025-02-12T11:28:02Z"
 }

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -26,6 +26,9 @@ import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidat
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionQueue;
+import uk.gov.pay.connector.refund.service.DefaultRefundEntityFactory;
+import uk.gov.pay.connector.refund.service.RefundEntityFactory;
+import uk.gov.pay.connector.refund.service.WorldpayRefundEntityFactory;
 import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
 import uk.gov.pay.connector.util.CidrUtils;
 import uk.gov.pay.connector.util.HashUtil;
@@ -183,6 +186,20 @@ public class ConnectorModule extends AbstractModule {
     @Named("WorldpayValidateCredentialsGatewayClient")
     public GatewayClient worldpayValidateCredentialsGatewayClient(GatewayClientFactory gatewayClientFactory) {
         return gatewayClientFactory.createGatewayClient(WORLDPAY, VALIDATE_CREDENTIALS, environment.metrics());
+    }
+
+    @Provides
+    @Singleton
+    @Named("DefaultRefundEntityFactory")
+    public RefundEntityFactory defaultRefundEntityFactory() {
+        return new DefaultRefundEntityFactory();
+    }
+
+    @Provides
+    @Singleton
+    @Named("WorldpayRefundEntityFactory")
+    public RefundEntityFactory worldpayRefundEntityFactory() {
+        return new WorldpayRefundEntityFactory();
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -20,6 +20,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
+import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.googlepay.GooglePayAuthorisationGatewayRequest;
 
@@ -67,4 +68,6 @@ public interface PaymentProvider {
     default void deleteStoredPaymentDetails(DeleteStoredPaymentDetailsGatewayRequest request) throws GatewayException {
         throw new NotImplementedException("Delete Stored Payment Details is not implemented for this payment provider");
     }
+    
+    RefundEntityFactory getRefundEntityFactory();
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -30,9 +30,12 @@ import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalcul
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
+import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.googlepay.GooglePayAuthorisationGatewayRequest;
 
+import javax.inject.Inject;
+import javax.inject.Named;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,11 +50,14 @@ public class SandboxPaymentProvider implements PaymentProvider {
 
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
     private final SandboxWalletAuthorisationHandler sandboxWalletAuthorisationHandler;
+    private final RefundEntityFactory refundEntityFactory;
     private final SandboxGatewayResponseGenerator fullCardNumberSandboxResponseGenerator = new SandboxGatewayResponseGenerator(new SandboxFullCardNumbers());
     private final SandboxGatewayResponseGenerator walletSandboxResponseGenerator = new SandboxGatewayResponseGenerator(new SandboxLast4DigitsCardNumbers());
     private final SandboxGatewayResponseGenerator recurringSandboxResponseGenerator = new SandboxGatewayResponseGenerator(new SandboxFirst6AndLast4CardNumbers());
 
-    public SandboxPaymentProvider() {
+    @Inject
+    public SandboxPaymentProvider(@Named("DefaultRefundEntityFactory") RefundEntityFactory refundEntityFactory) {
+        this.refundEntityFactory = refundEntityFactory;
         this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
         this.sandboxWalletAuthorisationHandler = new SandboxWalletAuthorisationHandler(walletSandboxResponseGenerator);
     }
@@ -186,5 +192,10 @@ public class SandboxPaymentProvider implements PaymentProvider {
     @Override
     public void deleteStoredPaymentDetails(DeleteStoredPaymentDetailsGatewayRequest request) {
         //No action needs to be taken in sandbox in response to a deleteStoredPaymentDetails task
+    }
+
+    @Override
+    public RefundEntityFactory getRefundEntityFactory() {
+        return refundEntityFactory;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/service/DefaultRefundEntityFactory.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/DefaultRefundEntityFactory.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.refund.service;
+
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+public class DefaultRefundEntityFactory implements RefundEntityFactory {
+
+    @Override
+    public RefundEntity create(long amount, String userExternalId, String refundUserEmail, String chargeExternalId) {
+        return new RefundEntity(amount, userExternalId, refundUserEmail, chargeExternalId);
+    }
+ 
+}

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundEntityFactory.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundEntityFactory.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.refund.service;
+
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+public interface RefundEntityFactory {
+    
+    RefundEntity create(long amount, String userExternalId, String refundUserEmail, String chargeExternalId);
+    
+}

--- a/src/main/java/uk/gov/pay/connector/refund/service/WorldpayRefundEntityFactory.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/WorldpayRefundEntityFactory.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.connector.refund.service;
+
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+public class WorldpayRefundEntityFactory implements RefundEntityFactory {
+
+    @Override
+    public RefundEntity create(long amount, String userExternalId, String refundUserEmail, String chargeExternalId) {
+        var refundEntity = new RefundEntity(amount, userExternalId, refundUserEmail, chargeExternalId);
+        // We set the Worldpay’s gateway transaction ID to be the same as the refund external ID
+        refundEntity.setGatewayTransactionId(refundEntity.getExternalId());
+        return refundEntity;
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -26,6 +26,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.paymentinstrument.service.PaymentInstrumentService;
+import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.time.Instant;
@@ -60,7 +61,7 @@ public class SandboxPaymentProviderTest {
     void setup() {
         chargeService = mock(ChargeService.class);
         paymentInstrumentService = mock(PaymentInstrumentService.class);
-        provider = new SandboxPaymentProvider();
+        provider = new SandboxPaymentProvider(mock(RefundEntityFactory.class));
         credentialsEntity = aGatewayAccountCredentialsEntity()
                 .withCredentials(Map.of())
                 .withPaymentProvider(SANDBOX.getName())

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -49,6 +49,7 @@ import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.queue.tasks.dispute.BalanceTransaction;
 import uk.gov.pay.connector.queue.tasks.dispute.EvidenceDetails;
+import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
@@ -147,6 +148,8 @@ class StripePaymentProviderTest {
     @Mock
     private GatewayClient.Response tokenResponse;
     @Mock
+    private RefundEntityFactory refundEntityFactory;
+    @Mock
     private StripeSdkClient stripeSDKClient;
 
     private final JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
@@ -159,7 +162,7 @@ class StripePaymentProviderTest {
         when(gatewayClientFactory.createGatewayClient(eq(STRIPE), any(MetricRegistry.class))).thenReturn(gatewayClient);
         when(environment.metrics()).thenReturn(metricRegistry);
 
-        provider = new StripePaymentProvider(gatewayClientFactory, configuration, objectMapper, environment, stripeSDKClient);
+        provider = new StripePaymentProvider(gatewayClientFactory, configuration, objectMapper, environment, refundEntityFactory, stripeSDKClient);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -50,6 +50,7 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
+import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
@@ -96,11 +97,11 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.gateway.util.XMLUnmarshaller.unmarshall;
-import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
-import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORLDPAY_MACHINE_COOKIE_NAME;
 import static uk.gov.pay.connector.gateway.worldpay.SendWorldpayExemptionRequest.DO_NOT_SEND_EXEMPTION_REQUEST;
 import static uk.gov.pay.connector.gateway.worldpay.SendWorldpayExemptionRequest.SEND_CORPORATE_EXEMPTION_REQUEST;
 import static uk.gov.pay.connector.gateway.worldpay.SendWorldpayExemptionRequest.SEND_EXEMPTION_ENGINE_REQUEST;
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORLDPAY_MACHINE_COOKIE_NAME;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
@@ -168,6 +169,8 @@ class WorldpayPaymentProviderTest {
     @Mock
     private WorldpayRefundHandler worldpayRefundHandler;
     @Mock
+    private RefundEntityFactory refundEntityFactory;
+    @Mock
     private GatewayClient.Response response = mock(GatewayClient.Response.class);
     @Mock
     private Appender<ILoggingEvent> mockAppender;
@@ -196,6 +199,7 @@ class WorldpayPaymentProviderTest {
                 worldpayAuthoriseHandler,
                 worldpayCaptureHandler,
                 worldpayRefundHandler,
+                refundEntityFactory,
                 new AuthorisationService(mock(CardExecutorService.class), mock(Environment.class), mock(ConnectorConfiguration.class)),
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
                 chargeDao,

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -48,6 +48,7 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.service.WorldpayRefundEntityFactory;
 import uk.gov.pay.connector.util.AcceptLanguageHeaderParser;
 import uk.gov.pay.connector.wallets.applepay.ApplePayDecrypter;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
@@ -659,6 +660,7 @@ class WorldpayPaymentProviderTest {
                 new WorldpayAuthoriseHandler(gatewayClient, gatewayUrlMap(), new AcceptLanguageHeaderParser()),
                 new WorldpayCaptureHandler(gatewayClient, gatewayUrlMap()),
                 new WorldpayRefundHandler(gatewayClient, gatewayUrlMap()),
+                new WorldpayRefundEntityFactory(),
                 new AuthorisationService(mockCardExecutorService, mockEnvironment, mockConnectorConfiguration),
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
                 mock(ChargeDao.class),

--- a/src/test/java/uk/gov/pay/connector/refund/service/DefaultRefundEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/refund/service/DefaultRefundEntityFactoryTest.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.connector.refund.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+class DefaultRefundEntityFactoryTest {
+
+    private static final long AMOUNT = 100L;
+    private static final String USER_EXTERNAL_ID = "luser";
+    public static final String EMAIL = "luser@email.test";
+    public static final String CHARGE_EXTERNAL_ID = "abc";
+
+    private final DefaultRefundEntityFactory defaultRefundEntityFactory = new DefaultRefundEntityFactory();
+
+    @Test
+    void shouldCreateRefundEntity() {
+        var refundEntity = defaultRefundEntityFactory.create(AMOUNT, USER_EXTERNAL_ID, EMAIL, CHARGE_EXTERNAL_ID);
+        
+        assertThat(refundEntity.getAmount(), is(AMOUNT));
+        assertThat(refundEntity.getUserExternalId(), is(USER_EXTERNAL_ID));
+        assertThat(refundEntity.getUserEmail(), is(EMAIL));
+        assertThat(refundEntity.getChargeExternalId(), is(CHARGE_EXTERNAL_ID));
+        assertThat(refundEntity.getExternalId(), is(notNullValue()));
+        assertThat(refundEntity.getGatewayTransactionId(), is(nullValue()));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/refund/service/WorldpayRefundEntityFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/refund/service/WorldpayRefundEntityFactoryTest.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.refund.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+class WorldpayRefundEntityFactoryTest {
+
+    private static final long AMOUNT = 100L;
+    private static final String USER_EXTERNAL_ID = "luser";
+    public static final String EMAIL = "luser@email.test";
+    public static final String CHARGE_EXTERNAL_ID = "abc";
+
+    private final WorldpayRefundEntityFactory worldpayRefundEntityFactory = new WorldpayRefundEntityFactory();
+
+    @Test
+    void shouldCreateRefundEntity() {
+        var refundEntity = worldpayRefundEntityFactory.create(AMOUNT, USER_EXTERNAL_ID, EMAIL, CHARGE_EXTERNAL_ID);
+
+        assertThat(refundEntity.getAmount(), is(AMOUNT));
+        assertThat(refundEntity.getUserExternalId(), is(USER_EXTERNAL_ID));
+        assertThat(refundEntity.getUserEmail(), is(EMAIL));
+        assertThat(refundEntity.getChargeExternalId(), is(CHARGE_EXTERNAL_ID));
+        assertThat(refundEntity.getExternalId(), is(notNullValue()));
+        assertThat(refundEntity.getGatewayTransactionId(), is(refundEntity.getExternalId()));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/report/ParityCheckerServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/report/ParityCheckerServiceTest.java
@@ -27,6 +27,7 @@ import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
+import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.tasks.HistoricalEventEmitter;
 import uk.gov.pay.connector.tasks.service.ChargeParityChecker;
@@ -89,6 +90,8 @@ class ParityCheckerServiceTest {
     private PaymentProviders mockProviders;
     @Mock
     private HistoricalEventEmitter historicalEventEmitter;
+    @Mock
+    private RefundEntityFactory refundEntityFactory;
     @InjectMocks
     ChargeParityChecker chargeParityChecker;
 
@@ -102,7 +105,7 @@ class ParityCheckerServiceTest {
 
     @BeforeEach
     void setUp() {
-        lenient().when(mockProviders.byName(any())).thenReturn(new SandboxPaymentProvider());
+        lenient().when(mockProviders.byName(any())).thenReturn(new SandboxPaymentProvider(refundEntityFactory));
         refundParityChecker = new RefundParityChecker(refundDao);
         parityCheckService = new ParityCheckService(ledgerService, chargeService, historicalEventEmitter,
                 chargeParityChecker, refundParityChecker, refundService);

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.tasks.service.ChargeParityChecker;
 import uk.gov.pay.connector.tasks.service.ParityCheckService;
@@ -70,6 +71,8 @@ public class ParityCheckServiceTest {
     private HistoricalEventEmitter mockHistoricalEventEmitter;
     @Mock
     private PaymentProviders mockProviders;
+    @Mock
+    private RefundEntityFactory mockRefundEntityFactory;
     @InjectMocks
     ChargeParityChecker chargeParityChecker;
     @Mock
@@ -112,7 +115,7 @@ public class ParityCheckServiceTest {
         LedgerTransaction transaction = from(chargeEntity, refundEntities)
                 .build();
         when(mockLedgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(transaction));
-        when(mockProviders.byName(any())).thenReturn(new SandboxPaymentProvider());
+        when(mockProviders.byName(any())).thenReturn(new SandboxPaymentProvider(mockRefundEntityFactory));
 
 
         ParityCheckStatus chargeAndRefundsParityCheckStatus = parityCheckService.getChargeAndRefundsParityCheckStatus(chargeEntity);
@@ -141,7 +144,7 @@ public class ParityCheckServiceTest {
         LedgerTransaction transaction = from(chargeEntity, refundEntities)
                 .build();
         when(mockLedgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(transaction));
-        when(mockProviders.byName(any())).thenReturn(new SandboxPaymentProvider());
+        when(mockProviders.byName(any())).thenReturn(new SandboxPaymentProvider(mockRefundEntityFactory));
 
         boolean matchesWithLedger = parityCheckService.parityCheckChargeForExpunger(chargeEntity);
 


### PR DESCRIPTION
For Worldpay, the gateway transaction ID (how Worldpay refers to the refund) is always the same as the external ID of the refund. Set the gateway transaction ID as soon as the refund entity is created, rather than when we process the response to the refund request to Worldpay, to avoid a possible race condition if we receive a refund notification from Worldpay immediately.

To do this, introduce a `RefundEntityFactory` interface so the code for different payment gateways can supply one with the desired behaviour.