### PR TITLE
PP-13997 implement processing send payer ip and send payer email for new gateway creation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,35 +160,35 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4319
+        "line_number": 4325
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4355
+        "line_number": 4361
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 5279
+        "line_number": 5293
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5770
+        "line_number": 5790
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5781
+        "line_number": 5801
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2025-05-23T14:03:08Z"
+  "generated_at": "2025-07-08T14:28:19Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3928,6 +3928,12 @@ components:
         requires_3ds:
           type: boolean
           example: true
+        send_payer_email_to_gateway:
+          type: boolean
+          example: true
+        send_payer_ip_address_to_gateway:
+          type: boolean
+          example: true
         service_name:
           type: string
           example: service name
@@ -4488,6 +4494,14 @@ components:
         requires_3ds:
           type: boolean
           description: Set to 'true' to enable 3DS for this account
+          writeOnly: true
+        send_payer_email_to_gateway:
+          type: boolean
+          description: Set to 'true' to enable send payer's email for this account
+          writeOnly: true
+        send_payer_ip_address_to_gateway:
+          type: boolean
+          description: Set to 'true' to enable send payer's IP address for this account
           writeOnly: true
         service_id:
           type: string
@@ -5568,6 +5582,12 @@ components:
             type: string
             writeOnly: true
           requires_3ds:
