### PR TITLE
PP-13387 Auth summary: log and send metrics for corporate cards/exemptions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -18,7 +18,6 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
@@ -63,7 +62,7 @@ public interface PaymentProvider {
 
     ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundEntityList);
     
-    AuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement);
+    AuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails, boolean isSetUpAgreement);
 
     default void deleteStoredPaymentDetails(DeleteStoredPaymentDetailsGatewayRequest request) throws GatewayException {
         throw new NotImplementedException("Delete Stored Payment Details is not implemented for this payment provider");

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
@@ -1,15 +1,15 @@
 package uk.gov.pay.connector.gateway.model;
 
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
+
+import java.util.Optional;
+
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
 
 public interface AuthorisationRequestSummary {
     
     enum Presence {
         PRESENT, NOT_PRESENT, NOT_APPLICABLE
-    }
-    
-    default Presence exemptionRequest() {
-        return NOT_APPLICABLE;
     }
 
     default Presence billingAddress() {
@@ -33,5 +33,17 @@ public interface AuthorisationRequestSummary {
     };
     
     default Presence setUpAgreement() { return NOT_APPLICABLE; }
+
+    default boolean corporateCard() {
+        return false;
+    }
+
+    default Optional<Boolean> corporateExemptionRequested() {
+        return Optional.empty();
+    }
+
+    default Optional<Exemption3ds> corporateExemptionResult() {
+        return Optional.empty();
+    }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxAuthorisationRequestSummary.java
@@ -1,7 +1,19 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 
 public class SandboxAuthorisationRequestSummary implements AuthorisationRequestSummary {
+
+    private final boolean isCorporateCard;
+    
+    public SandboxAuthorisationRequestSummary(AuthCardDetails authCardDetails) {
+        isCorporateCard = authCardDetails.isCorporateCard();
+    }
+
+    @Override
+    public boolean corporateCard() {
+        return isCorporateCard;
+    }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -28,7 +28,6 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayRespon
 import uk.gov.pay.connector.gateway.sandbox.wallets.SandboxWalletAuthorisationHandler;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
@@ -152,8 +151,8 @@ public class SandboxPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public SandboxAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
-        return new SandboxAuthorisationRequestSummary();
+    public SandboxAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails, boolean isSetupAgreement) {
+        return new SandboxAuthorisationRequestSummary(authCardDetails);
     }
 
     private GatewayResponse<BaseCancelResponse> createGatewayBaseCancelResponse() {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummary.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe;
 
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 
@@ -10,13 +11,15 @@ public class StripeAuthorisationRequestSummary implements AuthorisationRequestSu
 
     private final Presence billingAddress;
     private final String ipAddress;
+    private final boolean isCorporateCard;
     
-    private Presence isSetupAgreement;
+    private Presence isSetUpAgreement;
 
-    public StripeAuthorisationRequestSummary(AuthCardDetails authCardDetails, boolean isSetupAgreement) {
+    public StripeAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
         ipAddress = authCardDetails.getIpAddress().orElse(null);
-        this.isSetupAgreement = isSetupAgreement ? PRESENT: NOT_PRESENT;
+        isCorporateCard = authCardDetails.isCorporateCard();
+        this.isSetUpAgreement = isSetUpAgreement ? PRESENT: NOT_PRESENT;
     }
 
     @Override
@@ -31,6 +34,12 @@ public class StripeAuthorisationRequestSummary implements AuthorisationRequestSu
 
     @Override
     public Presence setUpAgreement() {
-        return isSetupAgreement;
+        return isSetUpAgreement;
     }
+
+    @Override
+    public boolean corporateCard() {
+        return isCorporateCard;
+    }
+ 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -198,8 +198,8 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public StripeAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
-        return new StripeAuthorisationRequestSummary(authCardDetails, isSetUpAgreement);
+    public StripeAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
+        return new StripeAuthorisationRequestSummary(chargeEntity, authCardDetails, isSetUpAgreement);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.util;
 
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -15,7 +16,7 @@ public class AuthorisationRequestSummaryStringifier {
         if (authorisationRequestSummary.setUpAgreement() == PRESENT) {
             stringJoiner.add("with set up agreement");
         }
-        
+
         switch (authorisationRequestSummary.billingAddress()) {
             case PRESENT:
                 stringJoiner.add("with billing address");
@@ -26,6 +27,17 @@ public class AuthorisationRequestSummaryStringifier {
             default:
                 break;
         }
+
+        if (authorisationRequestSummary.corporateCard()) {
+            stringJoiner.add("with corporate card");
+        }
+
+        authorisationRequestSummary.corporateExemptionRequested()
+                .filter(corporateExemptionRequested -> corporateExemptionRequested)
+                .ifPresent(corporateExemptionRequestedTrue -> {
+            stringJoiner.add("with corporate exemption requested");
+            authorisationRequestSummary.corporateExemptionResult().map(Exemption3ds::getDisplayName).ifPresent(stringJoiner::add);
+        });
 
         switch (authorisationRequestSummary.dataFor3ds()) {
             case PRESENT:
@@ -55,17 +67,6 @@ public class AuthorisationRequestSummaryStringifier {
                 break;
             case NOT_PRESENT:
                 stringJoiner.add("without device data collection result");
-                break;
-            default:
-                break;
-        }
-
-        switch (authorisationRequestSummary.exemptionRequest()) {
-            case PRESENT:
-                stringJoiner.add("with exemption");
-                break;
-            case NOT_PRESENT:
-                stringJoiner.add("without exemption");
                 break;
             default:
                 break;

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.util;
 
 import net.logstash.logback.argument.StructuredArgument;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -11,6 +12,9 @@ import static net.logstash.logback.argument.StructuredArguments.kv;
 public class AuthorisationRequestSummaryStructuredLogging {
     
     public static final String BILLING_ADDRESS = "billing_address";
+    public static final String CORPORATE_CARD = "corporate_card";
+    public static final String CORPORATE_EXEMPTION_REQUESTED = "corporate_exemption_requested";
+    public static final String CORPORATE_EXEMPTION_RESULT = "exemption_result";
     public static final String DATA_FOR_3DS = "data_for_3ds";
     public static final String DATA_FOR_3DS2 = "data_for_3ds2";
     public static final String WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT = "worldpay_3ds_flex_device_data_collection_result";
@@ -20,52 +24,37 @@ public class AuthorisationRequestSummaryStructuredLogging {
         var structuredArguments = new ArrayList<StructuredArgument>();
         
         switch (authorisationRequestSummary.billingAddress()) {
-            case PRESENT:
-                structuredArguments.add(kv(BILLING_ADDRESS, true));
-                break;
-            case NOT_PRESENT:
-                structuredArguments.add(kv(BILLING_ADDRESS, false));
-                break;
-            default:
-                break;
+            case PRESENT -> structuredArguments.add(kv(BILLING_ADDRESS, true));
+            case NOT_PRESENT -> structuredArguments.add(kv(BILLING_ADDRESS, false));
         }
-
+ 
         switch (authorisationRequestSummary.dataFor3ds()) {
-            case PRESENT:
-                structuredArguments.add(kv(DATA_FOR_3DS, true));
-                break;
-            case NOT_PRESENT:
-                structuredArguments.add(kv(DATA_FOR_3DS, false));
-                break;
-            default:
-                break;
+            case PRESENT -> structuredArguments.add(kv(DATA_FOR_3DS, true));
+            case NOT_PRESENT -> structuredArguments.add(kv(DATA_FOR_3DS, false));
         }
 
         switch (authorisationRequestSummary.dataFor3ds2()) {
-            case PRESENT:
-                structuredArguments.add(kv(DATA_FOR_3DS2, true));
-                break;
-            case NOT_PRESENT:
-                structuredArguments.add(kv(DATA_FOR_3DS2, false));
-                break;
-            default:
-                break;
+            case PRESENT -> structuredArguments.add(kv(DATA_FOR_3DS2, true));
+            case NOT_PRESENT -> structuredArguments.add(kv(DATA_FOR_3DS2, false));
         }
 
         switch (authorisationRequestSummary.deviceDataCollectionResult()) {
-            case PRESENT:
-                structuredArguments.add(kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, true));
-                break;
-            case NOT_PRESENT:
-                structuredArguments.add(kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false));
-                break;
-            default:
-                break;
+            case PRESENT -> structuredArguments.add(kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, true));
+            case NOT_PRESENT -> structuredArguments.add(kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false));
         }
 
         Optional.ofNullable(authorisationRequestSummary.ipAddress())
                 .map(ipAddress -> structuredArguments.add(kv(IP_ADDRESS, ipAddress)));
 
+        structuredArguments.add(kv(CORPORATE_CARD, authorisationRequestSummary.corporateCard()));
+
+        authorisationRequestSummary.corporateExemptionRequested()
+                .ifPresent(corporateExemptionRequested -> structuredArguments.add(kv(CORPORATE_EXEMPTION_REQUESTED, corporateExemptionRequested)));
+ 
+        authorisationRequestSummary.corporateExemptionResult()
+                .map(Exemption3ds::name)
+                .ifPresent(exemption3dsResult -> structuredArguments.add(kv(CORPORATE_EXEMPTION_RESULT, exemption3dsResult)));
+ 
         return structuredArguments.toArray(new StructuredArgument[structuredArguments.size()]);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
@@ -1,8 +1,12 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.Exemption3dsType;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
+
+import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
@@ -12,15 +16,23 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
     private final Presence billingAddress;
     private final Presence dataFor3ds;
     private final Presence deviceDataCollectionResult;
-    private String ipAddress;
-    private Presence isSetupAgreement;
+    private final String ipAddress;
+    private final Presence isSetupAgreement;
+    private final boolean isCorporateCard;
+    private final boolean isCorporateExemptionRequested;
+    private Exemption3ds corporateExemptionResult;
 
-    public WorldpayAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetupAgreement) {
+    public WorldpayAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails, boolean isSetupAgreement) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
         deviceDataCollectionResult = authCardDetails.getWorldpay3dsFlexDdcResult().map(address -> PRESENT).orElse(NOT_PRESENT);
-        dataFor3ds = (deviceDataCollectionResult == PRESENT || gatewayAccount.isRequires3ds()) ? PRESENT : NOT_PRESENT;
+        dataFor3ds = (deviceDataCollectionResult == PRESENT || chargeEntity.getGatewayAccount().isRequires3ds()) ? PRESENT : NOT_PRESENT;
         ipAddress = authCardDetails.getIpAddress().orElse(null);
+        isCorporateCard = authCardDetails.isCorporateCard();
         this.isSetupAgreement = isSetupAgreement ? PRESENT: NOT_PRESENT;
+        isCorporateExemptionRequested = chargeEntity.getExemption3dsRequested() == Exemption3dsType.CORPORATE;
+        if (isCorporateExemptionRequested) {
+            corporateExemptionResult = chargeEntity.getExemption3ds();
+        }
     }
 
     @Override
@@ -47,4 +59,20 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
     public Presence setUpAgreement() {
         return isSetupAgreement;
     }
+
+    @Override
+    public boolean corporateCard() {
+        return isCorporateCard;
+    }
+
+    @Override
+    public Optional<Boolean> corporateExemptionRequested() {
+        return Optional.of(isCorporateExemptionRequested);
+    }
+
+    @Override
+    public Optional<Exemption3ds> corporateExemptionResult() {
+        return Optional.ofNullable(corporateExemptionResult);
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -242,7 +242,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
 
         if (authorisationWithExemptionRequestSoftDeclinedButRetryableWithoutExemption(response, corporateExemptionsEnabledAndCorporateCardUsed)) {
 
-            var authorisationRequestSummary = generateAuthorisationRequestSummary(request.getGatewayAccount(), request.getAuthCardDetails(), request.isSavePaymentInstrumentToAgreement());
+            var authorisationRequestSummary = generateAuthorisationRequestSummary(charge, request.getAuthCardDetails(), request.isSavePaymentInstrumentToAgreement());
 
             authorisationLogger.logChargeAuthorisation(
                     LOGGER,
@@ -424,8 +424,8 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     }
 
     @Override
-    public WorldpayAuthorisationRequestSummary generateAuthorisationRequestSummary(GatewayAccountEntity gatewayAccount, AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
-        return new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails, isSetUpAgreement);
+    public WorldpayAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails, boolean isSetupAgreement) {
+        return new WorldpayAuthorisationRequestSummary(chargeEntity, authCardDetails, isSetupAgreement);
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxAuthorisationRequestSummaryTest.java
@@ -1,34 +1,57 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
 
+@ExtendWith(MockitoExtension.class)
 class SandboxAuthorisationRequestSummaryTest {
+
+    @Mock
+    private AuthCardDetails mockAuthCardDetails;
 
     @Test
     void billingAddressAlwaysNotApplicable() {
-        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary();
+        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary(mockAuthCardDetails);
         assertThat(sandboxAuthorisationRequestSummary.billingAddress(), is(NOT_APPLICABLE));
     }
 
     @Test
+    void corporateCardUsed() {
+        given(mockAuthCardDetails.isCorporateCard()).willReturn(true);
+        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary(mockAuthCardDetails);
+        assertThat(sandboxAuthorisationRequestSummary.corporateCard(), is(true));
+    }
+
+    @Test
+    void corporateCardNotUsed() {
+        given(mockAuthCardDetails.isCorporateCard()).willReturn(false);
+        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary(mockAuthCardDetails);
+        assertThat(sandboxAuthorisationRequestSummary.corporateCard(), is(false));
+    }
+
+    @Test
     void dataFor3dsAlwaysNotApplicable() {
-        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary();
+        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary(mockAuthCardDetails);
         assertThat(sandboxAuthorisationRequestSummary.dataFor3ds(), is(NOT_APPLICABLE));
     }
 
     @Test
     void dataFor3ds2AlwaysNotApplicable() {
-        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary();
+        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary(mockAuthCardDetails);
         assertThat(sandboxAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
     }
 
     @Test
     void deviceDataCollectionResultAlwaysNotApplicable() {
-        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary();
+        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary(mockAuthCardDetails);
         assertThat(sandboxAuthorisationRequestSummary.deviceDataCollectionResult(), is(NOT_APPLICABLE));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummaryTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 
@@ -20,49 +21,65 @@ import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Pre
 @ExtendWith(MockitoExtension.class)
 class StripeAuthorisationRequestSummaryTest {
 
+    @Mock private ChargeEntity mockChargeEntity;
     @Mock private AuthCardDetails mockAuthCardDetails;
 
     @Test
     void billingAddressPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(stripeAuthorisationRequestSummary.billingAddress(), is(PRESENT));
     }
 
     @Test
     void billingAddressNotPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(stripeAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
     }
 
     @Test
     void dataFor3dsAlwaysNotApplicable() {
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(stripeAuthorisationRequestSummary.dataFor3ds(), is(NOT_APPLICABLE));
     }
 
     @Test
     void dataFor3ds2AlwaysNotApplicable() {
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(stripeAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
     }
 
     @Test
     void deviceDataCollectionResultAlwaysNotApplicable() {
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(stripeAuthorisationRequestSummary.deviceDataCollectionResult(), is(NOT_APPLICABLE));
     }
 
     @Test
     void isSetUpAgreementPresent() {
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, true);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, true);
         assertThat(stripeAuthorisationRequestSummary.setUpAgreement(), is(PRESENT));
     }
 
     @Test
     void isSetUpAgreementNotPresent() {
-        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails, false);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(stripeAuthorisationRequestSummary.setUpAgreement(), is(NOT_PRESENT));
     }
+
+    @Test
+    void corporateCardUsed() {
+        given(mockAuthCardDetails.isCorporateCard()).willReturn(true);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
+        assertThat(stripeAuthorisationRequestSummary.corporateCard(), is(true));
+    }
+
+    @Test
+    void corporateCardNotUsed() {
+        given(mockAuthCardDetails.isCorporateCard()).willReturn(false);
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
+        assertThat(stripeAuthorisationRequestSummary.corporateCard(), is(false));
+    }
+
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
+
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -22,31 +25,62 @@ class AuthorisationRequestSummaryStringifierTest {
 
     @Test
     void stringifySummarises() {
+        given(mockAuthorisationRequestSummary.setUpAgreement()).willReturn(PRESENT);
         given(mockAuthorisationRequestSummary.billingAddress()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.corporateCard()).willReturn(true);
         given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(PRESENT);
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
-        given(mockAuthorisationRequestSummary.exemptionRequest()).willReturn(PRESENT);
         given(mockAuthorisationRequestSummary.ipAddress()).willReturn("1.1.1.1");
 
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 
-        assertThat(result, is(" with billing address and with 3DS data and without device data collection result and with exemption and with remote IP 1.1.1.1"));
+        assertThat(result, is(" with set up agreement and with billing address and with corporate card and with 3DS data and without device data collection result and with remote IP 1.1.1.1"));
     }
 
     @Test
-    void stringifySummarises_forSetUpAgreement() {
-        given(mockAuthorisationRequestSummary.billingAddress()).willReturn(PRESENT);
-        given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(PRESENT);
+    void stringifySummariesCorporateExemptionHonoured() {
+        given(mockAuthorisationRequestSummary.billingAddress()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.corporateCard()).willReturn(true);
+        given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
-        given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
-        given(mockAuthorisationRequestSummary.exemptionRequest()).willReturn(PRESENT);
-        given(mockAuthorisationRequestSummary.ipAddress()).willReturn("1.1.1.1");
-        given(mockAuthorisationRequestSummary.setUpAgreement()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.corporateExemptionRequested()).willReturn(Optional.of(Boolean.TRUE));
+        given(mockAuthorisationRequestSummary.corporateExemptionResult()).willReturn(Optional.of(Exemption3ds.EXEMPTION_HONOURED));
 
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 
-        assertThat(result, is(" with set up agreement and with billing address and with 3DS data and without device data collection result and with exemption and with remote IP 1.1.1.1"));
+        assertThat(result, is(" with corporate card and with corporate exemption requested and honoured"));
+    }
+
+    @Test
+    void stringifySummariesCorporateExemptionRejected() {
+        given(mockAuthorisationRequestSummary.billingAddress()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.corporateCard()).willReturn(true);
+        given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.corporateExemptionRequested()).willReturn(Optional.of(Boolean.TRUE));
+        given(mockAuthorisationRequestSummary.corporateExemptionResult()).willReturn(Optional.of(Exemption3ds.EXEMPTION_REJECTED));
+
+        String result = stringifier.stringify(mockAuthorisationRequestSummary);
+
+        assertThat(result, is(" with corporate card and with corporate exemption requested and rejected"));
+    }
+
+    @Test
+    void stringifySummariesCorporateExemptionOutOfScope() {
+        given(mockAuthorisationRequestSummary.billingAddress()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.corporateCard()).willReturn(true);
+        given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.corporateExemptionRequested()).willReturn(Optional.of(Boolean.TRUE));
+        given(mockAuthorisationRequestSummary.corporateExemptionResult()).willReturn(Optional.of(Exemption3ds.EXEMPTION_OUT_OF_SCOPE));
+
+        String result = stringifier.stringify(mockAuthorisationRequestSummary);
+
+        assertThat(result, is(" with corporate card and with corporate exemption requested and out of scope"));
     }
 
     @Test
@@ -55,7 +89,6 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
-        given(mockAuthorisationRequestSummary.exemptionRequest()).willReturn(NOT_APPLICABLE);
 
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLoggingTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLoggingTest.java
@@ -6,17 +6,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
+
+import java.util.Optional;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.ArrayMatching.arrayContaining;
-import static org.hamcrest.collection.IsArrayWithSize.emptyArray;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.BILLING_ADDRESS;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.CORPORATE_CARD;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.CORPORATE_EXEMPTION_REQUESTED;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.CORPORATE_EXEMPTION_RESULT;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.DATA_FOR_3DS;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.DATA_FOR_3DS2;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.IP_ADDRESS;
@@ -36,6 +41,9 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(PRESENT);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(PRESENT);
         given(mockAuthorisationRequestSummary.ipAddress()).willReturn("1.1.1.1");
+        given(mockAuthorisationRequestSummary.corporateCard()).willReturn(true);
+        given(mockAuthorisationRequestSummary.corporateExemptionRequested()).willReturn(Optional.of(Boolean.TRUE));
+        given(mockAuthorisationRequestSummary.corporateExemptionResult()).willReturn(Optional.of(Exemption3ds.EXEMPTION_HONOURED));
 
         StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
 
@@ -44,7 +52,10 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
                 kv(DATA_FOR_3DS, true),
                 kv(DATA_FOR_3DS2, true),
                 kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, true),
-                kv(IP_ADDRESS, "1.1.1.1")
+                kv(IP_ADDRESS, "1.1.1.1"),
+                kv(CORPORATE_CARD, true),
+                kv(CORPORATE_EXEMPTION_REQUESTED, true),
+                kv(CORPORATE_EXEMPTION_RESULT, Exemption3ds.EXEMPTION_HONOURED.name())
         ));
     }
 
@@ -61,7 +72,8 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
                 kv(BILLING_ADDRESS, false),
                 kv(DATA_FOR_3DS, false),
                 kv(DATA_FOR_3DS2, false),
-                kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false)
+                kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false),
+                kv(CORPORATE_CARD, false)
         )));
     }
 
