### PR TITLE
PP-12427 allow worldpay credential validation for gateways switching to worldpay

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -724,7 +724,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/pact/ContractTest.java",
         "hashed_secret": "d5662d7353c6257f68cab2a3b0f758cc79b1ac5e",
         "is_verified": false,
-        "line_number": 382
+        "line_number": 385
       }
     ],
     "src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-17T16:50:00Z"
+  "generated_at": "2025-02-17T18:52:36Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -140,70 +140,70 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 1247
+        "line_number": 1288
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 1902
+        "line_number": 1943
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 3411
+        "line_number": 3412
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 3455
+        "line_number": 3456
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3924
+        "line_number": 3925
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4337
+        "line_number": 4338
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4373
+        "line_number": 4374
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 5301
+        "line_number": 5302
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5803
+        "line_number": 5804
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5814
+        "line_number": 5815
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -323,7 +323,7 @@
         "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 136
       }
     ],
     "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java": [
@@ -630,7 +630,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 166
+        "line_number": 169
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-12T11:28:02Z"
+  "generated_at": "2025-02-17T16:50:00Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1236,6 +1236,47 @@ paths:
       summary: Handle Worldpay notifications
       tags:
       - Notifications
+  /v1/api/service/{serviceExternalId}/account/{accountType}/switch-psp:
+    post:
+      operationId: switchPaymentProviderByServiceIdAndAccountType
+      parameters:
+      - description: Service External Id
+        example: 1
+        in: path
+        name: serviceExternalId
+        required: true
+        schema:
+          type: string
+      - description: Account type
+        example: test
+        in: path
+        name: accountType
+        required: true
+        schema:
+          type: string
+          enum:
+          - test
+          - live
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GatewayAccountSwitchPaymentProviderRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Bad request
+        "404":
+          description: Not found
+      summary: Switch payment provider of a gateway account
+      tags:
+      - Gateway accounts
   /v1/api/service/{serviceId}/account/{accountType}:
     get:
       description: "Get gateway account by service external ID and account type (test|live).\
@@ -2089,47 +2130,6 @@ paths:
         given service ID and account type
       tags:
       - Gateway accounts
-  /v1/api/service/{serviceId}/account/{accountType}/switch-psp:
-    post:
-      operationId: switchPaymentProviderByServiceIdAndAcountType
-      parameters:
-      - description: Service ID
-        example: 1
-        in: path
-        name: serviceId
-        required: true
-        schema:
-          type: string
-      - description: Account type
-        example: test
-        in: path
-        name: accountType
-        required: true
-        schema:
-          type: string
-          enum:
-          - test
-          - live
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/GatewayAccountSwitchPaymentProviderRequest"
-        required: true
-      responses:
-        "200":
-          description: OK
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-          description: Bad request
-        "404":
-          description: Not found
-      summary: Switch payment provider of a gateway account
-      tags:
-      - Gateway accounts
   /v1/api/service/{serviceId}/account/{accountType}/telephone-charges:
     post:
       description: "Create a new telephone charge for a service and account type.\
@@ -2279,7 +2279,8 @@ paths:
           description: The response body will contain either 'valid' or 'invalid'
             to indicate if the supplied credentials are valid or not.
         "404":
-          description: Not found - account not found or not a Worldpay gateway account
+          description: "Not found - account not found, not a Worldpay gateway account\
+            \ or not a gateway account switching to Worldpay"
         "422":
           content:
             application/json:

--- a/src/main/java/uk/gov/pay/connector/common/dao/JpaDao.java
+++ b/src/main/java/uk/gov/pay/connector/common/dao/JpaDao.java
@@ -4,6 +4,7 @@ import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
 
 import javax.persistence.EntityManager;
+import java.util.Collection;
 import java.util.Optional;
 
 @Transactional
@@ -33,6 +34,12 @@ public abstract class JpaDao<T> {
 
     public T merge(final T object) {
         return entityManager.get().merge(object);
+    }
+
+    public void mergeInSequence(final Collection<T> objects) {
+        for (T object : objects) {
+            entityManager.get().merge(object);
+        }
     }
 
     public void forceRefresh(final T object) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountNotFoundException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountNotFoundException.java
@@ -16,11 +16,11 @@ public class GatewayAccountNotFoundException extends WebApplicationException {
         super(notFoundResponse(message));
     }
     
-    public GatewayAccountNotFoundException(String serviceId, GatewayAccountType accountType) {
-        this(format("Gateway account not found for service ID [%s] and account type [%s]", serviceId, accountType));
+    public GatewayAccountNotFoundException(String serviceExternalId, GatewayAccountType accountType) {
+        this(format("Gateway account not found for service external id [%s] and account type [%s]", serviceExternalId, accountType));
     }
     
-    public static GatewayAccountNotFoundException forNonWorldpayAccount(String serviceId, GatewayAccountType accountType) {
-        return new GatewayAccountNotFoundException(format("Gateway account for service ID [%s] and account type [%s] is not a Worldpay account.", serviceId, accountType));
+    public static GatewayAccountNotFoundException forNonWorldpayAccount(String serviceExternalId, GatewayAccountType accountType) {
+        return new GatewayAccountNotFoundException(format("Gateway account for service external id [%s] and account type [%s] is not a Worldpay account and does not have a pending Worldpay credential.", serviceExternalId, accountType));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountType.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountType.java
@@ -9,6 +9,7 @@ public enum GatewayAccountType {
         this.value = value;
     }
 
+    @Override
     public String toString() {
         return value;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -112,7 +112,7 @@ public class GatewayAccountResource {
             }
     )
     public GatewayAccountWithCredentialsWithInternalIdResponse getGatewayAccount(@Parameter(example = "1", description = "Gateway account ID")
-                                                                   @PathParam("accountId") Long gatewayAccountId) {
+                                                                                 @PathParam("accountId") Long gatewayAccountId) {
 
         return gatewayAccountService.getGatewayAccount(gatewayAccountId)
                 .map(GatewayAccountWithCredentialsWithInternalIdResponse::new)
@@ -324,13 +324,13 @@ public class GatewayAccountResource {
             JsonNode payload) {
 
         validator.validatePatchRequest(payload);
-        
+
         return gatewayAccountServicesFactory.getUpdateService()
                 .doPatch(serviceId, accountType, JsonPatchRequest.from(payload))
                 .map(gatewayAccount -> Response.ok().build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
     }
-    
+
     @PATCH
     @Path("/v1/api/accounts/{accountId}")
     @Consumes(APPLICATION_JSON)
@@ -355,7 +355,7 @@ public class GatewayAccountResource {
             }
     )
     public Response patchGatewayAccountByGatewayAccountId(
-            @Parameter(example = "1", description = "Gateway account ID") @PathParam("accountId") Long gatewayAccountId, 
+            @Parameter(example = "1", description = "Gateway account ID") @PathParam("accountId") Long gatewayAccountId,
             JsonNode payload) {
         validator.validatePatchRequest(payload);
 
@@ -386,21 +386,21 @@ public class GatewayAccountResource {
     public Response updateGatewayAccountServiceNameByServiceId(
             @Parameter(example = "46eb1b601348499196c99de90482ee68", description = "Service ID") @PathParam("serviceId") String serviceId,
             @Valid UpdateServiceNameRequest updateServiceNameRequest) {
-        
+
         Optional<GatewayAccountEntity> testAccount = gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, GatewayAccountType.TEST);
         Optional<GatewayAccountEntity> liveAccount = gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, GatewayAccountType.LIVE);
-        
+
         testAccount.ifPresent(gatewayAccount -> gatewayAccount.setServiceName(updateServiceNameRequest.getServiceName()));
         liveAccount.ifPresent(gatewayAccount -> gatewayAccount.setServiceName(updateServiceNameRequest.getServiceName()));
-        
+
         if (testAccount.isPresent() || liveAccount.isPresent()) {
             return Response.ok().build();
         } else {
-            
+
             throw new GatewayAccountNotFoundException(String.format("No gateway accounts found for service ID [%s]", serviceId));
         }
     }
-    
+
     @PATCH
     @Path("/v1/frontend/accounts/{accountId}/servicename")
     @Consumes(APPLICATION_JSON)
@@ -420,7 +420,7 @@ public class GatewayAccountResource {
             }
     )
     public Response updateGatewayAccountServiceNameByGatewayAccountId(@Parameter(example = "1", description = "Gateway account ID") @PathParam("accountId") Long gatewayAccountId,
-                                                    Map<String, String> payload) {
+                                                                      Map<String, String> payload) {
         if (!payload.containsKey(SERVICE_NAME_FIELD_NAME)) {
             return fieldsMissingResponse(Collections.singletonList(SERVICE_NAME_FIELD_NAME));
         }
@@ -464,7 +464,7 @@ public class GatewayAccountResource {
             @Parameter(example = "46eb1b601348499196c99de90482ee68", description = "Service ID") @PathParam("serviceId") String serviceId,
             @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType,
             Update3dsToggleRequest update3dsToggleRequest) {
-        
+
         return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
                 .map(gatewayAccount ->
                         {
@@ -477,7 +477,7 @@ public class GatewayAccountResource {
                 )
                 .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
     }
-    
+
     @PATCH
     @Path("/v1/frontend/accounts/{accountId}/3ds-toggle")
     @Consumes(APPLICATION_JSON)
@@ -644,7 +644,7 @@ public class GatewayAccountResource {
     )
     public Response switchPaymentProviderByServiceIdAndAccountType(
             @Parameter(example = "1", description = "Service External Id") @PathParam("serviceExternalId") String serviceExternalId,
-            @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType, 
+            @Parameter(example = "test", description = "Account type") @PathParam("accountType") GatewayAccountType accountType,
             @NotNull @Valid GatewayAccountSwitchPaymentProviderRequest request) {
 
         return gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceExternalId, accountType)
@@ -656,12 +656,12 @@ public class GatewayAccountResource {
                         gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, request);
                         // if the gateway account type is live, we need to clean up the test account as well
                         if (GatewayAccountType.LIVE.equals(GatewayAccountType.fromString(gatewayAccountEntity.getType()))) {
-                            Optional<GatewayAccountEntity> maybeTestAccountEntity = gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceExternalId, GatewayAccountType.TEST);
-                            maybeTestAccountEntity.ifPresent(testAccountEntity -> {
-                                if (testAccountEntity.isStripeTestAccount()) {
-                                    gatewayAccountSwitchPaymentProviderService.revertStripeTestAccountToSandbox(testAccountEntity, request);
-                                }
-                            });
+                            gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceExternalId, GatewayAccountType.TEST)
+                                    .ifPresent(testAccountEntity -> {
+                                        if (testAccountEntity.isStripeTestAccount()) {
+                                            gatewayAccountSwitchPaymentProviderService.revertStripeTestAccountToSandbox(testAccountEntity, request);
+                                        }
+                                    });
                         }
                     } catch (BadRequestException | NotFoundException ex) {
                         logger.error(SWITCHING_PROVIDER_ERROR, ex.getMessage());
@@ -687,9 +687,9 @@ public class GatewayAccountResource {
             }
     )
     public Response switchPaymentProviderByGatewayAccountId(@Parameter(example = "1", description = "Gateway account ID")
-                                          @PathParam("accountId") Long gatewayAccountId,
+                                                            @PathParam("accountId") Long gatewayAccountId,
                                                             @NotNull GatewayAccountSwitchPaymentProviderRequest request) {
-        
+
         return gatewayAccountService.getGatewayAccount(gatewayAccountId)
                 .map(gatewayAccountEntity -> {
                     if (!gatewayAccountEntity.isProviderSwitchEnabled()) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
@@ -77,7 +77,6 @@ public class StripeAccountResource {
         stripeCredentials.setStripeAccountId(stripeTestConnectAccount.getId());
         StripeGatewayAccountRequest stripeGatewayAccountRequest = StripeGatewayAccountRequest.Builder.aStripeGatewayAccountRequest()
                 .withProviderAccountType(TEST.toString())
-                .withDescription(String.format("Stripe test account for service %s", sandboxGatewayAccount.getServiceName()))
                 .withServiceName(sandboxGatewayAccount.getServiceName())
                 .withServiceId(sandboxGatewayAccount.getServiceId())
                 .withDescription(sandboxGatewayAccount.getDescription())
@@ -91,7 +90,7 @@ public class StripeAccountResource {
         
         GatewayAccountEntity stripeTestGatewayAccount = gatewayAccountService.createGatewayAccount(stripeGatewayAccountRequest);
         stripeAccountSetupService.completeTestAccountSetup(stripeTestGatewayAccount);
-        gatewayAccountService.disableAccount(sandboxGatewayAccount.getId(), String.format("Superseded by Stripe test account [ext id: %s]", stripeTestGatewayAccount.getExternalId()));
+        gatewayAccountService.disableAccount(sandboxGatewayAccount.getId(), String.format("Superseded by newer test account [gateway_account_id: %s]", stripeTestGatewayAccount.getId()));
 
         Map<String, String> response = Map.of("stripe_connect_account_id", stripeTestConnectAccount.getId(),
                 "gateway_account_id", stripeTestGatewayAccount.getId().toString(),

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderService.java
@@ -1,25 +1,33 @@
 package uk.gov.pay.connector.gatewayaccount.service;
 
 import com.google.inject.persist.Transactional;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.GatewayAccountSwitchPaymentProviderRequest;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.VERIFIED_WITH_LIVE_PAYMENT;
+import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_TYPE;
 import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER;
@@ -48,40 +56,117 @@ public class GatewayAccountSwitchPaymentProviderService {
             throw new BadRequestException("Account has no credential to switch to/from");
         }
 
-        var activeCredentialEntity = credentials
-                .stream()
-                .filter(credential -> ACTIVE.equals(credential.getState())).findFirst()
-                .orElseThrow(() -> new BadRequestException("Account credential with ACTIVE state not found."));
+        var activeCredentialEntity = findSingleCredentialEntityByState(credentials, ACTIVE);
+        var switchingCredentialEntity = findSingleCredentialEntityByState(credentials, VERIFIED_WITH_LIVE_PAYMENT);
 
-        var switchToCredentialsEntity = credentials
-                .stream()
-                .filter(credential -> request.getGatewayAccountCredentialExternalId().equals(credential.getExternalId())).findFirst()
-                .orElseThrow(() -> new NotFoundException(format("Account credential with id [%s] not found.", request.getGatewayAccountCredentialExternalId())));
-
-        if (!switchToCredentialsEntity.getState().equals(VERIFIED_WITH_LIVE_PAYMENT)) {
-            throw new BadRequestException(format("Credential with id [%s] is not in the VERIFIED_WITH_LIVE_PAYMENT state.", request.getGatewayAccountCredentialExternalId()));
+        if (!request.getGatewayAccountCredentialExternalId().equals(switchingCredentialEntity.getExternalId())) {
+            throw new NotFoundException(format("Credential with external id [%s] not found", request.getGatewayAccountCredentialExternalId()));
         }
 
-        switchToCredentialsEntity.setLastUpdatedByUserExternalId(request.getUserExternalId());
-        switchToCredentialsEntity.setActiveStartDate(Instant.now());
-        switchToCredentialsEntity.setState(ACTIVE);
+        switchingCredentialEntity.setLastUpdatedByUserExternalId(request.getUserExternalId());
+        switchingCredentialEntity.setActiveStartDate(Instant.now());
+        switchingCredentialEntity.setState(ACTIVE);
 
         activeCredentialEntity.setState(RETIRED);
         activeCredentialEntity.setLastUpdatedByUserExternalId(request.getUserExternalId());
         activeCredentialEntity.setActiveEndDate(Instant.now());
 
         gatewayAccountEntity.setProviderSwitchEnabled(false);
+        gatewayAccountEntity.setDescription(
+                replaceAllCaseInsensitive(
+                        gatewayAccountEntity.getDescription(),
+                        activeCredentialEntity.getPaymentProvider(),
+                        switchingCredentialEntity.getPaymentProvider()
+                )
+        );
 
-        gatewayAccountCredentialsDao.merge(switchToCredentialsEntity);
-        gatewayAccountCredentialsDao.merge(activeCredentialEntity);
+        gatewayAccountCredentialsDao.mergeInSequence(Arrays.asList(switchingCredentialEntity, activeCredentialEntity));
         gatewayAccountDao.merge(gatewayAccountEntity);
 
         LOGGER.info("Gateway account [id={}] switched to new payment provider", gatewayAccountEntity.getId(),
                 kv(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId()),
                 kv(GATEWAY_ACCOUNT_TYPE, gatewayAccountEntity.getType()),
                 kv(PROVIDER, activeCredentialEntity.getPaymentProvider()),
-                kv("new_payment_provider", switchToCredentialsEntity.getPaymentProvider()),
+                kv("new_payment_provider", switchingCredentialEntity.getPaymentProvider()),
                 kv(USER_EXTERNAL_ID, request.getUserExternalId())
         );
+    }
+
+    @Transactional
+    public void revertStripeTestAccountToSandbox(GatewayAccountEntity gatewayAccountEntity, GatewayAccountSwitchPaymentProviderRequest request) {
+        if (gatewayAccountEntity.isLive()) {
+            throw new IllegalArgumentException(format("Gateway account cannot be live [gateway account id: %s]", gatewayAccountEntity.getId()));
+        }
+        
+        List<GatewayAccountCredentialsEntity> credentials = gatewayAccountEntity.getGatewayAccountCredentials();
+        
+        var activeCredentialEntity = findSingleCredentialEntityByState(credentials, ACTIVE);
+
+        if (!PaymentGatewayName.STRIPE.getName().equals(activeCredentialEntity.getPaymentProvider())) {
+            throw new BadRequestException(format("Stripe credential with ACTIVE state not found for account [gateway account id: %s]",
+                    gatewayAccountEntity.getId()));
+        }
+
+        activeCredentialEntity.setState(RETIRED);
+        activeCredentialEntity.setLastUpdatedByUserExternalId(request.getUserExternalId());
+        activeCredentialEntity.setActiveEndDate(Instant.now());
+
+
+        var sandboxCredentialEntity = new GatewayAccountCredentialsEntity(
+                gatewayAccountEntity,
+                PaymentGatewayName.SANDBOX.getName(),
+                Map.of(),
+                ACTIVE
+        );
+
+        sandboxCredentialEntity.setExternalId(randomUuid());
+        sandboxCredentialEntity.setLastUpdatedByUserExternalId(request.getUserExternalId());
+        sandboxCredentialEntity.setActiveStartDate(Instant.now());
+
+        gatewayAccountEntity.setDescription(
+                replaceAllCaseInsensitive(
+                        gatewayAccountEntity.getDescription(),
+                        activeCredentialEntity.getPaymentProvider(),
+                        sandboxCredentialEntity.getPaymentProvider()
+                )
+        );
+
+        gatewayAccountCredentialsDao.mergeInSequence(Arrays.asList(sandboxCredentialEntity, activeCredentialEntity));
+        gatewayAccountDao.merge(gatewayAccountEntity);
+
+        LOGGER.info("Gateway account [id={}] reverted to sandbox", gatewayAccountEntity.getId(),
+                kv(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId()),
+                kv(GATEWAY_ACCOUNT_TYPE, gatewayAccountEntity.getType()),
+                kv(PROVIDER, activeCredentialEntity.getPaymentProvider()),
+                kv("new_payment_provider", sandboxCredentialEntity.getPaymentProvider()),
+                kv(USER_EXTERNAL_ID, request.getUserExternalId())
+        );
+    }
+
+    private String replaceAllCaseInsensitive(String value, String target, String replacement) {
+        if (value == null || target == null || replacement == null) {
+            return value;
+        }
+        // case in-sensitive word match
+        String pattern = "(?i)\\b" + Pattern.quote(target) + "\\b";
+        return value.replaceAll(pattern, StringUtils.capitalize(replacement));
+    }
+
+    private GatewayAccountCredentialsEntity findSingleCredentialEntityByState(List<GatewayAccountCredentialsEntity> credentials, GatewayAccountCredentialState credentialState) {
+        return credentials
+                .stream()
+                .filter(credential -> credentialState.equals(credential.getState()))
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toList(),
+                        list -> {
+                            if (list.isEmpty()) {
+                                throw new BadRequestException(format("Credential with %s state not found", credentialState.toString()));
+                            }
+                            if (list.size() > 1) {
+                                throw new BadRequestException(format("Multiple %s credentials found", credentialState.toString()));
+                            }
+                            return list.getFirst();
+                        }
+                ));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderService.java
@@ -101,7 +101,6 @@ public class GatewayAccountSwitchPaymentProviderService {
         
         List<GatewayAccountCredentialsEntity> gatewayAccountCredentials = gatewayAccountEntity.getGatewayAccountCredentials();
         
-        // there could be more than one active credential for a test account depending on when it was created
         var activeStripeCredentialEntities =  gatewayAccountCredentials.stream()
                 .filter(this::isActiveStripeCredential)
                 .collect(Collectors.toCollection(ArrayList::new));
@@ -117,9 +116,6 @@ public class GatewayAccountSwitchPaymentProviderService {
             cred.setActiveEndDate(Instant.now());
         });
 
-        var hasActiveSandboxCredential = gatewayAccountCredentials.stream()
-                .anyMatch(this::isActiveSandboxCredential);
-
         gatewayAccountEntity.setDescription(
                 replaceAllCaseInsensitive(
                         gatewayAccountEntity.getDescription(),
@@ -127,6 +123,9 @@ public class GatewayAccountSwitchPaymentProviderService {
                         PaymentGatewayName.SANDBOX.getName()
                 )
         );
+
+        var hasActiveSandboxCredential = gatewayAccountCredentials.stream()
+                .anyMatch(this::isActiveSandboxCredential);
 
         if (!hasActiveSandboxCredential) {
             var sandboxCredentialEntity = new GatewayAccountCredentialsEntity(

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResource.java
@@ -385,7 +385,7 @@ public class GatewayAccountCredentialsResource {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(
                             responseCode = "404", 
-                            description = "Not found - account not found or not a Worldpay gateway account"),
+                            description = "Not found - account not found, not a Worldpay gateway account or not a gateway account switching to Worldpay"),
                     @ApiResponse(
                             responseCode = "500", 
                             description = "Indicates an internal server error in connector, or an upstream Worldpay 5xx error.")
@@ -399,7 +399,7 @@ public class GatewayAccountCredentialsResource {
                 .or(() -> {
                     throw new GatewayAccountNotFoundException(serviceId, accountType);
                 })
-                .filter(GatewayAccountEntity::isWorldpayGatewayAccount)
+                .filter(gatewayAccountEntity -> gatewayAccountEntity.isWorldpayGatewayAccount() || gatewayAccountEntity.hasPendingWorldpayCredential())
                 .or(() -> {
                     throw GatewayAccountNotFoundException.forNonWorldpayAccount(serviceId, accountType);
                 })
@@ -409,7 +409,7 @@ public class GatewayAccountCredentialsResource {
     }
 
 
-    private final class ValidationResult {
+    public static final class ValidationResult {
         @Schema(example = "valid", description = "valid/invalid result for Worldpay flex credentials")
         private final String result;
 

--- a/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceTest.java
@@ -99,7 +99,7 @@ class AgreementsApiResourceTest {
         @Test
         void returnsNotFoundResponse_whenGatewayAccountNotFound() {
             when(agreementService.createByServiceIdAndAccountType(aValidAgreementCreateRequest(), VALID_SERVICE_ID, GatewayAccountType.TEST))
-                    .thenThrow(new GatewayAccountNotFoundException((String.format("Gateway account not found for service ID [%s] and account type [%s]", VALID_SERVICE_ID, GatewayAccountType.TEST))));
+                    .thenThrow(new GatewayAccountNotFoundException((String.format("Gateway account not found for service external id [%s] and account type [%s]", VALID_SERVICE_ID, GatewayAccountType.TEST))));
             Map payloadMap = Map.of("reference", REFERENCE_ID, "description", VALID_DESCRIPTION);
 
             Response response = resources.client()

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceResendConfirmationEmailIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceResendConfirmationEmailIT.java
@@ -140,8 +140,8 @@ public class ChargesApiResourceResendConfirmationEmailIT {
 
             private Stream<Arguments> shouldReturn404_argsProvider() {
                 return Stream.of(
-                        Arguments.of("not-this-service-id", GatewayAccountType.TEST, "Gateway account not found for service ID [not-this-service-id] and account type [test]"),
-                        Arguments.of(SERVICE_ID, GatewayAccountType.LIVE, format("Gateway account not found for service ID [%s] and account type [live]", SERVICE_ID))
+                        Arguments.of("not-this-service-id", GatewayAccountType.TEST, "Gateway account not found for service external id [not-this-service-id] and account type [test]"),
+                        Arguments.of(SERVICE_ID, GatewayAccountType.LIVE, format("Gateway account not found for service external id [%s] and account type [live]", SERVICE_ID))
                 );
             }
         }

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceTest.java
@@ -147,7 +147,7 @@ public class ChargesApiResourceTest {
                         .request()
                         .post(Entity.json(Collections.emptyMap()))) {
 
-                    assertGenericErrorResponse(response, 404, format("Gateway account not found for service ID [%s] and account type [%s]", A_SERVICE_ID, A_GATEWAY_ACCOUNT_TYPE));
+                    assertGenericErrorResponse(response, 404, format("Gateway account not found for service external id [%s] and account type [%s]", A_SERVICE_ID, A_GATEWAY_ACCOUNT_TYPE));
                 }
             }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceSwitchPspValidationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceSwitchPspValidationTest.java
@@ -86,7 +86,7 @@ class GatewayAccountResourceSwitchPspValidationTest {
             assertThat(response.getStatus(), is(400));
 
             String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-            assertThat(errorMessage, is("Account credential with ACTIVE state not found."));
+            assertThat(errorMessage, is("Credential with ACTIVE state not found"));
         }
 
         @Test
@@ -127,17 +127,17 @@ class GatewayAccountResourceSwitchPspValidationTest {
             when(gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, TEST))
                     .thenReturn(Optional.of(gatewayAccountEntity));
 
-            String nonExistentCredentialsId = randomUuid();
+            String nonExistentCredentialExternalId = randomUuid();
             Response response = resources.client()
                     .target(format("/v1/api/service/%s/account/test/switch-psp", serviceId))
                     .request()
                     .post(Entity.json(Map.of("user_external_id", "some-user-external-id",
-                            "gateway_account_credential_external_id", nonExistentCredentialsId)));
+                            "gateway_account_credential_external_id", nonExistentCredentialExternalId)));
 
             assertThat(response.getStatus(), is(404));
 
             String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-            assertThat(errorMessage, is("Account credential with id [" + nonExistentCredentialsId + "] not found."));
+            assertThat(errorMessage, is("Credential with external id [" + nonExistentCredentialExternalId + "] not found"));
         }
 
         @Test
@@ -165,7 +165,7 @@ class GatewayAccountResourceSwitchPspValidationTest {
             assertThat(response.getStatus(), is(400));
 
             String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-            assertThat(errorMessage, is("Credential with id [" + switchToExtId + "] is not in the VERIFIED_WITH_LIVE_PAYMENT state."));
+            assertThat(errorMessage, is("Credential with VERIFIED_WITH_LIVE_PAYMENT state not found"));
         }
 
         @Test
@@ -182,7 +182,7 @@ class GatewayAccountResourceSwitchPspValidationTest {
             assertThat(response.getStatus(), is(404));
 
             String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-            assertThat(errorMessage, is(format("Gateway account not found for service ID [%s] and account type [test]", serviceId)));
+            assertThat(errorMessage, is(format("Gateway account not found for service external id [%s] and account type [test]", serviceId)));
         }
 
         @Test
@@ -252,7 +252,7 @@ class GatewayAccountResourceSwitchPspValidationTest {
             assertThat(response.getStatus(), is(400));
 
             String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-            assertThat(errorMessage, is("Account credential with ACTIVE state not found."));
+            assertThat(errorMessage, is("Credential with ACTIVE state not found"));
         }
 
         @Test
@@ -302,7 +302,7 @@ class GatewayAccountResourceSwitchPspValidationTest {
             assertThat(response.getStatus(), is(404));
 
             String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-            assertThat(errorMessage, is("Account credential with id [" + switchToExtId + "] not found."));
+            assertThat(errorMessage, is("Credential with external id [" + switchToExtId + "] not found"));
         }
 
         @Test
@@ -329,7 +329,7 @@ class GatewayAccountResourceSwitchPspValidationTest {
             assertThat(response.getStatus(), is(400));
 
             String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-            assertThat(errorMessage, is("Credential with id [" + switchToExtId + "] is not in the VERIFIED_WITH_LIVE_PAYMENT state."));
+            assertThat(errorMessage, is("Credential with VERIFIED_WITH_LIVE_PAYMENT state not found"));
         }
 
         @Test

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderServiceTest.java
@@ -1,14 +1,21 @@
 package uk.gov.pay.connector.gatewayaccount.service;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.GatewayAccountSwitchPaymentProviderRequest;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
@@ -16,6 +23,7 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,7 +40,7 @@ import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccoun
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 @ExtendWith(MockitoExtension.class)
- class GatewayAccountSwitchPaymentProviderServiceTest {
+class GatewayAccountSwitchPaymentProviderServiceTest {
 
     private GatewayAccountSwitchPaymentProviderService gatewayAccountSwitchPaymentProviderService;
     private GatewayAccountEntity gatewayAccountEntity;
@@ -45,84 +53,222 @@ import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
     private GatewayAccountDao mockGatewayAccountDao;
 
     @BeforeEach
-     void setUp() {
+    void setUp() {
         gatewayAccountSwitchPaymentProviderService = new GatewayAccountSwitchPaymentProviderService(mockGatewayAccountDao, mockGatewayAccountCredentialsDao);
         gatewayAccountEntity = aGatewayAccountEntity().build();
         request = new GatewayAccountSwitchPaymentProviderRequest(randomUuid(), randomUuid());
     }
 
-    @Test
-     void shouldThrowExceptionWhenCredentialIsMissing() {
-        var gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
-                .withState(ACTIVE)
-                .build();
-        gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity));
-        var thrown = assertThrows(BadRequestException.class, () -> gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, null));
-        assertThat(thrown.getMessage(), is("Account has no credential to switch to/from"));
+    @Nested
+    class switchPaymentProviderForAccount {
+        @Test
+        void shouldThrowExceptionWhenCredentialIsMissing() {
+            var gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+                    .withState(ACTIVE)
+                    .build();
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity));
+            var thrown = assertThrows(BadRequestException.class, () -> gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, null));
+            assertThat(thrown.getMessage(), is("Account has no credential to switch to/from"));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenNoActiveCredentialFound() {
+            var gatewayAccountCredentialsEntity1 = aGatewayAccountCredentialsEntity()
+                    .withState(VERIFIED_WITH_LIVE_PAYMENT)
+                    .build();
+            var gatewayAccountCredentialsEntity2 = aGatewayAccountCredentialsEntity()
+                    .withState(RETIRED)
+                    .build();
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity1, gatewayAccountCredentialsEntity2));
+            var thrown = assertThrows(BadRequestException.class, () -> gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, request));
+            assertThat(thrown.getMessage(), is("Credential with ACTIVE state not found"));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenCredentialNonExistent() {
+            var gatewayAccountCredentialsEntity1 = aGatewayAccountCredentialsEntity()
+                    .withState(ACTIVE)
+                    .build();
+            var gatewayAccountCredentialsEntity2 = aGatewayAccountCredentialsEntity()
+                    .withState(VERIFIED_WITH_LIVE_PAYMENT)
+                    .build();
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity1, gatewayAccountCredentialsEntity2));
+            var thrown = assertThrows(NotFoundException.class, () -> gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, request));
+            assertThat(thrown.getMessage(), is(format("Credential with external id [%s] not found", request.getGatewayAccountCredentialExternalId())));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenCredentialNotCorrectState() {
+            var gatewayAccountCredentialsEntity1 = aGatewayAccountCredentialsEntity()
+                    .withState(ACTIVE)
+                    .build();
+            var gatewayAccountCredentialsEntity2 = aGatewayAccountCredentialsEntity()
+                    .withExternalId(request.getGatewayAccountCredentialExternalId())
+                    .withState(ENTERED)
+                    .build();
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity1, gatewayAccountCredentialsEntity2));
+            var thrown = assertThrows(BadRequestException.class, () -> gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, request));
+            assertThat(thrown.getMessage(), is("Credential with VERIFIED_WITH_LIVE_PAYMENT state not found"));
+        }
+
+        @Test
+        void shouldSwitchPaymentProvider() {
+            var gatewayAccountCredentialsEntity1 = aGatewayAccountCredentialsEntity()
+                    .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                    .withState(ACTIVE)
+                    .build();
+            var gatewayAccountCredentialsEntity2 = aGatewayAccountCredentialsEntity()
+                    .withPaymentProvider(PaymentGatewayName.WORLDPAY.getName())
+                    .withExternalId(request.getGatewayAccountCredentialExternalId())
+                    .withState(VERIFIED_WITH_LIVE_PAYMENT)
+                    .build();
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity1, gatewayAccountCredentialsEntity2));
+            gatewayAccountEntity.setDescription("I am a Stripe live account");
+
+
+            ArgumentCaptor<List<GatewayAccountCredentialsEntity>> credentialArgumentCaptor = ArgumentCaptor.forClass(List.class);
+            ArgumentCaptor<GatewayAccountEntity> gatewayArgumentCaptor = ArgumentCaptor.forClass(GatewayAccountEntity.class);
+
+            gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, request);
+
+            verify(mockGatewayAccountCredentialsDao, times(1)).mergeInSequence(credentialArgumentCaptor.capture());
+            verify(mockGatewayAccountDao, times(1)).merge(gatewayArgumentCaptor.capture());
+
+            List<GatewayAccountCredentialsEntity> credentialList = credentialArgumentCaptor.getValue();
+
+            Optional<GatewayAccountCredentialsEntity> activeCredential = credentialList.stream().filter(credential -> ACTIVE.equals(credential.getState())).findFirst();
+            assertThat(activeCredential.get().getExternalId(), is(gatewayAccountCredentialsEntity2.getExternalId()));
+
+            Optional<GatewayAccountCredentialsEntity> retiredCredential = credentialList.stream().filter(credential -> RETIRED.equals(credential.getState())).findFirst();
+            assertThat(retiredCredential.get().getExternalId(), is(gatewayAccountCredentialsEntity1.getExternalId()));
+
+            GatewayAccountEntity gatewayAccount = gatewayArgumentCaptor.getValue();
+            assertThat(gatewayAccount.getDescription(), is("I am a Worldpay live account"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideParamsForGatewayDescription")
+        void shouldCorrectlyUpdateGatewayDescriptionWhenSwitching(PaymentGatewayName paymentGatewayNameFrom, PaymentGatewayName paymentGatewayNameTo, String gatewayDescription, String expectedDescription) {
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(
+                    aGatewayAccountCredentialsEntity()
+                            .withPaymentProvider(paymentGatewayNameFrom.getName())
+                            .withState(ACTIVE)
+                            .build(),
+                    aGatewayAccountCredentialsEntity()
+                            .withPaymentProvider(paymentGatewayNameTo.getName())
+                            .withExternalId(request.getGatewayAccountCredentialExternalId())
+                            .withState(VERIFIED_WITH_LIVE_PAYMENT)
+                            .build()));
+            gatewayAccountEntity.setDescription(gatewayDescription);
+
+            ArgumentCaptor<GatewayAccountEntity> gatewayArgumentCaptor = ArgumentCaptor.forClass(GatewayAccountEntity.class);
+
+            gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, request);
+
+            verify(mockGatewayAccountDao, times(1)).merge(gatewayArgumentCaptor.capture());
+
+            GatewayAccountEntity gatewayAccount = gatewayArgumentCaptor.getValue();
+            assertThat(gatewayAccount.getDescription(), is(expectedDescription));
+        }
+
+        private static Stream<Arguments> provideParamsForGatewayDescription() {
+            return Stream.of(
+                    Arguments.of(PaymentGatewayName.STRIPE, PaymentGatewayName.WORLDPAY, "I am a Stripe live account", "I am a Worldpay live account"),
+                    Arguments.of(PaymentGatewayName.WORLDPAY, PaymentGatewayName.STRIPE, "I am a woRlDPay live account", "I am a Stripe live account"),
+                    Arguments.of(PaymentGatewayName.STRIPE, PaymentGatewayName.WORLDPAY, "I am a STRIPE live account", "I am a Worldpay live account"),
+                    Arguments.of(PaymentGatewayName.STRIPE, PaymentGatewayName.WORLDPAY, "I am a tiger stripes live account", "I am a tiger stripes live account"),
+                    Arguments.of(PaymentGatewayName.WORLDPAY, PaymentGatewayName.STRIPE, "I am a worldpaying live account", "I am a worldpaying live account"),
+                    Arguments.of(PaymentGatewayName.WORLDPAY, PaymentGatewayName.STRIPE, "", ""),
+                    Arguments.of(PaymentGatewayName.WORLDPAY, PaymentGatewayName.STRIPE, null, null)
+            );
+        }
     }
 
-    @Test
-     void shouldThrowExceptionWhenNoActiveCredentialFound() {
-        var gatewayAccountCredentialsEntity1 = aGatewayAccountCredentialsEntity()
-                .withState(VERIFIED_WITH_LIVE_PAYMENT)
-                .build();
-        var gatewayAccountCredentialsEntity2 = aGatewayAccountCredentialsEntity()
-                .withState(RETIRED)
-                .build();
-        gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity1, gatewayAccountCredentialsEntity2));
-        var thrown = assertThrows(BadRequestException.class, () -> gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, request));
-        assertThat(thrown.getMessage(), is(format("Account credential with ACTIVE state not found.", request.getGatewayAccountCredentialExternalId())));
-    }
+    @Nested
+    class revertStripeTestAccountToSandbox {
+        @Test
+        void shouldRevertStripeTestGatewayToSandbox() {
+            var stripeTestCredential = aGatewayAccountCredentialsEntity()
+                    .withState(ACTIVE)
+                    .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                    .build();
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(stripeTestCredential));
+            gatewayAccountEntity.setDescription("I am a Stripe test account");
 
-    @Test
-     void shouldThrowExceptionWhenCredentialNonExistent() {
-        var gatewayAccountCredentialsEntity1 = aGatewayAccountCredentialsEntity()
-                .withState(ACTIVE)
-                .build();
-        var gatewayAccountCredentialsEntity2 = aGatewayAccountCredentialsEntity()
-                .withState(VERIFIED_WITH_LIVE_PAYMENT)
-                .build();
-        gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity1, gatewayAccountCredentialsEntity2));
-        var thrown = assertThrows(NotFoundException.class, () -> gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, request));
-        assertThat(thrown.getMessage(), is(format("Account credential with id [%s] not found.", request.getGatewayAccountCredentialExternalId())));
-    }
+            ArgumentCaptor<List<GatewayAccountCredentialsEntity>> credentialArgumentCaptor = ArgumentCaptor.forClass(List.class);
+            ArgumentCaptor<GatewayAccountEntity> gatewayArgumentCaptor = ArgumentCaptor.forClass(GatewayAccountEntity.class);
 
