### PR TITLE
PP-13880 Add unit tests for PaymentEventWithoutDetails classes

### DIFF
--- a/src/test/java/uk/gov/pay/connector/events/model/charge/AuthorisationCancelledTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/AuthorisationCancelledTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class AuthorisationCancelledTest {
+    
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+    
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new AuthorisationCancelled(
+                SERVICE_ID, 
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("AUTHORISATION_CANCELLED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasMissingTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasMissingTest.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class AuthorisationErrorCheckedWithGatewayChargeWasMissingTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new AuthorisationErrorCheckedWithGatewayChargeWasMissing(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("AUTHORISATION_ERROR_CHECKED_WITH_GATEWAY_CHARGE_WAS_MISSING")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}
+

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasRejectedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasRejectedTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class AuthorisationErrorCheckedWithGatewayChargeWasRejectedTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new AuthorisationErrorCheckedWithGatewayChargeWasRejected(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("AUTHORISATION_ERROR_CHECKED_WITH_GATEWAY_CHARGE_WAS_REJECTED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/AuthorisationSucceededTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/AuthorisationSucceededTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class AuthorisationSucceededTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new AuthorisationSucceeded(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("AUTHORISATION_SUCCEEDED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationFailedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationFailedTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class CancelByExpirationFailedTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new CancelByExpirationFailed(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("CANCEL_BY_EXPIRATION_FAILED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationSubmittedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByExpirationSubmittedTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class CancelByExpirationSubmittedTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new CancelByExpirationSubmitted(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("CANCEL_BY_EXPIRATION_SUBMITTED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceFailedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceFailedTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class CancelByExternalServiceFailedTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new CancelByExternalServiceFailed(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("CANCEL_BY_EXTERNAL_SERVICE_FAILED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceSubmittedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByExternalServiceSubmittedTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class CancelByExternalServiceSubmittedTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new CancelByExternalServiceSubmitted(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("CANCEL_BY_EXTERNAL_SERVICE_SUBMITTED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByUserFailedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByUserFailedTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class CancelByUserFailedTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new CancelByUserFailed(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("CANCEL_BY_USER_FAILED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByUserSubmittedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelByUserSubmittedTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class CancelByUserSubmittedTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new CancelByUserSubmitted(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("CANCEL_BY_USER_SUBMITTED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByExpirationTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByExpirationTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class CancelledByExpirationTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new CancelledByExpiration(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("CANCELLED_BY_EXPIRATION")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByExternalServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByExternalServiceTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class CancelledByExternalServiceTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new CancelledByExternalService(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("CANCELLED_BY_EXTERNAL_SERVICE")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CaptureAbandonedAfterTooManyRetriesTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CaptureAbandonedAfterTooManyRetriesTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class CaptureAbandonedAfterTooManyRetriesTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new CaptureAbandonedAfterTooManyRetries(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("CAPTURE_ABANDONED_AFTER_TOO_MANY_RETRIES")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotificationTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotificationTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class CaptureConfirmedByGatewayNotificationTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new CaptureConfirmedByGatewayNotification(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("CAPTURE_CONFIRMED_BY_GATEWAY_NOTIFICATION")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CaptureErroredTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CaptureErroredTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class CaptureErroredTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new CaptureErrored(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("CAPTURE_ERRORED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/GatewayErrorDuringAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/GatewayErrorDuringAuthorisationTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class GatewayErrorDuringAuthorisationTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new GatewayErrorDuringAuthorisation(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("GATEWAY_ERROR_DURING_AUTHORISATION")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/GatewayTimeoutDuringAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/GatewayTimeoutDuringAuthorisationTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class GatewayTimeoutDuringAuthorisationTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new GatewayTimeoutDuringAuthorisation(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("GATEWAY_TIMEOUT_DURING_AUTHORISATION")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentExpiredTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentExpiredTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class PaymentExpiredTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new PaymentExpired(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("PAYMENT_EXPIRED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentStartedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentStartedTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class PaymentStartedTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new PaymentStarted(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("PAYMENT_STARTED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/QueuedForAuthorisationWithUserNotPresentTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/QueuedForAuthorisationWithUserNotPresentTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class QueuedForAuthorisationWithUserNotPresentTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new QueuedForAuthorisationWithUserNotPresent(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("QUEUED_FOR_AUTHORISATION_WITH_USER_NOT_PRESENT")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/QueuedForCaptureTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/QueuedForCaptureTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class QueuedForCaptureTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new QueuedForCapture(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("QUEUED_FOR_CAPTURE")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/ServiceApprovedForCaptureTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/ServiceApprovedForCaptureTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class ServiceApprovedForCaptureTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new ServiceApprovedForCapture(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("SERVICE_APPROVED_FOR_CAPTURE")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationErrorToMatchGatewayStatusTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationErrorToMatchGatewayStatusTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class StatusCorrectedToAuthorisationErrorToMatchGatewayStatusTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new StatusCorrectedToAuthorisationErrorToMatchGatewayStatus(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("STATUS_CORRECTED_TO_AUTHORISATION_ERROR_TO_MATCH_GATEWAY_STATUS")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationRejectedToMatchGatewayStatusTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationRejectedToMatchGatewayStatusTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class StatusCorrectedToAuthorisationRejectedToMatchGatewayStatusTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("STATUS_CORRECTED_TO_AUTHORISATION_REJECTED_TO_MATCH_GATEWAY_STATUS")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/SystemCancelledTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/SystemCancelledTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class SystemCancelledTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new SystemCancelled(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("SYSTEM_CANCELLED")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/UnexpectedGatewayErrorDuringAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/UnexpectedGatewayErrorDuringAuthorisationTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class UnexpectedGatewayErrorDuringAuthorisationTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new UnexpectedGatewayErrorDuringAuthorisation(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("UNEXPECTED_GATEWAY_ERROR_DURING_AUTHORISATION")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCaptureAwaitingServiceApprovalTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCaptureAwaitingServiceApprovalTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class UserApprovedForCaptureAwaitingServiceApprovalTest {
+    
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new UserApprovedForCaptureAwaitingServiceApproval(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("USER_APPROVED_FOR_CAPTURE_AWAITING_SERVICE_APPROVAL")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCaptureTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/UserApprovedForCaptureTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class UserApprovedForCaptureTest {
+
+    private static final String SERVICE_ID = "service";
+    private static final long GATEWAY_ACCOUNT_ID = 1L;
+    private static final String RESOURCE_EXTERNAL_ID = "resource";
+    private static final String TIMESTAMP = "2024-04-01T10:11:12.123456Z";
+
+    @Test
+    void serializes() throws JsonProcessingException {
+        var event = new UserApprovedForCapture(
+                SERVICE_ID,
+                true,
+                GATEWAY_ACCOUNT_ID,
+                RESOURCE_EXTERNAL_ID,
+                Instant.parse(TIMESTAMP));
+
+        String json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(TIMESTAMP)));
+        assertThat(json, hasJsonPath("$.event_type", equalTo("USER_APPROVED_FOR_CAPTURE")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.live", equalTo(true)));
+        assertThat(json, hasJsonPath("$.service_id", equalTo(SERVICE_ID)));
+        assertThat(json, hasJsonPath("$.gateway_account_id", equalTo((int) GATEWAY_ACCOUNT_ID)));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(RESOURCE_EXTERNAL_ID)));
+    }
+
+}


### PR DESCRIPTION
Add unit tests for subclasses of `PaymentEventWithoutDetails`. They are very repetitive and basically just test serialisation but will give us reassurance as we migrate our event classes to records.