### PR TITLE
PP-14364 test for email and ip sent if CIT transaction

### DIFF
--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -42,6 +42,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-recurring-request-without-scheme-identifier.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-without-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_SETUP_AGREEMENT = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-setup-agreement.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_SETUP_AGREEMENT_WITH_EMAIL_AND_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-setup-agreement-with-email-and-ip-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-min-data.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-with-email.xml";

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-setup-agreement-with-email-and-ip-address.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-setup-agreement-with-email-and-ip-address.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="CIT-MERCHANTCODE">
+    <submit>
+        <order orderCode="transaction-id">
+            <description>This is a description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <CARD-SSL>
+                    <cardNumber>4111111111111111</cardNumber>
+                    <expiryDate>
+                        <date month="12" year="2015"/>
+                    </expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cvc>123</cvc>
+                    <cardAddress>
+                        <address>
+                            <address1>123 My Street</address1>
+                            <address2>This road</address2>
+                            <postalCode>SW8URR</postalCode>
+                            <city>London</city>
+                            <countryCode>GB</countryCode>
+                        </address>
+                    </cardAddress>
+                </CARD-SSL>
+                <storedCredentials usage="FIRST" customerInitiatedReason="RECURRING"/>
+                <session id="test-chargeId-789" shopperIPAddress="127.0.0.1"/>
+            </paymentDetails>
+            <shopper>
+                <shopperEmailAddress>test@email.com</shopperEmailAddress>
+                <authenticatedShopperID>test-agreement-123456</authenticatedShopperID>
+                <browser>
+                    <acceptHeader>text/html</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0</userAgentHeader>
+                </browser>
+            </shopper>
+            <createToken tokenScope="shopper">
+                <tokenEventReference>test-chargeId-789</tokenEventReference>
+            </createToken>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
## WHAT YOU DID

‘CIT’ stands for 'Consumer Initiated Transaction' so in recurring payment space it is the initial payment (first one) where customer is present. 
We want to make sure that if a recurring CIT payment is being authorised and the gateway account has 3ds enabled, `send_payer_ip_address_to_gateway` and `send_payer_email_to_gateway` are both `true`, when the authorisation request is snt to Worldpay the email address and IP address are included. The logging for the authorisation is already taken care of in `AuthorisationREquestSummaryStructuredLogging`.
