### PR TITLE
 PP-14742 update open api schema definition

### DIFF
--- a/src/main/java/uk/gov/pay/connector/agreement/model/AgreementCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/model/AgreementCreateRequest.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.validator.constraints.Length;
 
 import jakarta.validation.constraints.NotNull;
-import java.util.Objects;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -14,13 +14,13 @@ public record AgreementCreateRequest (
         @NotNull(message = "Field [reference] cannot be null")
         @Length(min = 1, max = 255, message = "Field [reference] can have a size between 1 and 255")
         @JsonProperty("reference")
-        @Schema(example = "Service agreement reference", required = true)
+        @Schema(example = "Service agreement reference", requiredMode = REQUIRED)
         String reference,
 
         @NotNull(message = "Field [" + DESCRIPTION_FIELD + "] cannot be null")
         @Length(min = 1, max = 255, message = "Field [" + DESCRIPTION_FIELD + "] can have a size between 1 and 255")
         @JsonProperty(DESCRIPTION_FIELD)
-        @Schema(example = "Description for the paying user describing the purpose of the agreement", required = true)
+        @Schema(example = "Description for the paying user describing the purpose of the agreement", requiredMode = REQUIRED)
         String description,
 
         @Length(min = 1, max = 255, message = "Field [" + USER_IDENTIFIER_FIELD + "] can have a size between 0 and 255")

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
@@ -24,6 +24,7 @@ import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
 import java.util.Optional;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static java.util.function.Predicate.not;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -34,21 +35,21 @@ public class ChargeCreateRequest {
     @Min(value = 0, message = "Field [amount] can be between 0 and 10_000_000")
     @Max(value = 10_000_000, message = "Field [amount] can be between 0 and 10_000_000")
     @JsonProperty("amount")
-    @Schema(description = "Amount in pence", example = "100", required = true,
+    @Schema(description = "Amount in pence", example = "100", requiredMode = REQUIRED,
             minimum = "0", maximum = "10000000")
     private Long amount;
 
     @NotNull(message = "Field [description] cannot be null")
     @Length(max = 255, message = "Field [description] can have a size between 0 and 255")
     @JsonProperty("description")
-    @Schema(example = "payment description", description = "The payment description (shown to the user on the payment pages)", required = true,
+    @Schema(example = "payment description", description = "The payment description (shown to the user on the payment pages)", requiredMode = REQUIRED,
             maximum = "255")
     private String description;
 
     @NotNull(message = "Field [reference] cannot be null")
     @Length(max = 255, message = "Field [reference] can have a size between 0 and 255")
     @JsonProperty("reference")
-    @Schema(example = "payment reference", description = "The reference issued by the government service for this payment", required = true,
+    @Schema(example = "payment reference", description = "The reference issued by the government service for this payment",requiredMode = REQUIRED,
             maximum = "255")
     private String reference;
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/telephone/TelephoneChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/telephone/TelephoneChargeCreateRequest.java
@@ -13,19 +13,21 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.Optional;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TelephoneChargeCreateRequest {
 
     @NotNull(message = "Field [amount] cannot be null")
-    @Schema(example = "100", description = "Amount in pence", required = true, maximum = "10000000")
+    @Schema(example = "100", description = "Amount in pence", requiredMode = REQUIRED, maximum = "10000000")
     private Long amount;
 
     @NotNull(message = "Field [reference] cannot be null")
-    @Schema(example = "payment reference", description = "service payment reference", required = true, maxLength = 255)
+    @Schema(example = "payment reference", description = "service payment reference", requiredMode = REQUIRED, maxLength = 255)
     private String reference;
 
     @NotNull(message = "Field [description] cannot be null")
-    @Schema(example = "payment description", description = "The payment description", required = true, maxLength = 255)
+    @Schema(example = "payment description", description = "The payment description", requiredMode = REQUIRED, maxLength = 255)
     private String description;
 
     @ValidZonedDateTime(message = "Field [created_date] must be a valid ISO-8601 time and date format")
@@ -39,11 +41,11 @@ public class TelephoneChargeCreateRequest {
     private String authorisedDate;
 
     @NotNull(message = "Field [processor_id] cannot be null")
-    @Schema(example = "12345", description = "unique supplier internal reference number associated with the payment", required = true)
+    @Schema(example = "12345", description = "unique supplier internal reference number associated with the payment", requiredMode = REQUIRED)
     private String processorId;
 
     @NotNull(message = "Field [provider_id] cannot be null")
-    @Schema(example = "45678", description = "Gateway transaction ID", required = true)
+    @Schema(example = "45678", description = "Gateway transaction ID", requiredMode = REQUIRED)
     private String providerId;
 
     @Schema(example = "91011", description = "Authorisation ID received from payment provider when the payment was authorised", maxLength = 50)
@@ -51,7 +53,7 @@ public class TelephoneChargeCreateRequest {
 
     @NotNull(message = "Field [payment_outcome] cannot be null")
     @Valid
-    @Schema(description = "Outcome after the payment has been authorised with payment provider", required = true)
+    @Schema(description = "Outcome after the payment has been authorised with payment provider", requiredMode = REQUIRED)
     private PaymentOutcome paymentOutcome;
 
     @ValidCardBrand(message = "Field [card_type] must be either master-card, visa, maestro, diners-club, american-express or jcb")

--- a/src/main/java/uk/gov/pay/connector/common/model/api/ErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/ErrorResponse.java
@@ -9,6 +9,7 @@ import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import java.util.List;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 
 @JsonInclude(Include.NON_NULL)
 public record ErrorResponse (
@@ -21,7 +22,7 @@ public record ErrorResponse (
     List<String> messages,
     
     @JsonProperty("reason")
-    @Schema(required = false, example = "Optional - ex: amount_not_available")
+    @Schema(requiredMode = NOT_REQUIRED, example = "Optional - ex: amount_not_available")
     String reason
 ) {
     public ErrorResponse(ErrorIdentifier identifier, List<String> messages) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountResponse.java
@@ -6,11 +6,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Objects;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class StripeAccountResponse {
 
     @JsonProperty("stripe_account_id")
-    @Schema(required = true, example = "acct_123example123")
+    @Schema(requiredMode = REQUIRED, example = "acct_123example123")
     private final String stripeAccountId;
 
     public StripeAccountResponse(String stripeAccountId) {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/model/AuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/model/AuthoriseRequest.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.Objects;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoUnit.HOURS;
 import static uk.gov.pay.connector.common.validator.AuthCardDetailsValidator.isBetween3To4Digits;
@@ -24,27 +25,27 @@ import static uk.gov.service.payments.commons.model.CardExpiryDate.CARD_EXPIRY_D
 public class AuthoriseRequest {
 
     @NotBlank(message = "Missing mandatory attribute: one_time_token")
-    @Schema(example = "123abc123", required = true,
+    @Schema(example = "123abc123", requiredMode = REQUIRED,
             description = "the one time token provided in the `auth_url_post` link of the create payment API response")
     private String oneTimeToken;
 
     @NotBlank(message = "Missing mandatory attribute: card_number")
     @Length(min = 12, max = 19, message = "Invalid attribute value: card_number. Must be between {min} and {max} characters long")
-    @Schema(example = "4242424242424242", minLength = 12, maxLength = 19, required = true)
+    @Schema(example = "4242424242424242", minLength = 12, maxLength = 19, requiredMode = REQUIRED)
     private String cardNumber;
 
     @NotBlank(message = "Missing mandatory attribute: cvc")
     @Length(min = 3, max = 4, message = "Invalid attribute value: cvc. Must be between {min} and {max} characters long")
-    @Schema(example = "123", minLength = 3, maxLength = 4, required = true)
+    @Schema(example = "123", minLength = 3, maxLength = 4, requiredMode = REQUIRED)
     private String cvc;
 
     @NotBlank(message = "Missing mandatory attribute: expiry_date")
-    @Schema(example = "01/99", minLength = 5, maxLength = 5, description = "5 character string in MM/YY format", required = true)
+    @Schema(example = "01/99", minLength = 5, maxLength = 5, description = "5 character string in MM/YY format", requiredMode = REQUIRED)
     private String expiryDate;
 
     @NotBlank(message = "Missing mandatory attribute: cardholder_name")
     @Length(min = 1, max = 255, message = "Invalid attribute value: cardholder_name. Must be less than or equal to {max} characters length")
-    @Schema(example = "Joe B", maxLength = 255, description = "Cardholder name", required = true)
+    @Schema(example = "Joe B", maxLength = 255, description = "Cardholder name", requiredMode = REQUIRED)
     private String cardholderName;
 
     public AuthoriseRequest() {

--- a/src/main/java/uk/gov/pay/connector/refund/model/RefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/RefundRequest.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.refund.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 /**
  * The refund_amount_available field is a mechanism that acts as idempotency-lite, which is especially important when 
  * performing partial refunds. By having the consumer specify the amount available to refund at the time of the call, 
@@ -33,11 +35,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class RefundRequest {
 
     @JsonProperty("amount")
-    @Schema(example = "3444", required = true, description = "Amount to refund in pence")
+    @Schema(example = "3444", requiredMode = REQUIRED, description = "Amount to refund in pence")
     private long amount;
 
     @JsonProperty("refund_amount_available")
-    @Schema(example = "30000", required = true, description = "Total amount still available before issuing the refund")
+    @Schema(example = "30000", requiredMode = REQUIRED, description = "Total amount still available before issuing the refund")
     private long amountAvailableForRefund;
 
     @JsonProperty("user_external_id")


### PR DESCRIPTION
## WHAT YOU DID

- Some OpenAPI spec annotation fields like `required` are deprecated and show warnings every time we compile code
- This pr updates it with the relevant replacements: https://docs.swagger.io/swagger-core/v2.2.32/apidocs/io/swagger/v3/oas/annotations/media/Schema.html#required()




