### PR TITLE
Pp 12136 delete notification credentials table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2061,8 +2061,4 @@
         </addColumn>
     </changeSet>
 
-    <changeSet id="remove notification credentials table" author="">
-        <dropTable cascadeConstraints="true" tableName="notification_credentials" />
-    </changeSet>
-
 </databaseChangeLog>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2061,4 +2061,8 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="remove notification credentials table" author="">
+        <dropTable cascadeConstraints="true" tableName="notification_credentials" />
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2061,4 +2061,8 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="remove notification credentials table" author="">
+        <dropTable cascadeConstraints="true" tableName="notification_credentials"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
- Db migration to remove `notification_credentials` table
- To be merged after [this PR](https://github.com/alphagov/pay-connector/pull/5825) which removes notification credentials and references from the Java code 
