### PR TITLE
PP-14634 Fix null pointer when Stripe account requirements null

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAccountUpdatedHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAccountUpdatedHandler.java
@@ -11,6 +11,8 @@ import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCred
 
 import jakarta.inject.Inject;
 
+import java.util.Optional;
+
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 
@@ -44,10 +46,9 @@ public class StripeAccountUpdatedHandler {
     }
 
     private boolean canBeActivated(DataObject dataObject) {
-        return (!dataObject.getRequirements().hasCurrentlyDue() &&
-                !dataObject.getRequirements().hasPastDue() &&
-                dataObject.isChargesEnabled() &&
-                dataObject.isPayoutsEnabled());
+        return Optional.ofNullable(dataObject.getRequirements()).map(reqs -> !reqs.hasCurrentlyDue() && !reqs.hasPastDue()).orElse(true)
+                && dataObject.isChargesEnabled()
+                && dataObject.isPayoutsEnabled();
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
When processing a Stripe account updated notification, handle the requirements in the data object provided by Stripe being null by assuming that the requirements being null means all requirements are satisfied.