### PR TITLE
PP-13353 only filter disabled test accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -557,4 +557,8 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
                 .filter(credential -> credential.getPaymentProvider().equals(WORLDPAY.getName()))
                 .anyMatch(credential -> pendingCredentialStates.contains(credential.getState()));
     }
+    
+    public boolean isLiveOrEnabled() {
+        return this.isLive() || !this.isDisabled();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -193,11 +193,13 @@ public class GatewayAccountService {
     public Optional<GatewayAccountEntity> getGatewayAccountByExternal(String gatewayAccountExternalId) {
         return gatewayAccountDao.findByExternalId(gatewayAccountExternalId);
     }
-
+    
     public Optional<GatewayAccountEntity> getGatewayAccountByServiceIdAndAccountType(String serviceId, GatewayAccountType accountType) {
         List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.findByServiceIdAndAccountType(serviceId, accountType)
-                .stream().filter(gwe -> !gwe.isDisabled()).toList();
-
+                .stream()
+                .filter(GatewayAccountEntity::isLiveOrEnabled) // filter out any test accounts that are disabled
+                .toList();
+         
         if (accountType.equals(LIVE) && gatewayAccounts.size() > 1) {
             throw MultipleLiveGatewayAccountsException.multipleLiveGatewayAccounts(serviceId);
         }


### PR DESCRIPTION
## WHAT YOU DID

Previously, we filtered any disabled gateway account when querying via service external id and account type, this behaviour has been amended to only filter test gateway accounts that have been disabled. 

We still want services to be able to access their account via the admintool in the case of us disabling it.
