### PR TITLE
PP-14778 - Deprecated and warnings 1/3

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -181,14 +181,14 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5809
+        "line_number": 5812
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5820
+        "line_number": 5823
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -709,7 +709,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/pact/ContractTest.java",
         "hashed_secret": "d5662d7353c6257f68cab2a3b0f758cc79b1ac5e",
         "is_verified": false,
-        "line_number": 373
+        "line_number": 371
       }
     ],
     "src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java": [
@@ -718,7 +718,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java",
         "hashed_secret": "aa4f63822a427d27308ddef0e735bc21f8f2f7f7",
         "is_verified": false,
-        "line_number": 169
+        "line_number": 168
       }
     ],
     "src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-02T16:58:57Z"
+  "generated_at": "2025-12-08T18:54:14Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -181,14 +181,14 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5812
+        "line_number": 5809
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5823
+        "line_number": 5820
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -718,7 +718,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java",
         "hashed_secret": "aa4f63822a427d27308ddef0e735bc21f8f2f7f7",
         "is_verified": false,
-        "line_number": 168
+        "line_number": 169
       }
     ],
     "src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-08T18:54:14Z"
+  "generated_at": "2025-12-11T09:28:40Z"
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeStatus.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.charge.model.domain;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import uk.gov.pay.connector.common.model.Status;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 
@@ -57,7 +57,7 @@ public enum ChargeStatus implements Status {
     USER_CANCEL_SUBMITTED("USER CANCEL SUBMITTED", EXTERNAL_FAILED_CANCELLED, false),
     USER_CANCELLED("USER CANCELLED", EXTERNAL_FAILED_CANCELLED, true),
     USER_CANCEL_ERROR("USER CANCEL ERROR", EXTERNAL_FAILED_CANCELLED, true),
-    
+
     // Below statuses exist to facilitate cancellation on the gateway for charges that entered the various authorisation
     // error states. A recurring cleanup job moves charges into these states when it has handled them. This job is only
     // run for ePDQ charges, so only ePDQ charges will enter these states.
@@ -65,9 +65,9 @@ public enum ChargeStatus implements Status {
     AUTHORISATION_ERROR_REJECTED("AUTHORISATION ERROR REJECTED", EXTERNAL_ERROR_GATEWAY, true),
     AUTHORISATION_ERROR_CHARGE_MISSING("AUTHORISATION ERROR CHARGE MISSING", EXTERNAL_ERROR_GATEWAY, true);
 
-    private String value;
-    private ExternalChargeState externalStatus;
-    private boolean expungeable;
+    private final String value;
+    private final ExternalChargeState externalStatus;
+    private final boolean expungeable;
 
     ChargeStatus(String value, ExternalChargeState externalStatus, boolean expungeable) {
         this.value = value;
@@ -93,7 +93,7 @@ public enum ChargeStatus implements Status {
 
     public static ChargeStatus fromString(String status) {
         for (ChargeStatus stat : values()) {
-            if (StringUtils.equals(stat.getValue(), status)) {
+            if (Strings.CS.equals(stat.getValue(), status)) {
                 return stat;
             }
         }

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/HistoryCustomizer.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/HistoryCustomizer.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.common.model.domain;
 
-import org.eclipse.persistence.config.DescriptorCustomizer;
+import org.eclipse.persistence.descriptors.DescriptorCustomizer;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.history.HistoryPolicy;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayoutStatus.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayoutStatus.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe.json;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import uk.gov.pay.connector.events.model.payout.PayoutEvent;
 import uk.gov.pay.connector.events.model.payout.PayoutFailed;
 import uk.gov.pay.connector.events.model.payout.PayoutPaid;
@@ -32,7 +32,7 @@ public enum StripePayoutStatus {
 
     public static StripePayoutStatus fromString(String status) {
         for (StripePayoutStatus stat : values()) {
-            if (StringUtils.equals(stat.getStatus(), status)) {
+            if (Strings.CS.equals(stat.getStatus(), status)) {
                 return stat;
             }
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -78,17 +78,17 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
 
         logMissingDdcResultFor3dsFlexIntegration(request);
 
-        var worldpayOrderBuilder  = WorldpayOrderBuilder.buildAuthoriseOrder(request, sendExemptionRequest, acceptLanguageHeaderParser);
+        var worldpayOrderBuilder = WorldpayOrderBuilder.buildAuthoriseOrder(request, sendExemptionRequest, acceptLanguageHeaderParser);
         logAuthorisationRequestToBePosted(request, worldpayOrderBuilder);
 
-        try {            
+        try {
             GatewayClient.Response response = authoriseClient.postRequestFor(
                     gatewayUrlMap.get(request.getGatewayAccount().getType()),
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
                     worldpayOrderBuilder.build(),
                     getWorldpayAuthHeader(request.getGatewayCredentials(), request.getAuthorisationMode(), request.isForRecurringPayment()));
-            
+
             if (response.getEntity().contains("request3DSecure")) {
                 LOGGER.info(format("Worldpay authorisation response when 3ds required: %s", sanitiseMessage(response.getEntity())));
             }
@@ -127,7 +127,7 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
                 request.getGatewayAccount().getId()
         );
 
-        LOGGER.info(logMessage, structuredLoggingArguments);
+        LOGGER.info(logMessage, (Object) structuredLoggingArguments);
     }
 
     private String sanitiseMessage(String message) {
@@ -141,10 +141,10 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
             LOGGER.info("[3DS Flex] Missing device data collection result for {}", gatewayAccount.getId());
         }
     }
-    
+
     private String stringifyLogMessage(WorldpayOrderRequestBuilder orderRequestBuilder, AuthCardDetails authCardDetails, boolean isMoto) {
         var stringJoiner = new StringJoiner(" and ", " ", "");
-        
+
         stringJoiner.add(isMoto ? "MOTO" : "not MOTO");
 
         authCardDetails.getAddress()
@@ -153,14 +153,14 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
 
         Optional.ofNullable(orderRequestBuilder.getWorldpayTemplateData().getPayerEmail())
                 .map(email -> stringJoiner.add("with email address"))
-                .orElseGet(() ->stringJoiner.add("without email address"));
+                .orElseGet(() -> stringJoiner.add("without email address"));
 
         Optional.ofNullable(orderRequestBuilder.getWorldpayTemplateData().getPayerIpAddress())
                 .map(ipAddress -> stringJoiner.add("with IP address"))
-                .orElseGet(() ->stringJoiner.add("without IP address"));
+                .orElseGet(() -> stringJoiner.add("without IP address"));
 
         stringJoiner.add(orderRequestBuilder.getWorldpayTemplateData().isRequires3ds() ? "with 3DS data" : "without 3DS data");
-        
+
         return stringJoiner.toString();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -127,7 +127,7 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
                 request.getGatewayAccount().getId()
         );
 
-        LOGGER.info(logMessage, (Object) structuredLoggingArguments);
+        LOGGER.info(logMessage, structuredLoggingArguments);
     }
 
     private String sanitiseMessage(String message) {

--- a/src/main/java/uk/gov/pay/connector/logging/AuthorisationLogger.java
+++ b/src/main/java/uk/gov/pay/connector/logging/AuthorisationLogger.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.logging;
 
+import jakarta.inject.Inject;
+import net.logstash.logback.argument.StructuredArgument;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -9,7 +11,6 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
 
-import jakarta.inject.Inject;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -19,7 +20,7 @@ public class AuthorisationLogger {
     private final AuthorisationRequestSummaryStructuredLogging authorisationRequestSummaryStructuredLogging;
 
     @Inject
-    public AuthorisationLogger(AuthorisationRequestSummaryStringifier authorisationRequestSummaryStringifier, 
+    public AuthorisationLogger(AuthorisationRequestSummaryStringifier authorisationRequestSummaryStringifier,
                                AuthorisationRequestSummaryStructuredLogging authorisationRequestSummaryStructuredLogging) {
         this.authorisationRequestSummaryStringifier = authorisationRequestSummaryStringifier;
         this.authorisationRequestSummaryStructuredLogging = authorisationRequestSummaryStructuredLogging;
@@ -27,7 +28,7 @@ public class AuthorisationLogger {
 
     public void logChargeAuthorisation(Logger logger,
                                        AuthorisationRequestSummary authorisationRequestSummary,
-                                       ChargeEntity charge, 
+                                       ChargeEntity charge,
                                        String transactionId,
                                        GatewayResponse gatewayResponse,
                                        ChargeStatus oldStatus,
@@ -41,16 +42,15 @@ public class AuthorisationLogger {
                 charge.getGatewayAccount().getAnalyticsId(),
                 charge.getGatewayAccount().getId(),
                 gatewayResponse,
-                oldStatus, 
+                oldStatus,
                 newStatus);
 
         var structuredLoggingArguments = ArrayUtils.addAll(
                 charge.getStructuredLoggingArgs(),
                 Optional.ofNullable(authorisationRequestSummary)
                         .map(authorisationRequestSummaryStructuredLogging::createArgs)
-                        .orElse(null));
-
-        logger.info(logMessage, structuredLoggingArguments);
+                        .orElse(new StructuredArgument[0]));
+        logger.info(logMessage, (Object[]) structuredLoggingArguments);
     }
 
     public void logChargeAuthorisation(Logger logger,

--- a/src/main/java/uk/gov/pay/connector/logging/AuthorisationLogger.java
+++ b/src/main/java/uk/gov/pay/connector/logging/AuthorisationLogger.java
@@ -50,7 +50,7 @@ public class AuthorisationLogger {
                 Optional.ofNullable(authorisationRequestSummary)
                         .map(authorisationRequestSummaryStructuredLogging::createArgs)
                         .orElse(new StructuredArgument[0]));
-        logger.info(logMessage, (Object[]) structuredLoggingArguments);
+        logger.info(logMessage, structuredLoggingArguments);
     }
 
     public void logChargeAuthorisation(Logger logger,

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundStatus.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundStatus.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.refund.model.domain;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import uk.gov.pay.connector.common.model.Status;
 import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
 
@@ -41,7 +41,7 @@ public enum RefundStatus implements Status {
 
     public static RefundStatus fromString(String status) {
         for (RefundStatus stat : values()) {
-            if (StringUtils.equals(stat.getValue(), status)) {
+            if (Strings.CS.equals(stat.getValue(), status)) {
                 return stat;
             }
         }

--- a/src/main/java/uk/gov/pay/connector/util/RandomAlphaNumericString.java
+++ b/src/main/java/uk/gov/pay/connector/util/RandomAlphaNumericString.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.connector.util;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.util.concurrent.ThreadLocalRandom.current;
+
+public final class RandomAlphaNumericString {
+
+    private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final String NUMS = "0123456789";
+    private static final String ALPHA_NUM = CHARS + NUMS;
+
+    private RandomAlphaNumericString() {
+        // utility class - prevent instantiation
+    }
+
+    public static String randomAlphabetic(int length) {
+        return randomFromCharset(CHARS, length);
+    }
+    
+
+    public static String randomAlphaNumeric(int length) {
+        return randomFromCharset(ALPHA_NUM, length);
+    }
+
+    private static String randomFromCharset(String charset, int length) {
+        if (length < 0) {
+            throw new IllegalArgumentException("length must be non-negative");
+        }
+        ThreadLocalRandom rnd = current();
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(charset.charAt(rnd.nextInt(charset.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
@@ -105,17 +105,17 @@ class Worldpay3dsFlexJwtServiceTest {
         String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, paymentCreationTimeEpochSeconds19August2029, WORLDPAY.getName());
 
         Jws<Claims> jws = Jwts.parser()
-                .setSigningKey(new SecretKeySpec(VALID_CREDENTIALS.get("jwt_mac_id").getBytes(), "HmacSHA256"))
+                .verifyWith(new SecretKeySpec(VALID_CREDENTIALS.get("jwt_mac_id").getBytes(), "HmacSHA256"))
                 .build()
-                .parseClaimsJws(token);
+                .parseSignedClaims(token);
 
         assertThat(jws.getHeader().getAlgorithm(), is("HS256"));
         assertThat((Map<String, Object>) jws.getHeader(), hasEntry("typ", "JWT"));
-        assertThat(jws.getBody(), hasKey("jti"));
-        assertThat(jws.getBody(), hasKey("iat"));
-        assertThat(jws.getBody(), hasEntry("exp", expectedTokenExpirationTimeEpochSeconds.getEpochSecond()));
-        assertThat(jws.getBody(), hasEntry("iss", "me"));
-        assertThat(jws.getBody(), hasEntry("OrgUnitId", "myOrg"));
+        assertThat(jws.getPayload(), hasKey("jti"));
+        assertThat(jws.getPayload(), hasKey("iat"));
+        assertThat(jws.getPayload(), hasEntry("exp", expectedTokenExpirationTimeEpochSeconds.getEpochSecond()));
+        assertThat(jws.getPayload(), hasEntry("iss", "me"));
+        assertThat(jws.getPayload(), hasEntry("OrgUnitId", "myOrg"));
     }
 
     @Test
@@ -169,20 +169,20 @@ class Worldpay3dsFlexJwtServiceTest {
         assertThat(maybeToken.isPresent(), is(true));
 
         Jws<Claims> jws = Jwts.parser()
-                .setSigningKey(new SecretKeySpec(VALID_CREDENTIALS.get("jwt_mac_id").getBytes(), "HmacSHA256"))
+                .verifyWith(new SecretKeySpec(VALID_CREDENTIALS.get("jwt_mac_id").getBytes(), "HmacSHA256"))
                 .build()
-                .parseClaimsJws(maybeToken.get());
+                .parseSignedClaims(maybeToken.get());
 
         assertThat(jws.getHeader().getAlgorithm(), is("HS256"));
         assertThat((Map<String, Object>) jws.getHeader(), hasEntry("typ", "JWT"));
-        assertThat(jws.getBody(), hasKey("jti"));
-        assertThat(jws.getBody(), hasKey("iat"));
-        assertThat(jws.getBody(), hasEntry("iss", VALID_CREDENTIALS.get("issuer")));
-        assertThat(jws.getBody(), hasEntry("OrgUnitId", VALID_CREDENTIALS.get("organisational_unit_id")));
-        assertThat(jws.getBody(), hasEntry("ReturnUrl", format("%s/card_details/%s/3ds_required_in", FRONTEND_URL, CHARGE_EXTERNAL_ID)));
-        assertThat(jws.getBody(), hasEntry("ObjectifyPayload", true));
-        assertThat(jws.getBody(), hasEntry(is("Payload"), instanceOf(Map.class)));
-        Map<String, Object> payload = (Map<String, Object>) jws.getBody().get("Payload");
+        assertThat(jws.getPayload(), hasKey("jti"));
+        assertThat(jws.getPayload(), hasKey("iat"));
+        assertThat(jws.getPayload(), hasEntry("iss", VALID_CREDENTIALS.get("issuer")));
+        assertThat(jws.getPayload(), hasEntry("OrgUnitId", VALID_CREDENTIALS.get("organisational_unit_id")));
+        assertThat(jws.getPayload(), hasEntry("ReturnUrl", format("%s/card_details/%s/3ds_required_in", FRONTEND_URL, CHARGE_EXTERNAL_ID)));
+        assertThat(jws.getPayload(), hasEntry("ObjectifyPayload", true));
+        assertThat(jws.getPayload(), hasEntry(is("Payload"), instanceOf(Map.class)));
+        Map<String, Object> payload = (Map<String, Object>) jws.getPayload().get("Payload");
         assertThat(payload, hasEntry("ACSUrl", WORLDPAY_CHALLENGE_ACS_URL));
         assertThat(payload, hasEntry("Payload", WORLDPAY_CHALLENGE_PAYLOAD));
         assertThat(payload, hasEntry("TransactionId", WORLDPAY_CHALLENGE_TRANSACTION_ID));

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -79,7 +79,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -90,6 +89,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
 
 @ExtendWith(MockitoExtension.class)
 class EventFactoryTest {
@@ -153,7 +153,7 @@ class EventFactoryTest {
         assertThat(eventDetails.getUserEmail(), is("test@example.com"));
         assertThat(refundCreatedByUser.getResourceType(), is(ResourceType.REFUND));
         assertThat(refundCreatedByUser.getEventDetails(), is(instanceOf(RefundCreatedByUserEventDetails.class)));
-        
+
         assertThat(refundEvents, hasItem(refundAvailabilityUpdated));
     }
 
@@ -227,7 +227,7 @@ class EventFactoryTest {
                 .withStatus(RefundStatus.REFUND_ERROR.getValue())
                 .withUserExternalId("user_external_id")
                 .withChargeExternalId(chargeEntity.getExternalId())
-                .withGatewayTransactionId(randomAlphanumeric(30))
+                .withGatewayTransactionId(randomAlphaNumeric(30))
                 .withAmount(chargeEntity.getAmount())
                 .build();
         when(refundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(
@@ -274,7 +274,7 @@ class EventFactoryTest {
         RefundAvailabilityUpdated refundAvailabilityUpdated = mock(RefundAvailabilityUpdated.class);
         when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(chargeEntity), chargeEventEntity.getUpdated().toInstant()))
                 .thenReturn(refundAvailabilityUpdated);
-        
+
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
 
         assertThat(events.size(), is(2));
@@ -302,7 +302,7 @@ class EventFactoryTest {
         RefundAvailabilityUpdated refundAvailabilityUpdated = mock(RefundAvailabilityUpdated.class);
         when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(chargeEntity), chargeEventEntity.getUpdated().toInstant()))
                 .thenReturn(refundAvailabilityUpdated);
-        
+
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
 
         assertThat(events.size(), is(2)); // also creates RefundAvailabilityUpdated event
@@ -361,7 +361,7 @@ class EventFactoryTest {
         RefundAvailabilityUpdated refundAvailabilityUpdated = mock(RefundAvailabilityUpdated.class);
         when(chargeService.createRefundAvailabilityUpdatedEvent(Charge.from(chargeEntity), chargeEventEntity.getUpdated().toInstant()))
                 .thenReturn(refundAvailabilityUpdated);
-        
+
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
 
         assertThat(events.size(), is(2));
@@ -583,7 +583,7 @@ class EventFactoryTest {
         assertThat(eventDetails.getVersion3DS(), is("2.1.0"));
         assertThat(eventDetails.isRequires3DS(), is(true));
     }
-    
+
     @Test
     void shouldCreateCorrectEventForCancelledWithGatewayAfterAuthorisationErrorEvent() throws EventCreationException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
@@ -610,11 +610,11 @@ class EventFactoryTest {
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
 
         assertThat(events.size(), is(2));
-        
+
         CancelledWithGatewayAfterAuthorisationError event = (CancelledWithGatewayAfterAuthorisationError) events.get(0);
         assertThat(event.getEventDetails(), is(instanceOf(CancelledWithGatewayAfterAuthorisationErrorEventDetails.class)));
         assertThat(event.getResourceExternalId(), is(chargeEventEntity.getChargeEntity().getExternalId()));
-        
+
         CancelledWithGatewayAfterAuthorisationErrorEventDetails eventDetails = (CancelledWithGatewayAfterAuthorisationErrorEventDetails) event.getEventDetails();
         assertThat(eventDetails.getGatewayTransactionId(), is("gateway_transaction_id"));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/model/response/GatewayResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/response/GatewayResponseTest.java
@@ -10,10 +10,10 @@ import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 
 
- class GatewayResponseTest {
+class GatewayResponseTest {
 
     @Test
-     void shouldHandleAGatewayError() {
+    void shouldHandleAGatewayError() {
         GatewayError error = new GatewayError(
                 "an error message",
                 GENERIC_GATEWAY_ERROR);
@@ -22,8 +22,8 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
         GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
                 .withGatewayError(error)
                 .build();
-        assertThat(gatewayResponse.isFailed(), is(true));
-        assertThat(gatewayResponse.isSuccessful(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().get(), is(error));
@@ -31,28 +31,28 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
 
 
     @Test
-     void shouldHandleAValidGatewayResponse() {
+    void shouldHandleAValidGatewayResponse() {
         BaseResponse baseResponse = createBaseResponseWith(null, null);
         GatewayResponseBuilder<BaseResponse> gatewayResponseBuilder = responseBuilder();
         GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
                 .withResponse(baseResponse)
                 .build();
-        assertThat(gatewayResponse.isFailed(), is(false));
-        assertThat(gatewayResponse.isSuccessful(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get(), is(baseResponse));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
     }
 
     @Test
-     void shouldHandleAGatewayResponseWithAnErrorCodeAndMessage() {
+    void shouldHandleAGatewayResponseWithAnErrorCodeAndMessage() {
         BaseResponse baseResponse = createBaseResponseWith("123", "oops, something went wrong");
         GatewayResponseBuilder<BaseResponse> gatewayResponseBuilder = responseBuilder();
         GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
                 .withResponse(baseResponse)
                 .build();
-        assertThat(gatewayResponse.isFailed(), is(true));
-        assertThat(gatewayResponse.isSuccessful(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().get().getMessage(),

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
@@ -45,10 +45,10 @@ class StripeCancelHandlerTest {
     private GatewayClient client;
     @Mock
     private StripeGatewayConfig stripeGatewayConfig;
-    
+
     @InjectMocks
     private StripeCancelHandler stripeCancelHandler;
-    
+
     private ChargeEntity chargeEntity;
 
     @BeforeEach
@@ -70,24 +70,24 @@ class StripeCancelHandlerTest {
     void shouldCancelPaymentSuccessfully() throws Exception {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
         final GatewayResponse<BaseCancelResponse> response = stripeCancelHandler.cancel(request);
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         verify(client).postRequestFor(any(StripePaymentIntentCancelRequest.class));
-    } 
-    
+    }
+
     @Test
     void shouldCancelPaymentSuccessfullyUsingPaymentIntents() throws Exception {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(aValidChargeEntity()
                 .withGatewayAccountEntity(buildGatewayAccountEntity())
                 .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
-                                .withCredentials(Map.of("stripe_account_id", "stripe_account_id"))
-                                .withPaymentProvider(STRIPE.getName())
-                                .withState(ACTIVE)
-                                .build())
+                        .withCredentials(Map.of("stripe_account_id", "stripe_account_id"))
+                        .withPaymentProvider(STRIPE.getName())
+                        .withState(ACTIVE)
+                        .build())
                 .withTransactionId("pi_123")
                 .withAmount(10000L)
                 .build());
         final GatewayResponse<BaseCancelResponse> response = stripeCancelHandler.cancel(request);
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         verify(client).postRequestFor(any(StripePaymentIntentCancelRequest.class));
     }
 
@@ -99,7 +99,7 @@ class StripeCancelHandlerTest {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), Is.is(true));
         assertThat(gatewayResponse.getGatewayError().get().getMessage(), Is.is("Unexpected HTTP status code 402 from gateway"));
         assertThat(gatewayResponse.getGatewayError().get().getErrorType(), Is.is(GATEWAY_ERROR));
@@ -113,7 +113,7 @@ class StripeCancelHandlerTest {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), Is.is(true));
         assertThat(gatewayResponse.getGatewayError().get().getMessage(), Is.is("Problem with Stripe servers"));
         assertThat(gatewayResponse.getGatewayError().get().getErrorType(), Is.is(GATEWAY_ERROR));
@@ -127,16 +127,16 @@ class StripeCancelHandlerTest {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
     }
 
     private GatewayAccountEntity buildGatewayAccountEntity() {
         var gatewayAccountEntity = aGatewayAccountEntity()
-        .withId(1L)
-        .withGatewayName("stripe")
-        .withRequires3ds(false)
-        .withType(TEST)
-        .build();
+                .withId(1L)
+                .withGatewayName("stripe")
+                .withRequires3ds(false)
+                .withType(TEST)
+                .build();
 
         var gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
                 .withCredentials(Map.of("stripe_account_id", "stripe_account_id"))

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import jakarta.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -7,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
-import jakarta.ws.rs.WebApplicationException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,8 +18,8 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
@@ -139,10 +139,7 @@ class GatewayAccountEntityTest {
 
     @Test
     void isAllowGooglePayShouldReturnTrueForWorldpayAccountIfFlagIsEnabledAndMerchantAccountIdIsAvailableOnCredentials() {
-        GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
-                .withPaymentProvider("worldpay")
-                .withCredentials(Map.of("gateway_merchant_id", "some-id"))
-                .build();
+        GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGateway_account_credentials_entity_with_gateway_merchant_id();
         gatewayAccountEntity.setAllowGooglePay(true);
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay));
 
@@ -151,10 +148,7 @@ class GatewayAccountEntityTest {
 
     @Test
     void isAllowGooglePayShouldReturnFalseForWorldpayAccountIfFlagIsDisabledAndMerchantAccountIdIsAvailableOnCredentials() {
-        GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
-                .withPaymentProvider("worldpay")
-                .withCredentials(Map.of("gateway_merchant_id", "some-id"))
-                .build();
+        GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGateway_account_credentials_entity_with_gateway_merchant_id();
         gatewayAccountEntity.setAllowGooglePay(false);
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay));
 
@@ -168,16 +162,13 @@ class GatewayAccountEntityTest {
                 .build();
         gatewayAccountEntity.setAllowGooglePay(true);
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityStripe));
-        
+
         assertThat(gatewayAccountEntity.isAllowGooglePay(), is(true));
     }
 
     @Test
     void getGatewayMerchantIdShouldReturnIdAvailableOnCredentials() {
-        GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
-                .withPaymentProvider("worldpay")
-                .withCredentials(Map.of("gateway_merchant_id", "some-id"))
-                .build();
+        GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGateway_account_credentials_entity_with_gateway_merchant_id();
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay));
 
         assertThat(gatewayAccountEntity.getGooglePayMerchantId(), is("some-id"));
@@ -201,43 +192,47 @@ class GatewayAccountEntityTest {
                 .build();
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay));
 
-        assertThrows(WebApplicationException.class, () -> {
-            gatewayAccountEntity.getGatewayAccountCredentialsEntity("sandbox");
-        }, "No credentials exists for payment provider");
+        assertThrows(WebApplicationException.class, () -> gatewayAccountEntity.getGatewayAccountCredentialsEntity("sandbox"), "No credentials exists for payment provider");
     }
 
     @Test
-    void getGatewayAccountCredentialsEntityByProviderShouldReturnCorrectCredential() {
+    void getWorldpayGatewayAccountCredentialsEntityByProviderShouldReturnCorrectCredential() {
         GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
                 .withCredentials(Map.of("stripe-accnt-id", "some-id"))
                 .withPaymentProvider("stripe").build();
+
         GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
                 .withPaymentProvider("worldpay")
-                .withCredentials(Map.of("username", "some-user-name"))
+                .withCredentials(Map.of(ONE_OFF_CUSTOMER_INITIATED, Map.of("username", "some-user-name")))
                 .build();
+
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntity, credentialsEntityWorldpay));
 
         GatewayAccountCredentialsEntity actualCreds = gatewayAccountEntity.getGatewayAccountCredentialsEntity("worldpay");
         assertThat(actualCreds.getPaymentProvider(), is("worldpay"));
-        assertThat(actualCreds.getCredentials(), hasEntry("username", "some-user-name"));
+
+        var credsObj = (WorldpayCredentials) actualCreds.getCredentialsObject();
+        assertThat(credsObj.getOneOffCustomerInitiatedCredentials().isPresent(), is(true));
+        assertThat(credsObj.getOneOffCustomerInitiatedCredentials().get().getUsername(), is("some-user-name"));
     }
 
     @Test
     void getGatewayAccountCredentialsEntityByProviderShouldReturnLatestActiveCredentialIfMultipleExists() {
         GatewayAccountCredentialsEntity credentialsEntityWorldpayLatest = aGatewayAccountCredentialsEntity()
                 .withPaymentProvider("worldpay")
-                .withCredentials(Map.of("username", "latest-creds-user-name"))
+                .withCredentials(Map.of(ONE_OFF_CUSTOMER_INITIATED, Map.of("username", "latest-creds-user-name")))
                 .withActiveStartDate(Instant.now())
                 .build();
         GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
                 .withPaymentProvider("worldpay")
-                .withCredentials(Map.of("username", "old-creds-user-name"))
+                .withCredentials(Map.of(ONE_OFF_CUSTOMER_INITIATED, Map.of("username", "old-creds-user-name")))
                 .withActiveStartDate(Instant.now().minus(10, DAYS))
                 .build();
-        gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityWorldpay, credentialsEntityWorldpayLatest));
+        gatewayAccountEntitySetCredentialsList(credentialsEntityWorldpay, credentialsEntityWorldpayLatest);
 
         GatewayAccountCredentialsEntity actualCreds = gatewayAccountEntity.getGatewayAccountCredentialsEntity("worldpay");
-        assertThat(actualCreds.getCredentials(), hasEntry("username", "latest-creds-user-name"));
+        var worldpayCreds = (WorldpayCredentials) actualCreds.getCredentialsObject();
+        assertThat(worldpayCreds.getOneOffCustomerInitiatedCredentials().get().getUsername(), is("latest-creds-user-name"));
     }
 
     @Test
@@ -256,21 +251,23 @@ class GatewayAccountEntityTest {
             GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
                     .withCredentials(Map.of("stripe-accnt-id", "some-id"))
                     .withPaymentProvider("stripe").build();
+
             GatewayAccountCredentialsEntity credentialsEntityWorldpay = aGatewayAccountCredentialsEntity()
                     .withPaymentProvider("worldpay")
-                    .withCredentials(Map.of("username", "some-user-name"))
+                    .withCredentials(Map.of(ONE_OFF_CUSTOMER_INITIATED, Map.of("username", "some-user-name")))
                     .build();
             gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntity, credentialsEntityWorldpay));
 
             GatewayAccountCredentialsEntity actualCreds = gatewayAccountEntity.getRecentNonRetiredGatewayAccountCredentialsEntity("worldpay");
             assertThat(actualCreds.getPaymentProvider(), is("worldpay"));
-            assertThat(actualCreds.getCredentials(), hasEntry("username", "some-user-name"));
+            var worldpayCreds = (WorldpayCredentials) actualCreds.getCredentialsObject();
+            assertThat(worldpayCreds.getOneOffCustomerInitiatedCredentials().get().getUsername(), is("some-user-name"));
         }
 
         @Test
         void shouldReturnNonRetiredCredential() {
             GatewayAccountCredentialsEntity credentialsEntityRetired = aGatewayAccountCredentialsEntity()
-                    .withCredentials(Map.of("username", "retired-creds-user-name"))
+                    .withCredentials(Map.of(ONE_OFF_CUSTOMER_INITIATED, Map.of("username", "retired-creds-user-name")))
                     .withState(RETIRED)
                     .withCreatedDate(Instant.now())
                     .withPaymentProvider("worldpay")
@@ -278,34 +275,31 @@ class GatewayAccountEntityTest {
             GatewayAccountCredentialsEntity credentialsEntityActive = aGatewayAccountCredentialsEntity()
                     .withState(ACTIVE)
                     .withCreatedDate(Instant.now().minus(1, MINUTES))
-                    .withCredentials(Map.of("username", "active-creds-user-name"))
+                    .withCredentials(Map.of(ONE_OFF_CUSTOMER_INITIATED, Map.of("username", "active-creds-user-name")))
                     .withPaymentProvider("worldpay")
                     .build();
             gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityRetired, credentialsEntityActive));
 
             GatewayAccountCredentialsEntity actualCreds = gatewayAccountEntity.getRecentNonRetiredGatewayAccountCredentialsEntity("worldpay");
-            assertThat(actualCreds.getCredentials(), hasEntry("username", "active-creds-user-name"));
+            var worldpayCreds = (WorldpayCredentials) actualCreds.getCredentialsObject();
+            assertThat(worldpayCreds.getOneOffCustomerInitiatedCredentials().get().getUsername(), is("active-creds-user-name"));
             assertThat(actualCreds.getState(), is(ACTIVE));
         }
 
         @Test
         void shouldReturnLatestCredentialIfMultipleExistForPaymentProvider() {
             GatewayAccountCredentialsEntity credentialsEntityLatest = aGatewayAccountCredentialsEntity()
-                    .withCredentials(Map.of("username", "latest-creds-user-name"))
+                    .withCredentials(Map.of(ONE_OFF_CUSTOMER_INITIATED, Map.of("username", "latest-creds-user-name")))
                     .withState(CREATED)
                     .withCreatedDate(Instant.now())
                     .withPaymentProvider("worldpay")
                     .build();
-            GatewayAccountCredentialsEntity credentialsEntityOld = aGatewayAccountCredentialsEntity()
-                    .withState(ACTIVE)
-                    .withCreatedDate(Instant.now().minus(10, MINUTES))
-                    .withCredentials(Map.of("username", "old-creds-user-name"))
-                    .withPaymentProvider("worldpay")
-                    .build();
+            GatewayAccountCredentialsEntity credentialsEntityOld = aGatewayAccountCredentialsEntityOldWithActiveState();
             gatewayAccountEntity.setGatewayAccountCredentials(List.of(credentialsEntityLatest, credentialsEntityOld));
 
             GatewayAccountCredentialsEntity actualCreds = gatewayAccountEntity.getRecentNonRetiredGatewayAccountCredentialsEntity("worldpay");
-            assertThat(actualCreds.getCredentials(), hasEntry("username", "latest-creds-user-name"));
+            var worldpayCreds = (WorldpayCredentials) actualCreds.getCredentialsObject();
+            assertThat(worldpayCreds.getOneOffCustomerInitiatedCredentials().get().getUsername(), is("latest-creds-user-name"));
             assertThat(actualCreds.getState(), is(CREATED));
         }
 
@@ -317,5 +311,25 @@ class GatewayAccountEntityTest {
             });
         }
 
+    }
+
+    private GatewayAccountCredentialsEntity aGateway_account_credentials_entity_with_gateway_merchant_id() {
+        return aGatewayAccountCredentialsEntity()
+                .withPaymentProvider("worldpay")
+                .withCredentials(Map.of("gateway_merchant_id", "some-id"))
+                .build();
+    }
+
+    private void gatewayAccountEntitySetCredentialsList(GatewayAccountCredentialsEntity... entries) {
+        gatewayAccountEntity.setGatewayAccountCredentials(List.of(entries));
+    }
+
+    private GatewayAccountCredentialsEntity aGatewayAccountCredentialsEntityOldWithActiveState() {
+        return aGatewayAccountCredentialsEntity()
+                .withState(ACTIVE)
+                .withCreatedDate(Instant.now().minus(10, MINUTES))
+                .withCredentials(Map.of(ONE_OFF_CUSTOMER_INITIATED, Map.of("username", "old-creds-user-name")))
+                .withPaymentProvider("worldpay")
+                .build();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
@@ -12,31 +12,20 @@ import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.isA;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_CUSTOMER_INITIATED;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING_MERCHANT_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeCredentials.STRIPE_ACCOUNT_ID_KEY;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
-import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator.FIELD_GATEWAY_MERCHANT_ID;
 
 class GatewayAccountCredentialsEntityTest {
 
@@ -158,31 +147,34 @@ class GatewayAccountCredentialsEntityTest {
                 .withPaymentProvider(WORLDPAY.getName())
                 .build();
 
-        var worldpayCredentials = (WorldpayCredentials)credentialsEntity.getCredentialsObject();
+        var worldpayCredentials = (WorldpayCredentials) credentialsEntity.getCredentialsObject();
         worldpayCredentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials("one-off-merchant-code", "one-off-username", "one-off-password"));
         worldpayCredentials.setRecurringCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials("cit-merchant-code", "cit-username", "cit-password"));
         worldpayCredentials.setRecurringMerchantInitiatedCredentials(new WorldpayMerchantCodeCredentials("mit-merchant-code", "mit-username", "mit-password"));
         worldpayCredentials.setGooglePayMerchantId("google-pay-merchant-id");
-        
+
         credentialsEntity.setCredentials(worldpayCredentials);
 
-        assertThat(credentialsEntity.getCredentials().entrySet(), hasSize(4));
-        assertThat(credentialsEntity.getCredentials(), hasEntry(FIELD_GATEWAY_MERCHANT_ID, "google-pay-merchant-id"));
-        assertThat(credentialsEntity.getCredentials(), hasKey(ONE_OFF_CUSTOMER_INITIATED));
-        assertThat(((Map<String, String>) credentialsEntity.getCredentials().get(ONE_OFF_CUSTOMER_INITIATED)).entrySet(), hasSize(3));
-        assertThat((Map<String, String>) credentialsEntity.getCredentials().get(ONE_OFF_CUSTOMER_INITIATED), hasEntry(CREDENTIALS_MERCHANT_CODE, "one-off-merchant-code"));
-        assertThat((Map<String, String>) credentialsEntity.getCredentials().get(ONE_OFF_CUSTOMER_INITIATED), hasEntry(CREDENTIALS_USERNAME, "one-off-username"));
-        assertThat((Map<String, String>) credentialsEntity.getCredentials().get(ONE_OFF_CUSTOMER_INITIATED), hasEntry(CREDENTIALS_PASSWORD, "one-off-password"));
-        assertThat(credentialsEntity.getCredentials(), hasKey(RECURRING_CUSTOMER_INITIATED));
-        assertThat(((Map<String, String>) credentialsEntity.getCredentials().get(RECURRING_CUSTOMER_INITIATED)).entrySet(), hasSize(3));
-        assertThat((Map<String, String>) credentialsEntity.getCredentials().get(RECURRING_CUSTOMER_INITIATED), hasEntry(CREDENTIALS_MERCHANT_CODE, "cit-merchant-code"));
-        assertThat((Map<String, String>) credentialsEntity.getCredentials().get(RECURRING_CUSTOMER_INITIATED), hasEntry(CREDENTIALS_USERNAME, "cit-username"));
-        assertThat((Map<String, String>) credentialsEntity.getCredentials().get(RECURRING_CUSTOMER_INITIATED), hasEntry(CREDENTIALS_PASSWORD, "cit-password"));
-        assertThat(credentialsEntity.getCredentials(), hasKey(RECURRING_MERCHANT_INITIATED));
-        assertThat(((Map<String, String>) credentialsEntity.getCredentials().get(RECURRING_MERCHANT_INITIATED)).entrySet(), hasSize(3));
-        assertThat((Map<String, String>) credentialsEntity.getCredentials().get(RECURRING_MERCHANT_INITIATED), hasEntry(CREDENTIALS_MERCHANT_CODE, "mit-merchant-code"));
-        assertThat((Map<String, String>) credentialsEntity.getCredentials().get(RECURRING_MERCHANT_INITIATED), hasEntry(CREDENTIALS_USERNAME, "mit-username"));
-        assertThat((Map<String, String>) credentialsEntity.getCredentials().get(RECURRING_MERCHANT_INITIATED), hasEntry(CREDENTIALS_PASSWORD, "mit-password"));
+        var saved = (WorldpayCredentials) credentialsEntity.getCredentialsObject();
+
+        assertThat(saved.hasCredentials(), is(true));
+        assertThat(saved.getGooglePayMerchantId().orElse(null), is("google-pay-merchant-id"));
+
+        assertTrue(saved.getOneOffCustomerInitiatedCredentials().isPresent());
+        assertThat(saved.getOneOffCustomerInitiatedCredentials().get().getMerchantCode(), is("one-off-merchant-code"));
+        assertThat(saved.getOneOffCustomerInitiatedCredentials().get().getUsername(), is("one-off-username"));
+        assertThat(saved.getOneOffCustomerInitiatedCredentials().get().getPassword(), is("one-off-password"));
+
+        assertTrue(saved.getRecurringCustomerInitiatedCredentials().isPresent());
+        assertThat(saved.getRecurringCustomerInitiatedCredentials().get().getMerchantCode(), is("cit-merchant-code"));
+        assertThat(saved.getRecurringCustomerInitiatedCredentials().get().getUsername(), is("cit-username"));
+        assertThat(saved.getRecurringCustomerInitiatedCredentials().get().getPassword(), is("cit-password"));
+
+        assertTrue(saved.getRecurringMerchantInitiatedCredentials().isPresent());
+        assertThat(saved.getRecurringMerchantInitiatedCredentials().get().getMerchantCode(), is("mit-merchant-code"));
+        assertThat(saved.getRecurringMerchantInitiatedCredentials().get().getUsername(), is("mit-username"));
+        assertThat(saved.getRecurringMerchantInitiatedCredentials().get().getPassword(), is("mit-password"));
+
     }
 
     @Test
@@ -191,10 +183,16 @@ class GatewayAccountCredentialsEntityTest {
                 .withPaymentProvider(WORLDPAY.getName())
                 .build();
 
-        var worldpayCredentials = (WorldpayCredentials)credentialsEntity.getCredentialsObject();
+        var worldpayCredentials = (WorldpayCredentials) credentialsEntity.getCredentialsObject();
         credentialsEntity.setCredentials(worldpayCredentials);
 
-        assertThat(credentialsEntity.getCredentials().entrySet(), hasSize(0));
+        var saved = (WorldpayCredentials) credentialsEntity.getCredentialsObject();
+
+        assertThat(saved.hasCredentials(), is(false));
+        assertThat(saved.getGooglePayMerchantId().isPresent(), is(false));
+        assertTrue(saved.getOneOffCustomerInitiatedCredentials().isEmpty());
+        assertTrue(saved.getRecurringCustomerInitiatedCredentials().isEmpty());
+        assertTrue(saved.getRecurringMerchantInitiatedCredentials().isEmpty());
     }
 
     @Test
@@ -203,7 +201,7 @@ class GatewayAccountCredentialsEntityTest {
                 .withPaymentProvider(EPDQ.getName())
                 .build();
 
-        var epdqCredentials = (EpdqCredentials)credentialsEntity.getCredentialsObject();
+        var epdqCredentials = (EpdqCredentials) credentialsEntity.getCredentialsObject();
         epdqCredentials.setMerchantId("a-merchant-id");
         epdqCredentials.setUsername("a-username");
         epdqCredentials.setPassword("a-password");
@@ -212,12 +210,13 @@ class GatewayAccountCredentialsEntityTest {
 
         credentialsEntity.setCredentials(epdqCredentials);
 
-        assertThat(credentialsEntity.getCredentials().entrySet(), hasSize(5));
-        assertThat(credentialsEntity.getCredentials(), hasEntry(CREDENTIALS_MERCHANT_ID, "a-merchant-id"));
-        assertThat(credentialsEntity.getCredentials(), hasEntry(CREDENTIALS_USERNAME, "a-username"));
-        assertThat(credentialsEntity.getCredentials(), hasEntry(CREDENTIALS_PASSWORD, "a-password"));
-        assertThat(credentialsEntity.getCredentials(), hasEntry(CREDENTIALS_SHA_IN_PASSPHRASE, "a-sha-in-passphrase"));
-        assertThat(credentialsEntity.getCredentials(), hasEntry(CREDENTIALS_SHA_OUT_PASSPHRASE, "a-sha-out-passphrase"));
+        var saved = (EpdqCredentials) credentialsEntity.getCredentialsObject();
+        assertThat(saved.hasCredentials(), is(true));
+        assertThat(saved.getMerchantId(), is("a-merchant-id"));
+        assertThat(saved.getUsername(), is("a-username"));
+        assertThat(saved.getPassword(), is("a-password"));
+        assertThat(saved.getShaInPassphrase(), is("a-sha-in-passphrase"));
+        assertThat(saved.getShaOutPassphrase(), is("a-sha-out-passphrase"));
     }
 
     @Test
@@ -227,11 +226,13 @@ class GatewayAccountCredentialsEntityTest {
                 .build();
 
         var stripeAccountId = "a-stripe-account-id";
-        var stripeCredentials = (StripeCredentials)credentialsEntity.getCredentialsObject();
+        var stripeCredentials = (StripeCredentials) credentialsEntity.getCredentialsObject();
         stripeCredentials.setStripeAccountId(stripeAccountId);
-        
+
         credentialsEntity.setCredentials(stripeCredentials);
-        assertThat(credentialsEntity.getCredentials().entrySet(), hasSize(1));
-        assertThat(credentialsEntity.getCredentials(), hasEntry(STRIPE_ACCOUNT_ID_KEY, stripeAccountId));
+
+        var saved = (StripeCredentials) credentialsEntity.getCredentialsObject();
+        assertThat(saved.hasCredentials(), is(true));
+        assertThat(saved.getStripeAccountId(), is(stripeAccountId));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpayIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpayIT.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
@@ -46,7 +46,7 @@ public class GatewayAccountCredentialsResourceWorldpayIT {
         accountId = testAccount.getAccountId();
         credentialsId = testAccount.getCredentials().get(0).getId();
     }
-    
+
     @Test
     void existingOneOffCredentialsCanBeReplaced() {
         app.givenSetup()
@@ -173,7 +173,7 @@ public class GatewayAccountCredentialsResourceWorldpayIT {
     void checkWorldpayCredentials_returns500WhenWorldpayReturnsUnexpectedResponse() {
         app.getWorldpayMockClient().mockCredentialsValidationUnexpectedResponse();
 
-        long accountId = nextLong(2, 10000);
+        long accountId = current().nextLong(2, 10000);
         app.getDatabaseFixtures().aTestAccount().withAccountId(accountId).withPaymentProvider("worldpay").insert();
         app.givenSetup()
                 .body(Map.of(
@@ -189,7 +189,7 @@ public class GatewayAccountCredentialsResourceWorldpayIT {
 
     private DatabaseFixtures.TestAccount addGatewayAccountAndCredential(String paymentProvider, GatewayAccountCredentialState state,
                                                                         GatewayAccountType gatewayAccountType) {
-        long accountId = nextLong(2, 10000);
+        long accountId = current().nextLong(2, 10000);
         LocalDateTime createdDate = LocalDate.parse("2021-01-01").atStartOfDay();
         LocalDateTime activeStartDate = LocalDate.parse("2021-02-01").atStartOfDay();
         LocalDateTime activeEndDate = LocalDate.parse("2021-03-01").atStartOfDay();

--- a/src/test/java/uk/gov/pay/connector/it/base/AddChargeParameters.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/AddChargeParameters.java
@@ -7,7 +7,7 @@ import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.time.Instant;
 
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
 
 public record AddChargeParameters(long chargeId, String externalChargeId, ChargeStatus chargeStatus,
@@ -16,7 +16,7 @@ public record AddChargeParameters(long chargeId, String externalChargeId, Charge
 
 
     public static final class Builder {
-        private long chargeId = nextLong();
+        private long chargeId = current().nextLong(0, Long.MAX_VALUE);
         private String externalChargeId = RandomIdGenerator.newId();
         private ChargeStatus chargeStatus;
         private ServicePaymentReference reference = ServicePaymentReference.of("ref");

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -100,7 +100,7 @@ public class StripePaymentProviderTest {
     @Test
     public void createCharge() {
         GatewayResponse gatewayResponse = authorise();
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -113,7 +113,7 @@ public class StripePaymentProviderTest {
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class StripePaymentProviderTest {
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -151,7 +151,7 @@ public class StripePaymentProviderTest {
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -165,7 +165,7 @@ public class StripePaymentProviderTest {
 
         StripeAuthorisationResponse response = gatewayResponse.getBaseResponse().get();
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
         assertThat(response.getGatewayRecurringAuthToken().isPresent(), is(true));
         assertThat(response.getGatewayRecurringAuthToken().get(), hasKey(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY));
         assertThat(response.getGatewayRecurringAuthToken().get(), hasKey(STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY));
@@ -192,7 +192,7 @@ public class StripePaymentProviderTest {
         ChargeEntity chargeEntity = getCharge();
         chargeEntity.setGatewayTransactionId(gatewayResponse.getBaseResponse().get().getTransactionId());
         GatewayResponse<BaseCancelResponse> cancelResponse = stripePaymentProvider.cancel(CancelGatewayRequest.valueOf(chargeEntity));
-        assertTrue(cancelResponse.isSuccessful());
+        assertTrue(cancelResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -296,7 +296,7 @@ public class StripePaymentProviderTest {
 
         var gatewayRequest = RecurringPaymentAuthorisationGatewayRequest.valueOf(recurringCharge);
         GatewayResponse authoriseUserNotPresentResponse = stripePaymentProvider.authoriseUserNotPresent(gatewayRequest);
-        
+
         assertThat(authoriseUserNotPresentResponse.getBaseResponse().get(), instanceOf(StripeAuthorisationFailedResponse.class));
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsIT.java
@@ -25,7 +25,7 @@ import uk.gov.service.payments.commons.model.CardExpiryDate;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.nullValue;
@@ -73,7 +73,7 @@ public class ChargeDaoCardDetailsIT {
 
     @Test
     void findById_shouldFindCardDetails() {
-        long chargeId = nextLong();
+        long chargeId = current().nextLong(0, Long.MAX_VALUE);
         DatabaseFixtures.TestCardDetails testCardDetails = createCardDetailsForChargeWithId(chargeId);
         Optional<ChargeEntity> chargeDaoOptional = chargeDao.findById(chargeId);
 
@@ -96,7 +96,7 @@ public class ChargeDaoCardDetailsIT {
 
     @Test
     void findById_shouldFindCardDetailsIfCardDigitsAreNotPresent() {
-        long chargeId = nextLong();
+        long chargeId = current().nextLong(0, Long.MAX_VALUE);
         DatabaseFixtures.TestCardDetails testCardDetails = app.getDatabaseFixtures()
                 .aTestCardDetails()
                 .withFirstDigitsOfCardNumber(null)
@@ -177,6 +177,6 @@ public class ChargeDaoCardDetailsIT {
         chargeDao.persist(chargeEntity);
 
         Map<String, Object> cardDetailsSaved = app.getDatabaseTestHelper().getChargeCardDetails(chargeEntity.getId());
-        assertThat(cardDetailsSaved, hasEntry("card_type",null));
+        assertThat(cardDetailsSaved, hasEntry("card_type", null));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -50,16 +50,16 @@ public class GatewayAccountDaoIT {
     private GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
     private DatabaseFixtures databaseFixtures;
     private long gatewayAccountId;
-        
+
 
     @BeforeEach
     void setUp() {
         gatewayAccountDao = app.getInstanceFromGuiceContainer(GatewayAccountDao.class);
         gatewayAccountCredentialsDao = app.getInstanceFromGuiceContainer(GatewayAccountCredentialsDao.class);
         databaseFixtures = app.getDatabaseFixtures();
-        gatewayAccountId = nextLong();
+        gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
     }
-    
+
     @Nested
     class FindByServiceId {
 
@@ -93,6 +93,7 @@ public class GatewayAccountDaoIT {
             assertTrue(gatewayAccountDao.findByServiceId("non-existent").isEmpty());
         }
     }
+
     @Nested
     class FindByGatewayAccountId {
 
@@ -206,12 +207,12 @@ public class GatewayAccountDaoIT {
             assertThat(gatewayAccount.getGatewayName(), is(paymentProvider));
         }
     }
-    
+
     @Nested
     class Search {
         @Test
         void shouldReturnAllAccountsWhenNoSearchParameters() {
-            long gatewayAccountId_1 = nextLong();
+            long gatewayAccountId_1 = current().nextLong(0, Long.MAX_VALUE);
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId_1))
                     .build());
@@ -230,7 +231,7 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsById() {
-            long gatewayAccountId_1 = nextLong();
+            long gatewayAccountId_1 = current().nextLong(0, Long.MAX_VALUE);
             String externalId_1 = randomUuid();
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId_1))
@@ -260,7 +261,7 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsByMotoEnabled() {
-            long gatewayAccountId_1 = nextLong();
+            long gatewayAccountId_1 = current().nextLong(0, Long.MAX_VALUE);
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId_1))
                     .withAllowMoto(false)
@@ -281,7 +282,7 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsByApplePayEnabled() {
-            long gatewayAccountId_1 = nextLong();
+            long gatewayAccountId_1 = current().nextLong(0, Long.MAX_VALUE);
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId_1))
                     .withAllowApplePay(false)
@@ -302,7 +303,7 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsByGooglePayEnabled() {
-            long gatewayAccountId_1 = nextLong();
+            long gatewayAccountId_1 = current().nextLong(0, Long.MAX_VALUE);
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId_1))
                     .withAllowGooglePay(false)
@@ -323,7 +324,7 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsByRequires3ds() {
-            long gatewayAccountId_1 = nextLong();
+            long gatewayAccountId_1 = current().nextLong(0, Long.MAX_VALUE);
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId_1))
                     .withRequires3ds(false)
@@ -344,7 +345,7 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsByType() {
-            long gatewayAccountId_1 = nextLong();
+            long gatewayAccountId_1 = current().nextLong(0, Long.MAX_VALUE);
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId_1))
                     .withType(TEST)
@@ -365,9 +366,9 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsByPaymentProvider() {
-            long gatewayAccountId1 = nextLong();
-            long gatewayAccountId2 = nextLong();
-            long gatewayAccountId3 = nextLong();
+            long gatewayAccountId1 = current().nextLong(0, Long.MAX_VALUE);
+            long gatewayAccountId2 = current().nextLong(0, Long.MAX_VALUE);
+            long gatewayAccountId3 = current().nextLong(0, Long.MAX_VALUE);
             AddGatewayAccountCredentialsParams account1_credentials1 = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider(WORLDPAY.getName())
                     .withState(CREATED)
@@ -414,7 +415,7 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsByProviderSwitchEnabled() {
-            long gatewayAccountId_1 = nextLong();
+            long gatewayAccountId_1 = current().nextLong(0, Long.MAX_VALUE);
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId_1))
                     .withPaymentGateway("sandbox")
@@ -437,7 +438,7 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsByPaymentProviderAccountId() {
-            long gatewayAccountId = nextLong();
+            long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId))
                     .withPaymentGateway("sandbox")
@@ -454,7 +455,7 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsByWorldpayMerchantCodeInOneOffPaymentCredentials() {
-            long gatewayAccountId = nextLong();
+            long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId))
                     .withPaymentGateway("worldpay")
@@ -471,7 +472,7 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsByWorldpayMerchantCodeInRecurringCustomerInitiatedCredentials() {
-            long gatewayAccountId = nextLong();
+            long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId))
                     .withPaymentGateway("worldpay")
@@ -488,7 +489,7 @@ public class GatewayAccountDaoIT {
 
         @Test
         void shouldSearchForAccountsByWorldpayMerchantCodeInRecurringMerchantInitiatedCredentials() {
-            long gatewayAccountId = nextLong();
+            long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
             app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(gatewayAccountId))
                     .withPaymentGateway("worldpay")
@@ -503,7 +504,7 @@ public class GatewayAccountDaoIT {
             assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId));
         }
     }
-    
+
     @Test
     void persist_shouldCreateAnAccount() {
         final CardTypeEntity masterCardCredit = app.getDatabaseTestHelper().getMastercardCreditCard();
@@ -576,7 +577,7 @@ public class GatewayAccountDaoIT {
 
     @Test
     void findByExternalId_shouldFindGatewayAccount() {
-        Long id = nextLong();
+        Long id = current().nextLong(0, Long.MAX_VALUE);
         String externalId = randomUuid();
         databaseFixtures
                 .aTestAccount()
@@ -591,7 +592,7 @@ public class GatewayAccountDaoIT {
 
     @Test
     void findByServiceIdAndAccountType_shouldReturnAllAccounts() {
-        long firstAccountId = nextLong();
+        long firstAccountId = current().nextLong(0, Long.MAX_VALUE);
         String firstExternalId = randomUuid();
         String serviceId = randomUuid();
         databaseFixtures
@@ -609,7 +610,7 @@ public class GatewayAccountDaoIT {
                 .withExternalId(secondExternalId)
                 .withServiceId(serviceId)
                 .insert();
-        
+
         List<GatewayAccountEntity> gatewayAccount = gatewayAccountDao.findByServiceIdAndAccountType(serviceId, TEST);
         assertThat(gatewayAccount.size(), is(2));
         assertTrue(gatewayAccount.stream().anyMatch(ga -> ga.getExternalId().equals(firstExternalId)));
@@ -618,7 +619,7 @@ public class GatewayAccountDaoIT {
 
     @Test
     void isATelephonePaymentNotificationAccount_shouldReturnTrueIfTelephonePaymentNotificationsAreEnabled() {
-        long id = nextLong();
+        long id = current().nextLong(0, Long.MAX_VALUE);
         String externalId = randomUuid();
         Map<String, Object> credentials = Map.of(CREDENTIALS_MERCHANT_ID, "merchant-id");
 
@@ -643,7 +644,7 @@ public class GatewayAccountDaoIT {
 
     @Test
     void isATelephonePaymentNotificationAccount_shouldReturnFalseIfTelephonePaymentNotificationsAreNotEnabled() {
-        long id = nextLong();
+        long id = current().nextLong(0, Long.MAX_VALUE);
         String externalId = randomUuid();
         Map<String, Object> credentials = Map.of(CREDENTIALS_MERCHANT_ID, "merchant-id");
 
@@ -651,9 +652,9 @@ public class GatewayAccountDaoIT {
                 .withAccountId(id)
                 .withExternalId(externalId)
                 .withAllowTelephonePaymentNotifications(false)
-                .insert();  
+                .insert();
         databaseFixtures.aTestAccount()
-                .withAccountId(nextLong())
+                .withAccountId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalId(randomUuid())
                 .withPaymentProvider("random payment provider")
                 .withAllowTelephonePaymentNotifications(true)

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/ClientFactoryIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/ClientFactoryIT.java
@@ -30,7 +30,7 @@ import static java.lang.String.format;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
@@ -40,7 +40,7 @@ public class ClientFactoryIT {
 
     private DropwizardTestSupport<ConnectorConfiguration> app;
     
-    private static String DEFAULT_DROPWIZARD_CONFIG = "config/test-it-config.yaml";
+    private static final String DEFAULT_DROPWIZARD_CONFIG = "config/test-it-config.yaml";
 
     @Mock
     MetricRegistry mockMetricRegistry;

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.it.resources;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
@@ -77,7 +77,7 @@ public class CardResourceCaptureIT {
     @Test
     void shouldPreserveCardDetails_IfCaptureReady() {
         String externalChargeId = testBaseExtension.authoriseNewCharge();
-        Long chargeId = Long.valueOf(StringUtils.removeStart(externalChargeId, "charge-"));
+        Long chargeId = Long.valueOf(Strings.CS.removeStart(externalChargeId, "charge-"));
 
         Map<String, Object> chargeCardDetails = app.getDatabaseTestHelper().getChargeCardDetailsByChargeId(chargeId);
         assertThat(chargeCardDetails.isEmpty(), is(false));

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceIT.java
@@ -13,11 +13,11 @@ import java.util.List;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
+import static jakarta.ws.rs.core.Response.Status.OK;
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.util.Arrays.asList;
-import static jakarta.ws.rs.core.Response.Status.OK;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -40,10 +40,10 @@ public class ChargeExpiryResourceIT {
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
-    
+
     private static final String JSON_CHARGE_KEY = "charge_id";
     private static final String JSON_STATE_KEY = "state.status";
-    
+
     @Test
     void shouldExpireChargesAndHaveTheCorrectEvents() {
         String extChargeId1 = testBaseExtension.addCharge(
@@ -241,7 +241,7 @@ public class ChargeExpiryResourceIT {
                 .withCreatedDate(Instant.now().minus(90, MINUTES))
                 .withTransactionId(gatewayTransactionId1)
                 .build());
-        
+
         String extChargeId2 = testBaseExtension.addCharge(
                 anAddChargeParameters().withChargeStatus(AUTHORISATION_SUCCESS)
                         .withCreatedDate(Instant.now().minus(90, MINUTES)).build());
@@ -288,7 +288,7 @@ public class ChargeExpiryResourceIT {
 
     @Test
     void shouldPreserveCardDetailsIfChargeExpires() {
-        Long chargeId = nextLong();
+        Long chargeId = current().nextLong(0, Long.MAX_VALUE);
         AddChargeParameters addChargeParameters = anAddChargeParameters().withChargeStatus(AUTHORISATION_SUCCESS)
                 .withCreatedDate(Instant.now().minus(90, MINUTES))
                 .withChargeId(chargeId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -1072,7 +1072,6 @@ public class ChargesApiResourceCreateIT {
                     .then()
                     .statusCode(NOT_FOUND.getStatusCode())
                     .body("message[0]", CoreMatchers.is("Gateway account not found for service external id [valid-service-id] and account type [live]"));
-            ;
         }
 
         @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -5,9 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.restassured.response.ValidatableResponse;
 import jakarta.ws.rs.core.Response.Status;
-import org.apache.commons.lang3.RandomUtils;
 import org.hamcrest.CoreMatchers;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -51,6 +49,7 @@ import static jakarta.ws.rs.core.Response.Status.OK;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -91,15 +90,15 @@ import static uk.gov.service.payments.commons.model.Source.CARD_PAYMENT_LINK;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class ChargesApiResourceCreateIT {
-    
+
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(
             config("eventQueue.eventQueueEnabled", "true"),
             config("captureProcessConfig.backgroundProcessingEnabled", "true"));
-    
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
-    
+
     private static final String VALID_CARD_NUMBER = "4242424242424242";
     private static final String VALID_SERVICE_ID = "valid-service-id";
     private String testGatewayAccountId;
@@ -131,10 +130,10 @@ public class ChargesApiResourceCreateIT {
                 .statusCode(201)
                 .extract().path("gateway_account_id");
     }
-    
+
     @Nested
     class ByGatewayAccountId {
-        
+
         @Test
         void should_create_charge_and_retrieve_details_successfully() {
             ValidatableResponse response = app.givenSetup()
@@ -276,7 +275,7 @@ public class ChargesApiResourceCreateIT {
             var authLinkParams = (Map<String, String>) authLink.get("params");
             assertThat(authLinkParams.get("one_time_token"), is(not(blankOrNullString())));
         }
-        
+
         @Test
         void should_create_charge_with_no_email_field() {
             app.givenSetup()
@@ -316,14 +315,14 @@ public class ChargesApiResourceCreateIT {
 
         @ParameterizedTest
         @CsvSource(nullValues = "null", textBlock = """
-        instalment,INSTALMENT, 
-        recurring,RECURRING, 
-        unscheduled,UNSCHEDULED
-        null, RECURRING
-        """)
+                instalment,INSTALMENT, 
+                recurring,RECURRING, 
+                unscheduled,UNSCHEDULED
+                null, RECURRING
+                """)
         void should_create_recurring_charge_with_agreement_type_and_retrieve_details_successfully(String requestAgreementPaymentType, AgreementPaymentType expectedAgreementPaymentType) {
             app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testGatewayAccountId));
-            Long paymentInstrumentId = RandomUtils.nextLong();
+            Long paymentInstrumentId = current().nextLong(0, Long.MAX_VALUE);
 
             AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
                     .withPaymentInstrumentId(paymentInstrumentId)
@@ -339,14 +338,14 @@ public class ChargesApiResourceCreateIT {
             app.getDatabaseTestHelper().addAgreement(agreementParams);
 
             Map<String, Object> payloadMap = new HashMap<>();
-            
+
             payloadMap.put("amount", 6234L);
             payloadMap.put("reference", "Test reference");
             payloadMap.put("description", "Test description");
             payloadMap.put("authorisation_mode", "agreement");
             payloadMap.put("agreement_id", agreementId);
             payloadMap.put("agreement_payment_type", requestAgreementPaymentType);
-            
+
             ValidatableResponse createResponse = app.givenSetup()
                     .body(toJson(payloadMap))
                     .post(format("/v1/api/accounts/%s/charges", testGatewayAccountId))
@@ -387,14 +386,14 @@ public class ChargesApiResourceCreateIT {
                     .body("containsKey('card_details')", is(false))
                     .body("agreement_payment_type", is(expectedAgreementPaymentType.getName()));
         }
-        
+
         @Nested
         class BadRequest {
             @Test
             void when_reference_is_a_card_number_for_payment_link_payment() throws JsonProcessingException {
                 var cardInformation = aCardInformation().build();
                 app.getCardidStub().returnCardInformation(VALID_CARD_NUMBER, cardInformation);
-    
+
                 app.givenSetup()
                         .body(toJson(Map.of(
                                 "amount", 6234L,
@@ -411,7 +410,7 @@ public class ChargesApiResourceCreateIT {
                         .body("message[0]", is("Card number entered in a payment link reference"));
             }
         }
-        
+
         @Nested
         class ReturnUnprocessableContent {
 
@@ -433,7 +432,7 @@ public class ChargesApiResourceCreateIT {
                         .body("message[0]", is(format("Gateway account %s is LIVE, but is configured to use a " +
                                 "non-https return_url", liveGatewayAccountId)));
             }
-            
+
             @Test
             void when_moto_is_true_and_moto_not_allowed_for_account() {
                 //by default, gateway account does not have moto enabled
@@ -450,9 +449,10 @@ public class ChargesApiResourceCreateIT {
                         .statusCode(422)
                         .contentType(JSON)
                         .body("message", contains("MOTO payments are not enabled for this gateway account"))
-                        .body("error_identifier", is(ErrorIdentifier.MOTO_NOT_ALLOWED.toString()));;
+                        .body("error_identifier", is(ErrorIdentifier.MOTO_NOT_ALLOWED.toString()));
+                ;
             }
-            
+
             @Test
             void when_amount_is_zero_and_account_does_not_allow_zero_amount() {
                 //by default, gateway account does not have zero amount enabled
@@ -472,19 +472,19 @@ public class ChargesApiResourceCreateIT {
             }
 
             @ParameterizedTest
-            @ValueSource( strings = { "CARD_API", "CARD_PAYMENT_LINK", "CARD_AGENT_INITIATED_MOTO" })
+            @ValueSource(strings = {"CARD_API", "CARD_PAYMENT_LINK", "CARD_AGENT_INITIATED_MOTO"})
             void when_amount_is_under_30p_for_api_payment_for_Stripe_account(String source) {
                 DatabaseFixtures.TestAccount stripeTestAccount = app.getDatabaseFixtures()
                         .aTestAccount()
                         .withPaymentProvider("stripe")
                         .withCredentials(Collections.singletonMap("stripe_account_id", "acct_123example123"))
                         .insert();
-                
+
                 app.givenSetup()
                         .body(toJson(Map.of(
                                 "amount", 29,
                                 "reference", "Test reference",
-                                "description", "Test description", 
+                                "description", "Test description",
                                 "return_url", "http://service.local/success-page/",
                                 "source", source
                         )))
@@ -530,7 +530,7 @@ public class ChargesApiResourceCreateIT {
                     .body("metadata.key2", is(true))
                     .body("metadata.key3", is(123))
                     .body("metadata.key4", is(1.23F));
-            
+
         }
 
         @Test
@@ -549,7 +549,7 @@ public class ChargesApiResourceCreateIT {
                     .statusCode(Status.CREATED.getStatusCode())
                     .body("reference", is("Test reference"));
         }
-        
+
 
         @Test
         void should_create_moto_charge_when_moto_is_true_and_moto_allowed_for_account() {
@@ -563,7 +563,7 @@ public class ChargesApiResourceCreateIT {
                     .patch("/v1/api/accounts/" + testGatewayAccountId)
                     .then()
                     .statusCode(OK.getStatusCode());
-            
+
             app.givenSetup()
                     .body(toJson(Map.of(
                             "amount", 6234L,
@@ -591,7 +591,7 @@ public class ChargesApiResourceCreateIT {
                     .patch("/v1/api/accounts/" + testGatewayAccountId)
                     .then()
                     .statusCode(OK.getStatusCode());
-            
+
             app.givenSetup()
                     .body(toJson(Map.of(
                             "amount", 0,
@@ -605,7 +605,7 @@ public class ChargesApiResourceCreateIT {
                     .contentType(JSON)
                     .body("amount", is(0));
         }
-        
+
         @Test
         void should_return_404_when_account_not_found() {
             String nonExistentGatewayAccount = "1234123";
@@ -651,7 +651,7 @@ public class ChargesApiResourceCreateIT {
 
     @Nested
     class ByServiceIdAndAccountType {
-        
+
         @Test
         void should_create_charge_and_retrieve_details_successfully() {
             ValidatableResponse response = app.givenSetup()
@@ -709,7 +709,7 @@ public class ChargesApiResourceCreateIT {
 
             Map<String, Object> charge = app.getDatabaseTestHelper().getChargeByExternalId(testChargeId);
             assertThat(CARD_API.toString(), equalTo(charge.get("source")));
-            
+
             ValidatableResponse getChargeResponse = app.givenSetup()
                     .get(format("/v1/api/service/%s/account/%s/charges/%s", VALID_SERVICE_ID, GatewayAccountType.TEST, testChargeId))
                     .then()
@@ -808,7 +808,7 @@ public class ChargesApiResourceCreateIT {
                     .contentType(JSON);
 
         }
-        
+
         @Test
         void should_create_charge_when_reference_is_a_card_number_for_api_payment() throws JsonProcessingException {
             var cardInformation = aCardInformation().build();
@@ -951,7 +951,7 @@ public class ChargesApiResourceCreateIT {
                         .body("message[0]", is(format("Gateway account %s is LIVE, but is configured to use a " +
                                 "non-https return_url", liveGatewayAccountId)));
             }
-            
+
             @Test
             void when_moto_is_true_and_moto_not_allowed_for_account() {
                 //by default, gateway account does not have moto enabled
@@ -968,7 +968,8 @@ public class ChargesApiResourceCreateIT {
                         .statusCode(422)
                         .contentType(JSON)
                         .body("message", contains("MOTO payments are not enabled for this gateway account"))
-                        .body("error_identifier", is(ErrorIdentifier.MOTO_NOT_ALLOWED.toString()));;
+                        .body("error_identifier", is(ErrorIdentifier.MOTO_NOT_ALLOWED.toString()));
+                ;
             }
 
             @Test
@@ -990,7 +991,7 @@ public class ChargesApiResourceCreateIT {
             }
 
             @ParameterizedTest
-            @ValueSource( strings = { "CARD_API", "CARD_PAYMENT_LINK", "CARD_AGENT_INITIATED_MOTO" })
+            @ValueSource(strings = {"CARD_API", "CARD_PAYMENT_LINK", "CARD_AGENT_INITIATED_MOTO"})
             void when_amount_is_under_30p_for_api_payment_for_Stripe_account(String source) {
                 DatabaseFixtures.TestAccount stripeTestAccount = app.getDatabaseFixtures()
                         .aTestAccount()
@@ -1024,7 +1025,7 @@ public class ChargesApiResourceCreateIT {
                     "value", true);
 
             app.givenSetup()
-                    .body(toJson(payload)) 
+                    .body(toJson(payload))
                     .patch(format("/v1/api/service/%s/account/%s/", VALID_SERVICE_ID, GatewayAccountType.TEST))
                     .then()
                     .statusCode(OK.getStatusCode());
@@ -1042,7 +1043,7 @@ public class ChargesApiResourceCreateIT {
                     .contentType(JSON)
                     .body("amount", is(0));
         }
-        
+
         @Test
         void should_return_404_when_service_id_does_not_exist() {
             app.givenSetup()
@@ -1070,9 +1071,10 @@ public class ChargesApiResourceCreateIT {
                     .post(format("/v1/api/service/%s/account/%s/charges", VALID_SERVICE_ID, GatewayAccountType.LIVE))
                     .then()
                     .statusCode(NOT_FOUND.getStatusCode())
-                    .body("message[0]", CoreMatchers.is("Gateway account not found for service external id [valid-service-id] and account type [live]"));;
+                    .body("message[0]", CoreMatchers.is("Gateway account not found for service external id [valid-service-id] and account type [live]"));
+            ;
         }
-        
+
         @Test
         void should_return_404_when_account_disabled() {
             app.givenSetup()
@@ -1080,7 +1082,7 @@ public class ChargesApiResourceCreateIT {
                     .patch(format("/v1/api/service/%s/account/%s", VALID_SERVICE_ID, GatewayAccountType.TEST))
                     .then()
                     .statusCode(Status.OK.getStatusCode());
-            
+
             app.givenSetup()
                     .body(toJson(Map.of(
                             "amount", 6234L,
@@ -1095,11 +1097,12 @@ public class ChargesApiResourceCreateIT {
                     .body("message", contains(format("Gateway account not found for service external id [%s] and account type [test]", VALID_SERVICE_ID)));
         }
     }
-        /*
-    This test breaks when the device running the test is on BST (UTC+1). This is because JDBI assumes
-    the time stored in the database (UTC) is in local time (BST) and incorrectly tries to "correct" it to UTC
-    by moving it back an hour which results in the assertion failing as it is now 1 hour apart.
-     */
+
+    /*
+This test breaks when the device running the test is on BST (UTC+1). This is because JDBI assumes
+the time stored in the database (UTC) is in local time (BST) and incorrectly tries to "correct" it to UTC
+by moving it back an hour which results in the assertion failing as it is now 1 hour apart.
+ */
     @Disabled("British Summer Time cause this test to fail")
     @Test
     void shouldEmitPaymentCreatedEventWhenChargeIsSuccessfullyCreated() throws Exception {
@@ -1121,17 +1124,16 @@ public class ChargesApiResourceCreateIT {
         Thread.sleep(100);
         List<Message> messages = readMessagesFromEventQueue();
 
-        final Message message = messages.get(0);
+        final Message message = messages.getFirst();
         ZonedDateTime eventTimestamp = ZonedDateTime.parse(
-                new JsonParser()
-                        .parse(message.body())
+                JsonParser.parseString(message.body())
                         .getAsJsonObject()
                         .get("timestamp")
                         .getAsString()
         );
 
         Optional<JsonObject> createdMessage = messages.stream()
-                .map(m -> new JsonParser().parse(m.body()).getAsJsonObject())
+                .map(m -> JsonParser.parseString(m.body()).getAsJsonObject())
                 .filter(e -> e.get("event_type").getAsString().equals("PAYMENT_CREATED"))
                 .findFirst();
         assertThat(createdMessage.isPresent(), is(true));

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -857,7 +857,6 @@ public class ChargesApiResourceIT {
                     .contentType(JSON)
                     .body(JSON_MESSAGE_KEY, contains(format("Charge with id [%s] not found.", testChargeId)))
                     .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
-            ;
         }
 
         @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -1,8 +1,9 @@
 package uk.gov.pay.connector.it.resources;
 
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -25,22 +26,20 @@ import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 import uk.gov.service.payments.commons.queue.exception.QueueException;
 
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.Response;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
-import static java.lang.String.format;
-import static java.time.temporal.ChronoUnit.HOURS;
-import static java.time.temporal.ChronoUnit.MINUTES;
-import static java.time.temporal.ChronoUnit.SECONDS;
 import static jakarta.ws.rs.core.Response.Status.CONFLICT;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
 import static jakarta.ws.rs.core.Response.Status.OK;
-import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static java.lang.String.format;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
@@ -90,7 +89,7 @@ public class ChargesApiResourceIT {
 
     private final DatabaseTestHelper databaseTestHelper = app.getDatabaseTestHelper();
     private final String accountId = testBaseExtension.getAccountId();
-    
+
     @Test
     void makeChargeSubmitCaptureAndCheckSettlementSummary() throws QueueException, InterruptedException {
         Instant startOfTest = Instant.now();
@@ -141,7 +140,7 @@ public class ChargesApiResourceIT {
         @Test
         void shouldGetChargeStatusAsInProgressIfInternalStatusIsAuthorised() {
 
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = "charge1";
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -167,7 +166,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldGetCardDetails_whenStatusIsBeyondAuthorised() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -195,7 +194,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldGetMetadataWhenSet() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
             ExternalMetadata externalMetadata = new ExternalMetadata(
                     Map.of("key1", true, "key2", 123, "key3", "string1"));
@@ -222,7 +221,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldNotReturnMetadataWhenNull() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -244,7 +243,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnCardBrandLabel_whenChargeIsAuthorised() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             CardTypeEntity mastercardCredit = databaseTestHelper.getMastercardCreditCard();
@@ -271,7 +270,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnAuthorisationSummary_whenChargeIsAuthorisedWith3ds() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -296,7 +295,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnAuthorisationSummary_whenChargeIsAuthorisedWith3dsAndVersionIsNotPresent() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -321,7 +320,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnAuthorisationSummary_whenChargeIsAuthorisedWithOut3dsAndVersionIsNotPresent() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -345,7 +344,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnEmptyCardBrandLabel_whenChargeIsAuthorisedAndBrandUnknown() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -370,7 +369,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldNotReturnBillingAddress_whenNoAddressDetailsPresentInDB() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -395,7 +394,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnFeeIfItExists() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
             long feeCollected = 100L;
 
@@ -414,7 +413,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnNetAmountIfFeeExists() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
             long feeCollected = 100L;
 
@@ -447,10 +446,10 @@ public class ChargesApiResourceIT {
                     .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
         }
 
-    @Test
-    void shouldGetSuccessAndFailedResponseForExpiryChargeTask() {
-        String extChargeId = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(CREATED)
-                .withCreatedDate(Instant.now().minus(90, MINUTES)).build());
+        @Test
+        void shouldGetSuccessAndFailedResponseForExpiryChargeTask() {
+            String extChargeId = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(CREATED)
+                    .withCreatedDate(Instant.now().minus(90, MINUTES)).build());
 
             // run expiry task
             testBaseExtension.getConnectorRestApiClient()
@@ -472,10 +471,10 @@ public class ChargesApiResourceIT {
 
         }
 
-    @Test
-    void shouldGetSuccessResponseForExpiryChargeTaskFor3dsRequiredPayments() {
-        String extChargeId = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(AUTHORISATION_3DS_REQUIRED)
-                        .withCreatedDate(Instant.now().minus(90, MINUTES)).build());
+        @Test
+        void shouldGetSuccessResponseForExpiryChargeTaskFor3dsRequiredPayments() {
+            String extChargeId = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(AUTHORISATION_3DS_REQUIRED)
+                    .withCreatedDate(Instant.now().minus(90, MINUTES)).build());
 
             testBaseExtension.getConnectorRestApiClient()
                     .postChargeExpiryTask()
@@ -495,10 +494,10 @@ public class ChargesApiResourceIT {
 
         }
 
-    @Test
-    void shouldGetSuccessForExpiryChargeTask_withStatus_awaitingCaptureRequest() {
-        String extChargeId = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(AWAITING_CAPTURE_REQUEST)
-                .withCreatedDate(Instant.now().minus(120, HOURS)).build());
+        @Test
+        void shouldGetSuccessForExpiryChargeTask_withStatus_awaitingCaptureRequest() {
+            String extChargeId = testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(AWAITING_CAPTURE_REQUEST)
+                    .withCreatedDate(Instant.now().minus(120, HOURS)).build());
 
             // run expiry task
             testBaseExtension.getConnectorRestApiClient()
@@ -522,7 +521,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnNullCardType_whenCardTypeIsNull() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -548,7 +547,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnChargeWhenAuthorisationModeIsMotoApi() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -569,7 +568,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnCanRetryTrueWhenChargeCanBeRetried() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -592,7 +591,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnCanRetryFalseWhenChargeHasAuthorisationModeAgreementAndCanBeRetried() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -615,7 +614,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnCanRetryFalseWhenChargeHasAuthorisationModeAgreementAndCannotBeRetried() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -638,7 +637,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldNotReturnCanRetryWhenChargeHasAuthorisationModeAgreementAndUnspecifiedWhetherItCanBeRetried() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -661,7 +660,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldNotReturnCanRetryWhenChargeHasAuthorisationModeWeb() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -684,7 +683,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldReturnDebitCardType_whenCardTypeIsDebit() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -710,7 +709,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldGetFullExemptionObject_whenAllRelevantFieldIsSet() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -739,7 +738,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldNotGetOutcome_whenExemption3dsOutcomeNotYetKnown() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -767,7 +766,7 @@ public class ChargesApiResourceIT {
 
         @Test
         void shouldNotGetExemption_whenNotSet() {
-            long chargeId = nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             String externalChargeId = RandomIdGenerator.newId();
 
             databaseTestHelper.addCharge(anAddChargeParams()
@@ -787,14 +786,14 @@ public class ChargesApiResourceIT {
                     .body("exemption", is(nullValue()));
         }
     }
-    
+
     @Nested
     class GetChargeByServiceIdAndAccountType {
-        
+
         private static String VALID_SERVICE_ID = "valid-service-id";
         private static String NON_EXISTENT_SERVICE_ID = "non-existent-service-id";
         private String testChargeId;
-        
+
         @BeforeEach
         void setup() {
             app.givenSetup()
@@ -820,24 +819,24 @@ public class ChargesApiResourceIT {
                     .statusCode(Response.Status.CREATED.getStatusCode())
                     .extract().path("charge_id");
         }
-        
+
         @Test
         void shouldReturnCorrectChargeAndStatus() {
-            
+
             app.givenSetup()
                     .get(format("/v1/api/service/%s/account/%s/charges/%s", VALID_SERVICE_ID, GatewayAccountType.TEST, testChargeId))
                     .then()
                     .statusCode(OK.getStatusCode())
                     .body("charge_id", is(testChargeId))
                     .body("state.status", is(EXTERNAL_CREATED.getStatus()));
-            
+
             app.givenSetup()
                     .post(format("/v1/api/service/%s/account/%s/charges/%s/cancel", VALID_SERVICE_ID, GatewayAccountType.TEST, testChargeId))
                     .then()
                     .statusCode(NO_CONTENT.getStatusCode());
-            
+
             app.givenSetup()
-                    .get(format("/v1/api/service/%s/account/%s/charges/%s", VALID_SERVICE_ID, GatewayAccountType.TEST, testChargeId)) 
+                    .get(format("/v1/api/service/%s/account/%s/charges/%s", VALID_SERVICE_ID, GatewayAccountType.TEST, testChargeId))
                     .then()
                     .statusCode(OK.getStatusCode())
                     .body("charge_id", is(testChargeId))
@@ -857,7 +856,8 @@ public class ChargesApiResourceIT {
                     .statusCode(NOT_FOUND.getStatusCode())
                     .contentType(JSON)
                     .body(JSON_MESSAGE_KEY, contains(format("Charge with id [%s] not found.", testChargeId)))
-                    .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));;
+                    .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+            ;
         }
 
         @Test
@@ -868,10 +868,11 @@ public class ChargesApiResourceIT {
                     .statusCode(NOT_FOUND.getStatusCode())
                     .contentType(JSON)
                     .body(JSON_MESSAGE_KEY, contains(format("Charge with id [unknown-charge-id] not found.")))
-                    .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));;
+                    .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+            ;
         }
     }
-    
+
     @Nested
     class DelayedCaptureApproveByAccountId {
         @Test
@@ -1014,7 +1015,7 @@ public class ChargesApiResourceIT {
                     .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
         }
     }
-    
+
     private void createCharge(String externalChargeId, long chargeId) {
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.SandboxCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
@@ -56,7 +57,7 @@ public class GatewayAccountResourceCreateIT {
                     .withSendPayerIpAddressToGateway(true)
                     .withSendPayerEmailToGateway(true)
                     .build();
-            
+
             Map<String, String> requestForSecondAccountPayload = aCreateGatewayAccountPayloadBuilder()
                     .withProvider("worldpay")
                     .withServiceId("my-service-id")
@@ -65,14 +66,14 @@ public class GatewayAccountResourceCreateIT {
                     .withSendPayerEmailToGateway(true)
                     .withSendPayerIpAddressToGateway(true)
                     .build();
-            
+
             ValidatableResponse response = app.givenSetup()
                     .body(requestForAccountPayload)
                     .post(ACCOUNTS_API_URL + "?degatewayification=true")
                     .then()
                     .statusCode(201)
                     .contentType(JSON);
-            
+
             app.givenSetup()
                     .body(requestForSecondAccountPayload)
                     .post(ACCOUNTS_API_URL + "?degatewayification=true")
@@ -80,7 +81,7 @@ public class GatewayAccountResourceCreateIT {
                     .statusCode(409)
                     .contentType(JSON)
                     .body("message", contains("Gateway account with service id my-service-id and account type 'test' already exists."));
-            
+
             assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, true, true);
         }
     }
@@ -123,10 +124,10 @@ public class GatewayAccountResourceCreateIT {
                     .statusCode(201)
                     .contentType(JSON);
         }
-        
+
         @Test
         public void createASandboxGatewayAccount() {
-            Map<String, Object> payload = Map.of("payment_provider", "sandbox", "service_id", "a-valid-service-id", "description","my test service", 
+            Map<String, Object> payload = Map.of("payment_provider", "sandbox", "service_id", "a-valid-service-id", "description", "my test service",
                     "analytics_id", "analytics", "send_payer_email_to_gateway", true, "send_payer_ip_address_to_gateway", true);
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
             GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, true, true);
@@ -134,7 +135,7 @@ public class GatewayAccountResourceCreateIT {
 
         @Test
         public void createAWorldpaySandboxGatewayAccount() {
-            Map<String, Object> payload = Map.of("payment_provider", "worldpay", "service_id", "a-valid-service-id", "description","my test service", 
+            Map<String, Object> payload = Map.of("payment_provider", "worldpay", "service_id", "a-valid-service-id", "description", "my test service",
                     "analytics_id", "analytics", "send_payer_email_to_gateway", true, "send_payer_ip_address_to_gateway", true);
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
             GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, true, true);
@@ -142,7 +143,7 @@ public class GatewayAccountResourceCreateIT {
 
         @Test
         public void createAWorldpayStripeGatewayAccount() {
-            Map<String, Object> payload = Map.of("payment_provider", "stripe", "service_id", "a-valid-service-id", "description","my test service", 
+            Map<String, Object> payload = Map.of("payment_provider", "stripe", "service_id", "a-valid-service-id", "description", "my test service",
                     "analytics_id", "analytics", "send_payer_email_to_gateway", false, "send_payer_ip_address_to_gateway", false);
             ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
             GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, false, false);
@@ -166,66 +167,66 @@ public class GatewayAccountResourceCreateIT {
                     .then().statusCode(200).contentType(JSON).body("payment_provider", is("stripe")).body("gateway_account_id", is(notNullValue())).body("service_name", is("a-service-name")).body("service_id", is("some-special-service-id")).body("type", is("live")).body("analytics_id", is("an-analytics-id")).body("description", is("a-description")).body("requires3ds", is(true)).body("allow_apple_pay", is(true)).body("allow_google_pay", is(true));
         }
 
-    @Test
-    public void createStripeGatewayAccountWithoutCredentials() {
-        Map<String, Object> payload = Map.of(
-                "type", "test",
-                "payment_provider", "stripe",
-                "service_name", "My shiny new stripe service",
-                "service_id", "a-valid-service-id");
-        app.givenSetup()
-                .body(toJson(payload))
-                .post(ACCOUNTS_API_URL)
-                .then()
-                .statusCode(201)
-                .contentType(JSON)
-                .body("gateway_account_id", not(emptyString()))
-                .body("service_name", is("My shiny new stripe service"))
-                .body("type", is("test"))
-                .body("links.size()", is(1))
-                .body("links[0].href", matchesPattern("https://localhost:[0-9]*/v1/api/accounts/[0-9]*"))
-                .body("links[0].rel", is("self"))
-                .body("links[0].method", is("GET"));
-    }
+        @Test
+        public void createStripeGatewayAccountWithoutCredentials() {
+            Map<String, Object> payload = Map.of(
+                    "type", "test",
+                    "payment_provider", "stripe",
+                    "service_name", "My shiny new stripe service",
+                    "service_id", "a-valid-service-id");
+            app.givenSetup()
+                    .body(toJson(payload))
+                    .post(ACCOUNTS_API_URL)
+                    .then()
+                    .statusCode(201)
+                    .contentType(JSON)
+                    .body("gateway_account_id", not(emptyString()))
+                    .body("service_name", is("My shiny new stripe service"))
+                    .body("type", is("test"))
+                    .body("links.size()", is(1))
+                    .body("links[0].href", matchesPattern("https://localhost:[0-9]*/v1/api/accounts/[0-9]*"))
+                    .body("links[0].rel", is("self"))
+                    .body("links[0].method", is("GET"));
+        }
 
-    @Test
-    public void createStripeGatewayAccountWithCredentials() {
-        String stripeAccountId = "abc";
-        Map<String, Object> payload = Map.of(
-                "type", "test",
-                "payment_provider", "stripe",
-                "service_name", "My shiny new stripe service",
-                "service_id", "a-valid-service-id",
-                "credentials", Map.of("stripe_account_id", stripeAccountId));
-        String gatewayAccountId = app.givenSetup()
-                .body(toJson(payload))
-                .post(ACCOUNTS_API_URL)
-                .then()
-                .statusCode(201)
-                .contentType(JSON)
-                .body("gateway_account_id", not(emptyString()))
-                .body("service_name", is("My shiny new stripe service"))
-                .body("type", is("test"))
-                .body("links.size()", is(1))
-                .body("links[0].href", matchesPattern("https://localhost:[0-9]*/v1/api/accounts/[0-9]*"))
-                .body("links[0].rel", is("self"))
-                .body("links[0].method", is("GET"))
-                .extract()
-                .body()
-                .jsonPath()
-                .getString("gateway_account_id");
-        Optional<GatewayAccountEntity> gatewayAccount = gatewayAccountDao.findById(Long.valueOf(gatewayAccountId));
-        assertThat(gatewayAccount.isPresent(), is(true));
+        @Test
+        public void createStripeGatewayAccountWithCredentials() {
+            String stripeAccountId = "abc";
+            Map<String, Object> payload = Map.of(
+                    "type", "test",
+                    "payment_provider", "stripe",
+                    "service_name", "My shiny new stripe service",
+                    "service_id", "a-valid-service-id",
+                    "credentials", Map.of("stripe_account_id", stripeAccountId));
+            String gatewayAccountId = app.givenSetup()
+                    .body(toJson(payload))
+                    .post(ACCOUNTS_API_URL)
+                    .then()
+                    .statusCode(201)
+                    .contentType(JSON)
+                    .body("gateway_account_id", not(emptyString()))
+                    .body("service_name", is("My shiny new stripe service"))
+                    .body("type", is("test"))
+                    .body("links.size()", is(1))
+                    .body("links[0].href", matchesPattern("https://localhost:[0-9]*/v1/api/accounts/[0-9]*"))
+                    .body("links[0].rel", is("self"))
+                    .body("links[0].method", is("GET"))
+                    .extract()
+                    .body()
+                    .jsonPath()
+                    .getString("gateway_account_id");
+            Optional<GatewayAccountEntity> gatewayAccount = gatewayAccountDao.findById(Long.valueOf(gatewayAccountId));
+            assertThat(gatewayAccount.isPresent(), is(true));
 
-        List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsList = gatewayAccount.get().getGatewayAccountCredentials();
-        assertThat(gatewayAccountCredentialsList.size(), is(1));
-        GatewayCredentials credentialsObject = gatewayAccountCredentialsList.get(0).getCredentialsObject();
-        assertThat(credentialsObject, isA(StripeCredentials.class));
-        assertThat(((StripeCredentials) credentialsObject).getStripeAccountId(), is(stripeAccountId));
-        assertThat(gatewayAccountCredentialsList.get(0).getState(), is(ACTIVE));
-        assertThat(gatewayAccountCredentialsList.get(0).getPaymentProvider(), is("stripe"));
-        assertThat(gatewayAccountCredentialsList.get(0).getActiveStartDate(), is(notNullValue()));
-    }
+            List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsList = gatewayAccount.get().getGatewayAccountCredentials();
+            assertThat(gatewayAccountCredentialsList.size(), is(1));
+            GatewayCredentials credentialsObject = gatewayAccountCredentialsList.getFirst().getCredentialsObject();
+            assertThat(credentialsObject, isA(StripeCredentials.class));
+            assertThat(((StripeCredentials) credentialsObject).getStripeAccountId(), is(stripeAccountId));
+            assertThat(gatewayAccountCredentialsList.getFirst().getState(), is(ACTIVE));
+            assertThat(gatewayAccountCredentialsList.getFirst().getPaymentProvider(), is("stripe"));
+            assertThat(gatewayAccountCredentialsList.getFirst().getActiveStartDate(), is(notNullValue()));
+        }
 
         @Test
         public void createGatewayAccountWithoutPaymentProviderDefaultsToSandbox() {
@@ -245,16 +246,20 @@ public class GatewayAccountResourceCreateIT {
                     .body("payment_provider", is("sandbox"))
                     .body("gateway_account_id", is(notNullValue()))
                     .body("type", is("test"));
-            
+
             String gatewayAccountId = response.extract().body().jsonPath().getString("gateway_account_id");
             Optional<GatewayAccountEntity> gatewayAccount = gatewayAccountDao.findById(Long.valueOf(gatewayAccountId));
             assertThat(gatewayAccount.isPresent(), is(true));
 
             List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsList = gatewayAccount.get().getGatewayAccountCredentials();
             assertThat(gatewayAccountCredentialsList.size(), is(1));
-            assertThat(gatewayAccountCredentialsList.get(0).getState(), is(ACTIVE));
-            assertThat(gatewayAccountCredentialsList.get(0).getPaymentProvider(), is("sandbox"));
-            assertThat(gatewayAccountCredentialsList.get(0).getCredentials().isEmpty(), is(true));
+            assertThat(gatewayAccountCredentialsList.getFirst().getState(), is(ACTIVE));
+            assertThat(gatewayAccountCredentialsList.getFirst().getPaymentProvider(), is("sandbox"));
+
+            GatewayCredentials credentialsObj = gatewayAccountCredentialsList.getFirst().getCredentialsObject();
+            assertThat(credentialsObj, isA(SandboxCredentials.class));
+            //hasCredentials in SandboxCredentials.class is hardcoded to true
+            assertThat(credentialsObj.hasCredentials(), is(true));
         }
 
         private void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountType type) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
@@ -381,7 +381,6 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.card_type", is("debit"))
                 .body("card_details.card_brand", is("Visa"))
                 .body("card_details.expiry_date", is("08/24"));
-        ;
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
@@ -327,7 +327,6 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.card_type", is("debit"))
                 .body("card_details.card_brand", is("Visa"))
                 .body("card_details.expiry_date", is("08/24"));
-        ;
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
@@ -298,7 +298,6 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.card_type", is("debit"))
                 .body("card_details.card_brand", is("Visa"))
                 .body("card_details.expiry_date", is("08/24"));
-        ;
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.response.ValidatableResponse;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.hamcrest.collection.IsIn;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,10 +27,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static java.lang.String.format;
 import static java.net.URLEncoder.encode;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
 import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
 import static org.eclipse.jetty.http.HttpStatus.OK_200;
@@ -95,12 +95,12 @@ public class StripeCardResourceAuthoriseIT {
     private String accountId;
     private DatabaseTestHelper databaseTestHelper;
     private AddGatewayAccountCredentialsParams accountCredentialsParams;
-    
+
     @BeforeEach
     void setup() {
-        stripeAccountId = String.valueOf(RandomUtils.nextInt());
+        stripeAccountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         databaseTestHelper = app.getDatabaseTestHelper();
-        accountId = String.valueOf(RandomUtils.nextInt());
+        accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
 
         connectorRestApiClient = new RestAssuredClient(app.getLocalPort(), accountId);
 
@@ -230,7 +230,8 @@ public class StripeCardResourceAuthoriseIT {
         verifyPaymentIntentRequest(externalChargeId, stripeAccountId);
 
         Map<String, Object> paymentInstrument = databaseTestHelper.getPaymentInstrumentByChargeExternalId(externalChargeId.toString());
-        Map<String, String> recurringAuthTokenMap = mapper.readValue(paymentInstrument.get("recurring_auth_token").toString(), new TypeReference<Map<String, String>>() {});
+        Map<String, String> recurringAuthTokenMap = mapper.readValue(paymentInstrument.get("recurring_auth_token").toString(), new TypeReference<Map<String, String>>() {
+        });
 
         assertThat(recurringAuthTokenMap, hasKey(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY));
         assertThat(recurringAuthTokenMap, hasKey(STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY));
@@ -296,7 +297,8 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.last_digits_card_number", is("4242"))
                 .body("card_details.card_type", is("debit"))
                 .body("card_details.card_brand", is("Visa"))
-                .body("card_details.expiry_date", is("08/24"));;
+                .body("card_details.expiry_date", is("08/24"));
+        ;
     }
 
     @Test
@@ -324,7 +326,8 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.last_digits_card_number", is("4242"))
                 .body("card_details.card_type", is("debit"))
                 .body("card_details.card_brand", is("Visa"))
-                .body("card_details.expiry_date", is("08/24"));;
+                .body("card_details.expiry_date", is("08/24"));
+        ;
     }
 
     @Test
@@ -379,7 +382,8 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.last_digits_card_number", is("4242"))
                 .body("card_details.card_type", is("debit"))
                 .body("card_details.card_brand", is("Visa"))
-                .body("card_details.expiry_date", is("08/24"));;
+                .body("card_details.expiry_date", is("08/24"));
+        ;
     }
 
     @Test
@@ -435,7 +439,7 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.card_brand", is("Visa"))
                 .body("card_details.expiry_date", is(nullValue()));
     }
-    
+
     @Test
     void shouldCaptureCardPayment_IfChargeWasPreviouslyAuthorised() {
 
@@ -470,7 +474,7 @@ public class StripeCardResourceAuthoriseIT {
     }
 
     private String addChargeWithStatus(ChargeStatus chargeStatus) {
-        long chargeId = RandomUtils.nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
         String externalChargeId = "charge-" + chargeId;
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
@@ -485,7 +489,7 @@ public class StripeCardResourceAuthoriseIT {
     }
 
     private String addChargeWithAgreement(ChargeStatus chargeStatus, String agreementExternalId) {
-        long chargeId = RandomUtils.nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
         String externalChargeId = "charge-" + chargeId;
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
@@ -25,8 +25,7 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static io.restassured.RestAssured.given;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.MediaType.TEXT_XML;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -35,11 +34,12 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_NOTIFICATION;
 
 public class WorldpayNotificationResourceIT {
     private static final ReverseDnsLookup reverseDnsLookup = mock(ReverseDnsLookup.class);
-    
+
     // App must be instantiated after mock is set
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(WorldpayNotificationResourceIT.ConnectorAppWithCustomInjector.class, config("worldpay.notificationDomain", ".worldpay.com"));
@@ -50,7 +50,7 @@ public class WorldpayNotificationResourceIT {
     private static final String NOTIFICATION_PATH = "/v1/api/notifications/worldpay";
     private static final String WORLDPAY_IP_ADDRESS = "some-worldpay-ip";
     private static final String UNEXPECTED_IP_ADDRESS = "8.8.8.8";
-    
+
     @BeforeAll
     static void before() {
         when(reverseDnsLookup.lookup(new DnsPointerResourceRecord(WORLDPAY_IP_ADDRESS))).thenReturn(Optional.of("hello.worldpay.com."));
@@ -75,7 +75,7 @@ public class WorldpayNotificationResourceIT {
     @Test
     void shouldHandleARefundNotification() {
         String transactionId = RandomIdGenerator.newId();
-        String refundExternalId = String.valueOf(nextLong());
+        String refundExternalId = String.valueOf(current().nextLong(0, Long.MAX_VALUE));
         int refundAmount = 1000;
 
         String externalChargeId = createNewChargeWithRefund(transactionId, refundExternalId, refundAmount);
@@ -93,8 +93,8 @@ public class WorldpayNotificationResourceIT {
     @Test
     void shouldHandleARefundNotification_forAnExpungedCharge() throws Exception {
         String gatewayTransactionId = RandomIdGenerator.newId();
-        String refundExternalId = String.valueOf(nextLong());
-        String chargeExternalId = randomAlphanumeric(26);
+        String refundExternalId = String.valueOf(current().nextLong(0, Long.MAX_VALUE));
+        String chargeExternalId = randomAlphaNumeric(26);
 
         DatabaseFixtures.TestCharge testCharge = DatabaseFixtures.withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aTestCharge()
@@ -128,8 +128,8 @@ public class WorldpayNotificationResourceIT {
     @Test
     void shouldReturn500_whenChargeNotInConnectorAndLedgerReturnsAnError() throws Exception {
         String gatewayTransactionId = RandomIdGenerator.newId();
-        String refundExternalId = String.valueOf(nextLong());
-        String chargeExternalId = randomAlphanumeric(26);
+        String refundExternalId = String.valueOf(current().nextLong(0, Long.MAX_VALUE));
+        String chargeExternalId = randomAlphaNumeric(26);
 
         DatabaseFixtures.TestCharge testCharge = DatabaseFixtures.withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aTestCharge()
@@ -194,7 +194,7 @@ public class WorldpayNotificationResourceIT {
                 .then()
                 .statusCode(403);
     }
-    
+
     @Test
     void shouldReturnForbiddenIfXForwardedForHeaderIsMissing() {
         given().port(app.getLocalPort())

--- a/src/test/java/uk/gov/pay/connector/matcher/TransactionEventMatcher.java
+++ b/src/test/java/uk/gov/pay/connector/matcher/TransactionEventMatcher.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.connector.matcher;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.Objects;
 
 import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_INSTANT_MILLISECOND_PRECISION;
 
@@ -42,12 +42,12 @@ public class TransactionEventMatcher extends TypeSafeMatcher<Map<String, Object>
 
     }
 
-    private String type;
-    private State state;
-    private String amount;
-    private String updated;
-    private String refundReference;
-    private String refundSubmittedBy;
+    private final String type;
+    private final State state;
+    private final String amount;
+    private final String updated;
+    private final String refundReference;
+    private final String refundSubmittedBy;
 
     public TransactionEventMatcher(String type, State state, String amount, ZonedDateTime updated, String refundReference, String submittedBy) {
         this.type = type;
@@ -91,17 +91,17 @@ public class TransactionEventMatcher extends TypeSafeMatcher<Map<String, Object>
         if (record.get("state") == null) {
             stateMatches = (state == null);
         } else {
-            stateMatches = ObjectUtils.equals(((Map)record.get("state")).get("status"), state.getStatus()) &&
-                    ObjectUtils.equals(((Map)record.get("state")).get("finished").toString(), state.getFinished()) &&
-                    ObjectUtils.equals(((Map)record.get("state")).get("code"), state.getCode()) &&
-                    ObjectUtils.equals(((Map)record.get("state")).get("message"), state.getMessage());
+            stateMatches = Objects.equals(((Map<?, ?>) record.get("state")).get("status"), state.getStatus()) &&
+                    Objects.equals(((Map<?, ?>) record.get("state")).get("finished").toString(), state.getFinished()) &&
+                    Objects.equals(((Map<?, ?>) record.get("state")).get("code"), state.getCode()) &&
+                    Objects.equals(((Map<?, ?>) record.get("state")).get("message"), state.getMessage());
         }
 
         return stateMatches &&
-                ObjectUtils.equals(record.get("refund_reference"), refundReference) &&
-                ObjectUtils.equals(record.get("type"), type) &&
-                ObjectUtils.equals(record.get("amount"), Integer.valueOf(amount)) &&
-                ObjectUtils.equals(record.get("updated"), updated) &&
-                ObjectUtils.equals(record.get("submitted_by"), refundSubmittedBy);
+                Objects.equals(record.get("refund_reference"), refundReference) &&
+                Objects.equals(record.get("type"), type) &&
+                Objects.equals(record.get("amount"), Integer.valueOf(amount)) &&
+                Objects.equals(record.get("updated"), updated) &&
+                Objects.equals(record.get("submitted_by"), refundSubmittedBy);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stripe.Stripe;
 import io.dropwizard.testing.ConfigOverride;
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -48,15 +47,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static uk.gov.pay.connector.cardtype.model.domain.CardType.DEBIT;
 import static uk.gov.pay.connector.client.cardid.model.CardInformationFixture.aCardInformation;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
@@ -79,6 +76,7 @@ import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGa
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
 
 public class ContractTest {
 
@@ -134,7 +132,7 @@ public class ContractTest {
     @State("a charge with metadata exists")
     public void aChargeWithMetadataExists(Map<String, String> params) throws Exception {
         String gatewayAccountId = params.get("gateway_account_id");
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         dbHelper.addCharge(anAddChargeParams()
@@ -156,7 +154,7 @@ public class ContractTest {
     @State("a charge with a gateway transaction id exists")
     public void aChargeWithGatewayTxIdExists(Map<String, String> params) {
         String gatewayAccountId = params.get("gateway_account_id");
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         dbHelper.addCharge(anAddChargeParams()
@@ -182,8 +180,8 @@ public class ContractTest {
     private void setUpRefunds(int numberOfRefunds, Long chargeId,
                               ZonedDateTime createdDate, RefundStatus refundStatus, String chargeExternalId) {
         for (int i = 0; i < numberOfRefunds; i++) {
-            dbHelper.addRefund("external" + RandomUtils.nextInt(), 1L, refundStatus,
-                    randomAlphanumeric(10), createdDate, "user_external_id1234", null, chargeExternalId);
+            dbHelper.addRefund("external" + current().nextInt(0, Integer.MAX_VALUE), 1L, refundStatus,
+                    randomAlphaNumeric(10), createdDate, "user_external_id1234", null, chargeExternalId);
         }
     }
 
@@ -194,7 +192,7 @@ public class ContractTest {
     @State("a canceled charge exists")
     public void aCanceledChargeExists(Map<String, String> params) {
         String gatewayAccountId = params.get("gateway_account_id");
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         AddChargeParams addChargeParams = anAddChargeParams()
@@ -337,7 +335,7 @@ public class ContractTest {
     @State("a charge with fee and net_amount exists")
     public void createACharge(Map<String, String> params) {
         String gatewayAccountId = params.get("gateway_account_id");
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         AddChargeParams addChargeParams = anAddChargeParams()
@@ -353,7 +351,7 @@ public class ContractTest {
                 .withTransactionId("aGatewayTransactionId")
                 .build();
         setUpCharge(addChargeParams);
-        dbHelper.addFee(randomAlphanumeric(10), chargeId, 5, 5, ZonedDateTime.now(), randomAlphanumeric(10), FeeType.TRANSACTION);
+        dbHelper.addFee(randomAlphaNumeric(10), chargeId, 5, 5, ZonedDateTime.now(), randomAlphaNumeric(10), FeeType.TRANSACTION);
     }
 
     @State("a charge with service external id 'a-service-id', account type 'test' and charge external id 'a-charge-id-1a2b3c' exists")
@@ -366,12 +364,12 @@ public class ContractTest {
                 .withExternalChargeId("a-charge-id-1a2b3c")
                 .build());
     }
-    
+
     @State("a charge with gateway account id 42 and charge id abcdef1234 exists")
     public void createChargeWithHardCodedParams() {
         String gatewayAccountId = "42";
         String chargeExternalId = "abcdef1234";
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         AddChargeParams addChargeParams = anAddChargeParams()
                 .withExternalChargeId(chargeExternalId)
@@ -388,7 +386,7 @@ public class ContractTest {
     @State("a charge with delayed capture true exists")
     public void createChargeWithDelayedCaptureTrue(Map<String, String> params) {
         String gatewayAccountId = params.get("gateway_account_id");
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         AddChargeParams addChargeParams = anAddChargeParams()
@@ -407,7 +405,7 @@ public class ContractTest {
     @State("a charge with authorisation mode moto_api exists")
     public void createChargeWithAuthorisationModeMotoApi(Map<String, String> params) {
         String gatewayAccountId = params.get("gateway_account_id");
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         AddChargeParams addChargeParams = anAddChargeParams()
@@ -425,7 +423,7 @@ public class ContractTest {
     @State("a charge with wallet type APPLE_PAY exists")
     public void createChargeWithWalletTypeApplePay(Map<String, String> params) {
         String gatewayAccountId = params.get("gateway_account_id");
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         AddChargeParams addChargeParams = anAddChargeParams()
@@ -457,7 +455,7 @@ public class ContractTest {
         String oneTimeToken = params.get("one_time_token");
         String oneTimeTokenUsed = params.get("one_time_token_used");
         String chargeExternalId = params.get("charge_id");
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         AddChargeParams addChargeParams = anAddChargeParams()
                 .withExternalChargeId(chargeExternalId)
@@ -478,7 +476,7 @@ public class ContractTest {
         if (gatewayAccountId == null) {
             gatewayAccountId = "123456";
         }
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         if (chargeExternalId == null) {
             chargeExternalId = "ch_123abc456def";
@@ -500,14 +498,14 @@ public class ContractTest {
                 .withEmail("test@test.com")
                 .withDelayedCapture(true)
                 .build());
-        dbHelper.addFee(randomAlphanumeric(10), chargeId, 5, 5, ZonedDateTime.now(), params.get("gateway_transaction_id"), FeeType.TRANSACTION);
+        dbHelper.addFee(randomAlphaNumeric(10), chargeId, 5, 5, ZonedDateTime.now(), params.get("gateway_transaction_id"), FeeType.TRANSACTION);
         dbHelper.updateCharge3dsDetails(chargeId, null, null, null, "2.1.0");
     }
 
     @State("a charge with delayed capture true and awaiting capture request status exists")
     public void createChargeWithDelayedCaptureTrueAndAwaitingCaptureRequestStatus(Map<String, String> params) {
         String gatewayAccountId = params.get("gateway_account_id");
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         AddChargeParams addChargeParams = anAddChargeParams()
@@ -542,7 +540,7 @@ public class ContractTest {
     public void aChargeWithIdAndChargeEvents() {
         String gatewayAccountId = "42";
         String chargeExternalId = "abc123";
-        long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        long chargeId = current().nextLong(100, 100000);
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         AddChargeParams addChargeParams = anAddChargeParams()
                 .withExternalChargeId(chargeExternalId)
@@ -562,7 +560,7 @@ public class ContractTest {
     public void createChargeWithCardDetails(Map<String, String> params) {
         String chargeExternalId = params.get("charge_id");
         String gatewayAccountId = params.get("gateway_account_id");
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         String cardHolderName = params.get("cardholder_name");
         String lastDigitsCardNumber = params.get("last_digits_card_number");
         String firstDigitsCardNumber = params.get("first_digits_card_number");
@@ -627,7 +625,7 @@ public class ContractTest {
                 .build());
 
         dbHelper.addRefund(refundId, 100L, REFUNDED,
-                randomAlphanumeric(10), createdDate,
+                randomAlphaNumeric(10), createdDate,
                 Long.toString(paymentId));
     }
 
@@ -779,7 +777,7 @@ public class ContractTest {
                                         .withState(VERIFIED_WITH_LIVE_PAYMENT)
                                         .withPaymentProvider(STRIPE.getName())
                                         .build()
-                                ))
+                        ))
                         .build());
     }
 
@@ -788,7 +786,7 @@ public class ContractTest {
         var agreementExternalId = params.get("agreement_external_id");
         var gatewayAccountId = params.get("gateway_account_id");
         var addPaymentInstrumentParams = anAddPaymentInstrumentParams()
-                .withPaymentInstrumentId(nextLong())
+                .withPaymentInstrumentId(current().nextLong(0, Long.MAX_VALUE))
                 .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
                 .build();
         dbHelper.addPaymentInstrument(addPaymentInstrumentParams);
@@ -803,7 +801,7 @@ public class ContractTest {
     @State("a charge created with an idempotency key for an agreement exists")
     public void aChargeCreatedWithAnIdempotencyKeyForAnAgreementExists(Map<String, String> params) {
         Instant createdDate = Instant.parse(params.get("created"));
-        long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_external_id");
         String idempotencyKey = params.get("idempotency_key");
         String agreementExternalId = params.get("agreement_external_id");
@@ -836,7 +834,7 @@ public class ContractTest {
 
     @State("a charge with authorisation mode agreement and rejected status exists")
     public void aChargeWithAuthorisationModeAgreementAndRejectedStatusExists(Map<String, String> params) {
-        long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_external_id");
         String agreementExternalId = params.get("agreement_external_id");
         long amount = Long.parseLong(params.get("amount"));
@@ -868,7 +866,7 @@ public class ContractTest {
                 .build());
 
         var addPaymentInstrumentParams = anAddPaymentInstrumentParams()
-                .withPaymentInstrumentId(nextLong())
+                .withPaymentInstrumentId(current().nextLong(0, Long.MAX_VALUE))
                 .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
                 .build();
         dbHelper.addPaymentInstrument(addPaymentInstrumentParams);
@@ -894,7 +892,7 @@ public class ContractTest {
                 .withRecurringEnabled(true)
                 .build());
         var addPaymentInstrumentParams = anAddPaymentInstrumentParams()
-                .withPaymentInstrumentId(nextLong())
+                .withPaymentInstrumentId(current().nextLong(0, Long.MAX_VALUE))
                 .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
                 .build();
         dbHelper.addPaymentInstrument(addPaymentInstrumentParams);
@@ -919,7 +917,7 @@ public class ContractTest {
                 .withRecurringEnabled(true)
                 .build());
         var addPaymentInstrumentParams = anAddPaymentInstrumentParams()
-                .withPaymentInstrumentId(nextLong())
+                .withPaymentInstrumentId(current().nextLong(0, Long.MAX_VALUE))
                 .withPaymentInstrumentStatus(PaymentInstrumentStatus.CANCELLED)
                 .build();
         dbHelper.addPaymentInstrument(addPaymentInstrumentParams);
@@ -956,7 +954,7 @@ public class ContractTest {
         if (gatewayAccountId == null) {
             gatewayAccountId = "123456";
         }
-        Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
+        Long chargeId = current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         if (chargeExternalId == null) {
             chargeExternalId = "ch_123abc456def";
@@ -976,6 +974,6 @@ public class ContractTest {
                 .withTransactionId("aGatewayTransactionId")
                 .build();
         setUpCharge(addChargeParams);
-        dbHelper.addFee(randomAlphanumeric(10), chargeId, 5, 5, ZonedDateTime.now(), randomAlphanumeric(10), FeeType.TRANSACTION);
+        dbHelper.addFee(randomAlphaNumeric(10), chargeId, 5, 5, ZonedDateTime.now(), randomAlphaNumeric(10), FeeType.TRANSACTION);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -977,3 +977,4 @@ public class ContractTest {
         dbHelper.addFee(randomAlphaNumeric(10), chargeId, 5, 5, ZonedDateTime.now(), randomAlphaNumeric(10), FeeType.TRANSACTION);
     }
 }
+

--- a/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
@@ -52,14 +52,14 @@ public class FrontendContractTest {
 
     @ClassRule
     public static WireMockRule wireMockRule = new WireMockRule(app.getWireMockPort());
-    
+
     @TestTarget
     public static Target target;
     private static DatabaseTestHelper dbHelper;
-    
+
     private StripeMockClient stripeMockClient;
     private WorldpayMockClient worldpayMockClient;
-    
+
     @BeforeClass
     public static void setUp() {
         target = new HttpTarget(app.getLocalPort());
@@ -72,7 +72,7 @@ public class FrontendContractTest {
         stripeMockClient = new StripeMockClient(wireMockRule);
         worldpayMockClient = new WorldpayMockClient(wireMockRule);
     }
-    
+
     @State("an unused token testToken exists with external charge id chargeExternalId associated with it")
     public void anUnusedTokenExists() {
         long gatewayAccountId = 666L;
@@ -83,15 +83,15 @@ public class FrontendContractTest {
                 .withGatewayAccountId(String.valueOf(gatewayAccountId))
                 .build();
         dbHelper.addCharge(params);
-        
+
         dbHelper.addToken(params.chargeId(), "testToken", false);
     }
-    
+
     @State("a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.")
     public void aChargeExistsAwaitingAuthorisation() {
         long gatewayAccountId = 666L;
         setUpGatewayAccount(dbHelper, gatewayAccountId);
-        
+
         String chargeExternalId = "testChargeId";
 
         dbHelper.addCharge(anAddChargeParams()
@@ -130,7 +130,7 @@ public class FrontendContractTest {
                 .withDelayedCapture(false)
                 .build());
     }
-    
+
     @State("a sandbox account exists with a charge with id testChargeId and description ERROR that is in state ENTERING_CARD_DETAILS.")
     public void aChargeExistsAwaitingAuthorisationWithDescriptionError() {
         long gatewayAccountId = 666L;
@@ -205,7 +205,7 @@ public class FrontendContractTest {
                 "a-payload",
                 "2.1.0");
     }
-    
+
     @State("a Worldpay account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.")
     public void aWorldpayChargeExistsAwaitingAuthorisation() {
         worldpayMockClient.mockAuthorisationSuccess();
@@ -214,7 +214,7 @@ public class FrontendContractTest {
         createGatewayAccount(gatewayAccountId, gatewayCredentialId, PaymentGatewayName.WORLDPAY);
         createChargeEnteringCardDetails("testChargeId", gatewayAccountId, gatewayCredentialId, PaymentGatewayName.WORLDPAY);
     }
-    
+
     @State("a Stripe account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.")
     public void aStripeChargeExistsAwaitingAuthorisation() {
         stripeMockClient.mockCreatePaymentIntent();
@@ -223,19 +223,19 @@ public class FrontendContractTest {
         createGatewayAccount(gatewayAccountId, gatewayCredentialId, PaymentGatewayName.STRIPE);
         createChargeEnteringCardDetails("testChargeId", gatewayAccountId, gatewayCredentialId, PaymentGatewayName.STRIPE);
     }
-    
+
     private void createGatewayAccount(Long gatewayAccountId, int gatewayCredentialId, PaymentGatewayName paymentProvider) {
         Map<String, Object> credentials;
-        switch(paymentProvider) {
-            case WORLDPAY: 
+        switch (paymentProvider) {
+            case WORLDPAY:
                 credentials = Map.of(
-                    ONE_OFF_CUSTOMER_INITIATED, Map.of(
-                            CREDENTIALS_MERCHANT_CODE, "merchant-id",
-                            CREDENTIALS_USERNAME, "test-user",
-                            CREDENTIALS_PASSWORD, "test-password")
+                        ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, "merchant-id",
+                                CREDENTIALS_USERNAME, "test-user",
+                                CREDENTIALS_PASSWORD, "test-password")
                 );
                 break;
-            case STRIPE: 
+            case STRIPE:
                 credentials = Map.of("stripe_account_id", RandomUtils.nextInt());
                 break;
             default:
@@ -243,7 +243,7 @@ public class FrontendContractTest {
         }
         createGatewayAccount(gatewayAccountId, gatewayCredentialId, paymentProvider, credentials);
     }
-    
+
     private void createGatewayAccount(Long gatewayAccountId, int gatewayCredentialId, PaymentGatewayName paymentProvider, Map<String, Object> credentials) {
         AddGatewayAccountCredentialsParams accountCredentialsParams = anAddGatewayAccountCredentialsParams()
                 .withId(gatewayCredentialId)
@@ -264,7 +264,7 @@ public class FrontendContractTest {
                 .withCardTypeEntities(List.of(visaCreditCard))
                 .insert();
     }
-     
+
     private void createChargeEnteringCardDetails(String externalChargeId, Long gatewayAccountId, int gatewayCredentialId, PaymentGatewayName paymentProvider) {
         dbHelper.addCharge(anAddChargeParams()
                 .withExternalChargeId(externalChargeId)
@@ -275,5 +275,5 @@ public class FrontendContractTest {
                 .withGatewayCredentialId(Long.valueOf(gatewayCredentialId))
                 .build());
     }
-    
+
 }

--- a/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.pact;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
@@ -8,11 +7,12 @@ import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 
 import static java.time.ZoneOffset.UTC;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
 
 public class RefundHistoryEntityFixture {
 
     private Long id = 1L;
-    private String externalId = RandomStringUtils.randomAlphanumeric(10);
+    private String externalId = randomAlphaNumeric(10);
     private Long amount = 50L;
     private String status = RefundStatus.CREATED.getValue();
     private ZonedDateTime createdDate = ZonedDateTime.now(UTC).minusSeconds(5L);
@@ -22,10 +22,11 @@ public class RefundHistoryEntityFixture {
     private String userExternalId;
     private String userEmail;
     private String gatewayTransactionId = null;
-    private String chargeExternalId = RandomStringUtils.randomAlphanumeric(10);
+    private String chargeExternalId = randomAlphaNumeric(10);
     private Long gatewayAccountId = 123456L;
 
-    private RefundHistoryEntityFixture() {}
+    private RefundHistoryEntityFixture() {
+    }
 
     public static RefundHistoryEntityFixture aValidRefundHistoryEntity() {
         return new RefundHistoryEntityFixture();
@@ -43,7 +44,7 @@ public class RefundHistoryEntityFixture {
         this.externalId = externalId;
         return this;
     }
-    
+
     public RefundHistoryEntityFixture withStatus(String status) {
         this.status = status;
         return this;

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/AuthoriseWithUserNotPresentTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/AuthoriseWithUserNotPresentTaskHandlerIT.java
@@ -5,7 +5,6 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -24,6 +23,7 @@ import uk.gov.pay.connector.util.AddPaymentInstrumentParams;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -119,9 +119,9 @@ public class AuthoriseWithUserNotPresentTaskHandlerIT {
         testBaseExtension.assertApiStateIs(chargeWithValidAgreementAndPaymentInstrument, EXTERNAL_ERROR_GATEWAY.getStatus());
         verifyNoInteractions(mockAppender);
     }
-    
+
     private String setupChargeWithAgreementAndPaymentInstrument(String first6Digits, String last4Digits) {
-        Long paymentInstrumentId = RandomUtils.nextLong();
+        Long paymentInstrumentId = current().nextLong(0, Long.MAX_VALUE);
 
         AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)

--- a/src/test/java/uk/gov/pay/connector/resources/ApiValidatorsTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/ApiValidatorsTest.java
@@ -21,12 +21,13 @@ import static uk.gov.pay.connector.charge.resource.ChargesApiResource.AMOUNT_KEY
 import static uk.gov.pay.connector.charge.resource.ChargesApiResource.DELAYED_CAPTURE_KEY;
 import static uk.gov.pay.connector.charge.resource.ChargesApiResource.EMAIL_KEY;
 import static uk.gov.pay.connector.charge.resource.ChargesApiResource.LANGUAGE_KEY;
+import static uk.gov.pay.connector.charge.resource.ChargesApiResource.MAXIMUM_FIELDS_SIZE;
 import static uk.gov.pay.connector.charge.resource.ChargesApiResource.MAX_AMOUNT;
 import static uk.gov.pay.connector.charge.resource.ChargesApiResource.MIN_AMOUNT;
-import static uk.gov.pay.connector.charge.resource.ChargesApiResource.MAXIMUM_FIELDS_SIZE;
 import static uk.gov.pay.connector.common.validator.ApiValidators.parseZonedDateTime;
 import static uk.gov.pay.connector.common.validator.ApiValidators.validateChargeParams;
 import static uk.gov.pay.connector.common.validator.ApiValidators.validateChargePatchParams;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
 
 
 class ApiValidatorsTest {
@@ -35,10 +36,10 @@ class ApiValidatorsTest {
     void shouldValidateEmailLength_WhenPatchingAnEmail() {
 
         PatchRequestBuilder.PatchRequest request = PatchRequestBuilder.aPatchRequestBuilder(
-                ImmutableMap.of(
-                        "op", "replace",
-                        "path", "email",
-                        "value", "test@example.com"))
+                        ImmutableMap.of(
+                                "op", "replace",
+                                "path", "email",
+                                "value", "test@example.com"))
                 .withValidOps(singletonList("replace"))
                 .withValidPaths(ImmutableSet.of("email"))
                 .build();
@@ -49,10 +50,10 @@ class ApiValidatorsTest {
     void shouldInvalidateEmailLength_WhenPatchingAnEmail() {
 
         PatchRequestBuilder.PatchRequest request = PatchRequestBuilder.aPatchRequestBuilder(
-                ImmutableMap.of(
-                        "op", "replace",
-                        "path", "email",
-                        "value", randomAlphanumeric(255) + "@example.com"))
+                        ImmutableMap.of(
+                                "op", "replace",
+                                "path", "email",
+                                "value", randomAlphaNumeric(255) + "@example.com"))
                 .withValidOps(singletonList("replace"))
                 .withValidPaths(ImmutableSet.of("email"))
                 .build();
@@ -86,7 +87,7 @@ class ApiValidatorsTest {
     @Test
     void validateChargeParams_shouldRejectEmail_when255Characters() {
         Map<String, String> inputData = new HashMap<>();
-        inputData.put(EMAIL_KEY, randomAlphanumeric(255));
+        inputData.put(EMAIL_KEY, randomAlphaNumeric(255));
 
         Optional<List<String>> result = validateChargeParams(inputData);
 
@@ -122,7 +123,7 @@ class ApiValidatorsTest {
     @Test
     void validateChargeParams_shouldRejectEmailAndAmount_whenBothInvalid() {
         Map<String, String> inputData = new HashMap<>();
-        inputData.put(EMAIL_KEY, randomAlphanumeric(255));
+        inputData.put(EMAIL_KEY, randomAlphaNumeric(255));
         inputData.put(AMOUNT_KEY, String.valueOf(MAX_AMOUNT + 1));
 
         Optional<List<String>> result = validateChargeParams(inputData);
@@ -240,5 +241,5 @@ class ApiValidatorsTest {
 
         assertThat(result, is(Optional.of(Collections.singletonList("delayed_capture"))));
     }
-    
+
 }

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -46,15 +46,15 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
 
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -129,7 +129,7 @@ public class RefundServiceTest {
 
     @BeforeEach
     void setUp() {
-        refundId = ThreadLocalRandom.current().nextLong();
+        refundId = current().nextLong(0, Long.MAX_VALUE);
         refundEntity = aValidRefundEntity().withChargeExternalId(externalChargeId).withAmount(REFUND_AMOUNT).build();
         lenient().when(mockProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockProvider);
         lenient().when(mockProvider.getRefundEntityFactory()).thenReturn(mockRefundEntityFactory);
@@ -439,7 +439,7 @@ public class RefundServiceTest {
                 .build();
 
         Charge charge = Charge.from(chargeEntity);
-        
+
         var thrown = assertThrows(GatewayAccountDisabledException.class,
                 () -> refundService.submitRefund(disabledAccount, charge, new RefundRequest(100L, 0, userExternalId)));
         assertThat(thrown.getMessage(), is("Attempt to create a refund for a disabled gateway account"));
@@ -585,7 +585,7 @@ public class RefundServiceTest {
                 .withStatus(AUTHORISATION_SUCCESS)
                 .withPaymentProvider(SANDBOX.getName())
                 .build();
-        
+
         RefundEntity refundExpungedSinceWeFirstChecked = aValidRefundEntity()
                 .withAmount(100L)
                 .withExternalId("refund1")

--- a/src/test/java/uk/gov/pay/connector/util/AddAgreementParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddAgreementParams.java
@@ -2,8 +2,9 @@ package uk.gov.pay.connector.util;
 
 import java.time.Instant;
 import java.util.Objects;
-import java.util.Random;
 import java.util.stream.Stream;
+
+import static java.util.concurrent.ThreadLocalRandom.current;
 
 public class AddAgreementParams {
 
@@ -72,7 +73,7 @@ public class AddAgreementParams {
     }
 
     public static final class AddAgreementParamsBuilder {
-        private Long agreementId = new Random().nextLong();
+        private Long agreementId = current().nextLong(0, Long.MAX_VALUE);
         private String externalAgreementId = "anExternalAgreementId";
         private boolean live = false;
         private String serviceId = "aServiceId";

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.util;
 
 import com.google.gson.Gson;
-import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.postgresql.util.PGobject;
@@ -35,6 +34,7 @@ import java.util.stream.Collectors;
 import static java.sql.Types.OTHER;
 import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.now;
+import static java.util.concurrent.ThreadLocalRandom.current;
 
 public class DatabaseTestHelper {
 
@@ -272,7 +272,7 @@ public class DatabaseTestHelper {
     public int addRefund(String externalId, long amount, RefundStatus status,
                          String gatewayTransactionId, ZonedDateTime createdDate, String submittedByUserExternalId,
                          String userEmail, String chargeExternalId, ParityCheckStatus parityCheckStatus, ZonedDateTime parityCheckDate) {
-        int refundId = RandomUtils.nextInt();
+        int refundId = current().nextInt(0, Integer.MAX_VALUE);
         jdbi.withHandle(handle ->
                 handle
                         .createUpdate("INSERT INTO refunds(id, external_id, amount, status, " +
@@ -983,7 +983,7 @@ public class DatabaseTestHelper {
                         .list()
         );
     }
-    
+
     public List<String> getRefundStatusHistoryByChargeExternalId(String chargeExternalId) {
         return getRefundsHistoryByChargeExternalId(chargeExternalId).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
     }
@@ -1217,13 +1217,13 @@ public class DatabaseTestHelper {
         );
     }
 
-    public void insertIdempotency(String key, Long gatewayAccountId, String resourceExternalId, Map<String,Object> requestBody) {
+    public void insertIdempotency(String key, Long gatewayAccountId, String resourceExternalId, Map<String, Object> requestBody) {
         PGobject requestBodyJson = mapToJsonPGobject(requestBody);
 
         jdbi.withHandle(handle ->
                 handle.createUpdate("INSERT INTO idempotency(key, gateway_account_id, " +
-                        "resource_external_id, request_body) " +
-                        " VALUES (:key, :gatewayAccountId, :resourceExternalId, :requestBody)")
+                                "resource_external_id, request_body) " +
+                                " VALUES (:key, :gatewayAccountId, :resourceExternalId, :requestBody)")
                         .bind("key", key)
                         .bind("gatewayAccountId", gatewayAccountId)
                         .bind("resourceExternalId", resourceExternalId)
@@ -1231,7 +1231,7 @@ public class DatabaseTestHelper {
                         .execute());
     }
 
-    public void insertIdempotency(String key, Instant createdDate, Long gatewayAccountId, String resourceExternalId, Map<String,Object> requestBody) {
+    public void insertIdempotency(String key, Instant createdDate, Long gatewayAccountId, String resourceExternalId, Map<String, Object> requestBody) {
         PGobject requestBodyJson = mapToJsonPGobject(requestBody);
 
         jdbi.withHandle(handle ->
@@ -1245,7 +1245,7 @@ public class DatabaseTestHelper {
                         .bindBySqlType("requestBody", requestBodyJson, OTHER)
                         .execute());
     }
-    
+
     public void insertGatewayAccountCredentials(AddGatewayAccountCredentialsParams params) {
         PGobject credentialsJson = buildCredentialsJson(params);
 
@@ -1281,7 +1281,7 @@ public class DatabaseTestHelper {
             throw new RuntimeException(e);
         }
     }
-    
+
     private static PGobject mapToJsonPGobject(Map map) {
         PGobject json = getJsonPGobject();
         try {
@@ -1293,7 +1293,7 @@ public class DatabaseTestHelper {
             throw new RuntimeException("Failed to convert map to PGobject", e);
         }
     }
-    
+
     private static PGobject getJsonPGobject() {
         PGobject pGobject = new PGobject();
         pGobject.setType("json");


### PR DESCRIPTION
## WHAT YOU DID
_A brief description of the pull request:_
Changes Part 1/3:
- Removed unused import
- Reorganised imports
- Removed extra spaces
- Updated deprecated StringUntil to Strings
- Updated deprecated DescriptorCustomizer
- Updating deprecated Jwts from signingkey to verifywithf and parseclaimsjws to parsesignedclaims and get body to getpayload
- Added new class for random numbers and alphabets
- Updated deprecated randomAlphanumeric to custom
- Removed and depreacated isSuccesful and isFailed and replaced with appropriate method
- Rather than reading from a map use concrete classes 
- Updated deprecated nextLong and nextInt to appropriate methoda (hard coded the value as new method can generate 0, Long.MAX_VALUE
- get(0); to getFirst();
- Updated deprecated jsonparser with new appropriate method
- Updated deprecated ObjectUtils to objects

No functional changes intended; behavior preserved.

## How to test

- How should it be reviewed?  Looks at the code changes and see no functional changes, see that tests pass 
- What feedback do you need? Comments

## Notes
NOTE: 

1. Custom code using pure java removes dependency and using ThreadLocalRandom is faster
2. nextLong(0, Long.MAX_VALUE) was used rather than nextLong() because it also includes negative number and it does not mimic the behaviour of the deprecated call
3. It was considered to use RandomStringUtils.insecure()next/nextNumeric/nextAlphanumeric however it returns a string and needs to be parsed. it just makes the code longer. ThreadLocalRandom
