### PR TITLE
PP-14114 Fix refund authorisation code casting

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -40,6 +40,7 @@ public class WorldpayNotificationService {
             "SETTLED",
             "SETTLED_BY_MERCHANT"
     );
+    public static final String NULL_AUTHORISATION_CODE = "null";
     private static final List<String> REFUND_STATUSES = ImmutableList.of("REFUNDED", "REFUNDED_BY_MERCHANT", "REFUND_FAILED", "SENT_FOR_REFUND");
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -196,15 +197,10 @@ public class WorldpayNotificationService {
         if (!"SENT_FOR_REFUND".equals(notification.getStatus())) {
             return false;
         }
-
-        boolean hasRefundAuthorisationCode = false;
-        try {
-            Integer.parseInt(notification.getRefundAuthorisationReference());
-            hasRefundAuthorisationCode = true;
-        } catch (NumberFormatException e) {
-            hasRefundAuthorisationCode = false;
+        if (NULL_AUTHORISATION_CODE.equals(notification.getRefundAuthorisationReference())) {
+            return true;
         }
-        return !hasRefundAuthorisationCode;
+        return false;
     }
 
     public String notificationDomain() {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayNotificationService.NULL_AUTHORISATION_CODE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_NOTIFICATION;
 
 @ExtendWith(MockitoExtension.class)
@@ -271,24 +272,23 @@ class WorldpayNotificationServiceTest {
     }
 
     @Test
-    void shouldIgnoreNotificationWhenStatusIsSentForRefundWithoutAuthorisationCode() {
+    void shouldIgnoreNotificationWhenStatusIsSentForRefundWithStringOfNullAuthorisationCode() {
         setUpChargeServiceToReturnCharge(Optional.of(charge));
         setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
         String status = "SENT_FOR_REFUND";
-        String refundAuthorisationCode = "";
         final String payload = sampleWorldpayNotification(
-                transactionId, referenceId, refundAuthorisationCode, "", "", status,
+                transactionId, referenceId, NULL_AUTHORISATION_CODE, "", "", status,
                 "10", "03", "2017");
 
         assertTrue(notificationService.handleNotificationFor(ipAddress, payload));
 
         verifyNoInteractions(mockChargeNotificationProcessor);
         verifyNoInteractions(mockRefundNotificationProcessor);
-        }
+    }
 
     @Test
-    void shouldNotIgnoreNotificationWhenStatusIsSentForRefundWithAuthorisationCode() {
-        String refundAuthorisationCode = "987654321";
+    void shouldNotIgnoreNotificationWhenStatusIsSentForRefundWithAlphanumericAuthorisationCode() {
+        String refundAuthorisationCode = "ALPHANUM3R1C";
         setUpChargeServiceToReturnCharge(Optional.of(charge));
         setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
         String status = "SENT_FOR_REFUND";


### PR DESCRIPTION
With this change, we are updating the Worldpay Notification Service in order to accept alphanumeric values sent by Worldpay for the refund authorisation code when there has been a fast refund authorisation.

Previously we had been accepting numeric values only.

