### PR TITLE
PP-14435 parity checks reason matches for AgreementPaymentType

### DIFF
--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.connector.charge.model.ChargeResponse;
-import uk.gov.pay.connector.charge.model.domain.Exemption3dsType;
+import uk.gov.service.payments.commons.model.AgreementPaymentType;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
@@ -56,6 +56,7 @@ public class LedgerTransaction {
     private Exemption exemption;
     private boolean disputed;
     private AuthorisationMode authorisationMode;
+    private AgreementPaymentType agreementPaymentType;
     private String agreementId;
 
     public LedgerTransaction() {
@@ -342,5 +343,14 @@ public class LedgerTransaction {
 
     public void setAgreementId(String agreementId) {
         this.agreementId = agreementId;
+    }
+
+    public AgreementPaymentType getAgreementPaymentType() {
+        return agreementPaymentType;
+    }
+    
+    public LedgerTransaction setAgreementPaymentType(AgreementPaymentType agreementPaymentType) {
+        this.agreementPaymentType = agreementPaymentType;
+        return this;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
@@ -166,6 +166,7 @@ public class ChargeParityChecker {
         fieldsMatch = fieldsMatch && isEquals(chargeEntity.getReference().toString(), transaction.getReference(), "reference");
         fieldsMatch = fieldsMatch && isEquals(chargeEntity.getLanguage(), transaction.getLanguage(), "language");
         fieldsMatch = fieldsMatch && isEquals(chargeEntity.getPaymentProvider(), transaction.getPaymentProvider(), "payment_provider");
+        fieldsMatch = fieldsMatch && isEquals(chargeEntity.getAgreementPaymentType(), transaction.getAgreementPaymentType(), "agreement_payment_type");
 
         // email may be empty in connector but not in ledger, if service provides email but turns off email address collection
         fieldsMatch = fieldsMatch && (

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -26,6 +26,7 @@ import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.pay.connector.wallets.WalletType;
+import uk.gov.service.payments.commons.model.AgreementPaymentType;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.service.payments.commons.model.Source;
@@ -81,6 +82,7 @@ public class LedgerTransactionFixture {
     private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
     private String agreementId;
     private Exemption3ds exemption3ds;
+    private AgreementPaymentType agreementPaymentType;
     private Exemption3dsType exemption3dsType;
 
     public static LedgerTransactionFixture aValidLedgerTransaction() {
@@ -110,6 +112,7 @@ public class LedgerTransactionFixture {
                         .withTotalAmount(getTotalAmountFor(chargeEntity))
                         .withNetAmount(chargeEntity.getNetAmount().orElse(null))
                         .withExemption3ds(chargeEntity.getExemption3ds())
+                        .withAgreementPaymentType(chargeEntity.getAgreementPaymentType())
                         .withExemption3dsRequested(chargeEntity.getExemption3dsRequested());
 
         ledgerTransactionFixture.withCreatedDate(getEventDate(chargeEntity.getEvents(), List.of(CREATED, PAYMENT_NOTIFICATION_CREATED)));
@@ -246,6 +249,7 @@ public class LedgerTransactionFixture {
         ledgerTransaction.setDisputed(disputed);
         ledgerTransaction.setAuthorisationMode(authorisationMode);
         ledgerTransaction.setAgreementId(agreementId);
+        ledgerTransaction.setAgreementPaymentType(agreementPaymentType);
 
         return ledgerTransaction;
     }
@@ -422,6 +426,11 @@ public class LedgerTransactionFixture {
     
     public LedgerTransactionFixture withExemption3ds(Exemption3ds exemption3ds) {
         this.exemption3ds = exemption3ds;
+        return this;
+    }
+    
+    public LedgerTransactionFixture withAgreementPaymentType(AgreementPaymentType agreementPaymentType) {
+        this.agreementPaymentType = agreementPaymentType;
         return this;
     }
     


### PR DESCRIPTION
## WHAT YOU DID
Added an equal check in the `matchCommonFields` of the parity checker to ensure both Ledger and Connector agree on the type of recurring payment. 

## How to test

- How should it be reviewed? 
    - Check the test names and check. The ticket calls for checking for 'unexpected' values but I believe java is taking care of this for us in the type checking. 
- If manual testing is needed, give suggested testing steps.
    - Manual checking will need to be checked post-merge. The ticket specifically states 'Check parity checker results carefully after deployment'
