### PR TITLE
PP-13387 Rename exemption_result to corporate_exemption_result

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
@@ -14,7 +14,7 @@ public class AuthorisationRequestSummaryStructuredLogging {
     public static final String BILLING_ADDRESS = "billing_address";
     public static final String CORPORATE_CARD = "corporate_card";
     public static final String CORPORATE_EXEMPTION_REQUESTED = "corporate_exemption_requested";
-    public static final String CORPORATE_EXEMPTION_RESULT = "exemption_result";
+    public static final String CORPORATE_EXEMPTION_RESULT = "corporate_exemption_result";
     public static final String DATA_FOR_3DS = "data_for_3ds";
     public static final String DATA_FOR_3DS2 = "data_for_3ds2";
     public static final String WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT = "worldpay_3ds_flex_device_data_collection_result";


### PR DESCRIPTION
In authorisation request summary structured logging, rename `exemption_result` to `corporate_exemption_result` to make it clear it’s only populated for corporate exemptions for now.