### PR TITLE
PP-14318 Set Worldpay refund as submitted when gateway timeout

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -3,15 +3,20 @@ package uk.gov.pay.connector.gateway.worldpay;
 import com.google.inject.name.Named;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.RefundHandler;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.util.AuthUtil;
 
 import jakarta.inject.Inject;
 import java.net.URI;
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshallResponse;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
@@ -23,6 +28,7 @@ public class WorldpayRefundHandler implements RefundHandler {
 
     private final GatewayClient client;
     private final Map<String, URI> gatewayUrlMap;
+    private Logger logger = LoggerFactory.getLogger(getClass());
 
     @Inject
     public WorldpayRefundHandler(@Named("WorldpayRefundGatewayClient") GatewayClient client,
@@ -41,6 +47,11 @@ public class WorldpayRefundHandler implements RefundHandler {
                     buildRefundOrder(request), 
                     getWorldpayAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, WorldpayRefundResponse.class), PENDING);
+        } catch (GatewayConnectionTimeoutException e) {
+            logger.info("Despite a Worldpay Gateway connection timeout error, we are optimistically setting refund {} as SUBMITTED.",
+                    request.getRefundExternalId());
+            BaseRefundResponse refundResponse = BaseRefundResponse.fromReference(request.getRefundExternalId(), WORLDPAY);
+            return GatewayRefundResponse.fromBaseRefundResponse(refundResponse, PENDING);
         } catch (GatewayException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());
         }


### PR DESCRIPTION
With this change, we are addressing a problem that happened recently when the
Worldpay endpoint didn't respond in time to a refund submission request,
leading to Connector setting the refund failed when in fact it had been
correctly submitted.

We have decided to optimistically set the refund as submitted in such cases,
given that we have already a mechanism in place to deal with refunds stuck in
submitted status.

We are also logging a specific message in Splunk in order to be able to count
how many times this happens.