+            type: boolean
+            writeOnly: true
+          send_payer_email_to_gateway:
+            type: boolean
+            writeOnly: true
+          send_payer_ip_address_to_gateway:
             type: boolean
             writeOnly: true
           service_id:

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/CreateGatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/CreateGatewayAccountResponse.java
@@ -48,7 +48,15 @@ public record CreateGatewayAccountResponse (
 
     @JsonProperty("requires_3ds")
     @Schema(example = "true")
-    boolean requires3ds
+    boolean requires3ds,
+
+    @JsonProperty("send_payer_email_to_gateway")
+    @Schema(example = "true")
+    boolean sendPayerEmailToGateway,
+
+    @JsonProperty("send_payer_ip_address_to_gateway")
+    @Schema(example = "true")
+    boolean sendPayerIpAddressToGateway
 ) {    
 
     public CreateGatewayAccountResponse(GatewayAccountResponseBuilder gatewayAccountResponseBuilder) {
@@ -61,7 +69,9 @@ public record CreateGatewayAccountResponse (
             gatewayAccountResponseBuilder.analyticsId,
             gatewayAccountResponseBuilder.links,
             gatewayAccountResponseBuilder.location,
-            gatewayAccountResponseBuilder.requires3ds
+            gatewayAccountResponseBuilder.requires3ds, 
+            gatewayAccountResponseBuilder.sendPayerEmailToGateway, 
+            gatewayAccountResponseBuilder.sendPayerIpAddressToGateway
         );
     }
 
@@ -74,6 +84,8 @@ public record CreateGatewayAccountResponse (
         private String gatewayAccountId;
         private String externalId;
         private boolean requires3ds;
+        private boolean sendPayerEmailToGateway;
+        private boolean sendPayerIpAddressToGateway;
         private URI location;
         private List<Map<String, Object>> links;
 
@@ -123,6 +135,16 @@ public record CreateGatewayAccountResponse (
 
         public GatewayAccountResponseBuilder requires3ds(boolean requires3ds) {
             this.requires3ds = requires3ds;
+            return this;
+        }
+        
+        public GatewayAccountResponseBuilder sendPayerEmailToGateway(boolean sendPayerEmailToGateway) {
+            this.sendPayerEmailToGateway = sendPayerEmailToGateway;
+            return this;
+        }
+        
+        public GatewayAccountResponseBuilder sendPayerIpAddressToGateway(boolean sendPayerIpAddressToGateway) {
+            this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -55,6 +55,12 @@ public class GatewayAccountRequest {
     
     @JsonIgnore
     private boolean allowGooglePay;
+    
+    @JsonIgnore
+    private boolean sendPayerEmailToGateway;
+    
+    @JsonIgnore
+    private boolean sendPayerIpAddressToGateway;
 
     public GatewayAccountRequest(@JsonProperty("type") @Schema(example = "live", description = "Account type for this provider (test/live)", defaultValue = "test") String providerAccountType,
                                  @JsonProperty("payment_provider") @Schema(example = "stripe", description = "The payment provider for which this account is created", defaultValue = "sandbox")
@@ -66,7 +72,9 @@ public class GatewayAccountRequest {
                                  String analyticsId,
                                  @JsonProperty("requires_3ds") @Schema(description = "Set to 'true' to enable 3DS for this account") boolean requires3ds,
                                  @JsonProperty("allow_apple_pay") @Schema(description = "Set to 'true' to enable Apple Pay for this account") boolean allowApplePay,
-                                 @JsonProperty("allow_google_pay") @Schema(description = "Set to 'true' to enable Google Pay for this account") boolean allowGooglePay
+                                 @JsonProperty("allow_google_pay") @Schema(description = "Set to 'true' to enable Google Pay for this account") boolean allowGooglePay,
+                                 @JsonProperty("send_payer_email_to_gateway") @Schema(description = "Set to 'true' to enable send payer's email for this account") boolean sendPayerEmailToGateway,
+                                 @JsonProperty("send_payer_ip_address_to_gateway") @Schema(description = "Set to 'true' to enable send payer's IP address for this account") boolean sendPayerIpAddressToGateway
     ) {
         this.serviceName = serviceName;
         this.serviceId = serviceId;
@@ -75,6 +83,8 @@ public class GatewayAccountRequest {
         this.requires3ds = requires3ds;
         this.allowApplePay = allowApplePay;
         this.allowGooglePay = allowGooglePay;
+        this.sendPayerEmailToGateway = sendPayerEmailToGateway;
+        this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
 
         this.providerAccountType = (providerAccountType == null || providerAccountType.isEmpty()) ?
                 TEST.toString() : providerAccountType;
@@ -139,5 +149,13 @@ public class GatewayAccountRequest {
 
     public boolean isAllowGooglePay() {
         return allowGooglePay;
+    }
+
+    public boolean isSendPayerEmailToGateway() {
+        return sendPayerEmailToGateway;
+    }
+
+    public boolean isSendPayerIpAddressToGateway() {
+        return sendPayerIpAddressToGateway;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeGatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeGatewayAccountRequest.java
@@ -20,9 +20,12 @@ public class StripeGatewayAccountRequest extends GatewayAccountRequest {
                                        @JsonProperty("credentials") StripeCredentials credentials,
                                        @JsonProperty("requires_3ds") boolean requires3ds,
                                        @JsonProperty("allow_apple_pay") boolean allowApplePay,
-                                       @JsonProperty("allow_google_pay") boolean allowGooglePay
+                                       @JsonProperty("allow_google_pay") boolean allowGooglePay,
+                                       @JsonProperty("send_payer_email_to_gateway") boolean sendPayerEmailToGateway,
+                                       @JsonProperty("send_payer_ip_address_to_gateway") boolean sendPayerIPAddressToGateway
     ) {
-        super(providerAccountType, paymentProvider, serviceName, serviceId, description, analyticsId, requires3ds, allowApplePay, allowGooglePay);
+        super(providerAccountType, paymentProvider, serviceName, serviceId, description, analyticsId, requires3ds, allowApplePay, 
+                allowGooglePay, sendPayerEmailToGateway, sendPayerIPAddressToGateway);
         this.credentials = credentials;
     }
 
@@ -42,6 +45,8 @@ public class StripeGatewayAccountRequest extends GatewayAccountRequest {
         private boolean requires3ds;
         private boolean allowApplePay;
         private boolean allowGooglePay;
+        private boolean sendPayerEmailToGateway;
+        private boolean sendPayerIpAddressToGateway;
 
         private Builder() {
         }
@@ -99,9 +104,20 @@ public class StripeGatewayAccountRequest extends GatewayAccountRequest {
             this.allowGooglePay = allowGooglePay;
             return this;
         }
+        
+        public Builder withSendPayerEmailToGateway(boolean sendPayerEmailToGateway) {
+            this.sendPayerEmailToGateway = sendPayerEmailToGateway;
+            return this;
+        }
+        
+        public Builder withSendPayerIpAddressToGateway(boolean sendPayerIpAddressToGateway) {
+            this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
+            return this;
+        }
 
         public StripeGatewayAccountRequest build() {
-            return new StripeGatewayAccountRequest(providerAccountType, paymentProvider, serviceName, serviceId, description, analyticsId, credentials, requires3ds, allowApplePay, allowGooglePay);
+            return new StripeGatewayAccountRequest(providerAccountType, paymentProvider, serviceName, serviceId, description, analyticsId, credentials, requires3ds, 
+                    allowApplePay, allowGooglePay, sendPayerEmailToGateway, sendPayerIpAddressToGateway);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
@@ -85,6 +85,8 @@ public class StripeAccountResource {
                 .withRequires3ds(sandboxGatewayAccount.isRequires3ds())
                 .withAllowApplePay(sandboxGatewayAccount.isAllowApplePay())
                 .withAllowGooglePay(sandboxGatewayAccount.isAllowGooglePay())
+                .withSendPayerEmailToGateway(sandboxGatewayAccount.isSendPayerEmailToGateway())
+                .withSendPayerIpAddressToGateway(sandboxGatewayAccount.isSendPayerIpAddressToGateway())
                 .withCredentials(stripeCredentials)
                 .build();
         

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
@@ -31,6 +31,8 @@ public class GatewayAccountObjectConverter {
         gatewayAccountEntity.setAllowApplePay(gatewayAccountRequest.isAllowApplePay());
         gatewayAccountEntity.setAllowGooglePay(gatewayAccountRequest.isAllowGooglePay());
         gatewayAccountEntity.setIntegrationVersion3ds(DEFAULT_INTEGRATION_VERSION_3_DS);
+        gatewayAccountEntity.setSendPayerEmailToGateway(gatewayAccountRequest.isSendPayerEmailToGateway());
+        gatewayAccountEntity.setSendPayerIpAddressToGateway(gatewayAccountRequest.isSendPayerIpAddressToGateway());
 
         gatewayAccountEntity.addNotification(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(gatewayAccountEntity));
         gatewayAccountEntity.addNotification(EmailNotificationType.REFUND_ISSUED, new EmailNotificationEntity(gatewayAccountEntity));
@@ -50,6 +52,8 @@ public class GatewayAccountObjectConverter {
                 .analyticsId(entity.getAnalyticsId())
                 .providerAccountType(entity.getType())
                 .requires3ds(entity.isRequires3ds())
+                .sendPayerEmailToGateway(entity.isSendPayerEmailToGateway())
+                .sendPayerIpAddressToGateway(entity.isSendPayerIpAddressToGateway())
                 .location(uri)
                 .generateLinks(uri)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
@@ -228,6 +228,34 @@ class GatewayAccountRequestValidatorTest {
         assertThat(validationException.getErrors(), hasItems("Value [] is not valid for path [corporate_prepaid_debit_card_surcharge_amount]"));
     }
 
+    @Test
+    void shouldThrow_whenNotBooleanValueForSendPayerEmailToGateway() {
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "replace",
+                        FIELD_OPERATION_PATH, "send_payer_email_to_gateway",
+                        FIELD_VALUE, "true"));
+
+        var validationException = assertThrows(ValidationException.class,
+                () -> validator.validatePatchRequest(jsonNode));
+
+        assertThat(validationException.getErrors().size(), is(1));
+        assertThat(validationException.getErrors(), hasItems("Value [true] must be of type boolean for path [send_payer_email_to_gateway]"));
+    }
+
+    @Test
+    void shouldThrow_whenNotBooleanValueForSendPayerIPAddressToGateway() {
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "replace",
+                        FIELD_OPERATION_PATH, "send_payer_ip_address_to_gateway",
+                        FIELD_VALUE, "true"));
+
+        var validationException = assertThrows(ValidationException.class,
+                () -> validator.validatePatchRequest(jsonNode));
+
+        assertThat(validationException.getErrors().size(), is(1));
+        assertThat(validationException.getErrors(), hasItems("Value [true] must be of type boolean for path [send_payer_ip_address_to_gateway]"));
+    }
+
     static Stream<Arguments> provider() {
         return Stream.of(
                 arguments("bad", "allow_apple_pay", "true", "Operation [bad] is not valid for path [allow_apple_pay]"),

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -363,6 +363,8 @@ public class DatabaseFixtures {
                 CREDENTIALS_USERNAME, "username",
                 CREDENTIALS_PASSWORD, "password"
         );
+        private boolean sendPayerEmailToGateway;
+        private boolean sendPayerIpAddressToGateway;
 
         public long getAccountId() {
             return accountId;
@@ -428,6 +430,14 @@ public class DatabaseFixtures {
 
         public void setRecurringEnabled(boolean recurringEnabled) {
             this.recurringEnabled = recurringEnabled;
+        }
+
+        public boolean isSendPayerEmailToGateway() {
+            return sendPayerEmailToGateway;
+        }
+
+        public boolean isSendPayerIpAddressToGateway() {
+            return sendPayerIpAddressToGateway;
         }
 
         public TestAccount withAccountId(long accountId) {
@@ -559,6 +569,16 @@ public class DatabaseFixtures {
             this.providerSwitchEnabled = providerSwitchEnabled;
             return this;
         }
+        
+        public TestAccount withSendPayerEmailToGateway(boolean sendPayerEmailToGateway) {
+            this.sendPayerEmailToGateway = sendPayerEmailToGateway;
+            return this;
+        }
+        
+        public TestAccount withSendPayerIpAddressToGateway(boolean sendPayerIpAddressToGateway) {
+            this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
+            return this;
+        }
 
         public TestAccount insert() {
             if (gatewayAccountCredentialsParams == null) {
@@ -593,6 +613,8 @@ public class DatabaseFixtures {
                     .withRequires3ds(requires3ds)
                     .withRecurringEnabled(recurringEnabled)
                     .withProviderSwitchEnabled(providerSwitchEnabled)
+                    .withSendPayerEmailToGateway(sendPayerEmailToGateway)
+                    .withSendPayerIpAddressToGateway(sendPayerIpAddressToGateway)
                     .build());
             for (TestCardType cardType : cardTypes) {
                 databaseTestHelper.addAcceptedCardType(this.getAccountId(), cardType.getId());

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -514,6 +514,8 @@ public class GatewayAccountDaoIT {
         account.setExternalId(randomUuid());
         account.setCardTypes(Arrays.asList(masterCardCredit, visaCardDebit));
         account.setSendReferenceToGateway(true);
+        account.setSendPayerEmailToGateway(true);
+        account.setSendPayerIpAddressToGateway(true);
 
         gatewayAccountDao.persist(account);
 
@@ -524,8 +526,8 @@ public class GatewayAccountDaoIT {
         assertThat(account.getCorporateNonPrepaidCreditCardSurchargeAmount(), is(0L));
         assertThat(account.getCorporateNonPrepaidDebitCardSurchargeAmount(), is(0L));
         assertThat(account.getCorporatePrepaidDebitCardSurchargeAmount(), is(0L));
-        assertThat(account.isSendPayerIpAddressToGateway(), is(false));
-        assertThat(account.isSendPayerEmailToGateway(), is(false));
+        assertThat(account.isSendPayerIpAddressToGateway(), is(true));
+        assertThat(account.isSendPayerEmailToGateway(), is(true));
         assertThat(account.isProviderSwitchEnabled(), is(false));
         assertThat(account.isSendReferenceToGateway(), is(true));
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
@@ -53,6 +53,8 @@ public class GatewayAccountResourceCreateIT {
                     .withServiceId("my-service-id")
                     .withDescription("my test service")
                     .withAnalyticsId("analytics")
+                    .withSendPayerIpAddressToGateway(true)
+                    .withSendPayerEmailToGateway(true)
                     .build();
             
             Map<String, String> requestForSecondAccountPayload = aCreateGatewayAccountPayloadBuilder()
@@ -60,6 +62,8 @@ public class GatewayAccountResourceCreateIT {
                     .withServiceId("my-service-id")
                     .withDescription("my extra test service")
                     .withAnalyticsId("more analytics")
+                    .withSendPayerEmailToGateway(true)
+                    .withSendPayerIpAddressToGateway(true)
                     .build();
             
             ValidatableResponse response = app.givenSetup()
@@ -77,7 +81,7 @@ public class GatewayAccountResourceCreateIT {
                     .contentType(JSON)
                     .body("message", contains("Gateway account with service id my-service-id and account type 'test' already exists."));
             
-            assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
+            assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, true, true);
         }
     }
 
@@ -92,6 +96,8 @@ public class GatewayAccountResourceCreateIT {
                     .withServiceId("my-service-id")
                     .withDescription("my test service")
                     .withAnalyticsId("analytics")
+                    .withSendPayerEmailToGateway(true)
+                    .withSendPayerIpAddressToGateway(true)
                     .build();
 
             Map<String, String> requestForSecondAccountPayload = aCreateGatewayAccountPayloadBuilder()
@@ -99,6 +105,8 @@ public class GatewayAccountResourceCreateIT {
                     .withServiceId("my-service-id")
                     .withDescription("my extra test service")
                     .withAnalyticsId("more analytics")
+                    .withSendPayerEmailToGateway(true)
+                    .withSendPayerIpAddressToGateway(true)
                     .build();
 
             app.givenSetup()
@@ -118,23 +126,26 @@ public class GatewayAccountResourceCreateIT {
         
         @Test
         public void createASandboxGatewayAccount() {
-            Map<String, Object> payload = Map.of("payment_provider", "sandbox", "service_id", "a-valid-service-id", "description","my test service", "analytics_id", "analytics");
+            Map<String, Object> payload = Map.of("payment_provider", "sandbox", "service_id", "a-valid-service-id", "description","my test service", 
+                    "analytics_id", "analytics", "send_payer_email_to_gateway", true, "send_payer_ip_address_to_gateway", true);
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
-            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
+            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, true, true);
         }
 
         @Test
         public void createAWorldpaySandboxGatewayAccount() {
-            Map<String, Object> payload = Map.of("payment_provider", "worldpay", "service_id", "a-valid-service-id", "description","my test service", "analytics_id", "analytics");
+            Map<String, Object> payload = Map.of("payment_provider", "worldpay", "service_id", "a-valid-service-id", "description","my test service", 
+                    "analytics_id", "analytics", "send_payer_email_to_gateway", true, "send_payer_ip_address_to_gateway", true);
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
-            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
+            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, true, true);
         }
 
         @Test
         public void createAWorldpayStripeGatewayAccount() {
-            Map<String, Object> payload = Map.of("payment_provider", "stripe", "service_id", "a-valid-service-id", "description","my test service", "analytics_id", "analytics");
+            Map<String, Object> payload = Map.of("payment_provider", "stripe", "service_id", "a-valid-service-id", "description","my test service", 
+                    "analytics_id", "analytics", "send_payer_email_to_gateway", false, "send_payer_ip_address_to_gateway", false);
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
-            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null);
+            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, false, false);
         }
 
         @Test
@@ -218,7 +229,8 @@ public class GatewayAccountResourceCreateIT {
 
         @Test
         public void createGatewayAccountWithoutPaymentProviderDefaultsToSandbox() {
-            String payload = toJson(Map.of("name", "test account", "type", "test", "service_id", "a-valid-service-id"));
+            String payload = toJson(Map.of("name", "test account", "type", "test", "service_id", "a-valid-service-id",
+                    "send_payer_email_to_gateway", true, "send_payer_ip_address_to_gateway", true));
 
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201);
 
@@ -246,7 +258,7 @@ public class GatewayAccountResourceCreateIT {
         }
 
         private void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountType type) {
-            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, type, null, null, null);
+            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, type, null, null, null, true, true);
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -205,6 +205,8 @@ public class GatewayAccountResourceIT {
                     .withDefaultCredentials()
                     .withGatewayAccountCredentials(List.of(credentialsParams))
                     .withRequires3ds(true)
+                    .withSendPayerEmailToGateway(false)
+                    .withSendPayerIpAddressToGateway(false)
                     .insert();
 
             app.getDatabaseTestHelper().allowApplePay(accountId);
@@ -299,6 +301,8 @@ public class GatewayAccountResourceIT {
                     .withRecurringEnabled(true)
                     .withGatewayAccountCredentials(List.of(credentialsParams))
                     .withRequires3ds(true)
+                    .withSendPayerEmailToGateway(false)
+                    .withSendPayerIpAddressToGateway(false)
                     .insert();
 
             app.getDatabaseTestHelper().allowApplePay(accountId);
@@ -511,6 +515,8 @@ public class GatewayAccountResourceIT {
                     .withPaymentProvider(WORLDPAY.getName())
                     .withDefaultCredentials()
                     .withGatewayAccountCredentials(List.of(credentialsParams))
+                    .withSendPayerEmailToGateway(false)
+                    .withSendPayerIpAddressToGateway(false)
                     .insert();
 
             app.getDatabaseTestHelper().allowApplePay(accountId);

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITHelpers.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITHelpers.java
@@ -49,7 +49,8 @@ public class GatewayAccountResourceITHelpers {
                 .statusCode(200);
     }
 
-    public static void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountType type, String description, String analyticsId, String name) {
+    public static void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountType type, String description, String analyticsId,
+                                                   String name, boolean sendPayerEmailToGateway, boolean sendPayerIpAddressToGateway) {
         String accountId = response.extract().path("gateway_account_id");
         String urlSlug = "api/accounts/" + accountId;
 
@@ -62,6 +63,8 @@ public class GatewayAccountResourceITHelpers {
                 .body("analytics_id", is(analyticsId))
                 .body("corporate_credit_card_surcharge_amount", is(nullValue()))
                 .body("corporate_debit_card_surcharge_amount", is(nullValue()))
+                .body("send_payer_email_to_gateway", is(sendPayerEmailToGateway))
+                .body("send_payer_ip_address_to_gateway", is(sendPayerIpAddressToGateway))
                 .body("links[0].href", containsString(urlSlug))
                 .body("links[0].rel", is("self"))
                 .body("links[0].method", is("GET"));
@@ -119,6 +122,16 @@ public class GatewayAccountResourceITHelpers {
 
         public CreateGatewayAccountPayloadBuilder withType(GatewayAccountType type) {
             payload.put("type", type.name());
+            return this;
+        }
+
+        public CreateGatewayAccountPayloadBuilder withSendPayerEmailToGateway(boolean sendPayerEmailToGateway) {
+            payload.put("send_payer_email_to_gateway", String.valueOf(sendPayerEmailToGateway));
+            return this;
+        }
+
+        public CreateGatewayAccountPayloadBuilder withSendPayerIpAddressToGateway(boolean sendPayerIpAddressToGateway) {
+            payload.put("send_payer_ip_address_to_gateway", String.valueOf(sendPayerIpAddressToGateway));
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -109,7 +109,7 @@ class GatewayAccountServiceTest {
         
         var gatewayAccountRequest = new GatewayAccountRequest("test","stripe",
                 "a-service-name","a-service-id","description","analyticsId",
-                false,false,false);
+                false,false,false, true, true);
         
         assertThrows(MultipleStripeTestGatewayAccountsException.class, 
                 () -> gatewayAccountService.createGatewayAccount(gatewayAccountRequest, null));

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -50,6 +50,8 @@ public class AddGatewayAccountParams {
     private boolean disabled;
     private String disabledReason;
     private boolean providerSwitchEnabled;
+    private boolean sendPayerEmailToGateway;
+    private boolean sendPayerIpAddressToGateway;
 
     public int getIntegrationVersion3ds() {
         return integrationVersion3ds;
@@ -150,6 +152,14 @@ public class AddGatewayAccountParams {
     public boolean isProviderSwitchEnabled() {
         return providerSwitchEnabled;
     }
+    
+    public boolean isSendPayerEmailToGateway() {
+        return sendPayerEmailToGateway;
+    }
+    
+    public boolean isSendPayerIpAddressToGateway() {
+        return sendPayerIpAddressToGateway;
+    }
 
     public static final class AddGatewayAccountParamsBuilder {
         private String accountId;
@@ -179,6 +189,8 @@ public class AddGatewayAccountParams {
         private boolean disabled;
         private String disabledReason;
         private boolean providerSwitchEnabled = false;
+        private boolean sendPayerEmailToGateway = true;
+        private boolean sendPayerIpAddressToGateway = true;
 
         private AddGatewayAccountParamsBuilder() {
         }
@@ -348,6 +360,16 @@ public class AddGatewayAccountParams {
             return this;
         }
 
+        public AddGatewayAccountParamsBuilder withSendPayerEmailToGateway(boolean sendPayerEmailToGateway) {
+            this.sendPayerEmailToGateway = sendPayerEmailToGateway;
+            return this;
+        }
+
+        public AddGatewayAccountParamsBuilder withSendPayerIpAddressToGateway(boolean sendPayerIpAddressToGateway) {
+            this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
+            return this;
+        }
+
         public AddGatewayAccountParams build() {
             if (gatewayAccountCredentialsParams == null) {
                 gatewayAccountCredentialsParams = Collections.singletonList(
@@ -383,6 +405,8 @@ public class AddGatewayAccountParams {
             addGatewayAccountParams.disabledReason = this.disabledReason;
             addGatewayAccountParams.providerSwitchEnabled = this.providerSwitchEnabled;
             addGatewayAccountParams.serviceId = this.serviceId;
+            addGatewayAccountParams.sendPayerEmailToGateway = this.sendPayerEmailToGateway;
+            addGatewayAccountParams.sendPayerIpAddressToGateway = this.sendPayerIpAddressToGateway;
             return addGatewayAccountParams;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -53,8 +53,9 @@ public class DatabaseTestHelper {
                                 "corporate_debit_card_surcharge_amount, " +
                                 "corporate_prepaid_debit_card_surcharge_amount, allow_moto, moto_mask_card_number_input, " +
                                 "moto_mask_card_security_code_input, allow_apple_pay, allow_google_pay, requires_3ds, " +
-                                "allow_telephone_payment_notifications, allow_authorisation_api, recurring_enabled," +
-                                "disabled, disabled_reason, provider_switch_enabled, service_id) " +
+                                "allow_telephone_payment_notifications, allow_authorisation_api, recurring_enabled, " +
+                                "disabled, disabled_reason, provider_switch_enabled, service_id, send_payer_email_to_gateway, " +
+                                "send_payer_ip_address_to_gateway) " +
                                 "VALUES (:id, :external_id, :service_name, :type, " +
                                 ":description, :analytics_id, :email_collection_mode, :integration_version_3ds, " +
                                 ":corporate_credit_card_surcharge_amount, :corporate_debit_card_surcharge_amount, " +
@@ -62,7 +63,8 @@ public class DatabaseTestHelper {
                                 ":allow_moto, :moto_mask_card_number_input, :moto_mask_card_security_code_input, " +
                                 ":allow_apple_pay, :allow_google_pay, :requires_3ds, " +
                                 ":allow_telephone_payment_notifications, :allow_authorisation_api, :recurring_enabled," +
-                                ":disabled, :disabled_reason, :provider_switch_enabled, :service_id)")
+                                ":disabled, :disabled_reason, :provider_switch_enabled, :service_id, :send_payer_email_to_gateway," +
+                                ":send_payer_ip_address_to_gateway)")
                         .bind("id", Long.valueOf(params.getAccountId()))
                         .bind("external_id", params.getExternalId())
                         .bind("service_name", params.getServiceName())
@@ -87,6 +89,8 @@ public class DatabaseTestHelper {
                         .bind("disabled_reason", params.getDisabledReason())
                         .bind("provider_switch_enabled", params.isProviderSwitchEnabled())
                         .bind("service_id", params.getServiceId())
+                        .bind("send_payer_email_to_gateway", params.isSendPayerEmailToGateway())
+                        .bind("send_payer_ip_address_to_gateway", params.isSendPayerIpAddressToGateway())
                         .execute());
         if (params.getCredentials() != null) {
             params.getCredentials().forEach(this::insertGatewayAccountCredentials);


### PR DESCRIPTION
## WHAT YOU DID

Process the send_payer_ip_address_to_gateway and send_payer_email_to_gateway when creating a new gateway account. Implement it all the way to the persist level.

Add relevant tests.

This is based on the new requirements by Visa.