-    @Test
-     void shouldThrowExceptionWhenCredentialNotCorrectState() {
-        var gatewayAccountCredentialsEntity1 = aGatewayAccountCredentialsEntity()
-                .withState(ACTIVE)
-                .build();
-        var gatewayAccountCredentialsEntity2 = aGatewayAccountCredentialsEntity()
-                .withExternalId(request.getGatewayAccountCredentialExternalId())
-                .withState(ENTERED)
-                .build();
-        gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity1, gatewayAccountCredentialsEntity2));
-        var thrown = assertThrows(BadRequestException.class, () -> gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, request));
-        assertThat(thrown.getMessage(), is(format("Credential with id [%s] is not in the VERIFIED_WITH_LIVE_PAYMENT state.", request.getGatewayAccountCredentialExternalId())));
-    }
+            gatewayAccountSwitchPaymentProviderService.revertStripeTestAccountToSandbox(gatewayAccountEntity, request);
 
-    @Test
-     void shouldMergeCredentials() {
-        var gatewayAccountCredentialsEntity1 = aGatewayAccountCredentialsEntity()
-                .withState(ACTIVE)
-                .build();
-        var gatewayAccountCredentialsEntity2 = aGatewayAccountCredentialsEntity()
-                .withExternalId(request.getGatewayAccountCredentialExternalId())
-                .withState(VERIFIED_WITH_LIVE_PAYMENT)
-                .build();
-        gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity1, gatewayAccountCredentialsEntity2));
-        ArgumentCaptor<GatewayAccountCredentialsEntity> credentialArgumentCaptor = ArgumentCaptor.forClass(GatewayAccountCredentialsEntity.class);
-        ArgumentCaptor<GatewayAccountEntity> gatewayArgumentCaptor = ArgumentCaptor.forClass(GatewayAccountEntity.class);
-        gatewayAccountSwitchPaymentProviderService.switchPaymentProviderForAccount(gatewayAccountEntity, request);
-        verify(mockGatewayAccountCredentialsDao, times(2)).merge(credentialArgumentCaptor.capture());
-        verify(mockGatewayAccountDao).merge(gatewayArgumentCaptor.capture());
+            verify(mockGatewayAccountCredentialsDao, times(1)).mergeInSequence(credentialArgumentCaptor.capture());
+            verify(mockGatewayAccountDao, times(1)).merge(gatewayArgumentCaptor.capture());
 
