### PR TITLE
PP-14215 Added AUTH UNEXPECTED ERROR to historic exception statuses for expunging

### DIFF
--- a/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
@@ -62,7 +62,8 @@ public class ChargeExpungeService {
             CAPTURE_SUBMITTED,
             EXPIRE_CANCEL_SUBMITTED,
             SYSTEM_CANCEL_SUBMITTED,
-            USER_CANCEL_SUBMITTED);
+            USER_CANCEL_SUBMITTED,
+            AUTHORISATION_UNEXPECTED_ERROR);
 
     private final List<ChargeStatus> terminalStatesFor0pPayments = List.of(CAPTURE_SUBMITTED);
 


### PR DESCRIPTION
## WHAT

- `AUTHORISATION_UNEXPECTED_ERROR` can never reach a terminal state if the service has stopped taking payments, and credentials no longer work. Any payment attempts will go to AUTHORISATION_UNEXPECTED_ERROR, and charges will never be expunged as this state is not treated as terminal.
     -  Gateway cleanup sweep continues to query the payment provider and skips updating charges to terminal state due to error. 

- Adds `AUTHORISATION_UNEXPECTED_ERROR` to historic exception states, so charges in this state are expunged after 7 days. 