@@ -74,7 +86,9 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
 
         StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
 
-        assertThat(result, is(emptyArray()));
+        assertThat(result, is(arrayContaining(
+                kv(CORPORATE_CARD, false)
+        )));
     }
 
     @Test
@@ -91,7 +105,8 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
                 kv(BILLING_ADDRESS, true),
                 kv(DATA_FOR_3DS, true),
                 kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false),
-                kv(IP_ADDRESS, "1.1.1.1")
+                kv(IP_ADDRESS, "1.1.1.1"),
+                kv(CORPORATE_CARD, false)
         )));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
@@ -1,18 +1,23 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.Exemption3dsType;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
@@ -20,61 +25,135 @@ import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Pre
 
 @ExtendWith(MockitoExtension.class)
 class WorldpayAuthorisationRequestSummaryTest {
-    
+
+    @Mock private ChargeEntity mockChargeEntity;
     @Mock private GatewayAccountEntity mockGatewayAccountEntity;
     @Mock private AuthCardDetails mockAuthCardDetails;
     
+    @BeforeEach
+    public void setUp() {
+        lenient().when(mockChargeEntity.getGatewayAccount()).thenReturn(mockGatewayAccountEntity);
+    }
+
     @Test
     void billingAddressPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.billingAddress(), is(PRESENT));
     }
 
     @Test
     void billingAddressNotPresent() {
         given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
     }
 
     @Test
     void requires3dsFalseMeansDataFor3dsNotPresent() {
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(NOT_PRESENT));
     }
 
     @Test
     void deviceDataCollectionResultPresentMeansDataFor3dsPresent() {
         given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
     }
 
     @Test
     void deviceDataCollectionResultPresent() {
         given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.deviceDataCollectionResult(), is(PRESENT));
     }
 
     @Test
     void dataFor3ds2AlwaysNotApplicable() {
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
     }
 
     @Test
     void isSetUpAgreementTrue() {
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, true);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, true);
         assertThat(worldpayAuthorisationRequestSummary.setUpAgreement(), is(PRESENT));
     }
 
     @Test
     void isSetUpAgreementFalse() {
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockGatewayAccountEntity, mockAuthCardDetails, false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
         assertThat(worldpayAuthorisationRequestSummary.setUpAgreement(), is(NOT_PRESENT));
     }
