### PR TITLE
PP-14114 Fix refund authorisation code casting - version 2

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -196,15 +196,11 @@ public class WorldpayNotificationService {
         if (!"SENT_FOR_REFUND".equals(notification.getStatus())) {
             return false;
         }
-
-        boolean hasRefundAuthorisationCode = false;
-        try {
-            Integer.parseInt(notification.getRefundAuthorisationReference());
-            hasRefundAuthorisationCode = true;
-        } catch (NumberFormatException e) {
-            hasRefundAuthorisationCode = false;
-        }
-        return !hasRefundAuthorisationCode;
+        return switch (notification.getRefundAuthorisationReference()) {
+            case null -> true;
+            case "null" -> true;
+            default -> false;
+        };
     }
 
     public String notificationDomain() {


### PR DESCRIPTION
With this change, we are updating the Worldpay Notification Service in order
to accept alphanumeric values sent by Worldpay for the refund authorisation
code when there has been a fast refund authorisation.

Previously we had been accepting numeric values only.

Note that  this change was attempted yesterday,  however there was a bug for
which it treated offline refunds as successful refunds[1], interpreting a
null reference code as an authorisation code.  The bug was quickly reverted[2].

We are now introducing the functionality again.

[1]
https://github.com/alphagov/pay-connector/pull/5813

[2]
https://github.com/alphagov/pay-connector/pull/5814

