### PR TITLE
PP-13814 Create stored columns for provider IDs in credentials

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2065,4 +2065,23 @@
         <dropTable cascadeConstraints="true" tableName="notification_credentials"/>
     </changeSet>
 
+    <changeSet id="create stored columns for gateway_account_credentials credentials json fields" author="">
+        <sql>
+            ALTER TABLE gateway_account_credentials
+                ADD COLUMN stripe_account_id TEXT GENERATED ALWAYS AS ((credentials :: jsonb)->> 'stripe_account_id') STORED,
+                ADD COLUMN one_off_merchant_code TEXT GENERATED ALWAYS AS ((credentials :: jsonb)-> 'one_off_customer_initiated' ->> 'merchant_code') STORED,
+                ADD COLUMN recurring_cit_merchant_code TEXT GENERATED ALWAYS AS ((credentials :: jsonb)-> 'recurring_customer_initiated' ->> 'merchant_code') STORED,
+                ADD COLUMN recurring_mit_merchant_code TEXT GENERATED ALWAYS AS ((credentials :: jsonb)-> 'recurring_merchant_initiated' ->> 'merchant_code') STORED;
+        </sql>
+    </changeSet>
+
+    <changeSet id="create indexes on gateway_account_credentials stored fields" runInTransaction="false" author="">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_stripe_account_id ON gateway_account_credentials (stripe_account_id);
+            CREATE INDEX CONCURRENTLY idx_one_off_merchant_code ON gateway_account_credentials (one_off_merchant_code);
+            CREATE INDEX CONCURRENTLY idx_recurring_cit_merchant_code ON gateway_account_credentials (recurring_cit_merchant_code);
+            CREATE INDEX CONCURRENTLY idx_recurring_mit_merchant_code ON gateway_account_credentials (recurring_mit_merchant_code);
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
- gateway_account_credentials.credentials field datatype is `json`, so we can't create indexes supported for `jsonb` types https://www.postgresql.org/docs/current/datatype-json.html#JSON-INDEXING

- So, to improve the querying performance on the credentials field, the options are
   1. Convert column type to JSONB and create indexes - `alter type` will acquire an exclusive lock. So to safely change the datatype to JSONB, we need to make multiple small changes - add a new column, dual write, use the new column and remove the old one.

   2. Create generated stored columns - generated columns are similar to materialised views, but for columns. They are created on an existing column. Any updates to the existing column will be reflected in the stored columns. See https://www.postgresql.org/docs/15/ddl-generated-columns.html

For both options, even after creating indexes, it is not guaranteed that PostgreSQL will use the indexes. It depends on the query planner and the data in the column.

- Decided on option 2, which doesn't need downtime and the fields to query are known. If the needs grow (to support multiple payment methods, PSP,.. ), we can revisit option 1.

Query plan  (with SET enable_seqscan = off;)

```
     QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on gateway_account_credentials  (cost=16.55..20.61 rows=2 width=1838) (actual time=0.040..0.041 rows=0 loops=1)
   Recheck Cond: ((stripe_account_id = 'value'::text) OR (one_off_merchant_code = 'value'::text) OR (recurring_cit_merchant_code = 'value'::text) OR (recurring_mit_merchant_code = 'value'::text))
   ->  BitmapOr  (cost=16.55..16.55 rows=3 width=0) (actual time=0.038..0.039 rows=0 loops=1)
         ->  Bitmap Index Scan on idx_stripe_account_id  (cost=0.00..4.14 rows=1 width=0) (actual time=0.025..0.025 rows=0 loops=1)
               Index Cond: (stripe_account_id = 'value'::text)
         ->  Bitmap Index Scan on idx_one_off_merchant_code  (cost=0.00..4.14 rows=1 width=0) (actual time=0.007..0.007 rows=0 loops=1)
               Index Cond: (one_off_merchant_code = 'value'::text)
         ->  Bitmap Index Scan on idx_recurring_cit_merchant_code  (cost=0.00..4.14 rows=1 width=0) (actual time=0.003..0.003 rows=0 loops=1)
               Index Cond: (recurring_cit_merchant_code = 'value'::text)
         ->  Bitmap Index Scan on idx_recurring_mit_merchant_code  (cost=0.00..4.14 rows=1 width=0) (actual time=0.003..0.003 rows=0 loops=1)
               Index Cond: (recurring_mit_merchant_code = 'value'::text)
 Planning Time: 0.122 ms
 Execution Time: 0.096 ms
(13 rows)
```


- New fields and indexes will appear as follows

```
              Column              |            Type             | Collation | Nullable |                                                       Default
----------------------------------+-----------------------------+-----------+----------+---------------------------------------------------------------------------------------------------------------------
 id                               | bigint                      |           | not null | generated by default as identity
 payment_provider                 | character varying(255)      |           | not null |
 credentials                      | json                        |           | not null | '{}'::json
 ........
 stripe_account_id                | text                        |           |          | generated always as (credentials::jsonb ->> 'stripe_account_id'::text) stored
 one_off_merchant_code            | text                        |           |          | generated always as ((credentials::jsonb -> 'one_off_customer_initiated'::text) ->> 'merchant_code'::text) stored
 recurring_cit_merchant_code      | text                        |           |          | generated always as ((credentials::jsonb -> 'recurring_customer_initiated'::text) ->> 'merchant_code'::text) stored
 recurring_mit_merchant_code      | text                        |           |          | generated always as ((credentials::jsonb -> 'recurring_merchant_initiated'::text) ->> 'merchant_code'::text) stored
Indexes:
    "idx_one_off_merchant_code" btree (one_off_merchant_code)
    "idx_recurring_cit_merchant_code" btree (recurring_cit_merchant_code)
    "idx_recurring_mit_merchant_code" btree (recurring_mit_merchant_code)
    "idx_stripe_account_id" btree (stripe_account_id)
    ....
```