### PR TITLE
PP-13353: Exclude disabled gateway accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -195,16 +195,17 @@ public class GatewayAccountService {
     }
 
     public Optional<GatewayAccountEntity> getGatewayAccountByServiceIdAndAccountType(String serviceId, GatewayAccountType accountType) {
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.findByServiceIdAndAccountType(serviceId, accountType);
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.findByServiceIdAndAccountType(serviceId, accountType)
+                .stream().filter(gwe -> !gwe.isDisabled()).toList();
 
         if (accountType.equals(LIVE) && gatewayAccounts.size() > 1) {
             throw MultipleLiveGatewayAccountsException.multipleLiveGatewayAccounts(serviceId);
         }
 
-        return gatewayAccounts.stream().filter(GatewayAccountEntity::isStripeGatewayAccount).findFirst()
+        return gatewayAccounts.stream()
+                .filter(GatewayAccountEntity::isStripeGatewayAccount).findFirst()
                 .or(() -> gatewayAccounts.stream().filter(GatewayAccountEntity::isSandboxGatewayAccount).findFirst())
                 .or(() -> gatewayAccounts.stream().filter(GatewayAccountEntity::isWorldpayGatewayAccount).findFirst());
-
     }
 
     public boolean isATelephonePaymentNotificationAccount(String merchantCode) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -990,7 +990,7 @@ public class ChargesApiResourceCreateIT {
         }
         
         @Test
-        void should_return_403_when_account_disabled() {
+        void should_return_404_when_account_disabled() {
             app.givenSetup()
                     .body(toJson(Map.of("op", "replace", "path", "disabled", "value", true)))
                     .patch(format("/v1/api/service/%s/account/%s", VALID_SERVICE_ID, GatewayAccountType.TEST))
@@ -1006,9 +1006,9 @@ public class ChargesApiResourceCreateIT {
                     )))
                     .post(format("/v1/api/service/%s/account/%s/charges", VALID_SERVICE_ID, GatewayAccountType.TEST))
                     .then()
-                    .statusCode(403)
+                    .statusCode(404)
                     .contentType(JSON)
