### PR TITLE
PP-14769 Log calculated states for parity checker mismatches

### DIFF
--- a/src/main/java/uk/gov/pay/connector/tasks/service/ConnectorAuthorisationSummaryState.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/service/ConnectorAuthorisationSummaryState.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.tasks.service;
 
-public enum ConnectAuthorisationSummaryState {
+public enum ConnectorAuthorisationSummaryState {
         CONNECTOR_HAS_REQUIRES_3DS_TRUE,
         CONNECTOR_HAS_REQUIRES_3DS_FALSE,
         CONNECTOR_HAS_REQUIRES_3DS_NULL_BUT_HAS_3DS_REQUIRED_DETAILS,


### PR DESCRIPTION
Some of the more complex parity checker checks involve calculating two or more named states that represent what the data is in connector and ledger and then checking if they match according to specific rules.

When there is a data mismatch caused by the calculated states not agreeing, add `[calculated_states=…]` to the end of the log line with a list of the calculated states to make investigation easier.