### PR TITLE
PP-14430 Enable test `makeChargeSubmitCaptureAndCheckSettlementSummary`

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -92,8 +92,7 @@ public class ChargesApiResourceIT {
     private final String accountId = testBaseExtension.getAccountId();
     
     @Test
-    @Disabled
-    void makeChargeSubmitCaptureAndCheckSettlementSummary() throws QueueException {
+    void makeChargeSubmitCaptureAndCheckSettlementSummary() throws QueueException, InterruptedException {
         Instant startOfTest = Instant.now();
         String expectedDayOfCapture = ISO_LOCAL_DATE_IN_UTC.format(startOfTest);
 
@@ -103,6 +102,8 @@ public class ChargesApiResourceIT {
                 .post(testBaseExtension.captureChargeUrlFor(chargeId))
                 .then()
                 .statusCode(204);
+
+        Thread.sleep(500);
 
         // Trigger the capture process programmatically which normally would be invoked by the scheduler.
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).handleCaptureMessages();


### PR DESCRIPTION
## WHAT
- Enables test
- Ran test 3 times without any issues (before adding `sleep()`) 
      - https://github.com/alphagov/pay-connector/actions/runs/18403130058/job/52436844753  
      - https://github.com/alphagov/pay-connector/actions/runs/18403130058/job/52437743060 
      - https://github.com/alphagov/pay-connector/actions/runs/18403130058/job/52439506999 
- Added `sleep()` before starting the capture process, so that the message is visible for the capture process - potential cause of flakiness seen in [PP-14378](https://payments-platform.atlassian.net/browse/PP-14378).


[PP-14378]: https://payments-platform.atlassian.net/browse/PP-14378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