-                    .body("message", contains("This gateway account is disabled"));
+                    .body("message", contains(format("Gateway account not found for service external id [%s] and account type [test]", VALID_SERVICE_ID)));
         }
     }
         /*

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -211,8 +211,6 @@ public class GatewayAccountResourceIT {
             app.getDatabaseTestHelper().allowZeroAmount(accountId);
             app.getDatabaseTestHelper().blockPrepaidCards(accountId);
             app.getDatabaseTestHelper().enableProviderSwitch(accountId);
-            app.getDatabaseTestHelper().setDisabled(accountId);
-            app.getDatabaseTestHelper().setDisabledReason(accountId, "Disabled because reasons");
             app.getDatabaseTestHelper().insertWorldpay3dsFlexCredential(accountId, "macKey", "issuer", "org_unit_id", 2L);
 
             String url = ACCOUNTS_API_SERVICE_ID_URL.replace("{serviceId}", "valid-external-service-id").replace("{accountType}", GatewayAccountType.TEST.name());
@@ -248,8 +246,8 @@ public class GatewayAccountResourceIT {
                     .body("recurring_enabled", is(true))
                     .body("requires3ds", is(true))
                     .body("block_prepaid_cards", is(true))
-                    .body("disabled", is(true))
-                    .body("disabled_reason", is("Disabled because reasons"))
+                    .body("disabled", is(false))
+                    .body("disabled_reason", nullValue())
                     .body("gateway_account_credentials.size()", is(1))
                     .body("gateway_account_credentials[0].payment_provider", is("worldpay"))
                     .body("gateway_account_credentials[0].state", is("ACTIVE"))
@@ -307,8 +305,6 @@ public class GatewayAccountResourceIT {
             app.getDatabaseTestHelper().allowZeroAmount(accountId);
             app.getDatabaseTestHelper().blockPrepaidCards(accountId);
             app.getDatabaseTestHelper().enableProviderSwitch(accountId);
-            app.getDatabaseTestHelper().setDisabled(accountId);
-            app.getDatabaseTestHelper().setDisabledReason(accountId, "Disabled because reasons");
 
             String url = ACCOUNTS_API_SERVICE_ID_URL.replace("{serviceId}", "valid-external-service-id").replace("{accountType}", GatewayAccountType.TEST.name());
             app.givenSetup()
@@ -343,8 +339,8 @@ public class GatewayAccountResourceIT {
                     .body("recurring_enabled", is(true))
                     .body("requires3ds", is(true))
                     .body("block_prepaid_cards", is(true))
-                    .body("disabled", is(true))
-                    .body("disabled_reason", is("Disabled because reasons"))
+                    .body("disabled", is(false))
+                    .body("disabled_reason", nullValue())
                     .body("gateway_account_credentials.size()", is(1))
                     .body("gateway_account_credentials[0].payment_provider", is("stripe"))
                     .body("gateway_account_credentials[0].state", is("ACTIVE"))

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceUpdateIT.java
@@ -332,7 +332,7 @@ public class GatewayAccountResourceUpdateIT {
         }
 
         @Test
-        void updatingDisabledToFalseShouldClearDisabledReason() {
+        void returnNotFoundWhenUpdatingADisabledAccount() {
             app.givenSetup()
                     .get(format("/v1/api/service/%s/account/test", serviceId))
                     .then()
@@ -349,39 +349,13 @@ public class GatewayAccountResourceUpdateIT {
                     .then()
                     .statusCode(OK.getStatusCode());
 
-            payload = Map.of("op", "replace",
-                    "path", "disabled_reason",
-                    "value", "Disabled because Dolores Umbridge is evil");
-
             app.givenSetup()
-                    .body(toJson(payload))
+                    .body(toJson(Map.of("op", "replace",
+                            "path", "allow_telephone_payment_notifications",
+                            "value", true)))
                     .patch(format("/v1/api/service/%s/account/test", serviceId))
                     .then()
-                    .statusCode(OK.getStatusCode());
-
-            app.givenSetup()
-                    .get(format("/v1/api/service/%s/account/test", serviceId))
-                    .then()
-                    .statusCode(OK.getStatusCode())
-                    .body("disabled", is(true))
-                    .body("disabled_reason", is("Disabled because Dolores Umbridge is evil"));
-
-            payload = Map.of("op", "replace",
-                    "path", "disabled",
-                    "value", false);
-
-            app.givenSetup()
-                    .body(toJson(payload))
-                    .patch(format("/v1/api/service/%s/account/test", serviceId))
-                    .then()
-                    .statusCode(OK.getStatusCode());
-
-            app.givenSetup()
-                    .get(format("/v1/api/service/%s/account/test", serviceId))
-                    .then()
-                    .statusCode(OK.getStatusCode())
-                    .body("disabled", is(false))
-                    .body("disabled_reason", is(nullValue()));
+                    .statusCode(NOT_FOUND.getStatusCode());
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
@@ -34,6 +34,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static org.eclipse.jetty.http.HttpStatus.FORBIDDEN_403;
+import static org.eclipse.jetty.http.HttpStatus.NOT_FOUND_404;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -436,11 +437,10 @@ public class SandboxRefundsResourceIT  {
         class SubmitRefund {
             @Test
             @DisplayName("Should return 403 when gateway account is disabled")
-            void shouldRespond_403_WhenGatewayAccountDisabled() {
+            void shouldRespond_404_WhenGatewayAccountDisabled() {
                 int refundAmount = 50;
                 app.getDatabaseTestHelper().setDisabled(defaultTestAccount.getAccountId());
 
-                // Attempt to submit refund
                 app.givenSetup()
                     .body(toJson(Map.of(
                             "amount", refundAmount,
@@ -449,9 +449,9 @@ public class SandboxRefundsResourceIT  {
                     )))
                     .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
                     .then()
-                    .statusCode(FORBIDDEN_403)
-                    .body("message", contains("This gateway account is disabled"))
-                    .body("error_identifier", is(ErrorIdentifier.ACCOUNT_DISABLED.toString()));
+                    .statusCode(NOT_FOUND_404)
+                    .body("message", contains(format("Gateway account not found for service external id [%s] and account type [test]", SERVICE_ID)))
+                    .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
             }
 
             @Test


### PR DESCRIPTION
This commit fixes the following bug (some context of how the [selfservice app](https://github.com/alphagov/pay-selfservice/) works is required):

* When creating a new service and selecting to create a Stripe test account in selfservice, then in connector a sandbox account is created and immediately disabled when the stripe test account is created
* At this point calling connector's `GET /v1/api/service/{serviceId}/account/{accountType}` endpoint still works with selfservice because Stripe is the priority so that's returned
* Now use the selfservice switching functionality to switch to Worldpay
* Now when selfservice calls connector's `GET /v1/api/service/{serviceId}/account/{accountType}` endpoint connector returns the old sandbox one as that takes precedence over the Worldpay one which causes an error as the sandbox account was never associated with the service in the adminusers database to begin with.
    
The solution to the above is to filter out disabled gateway accounts which this commit fixes.

The solution caused some test breakages, but upon consulting with the team, we 
have come to the agreement that disabled gateway accounts should effectively be
extinct. If there is a need to PATCH a gateway account from disabled to
enabled, the `PATCH /v1/api/accounts/{accountId}` would need to be used.