### PR TITLE
PP-14318 Allow Worldpay Refund status change from error to refunded

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -107,6 +107,6 @@ public class RefundNotificationProcessor {
     }
 
     private boolean isRefundTransitionIllegal(RefundStatus oldStatus, RefundStatus newStatus) {
-            return (oldStatus == REFUNDED && newStatus == REFUND_ERROR) || (oldStatus == REFUND_ERROR && newStatus == REFUNDED);
+            return (oldStatus == REFUNDED && newStatus == REFUND_ERROR);
     }
 }


### PR DESCRIPTION
With this change, we are preventing a problem that occurred only once since we went live with Faster Refunds, but that requires an engineer on support to fix, correcting the data.

We had implemented a block for Connector to prevent refund status changes from REFUNDED to REFUND_FAILED and also from REFUND_FAILED to REFUNDED.

When notifications arrive from Worldpay indicating the change of refund status which looks like the transitions above, then Connector would prevent the state transition and would log a message that would then be picked up by Splunk creating an alert for Support to investigate[1].

While we want this behaviour to continue unchanged for notifications that would transition a refund from REFUNDED to REFUND_FAILED, we have realised that the opposite transition should be allowed.

This is because it can happen (although rarely) that a connection timeout with the PSP causes a Refund status to be set as REFUND_FAILED.

In those rare cases, we want to allow a subsequent REFUNDED notification to change the refund status.

Further information in the JIRA ticket[2].

[1]
https://manual.payments.service.gov.uk/manual/support/worldpay-refund-illegal-state-transition.html

[2]
https://payments-platform.atlassian.net/browse/PP-14318
