### PR TITLE
PP-13600 fix refund availability status when dispute is won in service favour

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.stripe.StripeDisputeStatus.LOST;
@@ -159,9 +160,8 @@ public class StripeWebhookTaskHandler {
 
                         if (disputeStatus == WON) {
                             disputeEvent = DisputeWon.from(disputeExternalId, disputeClosedEventTimestamp, transaction);
-                            Charge charge = Charge.from(transaction);
-                            RefundAvailabilityUpdated refundAvailabilityUpdatedEvent = chargeService.createRefundAvailabilityUpdatedEvent(charge,
-                                    disputeClosedEventTimestamp);
+                            var refundAvailabilityUpdatedEvent = RefundAvailabilityUpdated.from(
+                                    transaction, EXTERNAL_AVAILABLE, disputeClosedEventTimestamp);
                             emitEvent(refundAvailabilityUpdatedEvent);
                         } else if (disputeStatus == LOST) {
                             disputeEvent = handleDisputeLost(stripeDisputeData, transaction, disputeExternalId, disputeClosedEventTimestamp);


### PR DESCRIPTION
## WHAT YOU DID

When a dispute is raised by a user, we update the transaction’s refund availability to unavailable but, when the dispute is won the refundability status should be available.

Refund availability status should be set to available when a dispute is won.
