### PR TITLE
PP-13996 send ip address and email to worldpay

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -512,7 +512,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java",
         "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 84
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-28T14:29:33Z"
+  "generated_at": "2025-07-29T09:54:31Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
@@ -1,13 +1,16 @@
 package uk.gov.pay.connector.gateway.util;
 
 import net.logstash.logback.argument.StructuredArgument;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder;
 import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 
 import java.util.ArrayList;
 import java.util.Optional;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class AuthorisationRequestSummaryStructuredLogging {
     
@@ -20,6 +23,8 @@ public class AuthorisationRequestSummaryStructuredLogging {
     public static final String WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT = "worldpay_3ds_flex_device_data_collection_result";
     public static final String IP_ADDRESS = "remote_ip_address";
     public static final String EMAIL = "email_address";
+    public static final String THREE_DS_REQUIRED = "3ds_required";
+    public static final String MOTO = "moto";
 
     public StructuredArgument[] createArgs(AuthorisationRequestSummary authorisationRequestSummary) {
         var structuredArguments = new ArrayList<StructuredArgument>();
@@ -63,5 +68,21 @@ public class AuthorisationRequestSummaryStructuredLogging {
  
         return structuredArguments.toArray(new StructuredArgument[structuredArguments.size()]);
     }
-
+    
+    public StructuredArgument[] createArgsForPreAuthorisationLogging(WorldpayOrderRequestBuilder orderRequestBuilder, AuthCardDetails authCardDetails, boolean isMoto) {
+        var structuredArguments = new ArrayList<StructuredArgument>();
+        
+        structuredArguments.add(kv(MOTO, isMoto));
+        
+        structuredArguments.add(kv(BILLING_ADDRESS, authCardDetails.getAddress().isPresent()));
+        
+        structuredArguments.add(kv(EMAIL, !isBlank(orderRequestBuilder.getWorldpayTemplateData().getPayerEmail())));
+        
+        Optional.ofNullable(orderRequestBuilder.getWorldpayTemplateData().getPayerIpAddress())
+                .map(ipAddress -> structuredArguments.add(kv(IP_ADDRESS, ipAddress)));
+        
+        structuredArguments.add(kv(THREE_DS_REQUIRED, orderRequestBuilder.getWorldpayTemplateData().isRequires3ds()));
+        
+        return structuredArguments.toArray(new StructuredArgument[structuredArguments.size()]);
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -366,4 +366,8 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     public MediaType getMediaType() {
         return MediaType.APPLICATION_XML_TYPE;
     }
+
+    public WorldpayTemplateData getWorldpayTemplateData() {
+        return worldpayTemplateData;
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilderTest.java
@@ -1,0 +1,82 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
+import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.util.AcceptLanguageHeaderParser;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gateway.worldpay.SendWorldpayExemptionRequest.DO_NOT_SEND_EXEMPTION_REQUEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
+import static uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsServiceTest.WORLDPAY_ONE_OFF_CREDENTIALS;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+
+class WorldpayOrderBuilderTest {
+    @ParameterizedTest
+    @CsvSource(useHeadersInDisplayName = true, nullValues = "null", textBlock = """
+            3ds_enabled, send_payer_email_to_gateway, send_payer_ip_address_to_gateway, email_address, is_moto_payment, three_ds_flex_ddc_result, include_email, include_ip
+            true, true, true, citizen@example.org, false, null, true, true
+            true, true, true, null, false, null, false, true
+            true, false, true, test@email.invalid, false, null, false, true
+            true, true, false, citizen@example.org, false, null, true, false
+            true, false, false, citizen@example.org, false, null, false, false
+            false, true, true, citizen@example.org, false, null, false, false
+            false, true, true, null, false, null, false, false
+            false, true, true, citizen@example.org, false, three-ds-string, true, true
+            false, true, true, citizen@example.org, true, three-ds-string, false, false
+            true, true, true, citizen@example.org, true, three-ds-string, false, false
+            """)
+    void testVariationsOfSendPayerEmailAndSendPayerIPAddress(boolean is3dsEnabled, boolean sendEmail, boolean sendIPAddress, String emailAddress, 
+                                                             boolean isMotoPayment, String threeDsFlexDdcResult, boolean includeEmail, boolean includeIP) {
+        GatewayAccountEntity worldpayGatewayAccountEntity = aGatewayAccountEntity()
+                .withGatewayName(WORLDPAY.getName())
+                .withRequires3ds(is3dsEnabled)
+                .withSendPayerIpAddressToGateway(sendIPAddress)
+                .withSendPayerEmailAddressToGateway(sendEmail)
+                .build();
+        GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(worldpayGatewayAccountEntity)
+                .withCredentials(WORLDPAY_ONE_OFF_CREDENTIALS)
+                .withState(ACTIVE)
+                .build();
+        worldpayGatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntity));
+        ChargeEntity worldpayCharge = aValidChargeEntity()
+                .withGatewayAccountEntity(worldpayGatewayAccountEntity)
+                .withPaymentProvider("worldpay")
+                .withStatus(ChargeStatus.AUTHORISATION_READY)
+                .withEmail(emailAddress)
+                .withGatewayAccountCredentialsEntity(credentialsEntity)
+                .withMoto(isMotoPayment)
+                .build();
+        AuthCardDetails authCardDetails = anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT_OR_DEBIT)
+                .withCorporateCard(Boolean.FALSE)
+                .withPayersCardPrepaidStatus(PayersCardPrepaidStatus.NOT_PREPAID)
+                .withIpAddress(sendIPAddress ? "1.1.1.1" : null)
+                .withWorldpay3dsFlexDdcResult(threeDsFlexDdcResult)
+                .build();
+        
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(worldpayCharge, authCardDetails);
+
+        var gatewayOrder = WorldpayOrderBuilder.buildAuthoriseOrder(request, DO_NOT_SEND_EXEMPTION_REQUEST, new AcceptLanguageHeaderParser()).build();
+        
+        assertThat(gatewayOrder.getOrderRequestType(), is(OrderRequestType.AUTHORISE));
+        assertThat(gatewayOrder.getPayload().contains("shopperEmailAddress"), is(includeEmail));
+        assertThat(gatewayOrder.getPayload().contains("shopperIPAddress"), is(includeIP));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
@@ -45,6 +45,7 @@ public final class GatewayAccountEntityFixture {
     private boolean providerSwitchEnabled = false;
     private boolean blockPrepaidCards;
     private boolean disabled = false;
+    private boolean sendPayerEmailAddressToGateway;
 
     private GatewayAccountEntityFixture() {
     }
@@ -138,6 +139,16 @@ public final class GatewayAccountEntityFixture {
         return this;
     }
 
+    public GatewayAccountEntityFixture withSendPayerIpAddressToGateway(boolean sendPayerIpAddressToGateway) {
+        this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
+        return this;
+    }
+    
+    public GatewayAccountEntityFixture withSendPayerEmailAddressToGateway(boolean sendPayerEmailAddressToGateway) {
+        this.sendPayerEmailAddressToGateway = sendPayerEmailAddressToGateway;
+        return this;
+    }
+
     public GatewayAccountEntity build() {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity();
         gatewayAccountEntity.setId(id);
@@ -159,6 +170,7 @@ public final class GatewayAccountEntityFixture {
         gatewayAccountEntity.setCardTypes(cardTypes);
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
         gatewayAccountEntity.setSendPayerIpAddressToGateway(sendPayerIpAddressToGateway);
+        gatewayAccountEntity.setSendPayerEmailToGateway(sendPayerEmailAddressToGateway);
         gatewayAccountEntity.setProviderSwitchEnabled(providerSwitchEnabled);
         gatewayAccountEntity.setBlockPrepaidCards(blockPrepaidCards);
         gatewayAccountEntity.setDisabled(disabled);

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-3ds-with-email-and-ip.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-3ds-with-email-and-ip.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="transaction-id">
+            <description>This is a description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <CARD-SSL>
+                    <cardNumber>4111111111111111</cardNumber>
+                    <expiryDate>
+                        <date month="12" year="2015"/>
+                    </expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cvc>123</cvc>
+                    <cardAddress>
+                        <address>
+                            <address1>123 My Street</address1>
+                            <address2>This road</address2>
+                            <postalCode>SW8URR</postalCode>
+                            <city>London</city>
+                            <countryCode>GB</countryCode>
+                        </address>
+                    </cardAddress>
+                </CARD-SSL>
+                <session id="uniqueSessionId" shopperIPAddress="127.0.0.1"/>
+            </paymentDetails>
+            <shopper>
+                <shopperEmailAddress>citizen@example.org</shopperEmailAddress>
+                <browser>
+                    <acceptHeader>text/html</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0</userAgentHeader>
+                </browser>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-3ds.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-3ds.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="transaction-id">
+            <description>This is a description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <CARD-SSL>
+                    <cardNumber>4111111111111111</cardNumber>
+                    <expiryDate>
+                        <date month="12" year="2015"/>
+                    </expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cvc>123</cvc>
+                    <cardAddress>
+                        <address>
+                            <address1>123 My Street</address1>
+                            <address2>This road</address2>
+                            <postalCode>SW8URR</postalCode>
+                            <city>London</city>
+                            <countryCode>GB</countryCode>
+                        </address>
+                    </cardAddress>
+                </CARD-SSL>
+                <session id="uniqueSessionId"/>
+            </paymentDetails>
+            <shopper>
+                <browser>
+                    <acceptHeader>text/html</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0</userAgentHeader>
+                </browser>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
## WHAT YOU DID

- add lots of tests to see if we are covered for all cases of the new behaviour of sending email and ip address to the gateway (Visa requirement)

- add simple logging to see what actually we send to the gateway. Existing logging relies on options that might not reflect the reality of the actual payload sent to the gateway.

