### PR TITLE
PP-14571 refactor StripePaymentMethodRequest

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
@@ -56,9 +56,15 @@ public class StripePaymentMethodRequest extends StripePostRequest {
             northAmericanRegionMapper.getNorthAmericanRegionForCountry(address)
                     .map(NorthAmericaRegion::getFullName)
                     .ifPresent(stateOrProvince -> localParams.put("billing_details[address[state]]", stateOrProvince));
-            localParams.put("billing_details[address[city]]", address.getCity());
-            localParams.put("billing_details[address[country]]", address.getCountry());
-            localParams.put("billing_details[address[postal_code]]", address.getPostcode());
+            if (StringUtils.isNotBlank(address.getCity())) {
+                localParams.put("billing_details[address[city]]", address.getCity());
+            }
+            if (StringUtils.isNotBlank(address.getCountry())) {
+                localParams.put("billing_details[address[country]]", address.getCountry());
+            }
+            if (StringUtils.isNotBlank(address.getPostcode())) {
+                localParams.put("billing_details[address[postal_code]]", address.getPostcode());
+            }
         });
 
         return Map.copyOf(localParams);

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
@@ -162,6 +163,26 @@ class StripePaymentMethodRequestTest {
         assertThat(payload, containsString("billing_details%5Bname%5D=" + cardHolder));
         assertThat(payload, containsString("card%5Bexp_year%5D=" + endYear));
         assertThat(payload, containsString("card%5Bexp_month%5D=" + endMonth));
+    }
+    
+    @Test
+    void shouldCreateWithPartiallyFieldCardHolderDetail() {
+        Address address = new Address();
+        address.setLine1(line1);
+        address.setLine2(line2);
+        address.setCity(null);
+        address.setCountry(null);
+        address.setPostcode(null);
+        authCardDetails.setAddress(address);
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+
+        stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
+
+        String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
+        assertThat(payload, containsString("card%5Bcvc%5D=" + cvc));
+        assertThat(payload, not(containsString("city")));
+        assertThat(payload, not(containsString("country")));
+        assertThat(payload, not(containsString("postal_code")));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID

We do not require any fields to be not null of the prefilled_cardholder_details. However, a service has been sending it without a few fields and it broke the process with a NullPointerException.
