### PR TITLE
PP-1233 spike how we can apply our own 3ds on stripe

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
@@ -49,5 +49,9 @@ public interface AuthorisationRequestSummary {
     default Presence email() { 
         return NOT_APPLICABLE; 
     }
+    
+    default Presence shouldForce3ds() {
+        return NOT_APPLICABLE;
+    }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -28,6 +28,7 @@ public class StripePaymentIntentRequest extends StripePostRequest {
     private final String customerId;
     private boolean offSession;
     private String tokenId;
+    private boolean required3ds;
 
     private StripePaymentIntentRequest(
             GatewayAccountEntity gatewayAccount,
@@ -55,6 +56,7 @@ public class StripePaymentIntentRequest extends StripePostRequest {
         this.customerId = customerId;
         this.offSession = offSession;
         this.tokenId = tokenId;
+        this.required3ds = gatewayAccount.isForce3ds() || gatewayAccount.isRequires3ds();
     }
 
     public static StripePaymentIntentRequest createOneOffPaymentIntentRequest(
@@ -203,6 +205,9 @@ public class StripePaymentIntentRequest extends StripePostRequest {
             params.put("payment_method_data[type]", "card");
             params.put("payment_method_data[card][token]", tokenId);
         }
+        if (required3ds) {
+            params.put("payment_method_options[card][request_three_d_secure]", "any");
+        }
 
         return params;
     }
@@ -211,7 +216,6 @@ public class StripePaymentIntentRequest extends StripePostRequest {
     protected String idempotencyKeyType() {
         return "payment_intent";
     }
-
     @Override
     protected List<String> expansionFields() {
         return List.of("payment_method.card");

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
@@ -52,6 +52,11 @@ public class AuthorisationRequestSummaryStringifier {
             case PRESENT -> stringJoiner.add("with device data collection result");
             case NOT_PRESENT -> stringJoiner.add("without device data collection result");
         }
+        
+        switch (authorisationRequestSummary.shouldForce3ds()) {
+            case PRESENT -> stringJoiner.add("with forced 3ds");
+            case NOT_PRESENT -> stringJoiner.add("without forced 3ds");
+        }
 
         Optional.ofNullable(authorisationRequestSummary.ipAddress())
                 .map(ipAddress -> stringJoiner.add("with remote IP " + ipAddress));

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
@@ -20,7 +20,7 @@ public class AuthorisationRequestSummaryStructuredLogging {
     public static final String WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT = "worldpay_3ds_flex_device_data_collection_result";
     public static final String IP_ADDRESS = "remote_ip_address";
     public static final String EMAIL = "email_address";
-
+    public static final String SHOULD_FORCE_3DS = "3ds_forced";
     public StructuredArgument[] createArgs(AuthorisationRequestSummary authorisationRequestSummary) {
         var structuredArguments = new ArrayList<StructuredArgument>();
         
@@ -47,6 +47,11 @@ public class AuthorisationRequestSummaryStructuredLogging {
         switch (authorisationRequestSummary.deviceDataCollectionResult()) {
             case PRESENT -> structuredArguments.add(kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, true));
             case NOT_PRESENT -> structuredArguments.add(kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false));
+        }
+        
+        switch (authorisationRequestSummary.shouldForce3ds()) {
+            case PRESENT -> structuredArguments.add(kv(SHOULD_FORCE_3DS, true));
+            case NOT_PRESENT -> structuredArguments.add(kv(SHOULD_FORCE_3DS, false));
         }
 
         Optional.ofNullable(authorisationRequestSummary.ipAddress())

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -88,7 +88,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     @Column(name = "requires_3ds")
     private boolean requires3ds;
-
+    
+    @Column(name = "force_3ds")
+    private boolean force3ds;
+    
     @Column(name = "allow_google_pay")
     private boolean allowGooglePay;
 
@@ -307,6 +310,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return requires3ds;
     }
     
+    public boolean isForce3ds() {
+        return force3ds;
+    }
+    
     public boolean isAllowGooglePay() {
         Boolean hasCredentialsConfiguredForGooglePay = getCurrentOrActiveGatewayAccountCredential()
                 .map(GatewayAccountCredentialsEntity::getCredentialsObject)
@@ -418,7 +425,11 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     public void setRequires3ds(boolean requires3ds) {
         this.requires3ds = requires3ds;
     }
-
+    
+    public void setForce3ds(boolean force3ds) {
+        this.force3ds = force3ds;
+    }
+    
     public void setType(GatewayAccountType type) {
         this.type = type;
     }

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -545,6 +545,12 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add force-3ds-flag-to-gateway-account" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="force_3ds" type="boolean" defaultValue="false"/>
+        </addColumn>
+    </changeSet>
+
     <changeSet id="add 3ds details to charge table" author="">
         <addColumn tableName="charges">
             <column name="pa_request_3ds" type="text">

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
@@ -33,6 +33,7 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
         given(mockAuthorisationRequestSummary.ipAddress()).willReturn("1.1.1.1");
+        given(mockAuthorisationRequestSummary.shouldForce3ds()).willReturn(NOT_APPLICABLE);
 
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 
@@ -49,6 +50,7 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
         given(mockAuthorisationRequestSummary.ipAddress()).willReturn("1.1.1.1");
+        given(mockAuthorisationRequestSummary.shouldForce3ds()).willReturn(NOT_APPLICABLE);
 
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 
@@ -65,6 +67,7 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.corporateExemptionRequested()).willReturn(Optional.of(Boolean.TRUE));
         given(mockAuthorisationRequestSummary.corporateExemptionResult()).willReturn(Optional.of(Exemption3ds.EXEMPTION_HONOURED));
+        given(mockAuthorisationRequestSummary.shouldForce3ds()).willReturn(NOT_APPLICABLE);
 
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 
@@ -81,6 +84,7 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.corporateExemptionRequested()).willReturn(Optional.of(Boolean.TRUE));
         given(mockAuthorisationRequestSummary.corporateExemptionResult()).willReturn(Optional.of(Exemption3ds.EXEMPTION_REJECTED));
+        given(mockAuthorisationRequestSummary.shouldForce3ds()).willReturn(NOT_APPLICABLE);
 
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 
@@ -97,6 +101,7 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.corporateExemptionRequested()).willReturn(Optional.of(Boolean.TRUE));
         given(mockAuthorisationRequestSummary.corporateExemptionResult()).willReturn(Optional.of(Exemption3ds.EXEMPTION_OUT_OF_SCOPE));
+        given(mockAuthorisationRequestSummary.shouldForce3ds()).willReturn(NOT_APPLICABLE);
 
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 
@@ -110,6 +115,7 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.shouldForce3ds()).willReturn(NOT_APPLICABLE);
 
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLoggingTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLoggingTest.java
@@ -26,6 +26,7 @@ import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStruc
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.DATA_FOR_3DS2;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.EMAIL;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.IP_ADDRESS;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.SHOULD_FORCE_3DS;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,6 +47,7 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
         given(mockAuthorisationRequestSummary.corporateExemptionRequested()).willReturn(Optional.of(Boolean.TRUE));
         given(mockAuthorisationRequestSummary.corporateExemptionResult()).willReturn(Optional.of(Exemption3ds.EXEMPTION_HONOURED));
         given(mockAuthorisationRequestSummary.email()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.shouldForce3ds()).willReturn(PRESENT);
 
         StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
 
@@ -55,6 +57,7 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
                 kv(DATA_FOR_3DS2, true),
                 kv(EMAIL, true),
                 kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, true),
+                kv(SHOULD_FORCE_3DS, true),
                 kv(IP_ADDRESS, "1.1.1.1"),
                 kv(CORPORATE_CARD, true),
                 kv(CORPORATE_EXEMPTION_REQUESTED, true),
@@ -69,6 +72,7 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_PRESENT);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
         given(mockAuthorisationRequestSummary.email()).willReturn(NOT_PRESENT);
+        given(mockAuthorisationRequestSummary.shouldForce3ds()).willReturn(NOT_PRESENT);
 
         StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
 
@@ -78,6 +82,7 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
                 kv(DATA_FOR_3DS2, false),
                 kv(EMAIL, false),
                 kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false),
+                kv(SHOULD_FORCE_3DS, false),
                 kv(CORPORATE_CARD, false)
         )));
     }
@@ -89,7 +94,8 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.email()).willReturn(NOT_APPLICABLE);
-
+        given(mockAuthorisationRequestSummary.shouldForce3ds()).willReturn(NOT_APPLICABLE);
+        
         StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
 
         assertThat(result, is(arrayContaining(
@@ -105,6 +111,7 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
         given(mockAuthorisationRequestSummary.ipAddress()).willReturn("1.1.1.1");
         given(mockAuthorisationRequestSummary.email()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.shouldForce3ds()).willReturn(NOT_APPLICABLE);
 
         StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
 


### PR DESCRIPTION

## Context
- This PR is to  Look into if/how we could request 3DS for Stripe at a service level
 
  - Add new column for `force_3ds`
  - Add `"payment_method_options[card][request_three_d_secure]"=any` param to Stripe Payment intent