-        List<GatewayAccountCredentialsEntity> credentialList = credentialArgumentCaptor.getAllValues();
+            List<GatewayAccountCredentialsEntity> credentialList = credentialArgumentCaptor.getValue();
 
-        Optional<GatewayAccountCredentialsEntity> activeCredential = credentialList.stream().filter(credential -> ACTIVE.equals(credential.getState())).findFirst();
-        assertThat(activeCredential.get().getExternalId(), is(gatewayAccountCredentialsEntity2.getExternalId()));
+            Optional<GatewayAccountCredentialsEntity> activeCredential = credentialList.stream().filter(credential -> ACTIVE.equals(credential.getState())).findFirst();
+            assertThat(activeCredential.get().getPaymentProvider(), is(PaymentGatewayName.SANDBOX.getName()));
 
-        Optional<GatewayAccountCredentialsEntity> retiredCredential = credentialList.stream().filter(credential -> RETIRED.equals(credential.getState())).findFirst();
-        assertThat(retiredCredential.get().getExternalId(), is(gatewayAccountCredentialsEntity1.getExternalId()));
+            Optional<GatewayAccountCredentialsEntity> retiredCredential = credentialList.stream().filter(credential -> RETIRED.equals(credential.getState())).findFirst();
+            assertThat(retiredCredential.get().getExternalId(), is(stripeTestCredential.getExternalId()));
+
+            GatewayAccountEntity gatewayAccount = gatewayArgumentCaptor.getValue();
+            assertThat(gatewayAccount.getDescription(), is("I am a Sandbox test account"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideParamsForGatewayDescription")
+        void shouldCorrectlyUpdateGatewayDescriptionWhenRevertingStripeTestAccount(String gatewayDescription, String expectedDescription) {
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(
+                    aGatewayAccountCredentialsEntity()
+                            .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                            .withState(ACTIVE)
+                            .build()));
+            gatewayAccountEntity.setType(GatewayAccountType.TEST);
+            gatewayAccountEntity.setDescription(gatewayDescription);
+
+            ArgumentCaptor<GatewayAccountEntity> gatewayArgumentCaptor = ArgumentCaptor.forClass(GatewayAccountEntity.class);
+
+            gatewayAccountSwitchPaymentProviderService.revertStripeTestAccountToSandbox(gatewayAccountEntity, request);
+
+            verify(mockGatewayAccountDao, times(1)).merge(gatewayArgumentCaptor.capture());
+
+            GatewayAccountEntity gatewayAccount = gatewayArgumentCaptor.getValue();
+            assertThat(gatewayAccount.getDescription(), is(expectedDescription));
+        }
+
+        private static Stream<Arguments> provideParamsForGatewayDescription() {
+            return Stream.of(
+                    Arguments.of("I am a Stripe test account", "I am a Sandbox test account"),
+                    Arguments.of("I am a STRIPE test account", "I am a Sandbox test account"),
+                    Arguments.of("I am a STriPe test account", "I am a Sandbox test account"),
+                    Arguments.of("order your pinstripes service TEST", "order your pinstripes service TEST"),
+                    Arguments.of("", ""),
+                    Arguments.of(null, null)
+            );
+        }
+
+        @Test
+        void shouldThrowExceptionWhenAccountIsNotTest() {
+            var gatewayAccountCredentialsEntity1 = aGatewayAccountCredentialsEntity()
+                    .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                    .withState(ACTIVE)
+                    .build();
+            gatewayAccountEntity.setType(GatewayAccountType.LIVE);
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity1));
+            var thrown = assertThrows(IllegalArgumentException.class, () -> gatewayAccountSwitchPaymentProviderService.revertStripeTestAccountToSandbox(gatewayAccountEntity, request));
+            assertThat(thrown.getMessage(), is(format("Gateway account cannot be live [gateway account id: %s]", gatewayAccountEntity.getId())));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenAccountCredentialIsNotStripe() {
+            var gatewayAccountCredentialsEntity1 = aGatewayAccountCredentialsEntity()
+                    .withPaymentProvider(PaymentGatewayName.WORLDPAY.getName())
+                    .withState(ACTIVE)
+                    .build();
+            gatewayAccountEntity.setType(GatewayAccountType.TEST);
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity1));
+            var thrown = assertThrows(BadRequestException.class, () -> gatewayAccountSwitchPaymentProviderService.revertStripeTestAccountToSandbox(gatewayAccountEntity, request));
+            assertThat(thrown.getMessage(), is(format("Stripe credential with ACTIVE state not found for account [gateway account id: %s]", gatewayAccountEntity.getId())));
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
@@ -281,7 +281,6 @@ public class GatewayAccountCredentialsResourceIT {
                         .then()
                         .statusCode(OK.getStatusCode())
                         .body(not(hasKey("gateway_account_credential_id")));
-                ;
 
                 app.givenSetup()
                         .get("/v1/api/accounts/" + gatewayAccountId)

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
@@ -634,7 +634,7 @@ public class GatewayAccountCredentialsResourceIT {
                         .post(format("/v1/api/service/%s/account/%s/worldpay/check-credentials", VALID_SERVICE_ID, TEST))
                         .then()
                         .statusCode(404)
-                        .body("message[0]", is(format("Gateway account for service ID [%s] and account type [%s] is not a Worldpay account.", VALID_SERVICE_ID, TEST)));
+                        .body("message[0]", is(format("Gateway account for service external id [%s] and account type [%s] is not a Worldpay account and does not have a pending Worldpay credential.", VALID_SERVICE_ID, TEST)));
             }
 
             @Test

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceTest.java
@@ -527,7 +527,7 @@ public class GatewayAccountCredentialsResourceTest {
                         .method("PATCH", Entity.json(payload));
 
                 assertThat(response.getStatus(), is(404));
-                assertThat(extractErrorMessagesFromResponse(response).get(0), is("Gateway account not found for service ID [a-valid-service-id] and account type [test]"));
+                assertThat(extractErrorMessagesFromResponse(response).get(0), is("Gateway account not found for service external id [a-valid-service-id] and account type [test]"));
             }
         }
 