+
+    @Test
+    void corporateCardUsed() {
+        given(mockAuthCardDetails.isCorporateCard()).willReturn(true);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
+        assertThat(worldpayAuthorisationRequestSummary.corporateCard(), is(true));
+    }
+
+    @Test
+    void corporateCardNotUsed() {
+        given(mockAuthCardDetails.isCorporateCard()).willReturn(false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
+        assertThat(worldpayAuthorisationRequestSummary.corporateCard(), is(false));
+    }
+
+    @Test
+    void corporateExemptionRequested() {
+        given(mockChargeEntity.getExemption3dsRequested()).willReturn(Exemption3dsType.CORPORATE);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
+        assertThat(worldpayAuthorisationRequestSummary.corporateExemptionRequested(), is(Optional.of(Boolean.TRUE)));
+    }
+
+    @Test
+    void optimisedExemptionRequested() {
+        given(mockChargeEntity.getExemption3dsRequested()).willReturn(Exemption3dsType.OPTIMISED);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
+        assertThat(worldpayAuthorisationRequestSummary.corporateExemptionRequested(), is(Optional.of(Boolean.FALSE)));
+    }
+
+    @Test
+    void noExemptionRequested() {
+        given(mockChargeEntity.getExemption3dsRequested()).willReturn(null);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
+        assertThat(worldpayAuthorisationRequestSummary.corporateExemptionRequested(), is(Optional.of(Boolean.FALSE)));
+    }
+
+    @Test
+    void corporateExemptionHonoured() {
+        given(mockChargeEntity.getExemption3dsRequested()).willReturn(Exemption3dsType.CORPORATE);
+        given(mockChargeEntity.getExemption3ds()).willReturn(Exemption3ds.EXEMPTION_HONOURED);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
+        assertThat(worldpayAuthorisationRequestSummary.corporateExemptionResult(), is(Optional.of(Exemption3ds.EXEMPTION_HONOURED)));
+    }
+
+    @Test
+    void corporateExemptionRejected() {
+        given(mockChargeEntity.getExemption3dsRequested()).willReturn(Exemption3dsType.CORPORATE);
+        given(mockChargeEntity.getExemption3ds()).willReturn(Exemption3ds.EXEMPTION_REJECTED);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
+        assertThat(worldpayAuthorisationRequestSummary.corporateExemptionResult(), is(Optional.of(Exemption3ds.EXEMPTION_REJECTED)));
+    }
+
+    @Test
+    void corporateExemptionOutOfScope() {
+        given(mockChargeEntity.getExemption3dsRequested()).willReturn(Exemption3dsType.CORPORATE);
+        given(mockChargeEntity.getExemption3ds()).willReturn(Exemption3ds.EXEMPTION_OUT_OF_SCOPE);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
+        assertThat(worldpayAuthorisationRequestSummary.corporateExemptionResult(), is(Optional.of(Exemption3ds.EXEMPTION_OUT_OF_SCOPE)));
+    }
+
+    @Test
+    void corporateExemptionHasNoResult() {
+        given(mockChargeEntity.getExemption3dsRequested()).willReturn(Exemption3dsType.CORPORATE);
+        given(mockChargeEntity.getExemption3ds()).willReturn(null);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails, false);
+        assertThat(worldpayAuthorisationRequestSummary.corporateExemptionResult(), is(Optional.empty()));
+    }
+
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -28,9 +28,7 @@ import uk.gov.pay.connector.charge.util.PaymentInstrumentEntityToAuthCardDetails
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.events.EventService;
-import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.charge.GatewayDoesNotRequire3dsAuthorisation;
-import uk.gov.pay.connector.events.model.charge.PaymentEvent;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
@@ -56,7 +54,6 @@ import java.time.InstantSource;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -162,8 +159,8 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(WORLDPAY)).thenReturn(mockedWorldpayPaymentProvider);
         when(mockedWorldpayPaymentProvider.generateTransactionId()).thenReturn(Optional.of(TRANSACTION_ID));
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails, false))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails, false));
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge, authCardDetails, false))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(charge, authCardDetails, false));
 
         Logger root = (Logger) LoggerFactory.getLogger(CardAuthoriseService.class);
         root.setLevel(Level.INFO);
