### PR TITLE
PP-14432 implement handling of agreement payment type attribute

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -153,42 +153,42 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3906
+        "line_number": 3913
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4327
+        "line_number": 4334
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4363
+        "line_number": 4370
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 5295
+        "line_number": 5302
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5792
+        "line_number": 5799
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5803
+        "line_number": 5810
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-29T09:54:31Z"
+  "generated_at": "2025-09-18T08:44:07Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3627,6 +3627,13 @@ components:
           type: string
           description: Agreement ID to associate charge with
           example: md1mjge8gb6p4qndfs8mf8gto5
+        agreement_payment_type:
+          type: string
+          description: Reason for taking a recurring payment
+          enum:
+          - instalment
+          - recurring
+          - unscheduled
         amount:
           type: integer
           format: int64

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
@@ -8,19 +8,20 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
 import uk.gov.service.payments.commons.api.json.ExternalMetadataDeserialiser;
 import uk.gov.service.payments.commons.api.json.ExternalMetadataSerialiser;
+import uk.gov.service.payments.commons.model.AgreementPaymentType;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.SupportedLanguageJsonDeserializer;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import java.util.Optional;
 
 import static java.util.function.Predicate.not;
@@ -98,6 +99,11 @@ public class ChargeCreateRequest {
     @Schema(description = "Applicable for recurring card payments. Indicated whether the payment method should be saved to agreement")
     private Boolean savePaymentInstrumentToAgreement;
 
+    @JsonProperty("agreement_payment_type")
+    @Valid
+    @Schema(description = "Reason for taking a recurring payment")
+    private AgreementPaymentType agreementPaymentType;
+
     @JsonProperty("authorisation_mode")
     @Valid
     @Schema(description = "Mode of authorisation for the payment. Payments created in `web` mode require the paying user to visit the `next_url` to complete the payment.")
@@ -124,6 +130,7 @@ public class ChargeCreateRequest {
                         Source source,
                         boolean moto,
                         String agreementId,
+                        AgreementPaymentType agreementPaymentType,
                         boolean savePaymentInstrumentToAgreement,
                         AuthorisationMode authorisationMode,
                         String credentialId) {
@@ -142,6 +149,7 @@ public class ChargeCreateRequest {
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
         this.authorisationMode = authorisationMode;
         this.credentialId = credentialId;
+        this.agreementPaymentType = agreementPaymentType;
     }
 
     @JsonIgnore
@@ -214,6 +222,11 @@ public class ChargeCreateRequest {
         return Optional.ofNullable(authorisationMode).orElse(AuthorisationMode.WEB);
     }
 
+    @JsonIgnore
+    public Optional<AgreementPaymentType> getAgreementPaymentType() {
+        return Optional.ofNullable(agreementPaymentType);
+    }
+
     public String getCredentialId() {
         return credentialId;
     }
@@ -237,6 +250,7 @@ public class ChargeCreateRequest {
                 (getPrefilledCardHolderDetails().isPresent() && prefilledCardHolderDetails.getCardHolderName().isPresent() ? ", prefilled_cardholder_name=true" : "") +
                 (getEmail().isPresent() ? ", prefilled_email=true" : "") +
                 (getExternalMetadata().isPresent() ? ", metadata=true" : "") +
+                (getAgreementPaymentType() != null ? ", agreement_payment_type=" + agreementPaymentType : "") +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -189,7 +189,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @ManyToOne
     @JoinColumn(name = "agreement_external_id", referencedColumnName="external_id", updatable = false, nullable = true)
     private AgreementEntity agreementEntity;
-    
+
+    @Column(name = "agreement_payment_type")
+    @Enumerated(EnumType.STRING)
+    private AgreementPaymentType agreementPaymentType;
+
     @Column(name = "save_payment_instrument_to_agreement")
     private boolean savePaymentInstrumentToAgreement;
 
@@ -210,10 +214,6 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     @Column(name = "requires_3ds")
     private Boolean requires3ds;
-    
-    @Column(name = "agreement_payment_type")
-    @Enumerated(EnumType.STRING)
-    private AgreementPaymentType agreementPaymentType;
 
     public ChargeEntity() {
         //for jpa
@@ -240,11 +240,12 @@ public class ChargeEntity extends AbstractVersionedEntity {
             boolean moto,
             String serviceId,
             AgreementEntity agreementEntity,
+            AgreementPaymentType agreementPaymentType,
             boolean savePaymentInstrumentToAgreement,
             AuthorisationMode authorisationMode,
             Boolean canRetry,
-            Boolean requires3ds, 
-            AgreementPaymentType  agreementPaymentType
+            Boolean requires3ds
+   
     ) {
         this.amount = amount;
         this.status = status.getValue();
@@ -266,11 +267,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.moto = moto;
         this.serviceId = serviceId;
         this.agreementEntity = agreementEntity;
+        this.agreementPaymentType = agreementPaymentType;
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
         this.authorisationMode = authorisationMode;
         this.canRetry = canRetry;
         this.requires3ds = requires3ds;
-        this.agreementPaymentType = agreementPaymentType;
     }
 
     public Long getId() {
@@ -579,7 +580,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
     public Optional<AgreementEntity> getAgreement() {
         return Optional.ofNullable(agreementEntity);
     }
-    
+
+    public AgreementPaymentType getAgreementPaymentType() {
+        return agreementPaymentType;
+    }
+
     public boolean isSavePaymentInstrumentToAgreement() {
         return savePaymentInstrumentToAgreement;
     }
@@ -616,14 +621,6 @@ public class ChargeEntity extends AbstractVersionedEntity {
         return updatedDate;
     }
 
-    public AgreementPaymentType getAgreementPaymentType() {
-        return agreementPaymentType;
-    }
-
-    public void setAgreementPaymentType(AgreementPaymentType agreementPaymentType) {
-        this.agreementPaymentType = agreementPaymentType;
-    }
-
     public static final class WebChargeEntityBuilder {
         private Long amount;
         private String returnUrl;
@@ -642,6 +639,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         private AgreementEntity agreementEntity;
         private boolean savePaymentInstrumentToAgreement;
         private AuthorisationMode authorisationMode;
+        private AgreementPaymentType agreementPaymentType;
 
         private WebChargeEntityBuilder() {
         }
@@ -735,6 +733,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
             this.authorisationMode = authorisationMode;
             return this;
         }
+        
+        public WebChargeEntityBuilder withAgreementPaymentType(AgreementPaymentType agreementPaymentType) {
+            this.agreementPaymentType = agreementPaymentType;
+            return this;
+        }
 
         public ChargeEntity build() {
             return new ChargeEntity(
@@ -757,9 +760,9 @@ public class ChargeEntity extends AbstractVersionedEntity {
                     moto,
                     serviceId,
                     agreementEntity,
+                    agreementPaymentType,
                     savePaymentInstrumentToAgreement,
                     authorisationMode,
-                    null,
                     null,
                     null);
         }
@@ -874,9 +877,9 @@ public class ChargeEntity extends AbstractVersionedEntity {
                     false,
                     serviceId,
                     agreementEntity,
+                    null,
                     savePaymentInstrumentToAgreement,
                     AuthorisationMode.EXTERNAL,
-                    null,
                     null,
                     null);
         }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
@@ -44,11 +44,11 @@ public class PaymentCreatedEventDetails extends EventDetails {
     private final String addressCountry;
     private final Source source;
     private final boolean moto;
-    private String agreementId;
-    private String paymentInstrumentId;
-    private boolean savePaymentInstrumentToAgreement;
-    private final AuthorisationMode authorisationMode;
+    private final String agreementId;
     private final AgreementPaymentType agreementPaymentType;
+    private final String paymentInstrumentId;
+    private final boolean savePaymentInstrumentToAgreement;
+    private final AuthorisationMode authorisationMode;
 
     public PaymentCreatedEventDetails(Builder builder) {
         this.amount = builder.amount;
@@ -73,10 +73,10 @@ public class PaymentCreatedEventDetails extends EventDetails {
         this.source = builder.source;
         this.moto = builder.moto;
         this.agreementId = builder.agreementId;
+        this.agreementPaymentType = builder.agreementPaymentType;
         this.paymentInstrumentId = builder.paymentInstrumentId;
         this.savePaymentInstrumentToAgreement = builder.savePaymentInstrumentToAgreement;
         this.authorisationMode = builder.authorisationMode;
-        this.agreementPaymentType = builder.agreementPaymentType;
     }
 
     public static PaymentCreatedEventDetails from(ChargeEntity charge) {
@@ -94,9 +94,9 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 .withEmail(charge.getEmail())
                 .withSource(charge.getSource())
                 .withMoto(charge.isMoto())
+                .withAgreementPaymentType(charge.getAgreementPaymentType())
                 .withSavePaymentInstrumentToAgreement(charge.isSavePaymentInstrumentToAgreement())
-                .withAuthorisationMode(charge.getAuthorisationMode())
-                .withAgreementPaymentType(charge.getAgreementPaymentType());
+                .withAuthorisationMode(charge.getAuthorisationMode());
 
         charge.getAgreement().ifPresent(agreementEntity -> builder.withAgreementId(agreementEntity.getExternalId()));
         charge.getPaymentInstrument().map(PaymentInstrumentEntity::getExternalId).ifPresent(builder::withPaymentInstrumentId);
@@ -243,14 +243,14 @@ public class PaymentCreatedEventDetails extends EventDetails {
         return savePaymentInstrumentToAgreement;
     }
 
-    public AuthorisationMode getAuthorisationMode() {
-        return authorisationMode;
-    }
-
     public AgreementPaymentType getAgreementPaymentType() {
         return agreementPaymentType;
     }
 
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
+    }
+    
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -276,6 +276,7 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 Objects.equals(addressCounty, that.addressCounty) &&
                 Objects.equals(addressCountry, that.addressCountry) &&
                 Objects.equals(agreementId, that.agreementId) &&
+                Objects.equals(agreementPaymentType, that.agreementPaymentType) &&
                 Objects.equals(paymentInstrumentId, that.paymentInstrumentId) &&
                 Objects.equals(savePaymentInstrumentToAgreement, that.savePaymentInstrumentToAgreement) &&
                 Objects.equals(source, that.source);
@@ -284,8 +285,8 @@ public class PaymentCreatedEventDetails extends EventDetails {
     @Override
     public int hashCode() {
         return Objects.hash(amount, description, reference, returnUrl, gatewayAccountId, credentialExternalId,
-                paymentProvider, language, delayedCapture, live, externalMetadata, agreementId, paymentInstrumentId,
-                savePaymentInstrumentToAgreement, source);
+                paymentProvider, language, delayedCapture, live, externalMetadata, agreementId, agreementPaymentType,
+                paymentInstrumentId, savePaymentInstrumentToAgreement, source);
     }
 
     public static class Builder {
@@ -311,10 +312,10 @@ public class PaymentCreatedEventDetails extends EventDetails {
         private boolean moto;
         private String credentialExternalId;
         private String agreementId;
+        private AgreementPaymentType agreementPaymentType;
         private String paymentInstrumentId;
         private boolean savePaymentInstrumentToAgreement;
         private AuthorisationMode authorisationMode;
-        private AgreementPaymentType agreementPaymentType;
 
         public PaymentCreatedEventDetails build() {
             return new PaymentCreatedEventDetails(this);
@@ -425,6 +426,11 @@ public class PaymentCreatedEventDetails extends EventDetails {
             return this;
         }
 
+        public Builder withAgreementPaymentType(AgreementPaymentType agreementPaymentType) {
+            this.agreementPaymentType = agreementPaymentType;
+            return this;
+        }
+
         public Builder withPaymentInstrumentId(String paymentInstrumentId) {
             this.paymentInstrumentId = paymentInstrumentId;
             return this;
@@ -445,9 +451,5 @@ public class PaymentCreatedEventDetails extends EventDetails {
             return this;
         }
 
-        public Builder withAgreementPaymentType(AgreementPaymentType agreementPaymentType) {
-            this.agreementPaymentType = agreementPaymentType;
-            return this;
-        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/model/ChargeCreateRequestBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/ChargeCreateRequestBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.charge.model;
 
+import uk.gov.service.payments.commons.model.AgreementPaymentType;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
@@ -18,6 +19,7 @@ public final class ChargeCreateRequestBuilder {
     private Source source;
     private boolean moto;
     private String agreementId;
+    private AgreementPaymentType agreementPaymentType;
     private boolean savePaymentInstrumentToAgreement;
     private AuthorisationMode authorisationMode;
     private String credentialExternalId;
@@ -88,6 +90,11 @@ public final class ChargeCreateRequestBuilder {
         this.agreementId = agreementId;
         return this;
     }
+ 
+    public ChargeCreateRequestBuilder withAgreementPaymentType(AgreementPaymentType agreementPaymentType) {
+        this.agreementPaymentType = agreementPaymentType;
+        return this;
+    }
 
     public ChargeCreateRequestBuilder withSavePaymentInstrumentToAgreement(boolean savePaymentInstrumentToAgreement) {
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
@@ -106,7 +113,7 @@ public final class ChargeCreateRequestBuilder {
 
     public ChargeCreateRequest build() {
         return new ChargeCreateRequest(amount, description, reference, returnUrl, email, delayedCapture, language,
-                prefilledCardHolderDetails, externalMetadata, source, moto, agreementId, savePaymentInstrumentToAgreement, authorisationMode,
-                credentialExternalId);
+                prefilledCardHolderDetails, externalMetadata, source, moto, agreementId, agreementPaymentType,
+                savePaymentInstrumentToAgreement, authorisationMode, credentialExternalId);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -163,11 +163,11 @@ public class ChargeEntityFixture {
                 moto,
                 serviceId,
                 agreementEntity,
+                agreementPaymentType,
                 savePaymentInstrumentToAgreement,
                 authorisationMode,
                 canRetry,
-                requires3ds,
-                agreementPaymentType);
+                requires3ds);
         chargeEntity.setId(id);
         chargeEntity.setExternalId(externalId);
         chargeEntity.setCorporateSurcharge(corporateSurcharge);

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
@@ -405,6 +405,7 @@ class ChargeServiceCreateTest {
         assertThat(createdChargeEntity.getWalletType(), is(nullValue()));
         assertThat(createdChargeEntity.isMoto(), is(false));
         assertThat(createdChargeEntity.getAuthorisationMode(), is(AuthorisationMode.WEB));
+        assertThat(createdChargeEntity.getAgreementPaymentType(), is(nullValue()));
 
         verify(mockedChargeEventDao).persistChargeEventOf(eq(createdChargeEntity), isNull());
     }

--- a/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
@@ -25,6 +25,7 @@ import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.pay.connector.util.AddPaymentInstrumentParams;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.pay.connector.util.RestAssuredClient;
+import uk.gov.service.payments.commons.model.AgreementPaymentType;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
@@ -40,6 +41,7 @@ import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
@@ -263,6 +265,11 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
 
     public void assertApiStateIs(String chargeId, String stateString) {
         getCharge(chargeId).body("state.status", is(stateString));
+    }
+    
+    public void assertAgreementPaymentTypeIs(String chargeId, AgreementPaymentType agreementPaymentType) {
+        var charge = databaseTestHelper.getChargeByExternalId(chargeId);
+        assertThat(charge.get("agreement_payment_type"), is(agreementPaymentType.toString()));
     }
 
     public String authoriseNewCharge() {


### PR DESCRIPTION
## WHAT YOU DID

- Add new field `agreement_payment_type` to ChargeCreateRequest.
- Implement handling of the new field through the code (storing in DB, sending it in CreatePaymentEvent, etc)
- Add relevant tests

