### PR TITLE
PP-14228 Add required info for Stripe test accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
@@ -102,6 +102,12 @@ public class StripeAccountService {
                 .setPhone("+441212345678")
                 .setTaxId("000000000")
                 .setVatId("NOTAPPLI")
+                .setOwnershipDeclaration(
+                        Company.OwnershipDeclaration.builder()
+                                .setIp("0.0.0.0")
+                                .setDate(System.currentTimeMillis() / 1000)
+                                .build()
+                )
                 .setOwnersProvided(true)
                 .setDirectorsProvided(true)
                 .setExecutivesProvided(true);


### PR DESCRIPTION
## WHAT YOU DID
 - Stripe is flagging test accounts as missing below info


         "eventually_due": [
          "company.ownership_declaration.date",
          "company.ownership_declaration.ip"
        ],


- Tested using curl, and the account flagged is fully enabled


          curl -X POST https://api.stripe.com/v1/accounts/[ACCOUNT] \
            -u "[REPLACE-WITH-TEST-API-KEY]:" \
            -d "company[ownership_declaration][date]=1751619366" \
            -d "company[ownership_declaration][ip]=0.0.0.0"