@@ -552,6 +552,7 @@ public class GatewayAccountCredentialsResourceTest {
                 assertThat(extractErrorMessagesFromResponse(response).get(0), is(format("Field [%s] is required", fieldName)));
             }
             
+            @Test
             void forMissingMerchantIdOrMerchantCode_shouldReturn422 () {
                 var payload = Map.of(
                         "username", "valid-username",

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpay3dsFlexIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpay3dsFlexIT.java
@@ -289,7 +289,7 @@ public class GatewayAccountCredentialsResourceWorldpay3dsFlexIT {
                         .put(format("/v1/api/service/%s/account/%s/3ds-flex-credentials", serviceId, TEST))
                         .then()
                         .statusCode(404)
-                        .body("message[0]", is(format("Gateway account not found for service ID [%s] and account type [%s]", serviceId, TEST)));
+                        .body("message[0]", is(format("Gateway account not found for service external id [%s] and account type [%s]", serviceId, TEST)));
             }
 
             @Test
@@ -430,7 +430,7 @@ public class GatewayAccountCredentialsResourceWorldpay3dsFlexIT {
                         .post(format("/v1/api/service/%s/account/%s/worldpay/check-3ds-flex-config", NON_EXISTENT_SERVICE_ID, TEST))
                         .then()
                         .statusCode(404)
-                        .body("message[0]", is(format("Gateway account not found for service ID [%s] and account type [%s]", NON_EXISTENT_SERVICE_ID, TEST)));
+                        .body("message[0]", is(format("Gateway account not found for service external id [%s] and account type [%s]", NON_EXISTENT_SERVICE_ID, TEST)));
             }
 
             @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -971,7 +971,7 @@ public class ChargesApiResourceCreateIT {
                     .post(format("/v1/api/service/%s/account/%s/charges", "non-existent-service-id", GatewayAccountType.TEST))
                     .then()
                     .statusCode(NOT_FOUND.getStatusCode())
-                    .body("message[0]", CoreMatchers.is("Gateway account not found for service ID [non-existent-service-id] and account type [test]"));
+                    .body("message[0]", CoreMatchers.is("Gateway account not found for service external id [non-existent-service-id] and account type [test]"));
         }
 
         @Test
@@ -986,7 +986,7 @@ public class ChargesApiResourceCreateIT {
                     .post(format("/v1/api/service/%s/account/%s/charges", VALID_SERVICE_ID, GatewayAccountType.LIVE))
                     .then()
                     .statusCode(NOT_FOUND.getStatusCode())
-                    .body("message[0]", CoreMatchers.is("Gateway account not found for service ID [valid-service-id] and account type [live]"));;
+                    .body("message[0]", CoreMatchers.is("Gateway account not found for service external id [valid-service-id] and account type [live]"));;
         }
         
         @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceIT.java
@@ -206,7 +206,7 @@ public class EmailNotificationResourceIT {
                     .patch(format("/v1/api/service/%s/account/%s/email-notification", nonExistentServiceId, TEST))
                     .then()
                     .statusCode(404)
-                    .body("message[0]", is(format("Gateway account not found for service ID [%s] and account type [%s]", nonExistentServiceId, TEST)))
+                    .body("message[0]", is(format("Gateway account not found for service external id [%s] and account type [%s]", nonExistentServiceId, TEST)))
                     .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceSwitchPspIT.java
@@ -2,13 +2,16 @@ package uk.gov.pay.connector.it.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
-import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.util.List;
 import java.util.Map;
@@ -16,13 +19,9 @@ import java.util.Map;
 import static java.lang.String.format;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
-import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
-import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.VERIFIED_WITH_LIVE_PAYMENT;
-import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_API_URL;
+import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
+import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
@@ -31,123 +30,147 @@ public class GatewayAccountResourceSwitchPspIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    
     @Nested
     class ByServiceIdAndAccountType {
 
-        private final String serviceId = RandomIdGenerator.newId();
+        private String serviceExternalId;
+        private String worldpayCredentialExternalId;
+        private String stripeCredentialExternalId;
+        private DatabaseFixtures.TestAccount liveGatewayAccount;
+        private DatabaseFixtures.TestAccount testGatewayAccount;
+        
+        @BeforeEach
+        void setUp() {
+            serviceExternalId = randomUuid();
+            liveGatewayAccount = withDatabaseTestHelper(app.getDatabaseTestHelper())
+                    .aTestAccount()
+                    .withType(GatewayAccountType.LIVE)
+                    .withServiceId(serviceExternalId);
+            testGatewayAccount = withDatabaseTestHelper(app.getDatabaseTestHelper())
+                    .aTestAccount()
+                    .withType(GatewayAccountType.TEST)
+                    .withServiceId(serviceExternalId);
+            worldpayCredentialExternalId = randomUuid();
+            stripeCredentialExternalId = randomUuid();
+        }
 
         @Test
-        void switchPaymentProviderFromWorldpayToStripeSuccessfully() {
-            setupWorldpayGatewayAccount();
-            String worldpayCredentialsId = setupCredentialsForWorldpayGatewayAccount();
-            updateProviderSwitchEnabledOnWorldpayGatewayAccount();
-            verifyWorldpayCredentialsIsActiveAndProviderSwitchIsEnabled();
-            String stripeCredentialsExternalId = addStripeCredentialsOnTheGatewayAccount();
+        void shouldSwitchPaymentProviderFromStripeToWorldpay_andHandleStripeTestAccount() {
+            var stripeTestCredentialExternalId = randomUuid();
 
+            testGatewayAccount
+                    .withDescription("A Stripe TEST account")
+                    .withGatewayAccountCredentials(List.of(
+                            anAddGatewayAccountCredentialsParams()
+                                    .withGatewayAccountId(testGatewayAccount.getAccountId())
+                                    .withState(GatewayAccountCredentialState.ACTIVE)
+                                    .withExternalId(stripeTestCredentialExternalId)
+                                    .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                                    .build()
+                    ))
+                    .insert();
+            
+            liveGatewayAccount
+                    .withDescription("A Stripe LIVE account")
+                    .withProviderSwitchEnabled(true)
+                    .withGatewayAccountCredentials(List.of(
+                            anAddGatewayAccountCredentialsParams()
+                                    .withGatewayAccountId(liveGatewayAccount.getAccountId())
+                                    .withState(GatewayAccountCredentialState.ACTIVE)
+                                    .withExternalId(stripeCredentialExternalId)
+                                    .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                                    .build(),
+                            anAddGatewayAccountCredentialsParams()
+                                    .withGatewayAccountId(liveGatewayAccount.getAccountId())
+                                    .withState(GatewayAccountCredentialState.VERIFIED_WITH_LIVE_PAYMENT)
+                                    .withExternalId(worldpayCredentialExternalId)
+                                    .withPaymentProvider(PaymentGatewayName.WORLDPAY.getName())
+                                    .build()
+                    ))
+                    .insert();
+            
             String switchPspPayload = toJson(Map.of("user_external_id", "some-user-external-id",
-                    "gateway_account_credential_external_id", stripeCredentialsExternalId));
+                    "gateway_account_credential_external_id", worldpayCredentialExternalId));
 
             app.givenSetup()
                     .body(switchPspPayload)
-                    .post(format("/v1/api/service/%s/account/test/switch-psp", serviceId))
+                    .post(format("/v1/api/service/%s/account/%s/switch-psp", serviceExternalId, GatewayAccountType.LIVE))
                     .then()
                     .statusCode(OK.getStatusCode());
 
             app.givenSetup()
-                    .get(format("/v1/api/service/%s/account/test", serviceId))
+                    .get(format("/v1/api/service/%s/account/%s", serviceExternalId, GatewayAccountType.LIVE))
                     .then()
                     .statusCode(OK.getStatusCode())
                     .body("provider_switch_enabled", is(false))
-                    .body("gateway_account_credentials[0].state", is("RETIRED"))
-                    .body("gateway_account_credentials[0].external_id", is(worldpayCredentialsId))
-                    .body("gateway_account_credentials[1].state", is("ACTIVE"))
-                    .body("gateway_account_credentials[1].external_id", is(stripeCredentialsExternalId));
-        }
-
-        private String addStripeCredentialsOnTheGatewayAccount() {
-            String stripeCredentialsExternalId = app.givenSetup()
-                    .body(toJson(Map.of("payment_provider", "stripe",
-                            "credentials", Map.of("stripe_account_id", "some-account-id"))))
-                    .post(format("/v1/api/service/%s/account/test/credentials", serviceId))
-                    .then()
-                    .statusCode(OK.getStatusCode())
-                    .extract()
-                    .path("external_id");
+                    .body("description", is("A Worldpay LIVE account"))
+                    .body("gateway_account_credentials.size()", is(2))
+                    .body(String.format("gateway_account_credentials.find { it.external_id == '%s' }.state", worldpayCredentialExternalId),
+                            is(GatewayAccountCredentialState.ACTIVE.toString()))
+                    .body(String.format("gateway_account_credentials.find { it.external_id == '%s' }.state", stripeCredentialExternalId),
+                            is(GatewayAccountCredentialState.RETIRED.toString()));
 
             app.givenSetup()
-                    .body(toJson(List.of(
-                            Map.of("op", "replace",
-                                    "path", "state",
-                                    "value", "VERIFIED_WITH_LIVE_PAYMENT")
-                    )))
-                    .patch(format("/v1/api/service/%s/account/test/credentials/%s", serviceId, stripeCredentialsExternalId))
+                    .get(format("/v1/api/service/%s/account/%s", serviceExternalId, GatewayAccountType.TEST))
                     .then()
-                    .statusCode(200)
-                    .body("$", hasKey("credentials"))
-                    .body("credentials.stripe_account_id", is("some-account-id"))
-                    .body("state", CoreMatchers.is("VERIFIED_WITH_LIVE_PAYMENT"));
+                    .statusCode(OK.getStatusCode())
+                    .body("description", is("A Sandbox TEST account"))
+                    .body("gateway_account_credentials.size()", is(2))
+                    .body(String.format("gateway_account_credentials.find { it.external_id == '%s' }.state", stripeTestCredentialExternalId),
+                            is(GatewayAccountCredentialState.RETIRED.toString()))
+                    .body(String.format("gateway_account_credentials.find { it.state == '%s' }.payment_provider", GatewayAccountCredentialState.ACTIVE),
+                            is(PaymentGatewayName.SANDBOX.getName()));
+        }
+
+        @Test
+        void switchPaymentProviderFromWorldpayToStripeSuccessfully() {
+            testGatewayAccount
+                    .withProviderSwitchEnabled(true)
+                    .withGatewayAccountCredentials(List.of(
+                            anAddGatewayAccountCredentialsParams()
+                                    .withGatewayAccountId(testGatewayAccount.getAccountId())
+                                    .withState(GatewayAccountCredentialState.ACTIVE)
+                                    .withExternalId(worldpayCredentialExternalId)
+                                    .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                                    .build(),
+                            anAddGatewayAccountCredentialsParams()
+                                    .withGatewayAccountId(testGatewayAccount.getAccountId())
+                                    .withState(GatewayAccountCredentialState.VERIFIED_WITH_LIVE_PAYMENT)
+                                    .withExternalId(stripeCredentialExternalId)
+                                    .withPaymentProvider(PaymentGatewayName.WORLDPAY.getName())
+                                    .build()
+                    ))
+                    .withType(GatewayAccountType.TEST)
+                    .insert();
             
-            return stripeCredentialsExternalId;
-        }
+            String switchPspPayload = toJson(Map.of("user_external_id", "some-user-external-id",
+                    "gateway_account_credential_external_id", stripeCredentialExternalId));
 
-        private void verifyWorldpayCredentialsIsActiveAndProviderSwitchIsEnabled() {
             app.givenSetup()
-                    .get(format("/v1/api/service/%s/account/test", serviceId))
-                    .then()
-                    .statusCode(OK.getStatusCode())
-                    .body("provider_switch_enabled", is(true))
-                    .body("gateway_account_credentials", hasSize(1))
-                    .body("gateway_account_credentials[0].payment_provider", is("worldpay"))
-                    .body("gateway_account_credentials[0].state", is("ACTIVE"));
-        }
-
-        private void updateProviderSwitchEnabledOnWorldpayGatewayAccount() {
-            app.givenSetup()
-                    .body(toJson(Map.of("op", "replace",
-                            "path", "provider_switch_enabled",
-                            "value", true)))
-                    .patch(format("/v1/api/service/%s/account/test", serviceId))
+                    .body(switchPspPayload)
+                    .post(format("/v1/api/service/%s/account/%s/switch-psp", serviceExternalId, GatewayAccountType.TEST))
                     .then()
                     .statusCode(OK.getStatusCode());
-        }
-
-        private String setupCredentialsForWorldpayGatewayAccount() {
-            String worldpayCredentialsId = app.givenSetup()
-                    .get(format("/v1/api/service/%s/account/test", serviceId))
-                    .then()
-                    .extract()
-                    .path("gateway_account_credentials[0].external_id");
 
             app.givenSetup()
-                    .body(toJson(List.of(
-                            Map.of("op", "replace",
-                                    "path", "credentials/worldpay/one_off_customer_initiated",
-                                    "value", Map.of("merchant_code", "new-merchant-code",
-                                            "username", "new-username",
-                                            "password", "new-password")))))
-                    .patch(format("/v1/api/service/%s/account/test/credentials/%s", serviceId, worldpayCredentialsId))
+                    .get(format("/v1/api/service/%s/account/%s", serviceExternalId, GatewayAccountType.TEST))
                     .then()
-                    .statusCode(200);
-            
-            return worldpayCredentialsId;
-        }
-
-        private void setupWorldpayGatewayAccount() {
-            Map<String, String> gatewayAccountRequest = Map.of(
-                    "payment_provider", "worldpay",
-                    "service_id", serviceId,
-                    "service_name", "Service Name",
-                    "type", "test");
-
-            app.givenSetup().body(toJson(gatewayAccountRequest)).post(ACCOUNTS_API_URL);
+                    .statusCode(OK.getStatusCode())
+                    .body("provider_switch_enabled", is(false))
+                    .body("gateway_account_credentials.size()", is(2))
+                    .body(String.format("gateway_account_credentials.find { it.external_id == '%s' }.state", worldpayCredentialExternalId),
+                            is(GatewayAccountCredentialState.RETIRED.toString()))
+                    .body(String.format("gateway_account_credentials.find { it.external_id == '%s' }.state", stripeCredentialExternalId),
+                            is(GatewayAccountCredentialState.ACTIVE.toString()));
         }
     }
-    
+
     @Nested
     class ByGatewayAccountId {
-        
+
         @Test
         void shouldSwitchPaymentProvider() throws JsonProcessingException {
             String gatewayAccountId = "1000024";
@@ -155,21 +178,19 @@ public class GatewayAccountResourceSwitchPspIT {
             String switchToExtId = randomUuid();
 
             AddGatewayAccountCredentialsParams activeParams =
-                    AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder
-                            .anAddGatewayAccountCredentialsParams()
+                    anAddGatewayAccountCredentialsParams()
                             .withGatewayAccountId(Long.valueOf(gatewayAccountId))
                             .withCredentials(Map.of())
                             .withExternalId(activeExtId)
-                            .withState(ACTIVE)
+                            .withState(GatewayAccountCredentialState.ACTIVE)
                             .build();
 
             AddGatewayAccountCredentialsParams switchToParams =
-                    AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder
-                            .anAddGatewayAccountCredentialsParams()
+                    anAddGatewayAccountCredentialsParams()
                             .withGatewayAccountId(Long.valueOf(gatewayAccountId))
                             .withCredentials(Map.of())
                             .withExternalId(switchToExtId)
-                            .withState(VERIFIED_WITH_LIVE_PAYMENT)
+                            .withState(GatewayAccountCredentialState.VERIFIED_WITH_LIVE_PAYMENT)
                             .withPaymentProvider("stripe")
                             .build();
 
@@ -196,10 +217,10 @@ public class GatewayAccountResourceSwitchPspIT {
             assertThat((Boolean) account.get("provider_switch_enabled"), is(false));
 
             Map<String, Object> retiredCredentials = app.getDatabaseTestHelper().getGatewayAccountCredentialByExternalId(activeExtId);
-            assertThat(retiredCredentials.get("state").toString(), is(RETIRED.name()));
+            assertThat(retiredCredentials.get("state").toString(), is(GatewayAccountCredentialState.RETIRED.toString()));
 
             Map<String, Object> activeCredentials = app.getDatabaseTestHelper().getGatewayAccountCredentialByExternalId(switchToExtId);
-            assertThat(activeCredentials.get("state").toString(), is(ACTIVE.name()));
+            assertThat(activeCredentials.get("state").toString(), is(GatewayAccountCredentialState.ACTIVE.toString()));
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
@@ -313,7 +313,7 @@ public class StripeAccountSetupResourceIT {
                         .get("/v1/api/service/unknown-service-id/account/TEST/stripe-setup")
                         .then()
                         .statusCode(404)
-                        .body("message[0]", is("Gateway account not found for service ID [unknown-service-id] and account type [test]"));
+                        .body("message[0]", is("Gateway account not found for service external id [unknown-service-id] and account type [test]"));
             }
 
             @Test


### PR DESCRIPTION
## WHAT YOU DID

- allow gateway accounts that are switching to worldpay to validate credentials via the service external id and account type resource
- revert stripe test accounts to sandbox when a LIVE service psp switches from stripe to worldpay