### PR TITLE
Revert "PP-14114 Fix refund authorisation code casting"

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -40,7 +40,6 @@ public class WorldpayNotificationService {
             "SETTLED",
             "SETTLED_BY_MERCHANT"
     );
-    public static final String NULL_AUTHORISATION_CODE = "null";
     private static final List<String> REFUND_STATUSES = ImmutableList.of("REFUNDED", "REFUNDED_BY_MERCHANT", "REFUND_FAILED", "SENT_FOR_REFUND");
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -197,10 +196,15 @@ public class WorldpayNotificationService {
         if (!"SENT_FOR_REFUND".equals(notification.getStatus())) {
             return false;
         }
-        if (NULL_AUTHORISATION_CODE.equals(notification.getRefundAuthorisationReference())) {
-            return true;
+
+        boolean hasRefundAuthorisationCode = false;
+        try {
+            Integer.parseInt(notification.getRefundAuthorisationReference());
+            hasRefundAuthorisationCode = true;
+        } catch (NumberFormatException e) {
+            hasRefundAuthorisationCode = false;
         }
-        return false;
+        return !hasRefundAuthorisationCode;
     }
 
     public String notificationDomain() {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gateway.worldpay.WorldpayNotificationService.NULL_AUTHORISATION_CODE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_NOTIFICATION;
 
 @ExtendWith(MockitoExtension.class)
@@ -272,23 +271,24 @@ class WorldpayNotificationServiceTest {
     }
 
     @Test
-    void shouldIgnoreNotificationWhenStatusIsSentForRefundWithStringOfNullAuthorisationCode() {
+    void shouldIgnoreNotificationWhenStatusIsSentForRefundWithoutAuthorisationCode() {
         setUpChargeServiceToReturnCharge(Optional.of(charge));
         setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
         String status = "SENT_FOR_REFUND";
+        String refundAuthorisationCode = "";
         final String payload = sampleWorldpayNotification(
-                transactionId, referenceId, NULL_AUTHORISATION_CODE, "", "", status,
+                transactionId, referenceId, refundAuthorisationCode, "", "", status,
                 "10", "03", "2017");
 
         assertTrue(notificationService.handleNotificationFor(ipAddress, payload));
 
         verifyNoInteractions(mockChargeNotificationProcessor);
         verifyNoInteractions(mockRefundNotificationProcessor);
-    }
+        }
 
     @Test
-    void shouldNotIgnoreNotificationWhenStatusIsSentForRefundWithAlphanumericAuthorisationCode() {
-        String refundAuthorisationCode = "ALPHANUM3R1C";
+    void shouldNotIgnoreNotificationWhenStatusIsSentForRefundWithAuthorisationCode() {
+        String refundAuthorisationCode = "987654321";
         setUpChargeServiceToReturnCharge(Optional.of(charge));
         setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
         String status = "SENT_FOR_REFUND";


### PR DESCRIPTION
Reverts alphagov/pay-connector#5813

For some reason "null" authorisation codes are accepted as successful refunds.