### PR TITLE
PP-14408 set recurring payment reason as RECURRING

### DIFF
--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -32,7 +32,7 @@
                     </#if>
                 </CARD-SSL>
                 <#if savePaymentInstrumentToAgreement>
-                <storedCredentials usage="FIRST"/>
+                <storedCredentials usage="FIRST" customerInitiatedReason="RECURRING"/>
                 </#if>
                 <#if requires3ds>
                 <#if payerIpAddress??>

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseRecurringOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseRecurringOrderTemplate.xml
@@ -10,7 +10,7 @@
                 <TOKEN-SSL tokenScope="shopper">
                     <paymentTokenID>${paymentTokenId}</paymentTokenID>
                 </TOKEN-SSL>
-                <storedCredentials usage="USED" merchantInitiatedReason="UNSCHEDULED">
+                <storedCredentials usage="USED" merchantInitiatedReason="RECURRING">
                     <#if schemeTransactionIdentifier??>
                         <schemeTransactionIdentifier>${schemeTransactionIdentifier}</schemeTransactionIdentifier>
                     </#if>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-with-scheme-identifier.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-with-scheme-identifier.xml
@@ -10,7 +10,7 @@
                 <TOKEN-SSL tokenScope="shopper">
                     <paymentTokenID>test-payment-token-123456</paymentTokenID>
                 </TOKEN-SSL>
-                <storedCredentials usage="USED" merchantInitiatedReason="UNSCHEDULED">
+                <storedCredentials usage="USED" merchantInitiatedReason="RECURRING">
                         <schemeTransactionIdentifier>test-transaction-id-999999</schemeTransactionIdentifier>
                 </storedCredentials>
             </paymentDetails>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-without-scheme-identifier.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-recurring-request-without-scheme-identifier.xml
@@ -10,7 +10,7 @@
                 <TOKEN-SSL tokenScope="shopper">
                     <paymentTokenID>test-payment-token-123456</paymentTokenID>
                 </TOKEN-SSL>
-                <storedCredentials usage="USED" merchantInitiatedReason="UNSCHEDULED">
+                <storedCredentials usage="USED" merchantInitiatedReason="RECURRING">
                 </storedCredentials>
             </paymentDetails>
             <shopper>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-setup-agreement.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-setup-agreement.xml
@@ -24,7 +24,7 @@
                         </address>
                     </cardAddress>
                 </CARD-SSL>
-                <storedCredentials usage="FIRST"/>
+                <storedCredentials usage="FIRST" customerInitiatedReason="RECURRING"/>
             </paymentDetails>
             <shopper>
                 <authenticatedShopperID>test-agreement-123456</authenticatedShopperID>


### PR DESCRIPTION
## WHAT YOU DID

When the authorisation request for a first (customer-initiated) recurring payment is sent to Worldpay then set the value of the attribute named `customerInitiatedReason` to RECURRING.

When the authorisation request for a recurring payment using stored details (merchant-initiated) is sent to Worldpay then set the value of the attribute named `merchantInitiatedReason` to RECURRING.