@@ -176,8 +173,8 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
         var worldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build();
         gatewayAccount.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails, false))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails, false));
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge, authCardDetails, false))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(charge, authCardDetails, false));
 
         AuthorisationResponse response = cardAuthorisationService.doAuthoriseWeb(charge.getExternalId(), authCardDetails);
 
@@ -201,8 +198,8 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
 
         var worldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build();
         gatewayAccount.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
-        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(gatewayAccount, authCardDetails, false))
-                .thenReturn(new WorldpayAuthorisationRequestSummary(gatewayAccount, authCardDetails, false));
+        when(mockedWorldpayPaymentProvider.generateAuthorisationRequestSummary(charge, authCardDetails, false))
+                .thenReturn(new WorldpayAuthorisationRequestSummary(charge, authCardDetails, false));
 
         AuthorisationResponse response = cardAuthorisationService.doAuthoriseWeb(charge.getExternalId(), authCardDetails);
 


### PR DESCRIPTION
When logging an authorisation request summary:

- Include `with corporate card` if the payment was made using a corporate card
- Include `"corporate_card": true` or `"corporate_card": false` with associated structured logging
- Include `with corporate exemption requested and honoured` (or `rejected` or `out of scope`) for Worldpay payments
- Include `"corporate_exemption_requested": true` or `"corporate_exemption_requested": false` and `"exemption_result": EXEMPTION_HONOURED` (or `EXEMPTION_REJECTED` or `EXEMPTION_OUT_OF_SCOPE`) with associated structured logging for Worldpay payments
- Intentionally not add any logging or structured logging for Exemption Engine exemptions for now (soft decline retries make this tricky to get right)

When sending `gateway_operations_authorisation_result_total` metric:

- Include new `corporateCardUsed` label with value of `with corporate card` or `with non-corporate card`
- Include new `corporateExemption` label with value of `not requested`, `honoured`, `rejected` or `out of scope`