### PR TITLE
PP-14778 - Deprecated and warnings 2/3

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -718,7 +718,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java",
         "hashed_secret": "aa4f63822a427d27308ddef0e735bc21f8f2f7f7",
         "is_verified": false,
-        "line_number": 169
+        "line_number": 168
       }
     ],
     "src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-02T16:58:57Z"
+  "generated_at": "2025-12-11T08:34:11Z"
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeType.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeType.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.Arrays;
 
@@ -9,11 +9,11 @@ public enum FeeType {
     RADAR("radar"),
     THREE_D_S("three_ds"),
     TRANSACTION("transaction");
-    
+
     FeeType(String name) {
         this.name = name;
     }
-    
+
     private String name;
 
     @JsonValue
@@ -23,7 +23,7 @@ public enum FeeType {
 
     public static FeeType fromString(String feeTypeValue) {
         return Arrays.stream(FeeType.values())
-                .filter(feeTypeEnum -> StringUtils.equals(feeTypeEnum.getName(), feeTypeValue))
+                .filter(feeTypeEnum -> Strings.CS.equals(feeTypeEnum.getName(), feeTypeValue))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("fee type not recognized: " + feeTypeValue));
     }

--- a/src/main/java/uk/gov/pay/connector/events/HistoricalEventEmitterService.java
+++ b/src/main/java/uk/gov/pay/connector/events/HistoricalEventEmitterService.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.events;
 
 import com.google.inject.persist.Transactional;
-import org.apache.commons.lang3.RandomUtils;
+import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -20,12 +20,12 @@ import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.tasks.HistoricalEventEmitter;
 
-import jakarta.inject.Inject;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static uk.gov.service.payments.logging.LoggingKeys.MDC_REQUEST_ID_KEY;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 
@@ -61,7 +61,7 @@ public class HistoricalEventEmitterService {
 
     public void emitHistoricEventsById(Long startId, OptionalLong maybeMaxId, Long doNotRetryEmitUntilDuration) {
         try {
-            MDC.put(MDC_REQUEST_ID_KEY, "HistoricalEventEmitterWorker-" + RandomUtils.nextLong(0, 10000));
+            MDC.put(MDC_REQUEST_ID_KEY, "HistoricalEventEmitterWorker-" + current().nextLong(0, 10000));
             initializeHistoricalEventEmitter(doNotRetryEmitUntilDuration);
             maxId = maybeMaxId.orElseGet(chargeDao::findMaxId);
             logger.info("Starting from {} up to {}", startId, maxId);
@@ -83,7 +83,7 @@ public class HistoricalEventEmitterService {
     }
 
     public void emitHistoricEventsByDate(ZonedDateTime startDate, ZonedDateTime endDate, Long doNotRetryEmitUntilDuration) {
-        MDC.put(MDC_REQUEST_ID_KEY, "HistoricalEventEmitterWorker-" + RandomUtils.nextLong(0, 10000));
+        MDC.put(MDC_REQUEST_ID_KEY, "HistoricalEventEmitterWorker-" + current().nextLong(0, 10000));
 
         initializeHistoricalEventEmitter(doNotRetryEmitUntilDuration);
         logger.info("Starting to emit events from date range {} up to {}", startDate, endDate);
@@ -94,7 +94,7 @@ public class HistoricalEventEmitterService {
 
     public void emitRefundEventsOnlyById(Long startId, OptionalLong maybeMaxId, Long doNotRetryEmitUntilDuration) {
         try {
-            MDC.put(MDC_REQUEST_ID_KEY, "HistoricalEventEmitterWorker-" + RandomUtils.nextLong(0, 10000));
+            MDC.put(MDC_REQUEST_ID_KEY, "HistoricalEventEmitterWorker-" + current().nextLong(0, 10000));
             initializeHistoricalEventEmitter(doNotRetryEmitUntilDuration);
 
             maxId = maybeMaxId.orElseGet(refundDao::findMaxId);

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/model/StripeChargeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/model/StripeChargeStatus.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.stripe.model;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 
 import java.util.Arrays;
@@ -28,7 +28,7 @@ public enum StripeChargeStatus {
 
     public static StripeChargeStatus fromString(String stripeStatusValue) {
         return Arrays.stream(StripeChargeStatus.values())
-                .filter(stripeChargeStatusEnum -> StringUtils.equals(stripeChargeStatusEnum.getName(), stripeStatusValue))
+                .filter(stripeChargeStatusEnum -> Strings.CS.equals(stripeChargeStatusEnum.getName(), stripeStatusValue))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Stripe charge status not recognized: " + stripeStatusValue));
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
+import jakarta.inject.Inject;
 import net.logstash.logback.argument.StructuredArgument;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -17,7 +18,6 @@ import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 
-import jakarta.inject.Inject;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -104,7 +104,7 @@ public class Card3dsResponseAuthService {
         ChargeStatus newStatus = operationResponse.getMappedChargeStatus();
         if (newStatus == AUTHORISATION_3DS_REQUIRED) {
             int numberOf3dsRequiredEventsRecorded = chargeService.count3dsRequiredEvents(chargeExternalId);
-            if (numberOf3dsRequiredEventsRecorded < authorisation3dsConfig.getMaximumNumberOfTimesToAllowUserToAttempt3ds()){
+            if (numberOf3dsRequiredEventsRecorded < authorisation3dsConfig.getMaximumNumberOfTimesToAllowUserToAttempt3ds()) {
                 LOGGER.info("Gateway instructed us to send the user through 3DS again for {} — this will be attempt {} of {}",
                         chargeExternalId, numberOf3dsRequiredEventsRecorded + 1, authorisation3dsConfig.getMaximumNumberOfTimesToAllowUserToAttempt3ds());
             } else {
@@ -133,9 +133,9 @@ public class Card3dsResponseAuthService {
         var worldPay3dsOrFlexLogMessage = integration3dsType(auth3dsResult, updatedCharge);
         var structuredLoggingArguments = updatedCharge.getStructuredLoggingArgs();
         if (worldPay3dsOrFlexLogMessage == WORLDPAY_3DS_CLASSIC) {
-            structuredLoggingArguments = ArrayUtils.addAll(structuredLoggingArguments, new StructuredArgument[] {kv(INTEGRATION_3DS_VERSION, "3DS")});
+            structuredLoggingArguments = ArrayUtils.addAll(structuredLoggingArguments, new StructuredArgument[]{kv(INTEGRATION_3DS_VERSION, "3DS")});
         } else if (worldPay3dsOrFlexLogMessage == WORLDPAY_3DS_FLEX) {
-            structuredLoggingArguments = ArrayUtils.addAll(structuredLoggingArguments, new StructuredArgument[] {kv(INTEGRATION_3DS_VERSION, "3DS Flex")});
+            structuredLoggingArguments = ArrayUtils.addAll(structuredLoggingArguments, new StructuredArgument[]{kv(INTEGRATION_3DS_VERSION, "3DS Flex")});
         }
 
         var logMessage = String.format(Locale.UK, "3DS authentication result%s authorisation for %s (%s %s) for %s (%s) - %s .'. %s -> %s",
@@ -149,7 +149,7 @@ public class Card3dsResponseAuthService {
                 oldChargeStatus,
                 updatedCharge.getStatus());
 
-        LOGGER.info(logMessage, structuredLoggingArguments);
+        LOGGER.info(logMessage, (Object[]) structuredLoggingArguments);
 
         authorisationService.emitAuthorisationMetric(updatedCharge, "authorise-3ds");
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -149,7 +149,7 @@ public class Card3dsResponseAuthService {
                 oldChargeStatus,
                 updatedCharge.getStatus());
 
-        LOGGER.info(logMessage, (Object[]) structuredLoggingArguments);
+        LOGGER.info(logMessage, structuredLoggingArguments);
 
         authorisationService.emitAuthorisationMetric(updatedCharge, "authorise-3ds");
     }

--- a/src/main/java/uk/gov/pay/connector/tasks/service/ParityCheckerService.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/service/ParityCheckerService.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.tasks.service;
 
 import com.google.inject.persist.Transactional;
-import org.apache.commons.lang3.RandomUtils;
+import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -17,11 +17,11 @@ import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.tasks.HistoricalEventEmitter;
 
-import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.EXISTS_IN_LEDGER;
 import static uk.gov.service.payments.logging.LoggingKeys.MDC_REQUEST_ID_KEY;
@@ -44,8 +44,8 @@ public class ParityCheckerService {
 
     @Inject
     public ParityCheckerService(ChargeDao chargeDao, ChargeService chargeService, EmittedEventDao emittedEventDao,
-                             StateTransitionService stateTransitionService, EventService eventService,
-                             RefundService refundService, RefundDao refundDao, ParityCheckService parityCheckService) {
+                                StateTransitionService stateTransitionService, EventService eventService,
+                                RefundService refundService, RefundDao refundDao, ParityCheckService parityCheckService) {
         this.chargeDao = chargeDao;
         this.chargeService = chargeService;
         this.emittedEventDao = emittedEventDao;
@@ -62,7 +62,7 @@ public class ParityCheckerService {
         try {
             initializeHistoricalEventEmitter(doNotRetryEmitUntilDuration);
 
-            MDC.put(MDC_REQUEST_ID_KEY, "ParityCheckWorker-" + RandomUtils.nextLong(0, 10000));
+            MDC.put(MDC_REQUEST_ID_KEY, "ParityCheckWorker-" + current().nextLong(0, 10000));
 
             if (parityCheckStatus.isPresent()) {
                 checkParityForParityCheckStatus(parityCheckStatus.get());
@@ -86,7 +86,7 @@ public class ParityCheckerService {
 
     public void checkParityForRefundsOnly(Long startId, Long maxId, boolean doNotReprocessValidRecords,
                                           String parityCheckStatus, Long doNotRetryEmitUntilDuration) {
-        String parityCheckRequestId = "ParityCheckWorker-" + RandomUtils.nextLong(0, 10000);
+        String parityCheckRequestId = "ParityCheckWorker-" + current().nextLong(0, 10000);
         try {
             initializeHistoricalEventEmitter(doNotRetryEmitUntilDuration);
             MDC.put(MDC_REQUEST_ID_KEY, parityCheckRequestId);

--- a/src/main/java/uk/gov/pay/connector/util/RandomAlphaNumericString.java
+++ b/src/main/java/uk/gov/pay/connector/util/RandomAlphaNumericString.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.connector.util;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.util.concurrent.ThreadLocalRandom.current;
+
+public final class RandomAlphaNumericString {
+
+    private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final String NUMS = "0123456789";
+    private static final String ALPHA_NUM = CHARS + NUMS;
+
+    private RandomAlphaNumericString() {
+        // utility class - prevent instantiation
+    }
+
+    public static String randomAlphabetic(int length) {
+        return randomFromCharset(CHARS, length);
+    }
+
+
+    public static String randomAlphaNumeric(int length) {
+        return randomFromCharset(ALPHA_NUM, length);
+    }
+
+    private static String randomFromCharset(String charset, int length) {
+        if (length < 0) {
+            throw new IllegalArgumentException("length must be non-negative");
+        }
+        ThreadLocalRandom rnd = current();
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(charset.charAt(rnd.nextInt(charset.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequest.java
@@ -2,24 +2,26 @@ package uk.gov.pay.connector.wallets.googlepay.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import uk.gov.pay.connector.wallets.WalletAuthorisationRequest;
 import uk.gov.pay.connector.wallets.WalletType;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import java.util.Optional;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.WRITE_ONLY;
+
 public class GooglePayAuthRequest implements WalletAuthorisationRequest {
-    
+
     @Schema(hidden = true)
     @NotNull
     @Valid
     private final GooglePayPaymentInfo paymentInfo;
-    
+
     @Valid
     @Schema(hidden = true)
     private final GooglePayEncryptedPaymentData encryptedPaymentData;
-    
+
     @Valid
     @JsonProperty("token_id")
     private final String tokenId;
@@ -41,19 +43,19 @@ public class GooglePayAuthRequest implements WalletAuthorisationRequest {
                                 String tokenId) {
         this(paymentInfo, null, tokenId);
     }
-    
+
     @Override
     public GooglePayPaymentInfo getPaymentInfo() {
         return paymentInfo;
     }
 
-    @Schema(description = "only required for Stripe payments", writeOnly = true)
+    @Schema(description = "only required for Stripe payments", accessMode = WRITE_ONLY)
     public Optional<String> getTokenId() { return Optional.of(tokenId); }
-    
+
     public Optional<GooglePayEncryptedPaymentData> getEncryptedPaymentData() {
         return Optional.of(encryptedPaymentData);
     }
-    
+
     @Schema(hidden = true)
     @Override
     public WalletType getWalletType() {

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
@@ -11,7 +11,7 @@ import uk.gov.pay.connector.it.base.ITestBaseExtension;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -37,7 +37,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
                 "organisational_unit_id", "My Org",
                 "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
         );
-        setUpChargeAndAccount(gatewayAccountId, WORLDPAY, validCredentials, nextLong(), chargeExternalId, ChargeStatus.CREATED);
+        setUpChargeAndAccount(gatewayAccountId, WORLDPAY, validCredentials, current().nextLong(0, Long.MAX_VALUE), chargeExternalId, ChargeStatus.CREATED);
 
         testBaseExtension.getConnectorRestApiClient()
                 .withChargeId(chargeExternalId)
@@ -50,7 +50,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
     void shouldReturn409WhenCredentialsAreMissingForGatewayAccount() {
         var chargeExternalId = "mySecondChargeId";
         var gatewayAccountId = "202";
-        setUpChargeAndAccount(gatewayAccountId, WORLDPAY, null, nextLong(), chargeExternalId,
+        setUpChargeAndAccount(gatewayAccountId, WORLDPAY, null, current().nextLong(0, Long.MAX_VALUE), chargeExternalId,
                 ChargeStatus.CREATED);
 
         testBaseExtension.getConnectorRestApiClient()
@@ -69,7 +69,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
                 "organisational_unit_id", "My Org",
                 "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
         );
-        setUpChargeAndAccount(gatewayAccountId, STRIPE, validCredentials, nextLong(), chargeExternalId,
+        setUpChargeAndAccount(gatewayAccountId, STRIPE, validCredentials, current().nextLong(0, Long.MAX_VALUE), chargeExternalId,
                 ChargeStatus.CREATED);
 
         testBaseExtension.getConnectorRestApiClient()
@@ -81,7 +81,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
 
     @Test
     void shouldReturnChallengeJwt() {
-        long chargeId = nextLong();
+        long chargeId = current().nextLong(0, Long.MAX_VALUE);
         var chargeExternalId = "myFirstChargeId";
         var gatewayAccountId = "101";
         var validCredentials = Map.of(
@@ -94,8 +94,8 @@ public class ChargesFrontendResourceWorldpayJwtIT {
 
         app.getDatabaseTestHelper().updateCharge3dsFlexChallengeDetails(chargeId,
                 "http://example.com",
-                "a-transaction-id", 
-                "a-payload", 
+                "a-transaction-id",
+                "a-payload",
                 "2.1.0");
 
         testBaseExtension.getConnectorRestApiClient()
@@ -109,7 +109,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
 
     @Test
     void shouldOmitChallengeJwtWhenChargeNotInAppropriateState() {
-        long chargeId = nextLong();
+        long chargeId = current().nextLong(0, Long.MAX_VALUE);
         var chargeExternalId = "myFirstChargeId";
         var gatewayAccountId = "101";
         var validCredentials = Map.of(

--- a/src/test/java/uk/gov/pay/connector/charge/util/JwtGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/util/JwtGeneratorTest.java
@@ -24,13 +24,13 @@ public class JwtGeneratorTest {
         String token = jwtGenerator.createJwt(claims, secret);
 
         Jws<Claims> jws = Jwts.parser()
-                .setSigningKey(new SecretKeySpec(secret.getBytes(), "HmacSHA256"))
+                .verifyWith(new SecretKeySpec(secret.getBytes(), "HmacSHA256"))
                 .build()
-                .parseClaimsJws(token);
+                .parseSignedClaims(token);
 
         assertThat(jws.getHeader().getAlgorithm(), is("HS256"));
         assertThat(jws.getHeader().get("typ"), is("JWT"));
-        assertThat(jws.getBody().get("key1"), is("value1"));
-        assertThat(jws.getBody().get("key2"), is("value2"));
+        assertThat(jws.getPayload().get("key1"), is("value1"));
+        assertThat(jws.getPayload().get("key2"), is("value2"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
+++ b/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
@@ -7,7 +7,6 @@ import com.google.inject.persist.jpa.JpaPersistModule;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.restassured.specification.RequestSpecification;
-import org.apache.commons.lang3.RandomUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -41,6 +40,7 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static uk.gov.pay.connector.rules.PostgresTestDocker.getConnectionUrl;
 import static uk.gov.pay.connector.rules.PostgresTestDocker.getDbPassword;
 import static uk.gov.pay.connector.rules.PostgresTestDocker.getDbUsername;
@@ -71,19 +71,19 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
     private LedgerStub ledgerStub;
     private CardidStub cardidStub;
     private NotifyStub notifyStub;
-    
-    protected static String accountId = String.valueOf(RandomUtils.nextInt());
+
+    protected static String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
     protected static ObjectMapper mapper;
     protected DatabaseFixtures databaseFixtures;
 
     public AppWithPostgresAndSqsExtension() {
         this(ConnectorApp.class, new ConfigOverride[0]);
     }
-    
+
     public AppWithPostgresAndSqsExtension(Class CustomConnectorClass) {
         this(CustomConnectorClass, new ConfigOverride[0]);
     }
-    
+
     public AppWithPostgresAndSqsExtension(ConfigOverride... configOverrides) {
         this(ConnectorApp.class, configOverrides);
     }
@@ -96,13 +96,13 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
         stripeWireMockServer = new WireMockServer(wireMockConfig().dynamicPort().bindAddress("localhost"));
         ledgerWireMockServer = new WireMockServer(wireMockConfig().dynamicPort().bindAddress("localhost"));
         notifyWireMockServer = new WireMockServer(wireMockConfig().dynamicPort().bindAddress("localhost"));
-        
+
         wireMockServer.start();
         worldpayWireMockServer.start();
         stripeWireMockServer.start();
         ledgerWireMockServer.start();
         notifyWireMockServer.start();
-        
+
         wireMockPort = wireMockServer.port();
         worldpayWireMockPort = worldpayWireMockServer.port();
         stripeWireMockPort = stripeWireMockServer.port();
@@ -129,7 +129,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
 
         jdbi = Jdbi.create(getConnectionUrl(), getDbUsername(), getDbPassword());
         jdbi.installPlugin(new SqlObjectPlugin());
-        
+
         databaseTestHelper = new DatabaseTestHelper(jdbi);
 
         worldpayMockClient = new WorldpayMockClient(worldpayWireMockServer);
@@ -138,13 +138,13 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
         ledgerStub = new LedgerStub(ledgerWireMockServer);
         cardidStub = new CardidStub(wireMockServer);
         notifyStub = new NotifyStub(notifyWireMockServer);
-        
+
         databaseFixtures = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper);
         mapper = new ObjectMapper();
 
         injector = InjectorLookup.getInjector(dropwizardAppExtension.getApplication()).get();
     }
-    
+
     public void resetWireMockServer() {
         wireMockServer.resetAll();
         worldpayWireMockServer.resetAll();
@@ -153,10 +153,11 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
         notifyWireMockServer.resetAll();
         ledgerStub.acceptPostEvent();
     }
+
     public void resetDatabase() {
         databaseTestHelper.truncateAllData();
     }
-    
+
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
         if (context.getRequiredTestClass().getEnclosingClass() == null) {
@@ -169,6 +170,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
     public void beforeEach(ExtensionContext context) {
         ledgerStub.acceptPostEvent();
     }
+
     @Override
     public void afterEach(ExtensionContext context) {
         resetWireMockServer();
@@ -199,7 +201,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
         newConfigOverride.add(config("database.password", getDbPassword()));
         return newConfigOverride.toArray(new ConfigOverride[0]);
     }
-    
+
     private ConfigOverride[] overrideEndpointConfig(ConfigOverride[] configOverrides) {
         List<ConfigOverride> newConfigOverride = newArrayList(configOverrides);
         newConfigOverride.add(config("worldpay.urls.test", "http://localhost:" + worldpayWireMockPort + "/jsp/merchant/xml/paymentService.jsp"));
@@ -262,7 +264,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
     public WireMockServer getWireMockServer() {
         return wireMockServer;
     }
-    
+
     public WireMockServer getStripeWireMockServer() {
         return stripeWireMockServer;
     }
@@ -290,11 +292,11 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
     public LedgerStub getLedgerStub() {
         return ledgerStub;
     }
-    
+
     public CardidStub getCardidStub() {
         return cardidStub;
     }
-    
+
     public NotifyStub getNotifyStub() {
         return notifyStub;
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -89,8 +89,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -102,6 +102,7 @@ public class SandboxPaymentProviderTest {
         assertThat(authoriseResponse.getErrorMessage(), is(nullValue()));
         assertThat(authoriseResponse.getGatewayRecurringAuthToken().isPresent(), is(true));
     }
+
     @Test
     void authorise_shouldBeAuthorisedWithUserNotPresetSuccessPaymentInstrument() {
         var cardNumber = AUTH_SUCCESS_CARD_NUMBER;
@@ -119,8 +120,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().withPaymentInstrument(paymentInstrument).build();
         GatewayResponse gatewayResponse = provider.authoriseUserNotPresent(RecurringPaymentAuthorisationGatewayRequest.valueOf(charge));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -132,7 +133,7 @@ public class SandboxPaymentProviderTest {
         assertThat(authoriseResponse.getErrorMessage(), is(nullValue()));
         assertThat(authoriseResponse.getGatewayRecurringAuthToken().isPresent(), is(true));
     }
-    
+
     @Test
     void authorise_shouldSetRecurringAuthToken() {
         AuthCardDetails authCardDetails = new AuthCardDetails();
@@ -143,8 +144,8 @@ public class SandboxPaymentProviderTest {
                 .build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -165,8 +166,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -186,8 +187,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
 
@@ -204,8 +205,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
 
@@ -234,8 +235,8 @@ public class SandboxPaymentProviderTest {
 
         GatewayResponse<BaseCancelResponse> gatewayResponse = provider.cancel(CancelGatewayRequest.valueOf(ChargeEntityFixture.aValidChargeEntity().build()));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeAuthoriseHandlerTest.java
@@ -126,7 +126,7 @@ public class StripeAuthoriseHandlerTest {
             GatewayResponse<BaseAuthoriseResponse> response = handler.authorise(buildTestAuthorisationRequest(charge));
             
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().isPresent(), is(true));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().get().getTwoDigitMonth(), is("08"));
@@ -146,7 +146,7 @@ public class StripeAuthoriseHandlerTest {
             GatewayResponse<BaseAuthoriseResponse> response = handler.authorise(buildTestUsAuthorisationRequest(charge));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
         }
 
@@ -176,7 +176,7 @@ public class StripeAuthoriseHandlerTest {
             assertThat(response.getBaseResponse().get().getGatewayRecurringAuthToken().get().get(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY), is("cus_4QFOF3xrvBT3nU"));
             assertThat(response.getBaseResponse().get().getGatewayRecurringAuthToken().get().get(STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY), is("pm_1FHESdEZsufgnuO0bzghQoZ2"));
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
         }
 
@@ -193,7 +193,7 @@ public class StripeAuthoriseHandlerTest {
             GatewayResponse<BaseAuthoriseResponse> response = handler.authorise(buildTestAuthorisationRequest(charge));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_123")); // id from templates/stripe/create_payment_intent_requires_3ds_response.json
 
             Optional<Stripe3dsRequiredParams> stripeParamsFor3ds = (Optional<Stripe3dsRequiredParams>) response.getBaseResponse().get().getGatewayParamsFor3ds();
@@ -212,7 +212,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestCharge();
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertEquals("jakarta.ws.rs.ProcessingException: java.io.IOException",
                     authoriseResponse.getGatewayError().get().getMessage());
@@ -303,7 +303,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestCharge();
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -320,7 +320,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestCharge();
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -337,7 +337,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestChargeToSetUpAgreement(buildTestGatewayAccountEntity(), "agreement description");
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -356,7 +356,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestChargeToSetUpAgreement(buildTestGatewayAccountEntity(), "agreement description");
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -382,7 +382,7 @@ public class StripeAuthoriseHandlerTest {
             assertThat(paymentIntentRequest.getPaymentMethodId(), is(PAYMENT_METHOD_ID));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
         }
 
@@ -413,7 +413,7 @@ public class StripeAuthoriseHandlerTest {
             RecurringPaymentAuthorisationGatewayRequest authRequest = RecurringPaymentAuthorisationGatewayRequest.valueOf(charge);
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authoriseUserNotPresent(authRequest);
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -429,7 +429,7 @@ public class StripeAuthoriseHandlerTest {
             RecurringPaymentAuthorisationGatewayRequest authRequest = RecurringPaymentAuthorisationGatewayRequest.valueOf(charge);
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authoriseUserNotPresent(authRequest);
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertEquals("jakarta.ws.rs.ProcessingException: java.io.IOException",
                     authoriseResponse.getGatewayError().get().getMessage());
@@ -456,7 +456,7 @@ public class StripeAuthoriseHandlerTest {
             var paymentIntentRequest = (StripePaymentIntentRequest) allRequests.get(1);
             assertThat(paymentIntentRequest.getTokenId(), is("tok_1NrjK3Hj08j2jFuBm3LGVHYe"));
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().isPresent(), is(true));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().get().getTwoDigitMonth(), is("08"));
@@ -534,7 +534,7 @@ public class StripeAuthoriseHandlerTest {
             assertThat(paymentIntentRequest.getTokenId(), is(TOKEN_ID));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().isPresent(), is(true));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().get().getTwoDigitMonth(), is("08"));
@@ -553,7 +553,7 @@ public class StripeAuthoriseHandlerTest {
         GatewayResponse<BaseAuthoriseResponse> response = handler.authoriseGooglePay(buildGooglePayAuthorisationRequest(charge));
 
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS));
-        assertTrue(response.isSuccessful());
+        assertTrue(response.getBaseResponse().isPresent());
         assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_123"));
 
         Optional<Stripe3dsRequiredParams> stripeParamsFor3ds = (Optional<Stripe3dsRequiredParams>) response.getBaseResponse().get().getGatewayParamsFor3ds();

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
@@ -20,10 +20,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static jakarta.ws.rs.core.Response.Status.OK;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
-import static jakarta.ws.rs.core.Response.Status.OK;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -676,7 +676,7 @@ public class GatewayAccountCredentialsResourceIT {
             GatewayAccountType gatewayAccountType,
             Map<String, Object> credentials) {
 
-        long accountId = nextLong(2, 10000);
+        long accountId = current().nextLong(2, 10000);
         LocalDateTime createdDate = LocalDate.parse("2021-01-01").atStartOfDay();
         LocalDateTime activeStartDate = LocalDate.parse("2021-02-01").atStartOfDay();
         LocalDateTime activeEndDate = LocalDate.parse("2021-03-01").atStartOfDay();

--- a/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.it.base;
 import com.google.gson.JsonObject;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.apache.commons.lang3.RandomUtils;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -36,11 +35,9 @@ import java.util.Optional;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.lang.String.format;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
-import static org.apache.commons.lang3.RandomUtils.nextInt;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.lang.String.format;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyOrNullString;
@@ -69,6 +66,8 @@ import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.a
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphabetic;
 import static uk.gov.pay.connector.util.TransactionId.randomId;
 
 public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback, AfterEachCallback, AfterAllCallback {
@@ -105,15 +104,15 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
 
     private String paymentProvider;
 
-    protected static String accountId = String.valueOf(RandomUtils.nextInt());
-    private int gatewayAccountCredentialsId  = RandomUtils.nextInt();
+    protected static String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
+    private int gatewayAccountCredentialsId = current().nextInt(0, Integer.MAX_VALUE);
     private Map<String, Object> credentials;
     private DatabaseFixtures.TestAccount testAccount;
     private static AddGatewayAccountCredentialsParams credentialParams;
     public RestAssuredClient connectorRestApiClient;
     private final DatabaseTestHelper databaseTestHelper;
     private final int appLocalPort;
-    
+
     public ITestBaseExtension(String paymentProvider, int appLocalPort, DatabaseTestHelper databaseTestHelper) {
         this.paymentProvider = paymentProvider;
         this.databaseTestHelper = databaseTestHelper;
@@ -125,25 +124,28 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
         createConnectorRestApiClient();
         createTestAccount();
     }
-    
+
     @Override
     public void beforeEach(ExtensionContext context) {
         setUpBase();
     }
-    
-    @Override
-    public void afterEach(ExtensionContext context) {}
-    
-    @Override
-    public void beforeAll(ExtensionContext context) {}
 
     @Override
-    public void afterAll(ExtensionContext context) {}
+    public void afterEach(ExtensionContext context) {
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+    }
 
     public void createConnectorRestApiClient() {
         connectorRestApiClient = new RestAssuredClient(appLocalPort, accountId);
     }
-    
+
     public void createTestAccount() {
         CardTypeEntity visaCreditCard = databaseTestHelper.getVisaCreditCard();
         testAccount = withDatabaseTestHelper(databaseTestHelper)
@@ -156,7 +158,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
                 .withCardTypeEntities(List.of(visaCreditCard))
                 .insert();
     }
-    
+
     public void createCredentialParams() {
         if (paymentProvider.equals(STRIPE.getName())) {
             credentials = Map.of(CREDENTIALS_STRIPE_ACCOUNT_ID, "stripe-account-id");
@@ -193,7 +195,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
                 .withCredentials(credentials)
                 .build();
     }
-    
+
     public Map<String, Object> getCredentials() {
         return credentials;
     }
@@ -266,7 +268,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     public void assertApiStateIs(String chargeId, String stateString) {
         getCharge(chargeId).body("state.status", is(stateString));
     }
-    
+
     public void assertAgreementPaymentTypeIs(String chargeId, AgreementPaymentType agreementPaymentType) {
         var charge = databaseTestHelper.getChargeByExternalId(chargeId);
         assertThat(charge.get("agreement_payment_type"), is(agreementPaymentType.toString()));
@@ -296,7 +298,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     public String createNewChargeWithServiceId(String serviceId) {
         return createNewChargeWithServiceIdAndStatus(serviceId, CREATED);
     }
-    
+
     public String createNewChargeWithServiceIdAndStatus(String serviceId, ChargeStatus chargeStatus) {
         String chargeExternalId = createNewChargeWith(chargeStatus, "");
         databaseTestHelper.updateServiceIdForCharge(chargeExternalId, serviceId);
@@ -347,6 +349,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     public static String authoriseChargeUrlForApplePay(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/wallets/apple".replace("{chargeId}", chargeId);
     }
+
     public static String authoriseChargeUrlForGooglePayStripe(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/wallets/google/stripe".replace("{chargeId}", chargeId);
     }
@@ -354,11 +357,11 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     public static String authoriseChargeUrlForGooglePayWorldpay(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/wallets/google/worldpay".replace("{chargeId}", chargeId);
     }
-    
+
     public static String authoriseChargeUrlForGooglePay(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/wallets/google".replace("{chargeId}", chargeId);
     }
-    
+
 
     public static String authoriseChargeUrlFor(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeId);
@@ -468,7 +471,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     }
 
     public ChargeUtils.ExternalChargeId addChargeForSetUpAgreement(ChargeStatus status, String agreementExternalId, Long paymentInstrumentId) {
-        long chargeId = RandomUtils.nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
         ChargeUtils.ExternalChargeId externalChargeId = ChargeUtils.ExternalChargeId.fromChargeId(chargeId);
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
@@ -487,7 +490,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     }
 
     public String addAgreement() {
-        String agreementExternalId = String.valueOf(nextLong());
+        String agreementExternalId = String.valueOf(current().nextLong(0, Long.MAX_VALUE));
         AddAgreementParams agreementParams = anAddAgreementParams()
                 .withGatewayAccountId(accountId)
                 .withExternalAgreementId(agreementExternalId)
@@ -497,7 +500,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     }
 
     public Long addPaymentInstrument(String agreementExternalId, PaymentInstrumentStatus status) {
-        Long paymentInstrumentId = nextLong();
+        Long paymentInstrumentId = current().nextLong(0, Long.MAX_VALUE);
         AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)
                 .withAgreementExternalId(agreementExternalId)
@@ -518,10 +521,10 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     ) {
         String agreementExternalId = addAgreement();
 
-        long paymentInstrumentId = nextInt();
+        long paymentInstrumentId = current().nextInt(0, Integer.MAX_VALUE);
         AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder paymentInstrumentParamsBuilder = anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)
-                .withExternalPaymentInstrumentId(String.valueOf(nextInt()))
+                .withExternalPaymentInstrumentId(String.valueOf(current().nextInt(0, Integer.MAX_VALUE)))
                 .withRecurringAuthToken(recurringAuthToken)
                 .withAgreementExternalId(agreementExternalId);
 
@@ -531,7 +534,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
         databaseTestHelper.addPaymentInstrument(paymentInstrumentParamsBuilder.build());
         databaseTestHelper.updateAgreementPaymentInstrumentId(agreementExternalId, paymentInstrumentId);
 
-        long chargeId = RandomUtils.nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
         ChargeUtils.ExternalChargeId externalChargeId = ChargeUtils.ExternalChargeId.fromChargeId(chargeId);
         var chargeParams = anAddChargeParams()
                 .withChargeId(chargeId)
@@ -564,7 +567,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     public String getAccountId() {
         return accountId;
     }
-    
+
     public int getGatewayAccountCredentialsId() {
         return gatewayAccountCredentialsId;
     }

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -148,9 +148,7 @@ class WorldpayPaymentProviderTest {
         } catch (IllegalStateException ex) {
             assumeTrue(false, "Ignoring test since credentials not configured");
         }
-
-        new URL(gatewayUrlMap().get(TEST.toString()).toString()).openConnection().connect();
-
+        gatewayUrlMap().get(TEST.toString()).toURL().openConnection().connect();
 
         validGatewayAccount = new GatewayAccountEntity();
         validGatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.it.dao;
 
 import com.google.common.collect.Lists;
 import jakarta.validation.ConstraintViolationException;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -39,8 +38,8 @@ import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.now;
 import static java.time.temporal.ChronoUnit.MICROS;
 import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static junit.framework.TestCase.assertTrue;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -70,6 +69,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 import static uk.gov.pay.connector.model.domain.Auth3dsRequiredEntityFixture.anAuth3dsRequiredEntity;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.EXTERNAL;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
 
@@ -136,7 +136,7 @@ public class ChargeDaoIT {
         assertThrows(RuntimeException.class, () -> {
             chargeDao.persist(aValidChargeEntity()
                     .withGatewayAccountEntity(gatewayAccount)
-                    .withReference(ServicePaymentReference.of(RandomStringUtils.randomAlphanumeric(255)))
+                    .withReference(ServicePaymentReference.of(randomAlphaNumeric(255)))
                     .build());
         });
     }
@@ -592,7 +592,7 @@ public class ChargeDaoIT {
         TestCharge charge = app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .insert();
@@ -610,7 +610,7 @@ public class ChargeDaoIT {
         app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .insert();
@@ -627,7 +627,7 @@ public class ChargeDaoIT {
         app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withCreatedDate(Instant.now().minus(ofMinutes(30)))
                 .insert();
@@ -666,7 +666,7 @@ public class ChargeDaoIT {
         return app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withCreatedDate(createdDate)
                 .withUpdatedDate(updatedDate)
@@ -679,7 +679,7 @@ public class ChargeDaoIT {
         TestCharge charge = app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withCreatedDate(Instant.now())
                 .withAmount(300L)
@@ -713,7 +713,7 @@ public class ChargeDaoIT {
         app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .withChargeStatus(CAPTURE_APPROVED)
@@ -721,7 +721,7 @@ public class ChargeDaoIT {
         app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .withChargeStatus(CAPTURE_APPROVED_RETRY)
@@ -729,7 +729,7 @@ public class ChargeDaoIT {
         TestCharge charge = app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withCreatedDate(Instant.now())
                 .withChargeStatus(CAPTURE_APPROVED_RETRY)
@@ -751,7 +751,7 @@ public class ChargeDaoIT {
             TestCharge earliestCaptureReadyCharge = app.getDatabaseFixtures()
                     .aTestCharge()
                     .withTestAccount(defaultTestAccount)
-                    .withChargeId(nextLong())
+                    .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                     .withExternalChargeId(RandomIdGenerator.newId())
                     .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                     .withUpdatedDate(Instant.now().minus(Duration.ofHours(2)))
@@ -760,7 +760,7 @@ public class ChargeDaoIT {
             TestCharge charge = app.getDatabaseFixtures()
                     .aTestCharge()
                     .withTestAccount(defaultTestAccount)
-                    .withChargeId(nextLong())
+                    .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                     .withExternalChargeId(RandomIdGenerator.newId())
                     .withCreatedDate(Instant.now())
                     .withUpdatedDate(Instant.now())
@@ -776,7 +776,7 @@ public class ChargeDaoIT {
             TestCharge authSuccessChargeToBeIgnored = app.getDatabaseFixtures()
                     .aTestCharge()
                     .withTestAccount(defaultTestAccount)
-                    .withChargeId(nextLong())
+                    .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                     .withExternalChargeId(RandomIdGenerator.newId())
                     .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                     .withUpdatedDate(Instant.now().minus(Duration.ofHours(2)))
@@ -785,7 +785,7 @@ public class ChargeDaoIT {
             TestCharge captureReadyButRetriedWithInLastHourAndIsIgnored = app.getDatabaseFixtures()
                     .aTestCharge()
                     .withTestAccount(defaultTestAccount)
-                    .withChargeId(nextLong())
+                    .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                     .withExternalChargeId(RandomIdGenerator.newId())
                     .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                     .withUpdatedDate(Instant.now().minus(Duration.ofHours(2)))
@@ -804,7 +804,7 @@ public class ChargeDaoIT {
 
     @Test
     void countCaptureRetriesForChargeExternalId_shouldReturnNumberOfRetries() {
-        long chargeId = nextLong();
+        long chargeId = current().nextLong(0, Long.MAX_VALUE);
         String externalChargeId = RandomIdGenerator.newId();
 
         app.getDatabaseFixtures()
@@ -834,7 +834,7 @@ public class ChargeDaoIT {
 
     @Test
     void count3dsRequiredEventsForChargeExternalId() {
-        long chargeId = nextLong();
+        long chargeId = current().nextLong(0, Long.MAX_VALUE);
         String externalChargeId = RandomIdGenerator.newId();
 
         app.getDatabaseFixtures()
@@ -865,7 +865,7 @@ public class ChargeDaoIT {
         app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .withChargeStatus(CAPTURE_APPROVED)
@@ -873,7 +873,7 @@ public class ChargeDaoIT {
         app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .withChargeStatus(CAPTURE_APPROVED_RETRY)
@@ -909,7 +909,7 @@ public class ChargeDaoIT {
 
         DatabaseFixtures.TestAccount anotherGatewayAccount = app.getDatabaseFixtures()
                 .aTestAccount()
-                .withAccountId(nextLong())
+                .withAccountId(current().nextLong(0, Long.MAX_VALUE))
                 .insert();
         app.getDatabaseFixtures()
                 .aTestCharge()
@@ -1160,14 +1160,14 @@ public class ChargeDaoIT {
     private void insertTestAccount() {
         this.defaultTestAccount = app.getDatabaseFixtures()
                 .aTestAccount()
-                .withAccountId(nextLong())
+                .withAccountId(current().nextLong(0, Long.MAX_VALUE))
                 .insert();
     }
 
     private DatabaseFixtures.TestAccount insertTestAccountWithProvider(String provider) {
         return app.getDatabaseFixtures()
                 .aTestAccount()
-                .withAccountId(nextLong())
+                .withAccountId(current().nextLong(0, Long.MAX_VALUE))
                 .withPaymentProvider(provider)
                 .insert();
     }

--- a/src/test/java/uk/gov/pay/connector/it/dao/IdempotencyDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/IdempotencyDaoIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.it.dao;
 
-import org.apache.commons.lang3.RandomUtils;
+import jakarta.persistence.RollbackException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -10,12 +10,12 @@ import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
 import uk.gov.pay.connector.idempotency.model.IdempotencyEntity;
 import uk.gov.pay.connector.it.base.ITestBaseExtension;
 
-import jakarta.persistence.RollbackException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -55,11 +55,11 @@ public class IdempotencyDaoIT {
     void shouldThrowException_whenGatewayAccountIdAndKeyExists() {
         Map<String, Object> requestBody = Map.of("foo", "bar");
         gatewayAccountDao = app.getInstanceFromGuiceContainer(GatewayAccountDao.class);
-        long gatewayAccountId = RandomUtils.nextLong();
+        long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
         app.getDatabaseTestHelper().addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(String.valueOf(gatewayAccountId))
                 .build());
-        
+
         IdempotencyEntity entity = new IdempotencyEntity(key, gatewayAccountDao.findById(gatewayAccountId).get(),
                 resourceExternalId, requestBody, Instant.now());
         idempotencyDao.persist(entity);
@@ -90,14 +90,14 @@ public class IdempotencyDaoIT {
         String expiringKey = "expiring-idempotency-key";
         String newKey = "new-idempotency-key";
         Instant nowMinus25Hours = Instant.now().minus(25, ChronoUnit.HOURS);
-        
+
         app.getDatabaseTestHelper().insertIdempotency(expiringKey, nowMinus25Hours, Long.parseLong(testBaseExtension.getAccountId()), resourceExternalId, requestBody);
         app.getDatabaseTestHelper().insertIdempotency(newKey, Long.parseLong(testBaseExtension.getAccountId()), resourceExternalId, requestBody);
 
         Instant idempotencyKeyExpiryDate = Instant.now().minus(86400, ChronoUnit.SECONDS);
         idempotencyDao.deleteIdempotencyKeysOlderThanSpecifiedDateTime(idempotencyKeyExpiryDate);
-        
-        Optional<IdempotencyEntity> optionalOldEntity = idempotencyDao.findByGatewayAccountIdAndKey(Long.parseLong(testBaseExtension.getAccountId()),expiringKey);
+
+        Optional<IdempotencyEntity> optionalOldEntity = idempotencyDao.findByGatewayAccountIdAndKey(Long.parseLong(testBaseExtension.getAccountId()), expiringKey);
         assertThat(optionalOldEntity.isPresent(), is(false));
 
         Optional<IdempotencyEntity> optionalNewEntity = idempotencyDao.findByGatewayAccountIdAndKey(Long.parseLong(testBaseExtension.getAccountId()), newKey);

--- a/src/test/java/uk/gov/pay/connector/it/events/EmittedEventResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/EmittedEventResourceIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.it.events;
 
 import io.dropwizard.core.setup.Environment;
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -19,8 +18,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static java.time.temporal.ChronoUnit.MICROS;
 import static jakarta.ws.rs.core.Response.Status.OK;
+import static java.time.temporal.ChronoUnit.MICROS;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -35,11 +35,11 @@ public class EmittedEventResourceIT {
             EmittedEventResourceIT.ConnectorAppWithCustomStateTransitionQueue.class,
             config("emittedEventSweepConfig.notEmittedEventMaxAgeInSeconds", "0")
     );
-    
+
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
     private String externalChargeId;
-    
+
     @BeforeEach
     void setUp() {
         stateTransitionQueue.clear();
@@ -113,7 +113,7 @@ public class EmittedEventResourceIT {
     }
 
     private long addCharge() {
-        long chargeId = RandomUtils.nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
         externalChargeId = "charge" + chargeId;
         app.getDatabaseTestHelper().addCharge(anAddChargeParams()
                 .withChargeId(chargeId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/AgreementsApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/AgreementsApiResourceIT.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
@@ -35,11 +35,11 @@ import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentIns
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class AgreementsApiResourceIT {
-    
+
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     public static GatewayAccountResourceITHelpers testHelpers = new GatewayAccountResourceITHelpers(app.getLocalPort());
-    
+
     public static final String VALID_SERVICE_ID = "a-valid-service-id";
     private static final String REFERENCE_ID = "1234";
     private static final String DESCRIPTION = "a valid description";
@@ -136,7 +136,7 @@ public class AgreementsApiResourceIT {
                         "description", DESCRIPTION,
                         "user_identifier", USER_IDENTIFIER
                 ));
-                
+
                 app.givenSetup()
                         .body(payload)
                         .post(format(CREATE_AGREEMENT_URL, accountId))
@@ -146,14 +146,14 @@ public class AgreementsApiResourceIT {
                         .body("error_identifier", is(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED.toString()));
             }
         }
-        
+
         @Nested
         class CancelAgreement {
             @Test
             void shouldReturn204AndCancelAgreement() {
                 var agreementId = "an-external-id";
                 AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
-                        .withPaymentInstrumentId(nextLong())
+                        .withPaymentInstrumentId(current().nextLong())
                         .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
                         .build();
                 app.getDatabaseTestHelper().addPaymentInstrument(paymentInstrumentParams);
@@ -175,7 +175,7 @@ public class AgreementsApiResourceIT {
                 assertThat(agreementMap.get("cancelled_date"), is(notNullValue()));
             }
         }
-        
+
     }
 
     @Nested
@@ -189,10 +189,10 @@ public class AgreementsApiResourceIT {
                             .withServiceId(VALID_SERVICE_ID)
                             .build());
         }
-        
+
         @Nested
         class CreateAgreement {
-            
+
             @Test
             void shouldCreateAgreement_forValidRequest() {
                 testHelpers.updateGatewayAccount(gatewayAccountId, "recurring_enabled", true);
@@ -305,7 +305,7 @@ public class AgreementsApiResourceIT {
                         "description", DESCRIPTION,
                         "user_identifier", USER_IDENTIFIER
                 ));
-                
+
                 app.givenSetup()
                         .body(payload)
                         .post(format(CREATE_AGREEMENT_BY_SERVICE_ID_URL, VALID_SERVICE_ID, GatewayAccountType.TEST))
@@ -315,10 +315,10 @@ public class AgreementsApiResourceIT {
                         .body("error_identifier", is(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED.toString()));
             }
         }
-        
+
         @Nested
         class CancelAgreement {
-            
+
             @Test
             void shouldReturn204AndCancelAgreement() {
                 testHelpers.updateGatewayAccount(gatewayAccountId, "recurring_enabled", true);
@@ -346,7 +346,7 @@ public class AgreementsApiResourceIT {
 
                 // creating the payment instrument using the database because adding a payment instrument to an agreement via the API is laborious
                 // it would require creating a successful payment to set up the agreement via Charges API
-                long paymentInstrumentId = nextLong();
+                long paymentInstrumentId = current().nextLong();
                 AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
                         .withPaymentInstrumentId(paymentInstrumentId)
                         .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
@@ -366,9 +366,9 @@ public class AgreementsApiResourceIT {
             }
         }
     }
-    
+
     private DatabaseFixtures.TestAccount createTestAccount(String paymentProvider, boolean recurringEnabled) {
-        long accountId = nextLong(2, 10000);
+        long accountId = current().nextLong(2, 10000);
 
         return app.getDatabaseFixtures().aTestAccount().withPaymentProvider(paymentProvider)
                 .withIntegrationVersion3ds(2)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.it.resources;
 
-import org.apache.commons.lang3.RandomUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,6 +22,7 @@ import java.util.stream.Stream;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.HOURS;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItems;
@@ -45,7 +45,7 @@ public class ChargeCancelResourceIT {
 
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
-    
+
     public static Stream<Arguments> cancellableChargeStatesPriorToAuthorisation() {
         return Stream.of(
                 Arguments.of(ChargeStatus.CREATED),
@@ -72,7 +72,7 @@ public class ChargeCancelResourceIT {
     }
 
     @Nested
-    class ByGatewayAccountId {        
+    class ByGatewayAccountId {
         @Test
         @DisplayName("Should return 204 when successful")
         void success_shouldReturn204() {
@@ -142,20 +142,20 @@ public class ChargeCancelResourceIT {
                     .then().statusCode(404)
                     .body("message", is("HTTP 404 Not Found"));
         }
-        
+
         @Test
         @DisplayName("Should preserve charge card details when charge is cancelled")
         void shouldPreserveCardDetailsIfCancelled() {
             String externalChargeId = createNewInPastChargeWithStatus(AUTHORISATION_SUCCESS);
-            Long chargeId = Long.valueOf(StringUtils.removeStart(externalChargeId, "charge"));
-    
+            Long chargeId = Long.valueOf(Strings.CS.removeStart(externalChargeId, "charge"));
+
             app.getWorldpayMockClient().mockCancelSuccess();
-    
+
             Map<String, Object> cardDetails = app.getDatabaseTestHelper().getChargeCardDetailsByChargeId(chargeId);
             assertThat(cardDetails.isEmpty(), is(false));
-    
+
             testBaseExtension.cancelChargeAndCheckApiStatus(externalChargeId, SYSTEM_CANCELLED, 204);
-    
+
             cardDetails = app.getDatabaseTestHelper().getChargeCardDetailsByChargeId(chargeId);
             assertThat(cardDetails, is(notNullValue()));
             assertThat(cardDetails.get("card_brand"), is(notNullValue()));
@@ -168,51 +168,51 @@ public class ChargeCancelResourceIT {
             assertThat(cardDetails.get("address_postcode"), is(notNullValue()));
             assertThat(cardDetails.get("address_country"), is(notNullValue()));
         }
-    
+
         @Test
         @DisplayName("Should add locking status to charge events if charge is cancelled after auth success")
         void chargeEventsShouldHaveLockingStatus_IfCancelledAfterAuth() {
             String chargeId = createNewInPastChargeWithStatus(AUTHORISATION_SUCCESS);
             app.getWorldpayMockClient().mockCancelSuccess();
-    
+
             testBaseExtension.cancelChargeAndCheckApiStatus(chargeId, SYSTEM_CANCELLED, 204);
-    
+
             List<String> events = app.getDatabaseTestHelper().getInternalEvents(chargeId);
             assertThat(events.size(), is(3));
             assertThat(events, hasItems(AUTHORISATION_SUCCESS.getValue(),
                     SYSTEM_CANCEL_READY.getValue(),
                     SYSTEM_CANCELLED.getValue()));
         }
-    
+
         @Test
         @DisplayName("Should add locking status to charge events if charge is cancelled after auth failed")
         void chargeEventsShouldHaveLockingStatus_IfCancelFailedAfterAuth() {
             String chargeId = createNewInPastChargeWithStatus(AUTHORISATION_SUCCESS);
             app.getWorldpayMockClient().mockCancelError();
-    
+
             testBaseExtension.cancelChargeAndCheckApiStatus(chargeId, SYSTEM_CANCEL_ERROR, 204);
-    
+
             List<String> events = app.getDatabaseTestHelper().getInternalEvents(chargeId);
             assertThat(events.size(), is(3));
             assertThat(events, hasItems(AUTHORISATION_SUCCESS.getValue(),
                     SYSTEM_CANCEL_READY.getValue(),
                     SYSTEM_CANCEL_ERROR.getValue()));
         }
-    
+
         @ParameterizedTest()
         @MethodSource("uk.gov.pay.connector.it.resources.ChargeCancelResourceIT#cancellableChargeStatesPriorToAuthorisation")
         @DisplayName("Should not add locking status to charge events if charge is cancelled before auth")
         void chargeEventsShouldNotHaveLockingStatus_IfCancelledBeforeAuth(ChargeStatus status) {
             String chargeId = createNewInPastChargeWithStatus(status);
             testBaseExtension.cancelChargeAndCheckApiStatus(chargeId, ChargeStatus.SYSTEM_CANCELLED, 204);
-    
+
             List<String> events = app.getDatabaseTestHelper().getInternalEvents(chargeId);
             assertThat(events.size(), is(2));
             assertThat(events, hasItems(status.getValue(), ChargeStatus.SYSTEM_CANCELLED.getValue()));
         }
-        
+
         private String createNewInPastChargeWithStatus(ChargeStatus status) {
-            long chargeId = RandomUtils.nextInt();
+            long chargeId = current().nextInt(0, Integer.MAX_VALUE);
             return testBaseExtension.addCharge(anAddChargeParameters().withChargeStatus(status)
                     .withCreatedDate(Instant.now().minus(1, HOURS))
                     .withChargeId(chargeId)
@@ -276,13 +276,13 @@ public class ChargeCancelResourceIT {
         @DisplayName("Should return 404 if account is not found")
         void accountNotFound_shouldReturn404() {
             var chargeId = testBaseExtension.createNewCharge();
-            
+
             app.givenSetup()
                     .post(String.format("/v1/api/service/%s/account/%s/charges/%s/cancel", "not-real-service-id", GatewayAccountType.TEST, chargeId))
                     .then().statusCode(404)
                     .body("message", contains(String.format("Charge with id [%s] not found.", chargeId)));
         }
-    
+
 
         @Test
         @DisplayName("Should preserve charge card details when charge is cancelled")
@@ -290,7 +290,7 @@ public class ChargeCancelResourceIT {
             String chargeExternalId = testBaseExtension.authoriseNewChargeWithServiceId(SERVICE_ID);
             long chargeInternalId = app.getDatabaseTestHelper().getChargeIdByExternalId(chargeExternalId);
             app.getDatabaseTestHelper().addEvent(chargeInternalId, AUTHORISATION_SUCCESS.toString());
-            
+
             app.getWorldpayMockClient().mockCancelSuccess();
 
             Map<String, Object> cardDetails = app.getDatabaseTestHelper().getChargeCardDetailsByChargeId(chargeInternalId);
@@ -300,9 +300,9 @@ public class ChargeCancelResourceIT {
                     .post(String.format("/v1/api/service/%s/account/%s/charges/%s/cancel", SERVICE_ID, GatewayAccountType.TEST, chargeExternalId))
                     .then()
                     .statusCode(204);
-            
+
             checkCancelStatusViaApi(chargeExternalId, SYSTEM_CANCELLED);
-            
+
             cardDetails = app.getDatabaseTestHelper().getChargeCardDetailsByChargeId(chargeInternalId);
             assertThat(cardDetails, is(notNullValue()));
             assertThat(cardDetails.get("card_brand"), is(notNullValue()));
@@ -315,23 +315,23 @@ public class ChargeCancelResourceIT {
             assertThat(cardDetails.get("address_postcode"), is(notNullValue()));
             assertThat(cardDetails.get("address_country"), is(notNullValue()));
         }
-        
+
         @Test
         @DisplayName("Should add locking status to charge events if charge is cancelled after auth success")
-        void chargeEventsShouldHaveLockingStatus_IfCancelledAfterAuth() {            
+        void chargeEventsShouldHaveLockingStatus_IfCancelledAfterAuth() {
             String chargeExternalId = testBaseExtension.authoriseNewChargeWithServiceId(SERVICE_ID);
             long chargeInternalId = app.getDatabaseTestHelper().getChargeIdByExternalId(chargeExternalId);
             app.getDatabaseTestHelper().addEvent(chargeInternalId, AUTHORISATION_SUCCESS.toString());
 
             app.getWorldpayMockClient().mockCancelSuccess();
-    
+
             app.givenSetup()
                     .post(String.format("/v1/api/service/%s/account/%s/charges/%s/cancel", SERVICE_ID, GatewayAccountType.TEST, chargeExternalId))
                     .then()
                     .statusCode(204);
 
             checkCancelStatusViaApi(chargeExternalId, SYSTEM_CANCELLED);
-            
+
             List<String> events = app.getDatabaseTestHelper().getInternalEvents(chargeExternalId);
             assertThat(events.size(), is(3));
             assertThat(events, hasItems(AUTHORISATION_SUCCESS.getValue(),
@@ -354,28 +354,28 @@ public class ChargeCancelResourceIT {
                     .statusCode(204);
 
             checkCancelStatusViaApi(chargeExternalId, SYSTEM_CANCEL_ERROR);
-            
+
             List<String> events = app.getDatabaseTestHelper().getInternalEvents(chargeExternalId);
             assertThat(events.size(), is(3));
             assertThat(events, hasItems(AUTHORISATION_SUCCESS.getValue(),
                     SYSTEM_CANCEL_READY.getValue(),
                     SYSTEM_CANCEL_ERROR.getValue()));
         }
-        
+
         @Test
         @DisplayName("Should not add locking status to charge events if charge is cancelled in created state")
         void chargeEventsShouldNotHaveLockingStatus_IfCancelledFromCreatedState() {
             String chargeExternalId = testBaseExtension.createNewChargeWithServiceId(SERVICE_ID);
             long chargeInternalId = app.getDatabaseTestHelper().getChargeIdByExternalId(chargeExternalId);
             app.getDatabaseTestHelper().addEvent(chargeInternalId, CREATED.toString());
-            
+
             app.givenSetup()
                     .post(String.format("/v1/api/service/%s/account/%s/charges/%s/cancel", SERVICE_ID, GatewayAccountType.TEST, chargeExternalId))
                     .then()
                     .statusCode(204);
 
             checkCancelStatusViaApi(chargeExternalId, SYSTEM_CANCELLED);
-            
+
             List<String> events = app.getDatabaseTestHelper().getInternalEvents(chargeExternalId);
             assertThat(events.size(), is(2));
             assertThat(events, hasItems(ChargeStatus.CREATED.getValue(), ChargeStatus.SYSTEM_CANCELLED.getValue()));
@@ -399,7 +399,7 @@ public class ChargeCancelResourceIT {
             assertThat(events.size(), is(2));
             assertThat(events, hasItems(ENTERING_CARD_DETAILS.getValue(), ChargeStatus.SYSTEM_CANCELLED.getValue()));
         }
-        
+
         void checkCancelStatusViaApi(String chargeId, ChargeStatus targetState) {
             app.givenSetup()
                     .get(format("/v1/api/service/%s/account/%s/charges/%s", SERVICE_ID, GatewayAccountType.TEST, chargeId))

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
@@ -37,14 +37,14 @@ import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGa
 public class ChargesApiResourceAllowWebPaymentsIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-    
+
     private static ObjectMapper objectMapper = new ObjectMapper();
 
     private DatabaseFixtures.TestAccount testAccount;
     private Long accountId;
     private String chargeId;
     private Long credentialsId;
-    
+
     @BeforeEach
     void setupGateway() {
         testAccount = addGatewayAccountAndCredential("worldpay");
@@ -74,7 +74,7 @@ public class ChargesApiResourceAllowWebPaymentsIT {
         if (setAllowGooglePayFlag) {
             allowWebPaymentsOnGatewayAccount("allow_google_pay");
         }
-        
+
         if (setGatewayMerchantId) {
             addGatewayMerchantIdToGatewayAccount();
         }
@@ -104,12 +104,12 @@ public class ChargesApiResourceAllowWebPaymentsIT {
                 .then()
                 .statusCode(HttpStatus.SC_OK);
     }
-    
+
     private void addGatewayMerchantIdToGatewayAccount() throws JsonProcessingException {
         String payload = objectMapper.writeValueAsString(
                 List.of(Map.of("op", "replace",
-                "path", "credentials/gateway_merchant_id",
-                "value", "94b53bf6b12b6c5")));
+                        "path", "credentials/gateway_merchant_id",
+                        "value", "94b53bf6b12b6c5")));
 
         given().port(app.getLocalPort()).contentType(JSON)
                 .body(payload)
@@ -117,7 +117,7 @@ public class ChargesApiResourceAllowWebPaymentsIT {
                 .then()
                 .statusCode(HttpStatus.SC_OK);
     }
-    
+
     private String createCharge(int port, String accountId) {
         return given().port(port).contentType(JSON)
                 .contentType(JSON)
@@ -129,7 +129,7 @@ public class ChargesApiResourceAllowWebPaymentsIT {
     }
 
     private DatabaseFixtures.TestAccount addGatewayAccountAndCredential(String paymentProvider) {
-        long accountId = nextLong(2, 10000);
+        long accountId = current().nextLong(2, 10000);
         LocalDateTime createdDate = LocalDate.parse("2021-01-01").atStartOfDay();
         LocalDateTime activeStartDate = LocalDate.parse("2021-02-01").atStartOfDay();
         LocalDateTime activeEndDate = LocalDate.parse("2021-03-01").atStartOfDay();
@@ -142,10 +142,10 @@ public class ChargesApiResourceAllowWebPaymentsIT {
                 .withActiveEndDate(activeEndDate.toInstant(ZoneOffset.UTC))
                 .withState(GatewayAccountCredentialState.ACTIVE)
                 .withCredentials(Map.of(
-                                ONE_OFF_CUSTOMER_INITIATED, Map.of(
-                                        CREDENTIALS_MERCHANT_CODE, "a-merchant-code",
-                                        CREDENTIALS_USERNAME, "a-username",
-                                        CREDENTIALS_PASSWORD, "a-password")))
+                        ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, "a-merchant-code",
+                                CREDENTIALS_USERNAME, "a-username",
+                                CREDENTIALS_PASSWORD, "a-password")))
                 .build();
 
         return app.getDatabaseFixtures().aTestAccount().withPaymentProvider(paymentProvider)
@@ -157,7 +157,7 @@ public class ChargesApiResourceAllowWebPaymentsIT {
 
     static Stream<Arguments> permissions() {
         return Stream.of(
-                Arguments.of(true, false, false ),
+                Arguments.of(true, false, false),
                 Arguments.of(true, true, true),
                 Arguments.of(false, true, false)
         );

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreatePrefilledCardholderDetailsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreatePrefilledCardholderDetailsIT.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.it.resources;
 
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -7,35 +8,20 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
-import uk.gov.pay.connector.it.base.ITestBaseExtension;
 
-import jakarta.ws.rs.core.Response;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.common.model.domain.NumbersInStringsSanitizer.sanitize;
-import static uk.gov.pay.connector.it.base.ITestBaseExtension.AMOUNT;
-import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_AMOUNT_KEY;
-import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_CHARGE_KEY;
-import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_DESCRIPTION_KEY;
-import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_DESCRIPTION_VALUE;
-import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_PROVIDER_KEY;
-import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_REFERENCE_KEY;
-import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_REFERENCE_VALUE;
-import static uk.gov.pay.connector.it.base.ITestBaseExtension.JSON_RETURN_URL_KEY;
-import static uk.gov.pay.connector.it.base.ITestBaseExtension.PROVIDER_NAME;
-import static uk.gov.pay.connector.it.base.ITestBaseExtension.RETURN_URL;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
-import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
 
 public class ChargesApiResourceCreatePrefilledCardholderDetailsIT {
-    
+
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     private static final String VALID_SERVICE_ID = "valid-service-id";
@@ -103,11 +89,11 @@ public class ChargesApiResourceCreatePrefilledCardholderDetailsIT {
 
         @Test
         void shouldReturn201_withPrefilledCardHolderDetailsFieldsAtMaximumLength() {
-            String cardholderName = randomAlphanumeric(255);
-            String line1 = randomAlphanumeric(255);
-            String line2 = randomAlphanumeric(255);
-            String city = randomAlphanumeric(255);
-            String postcode = randomAlphanumeric(25);
+            String cardholderName = randomAlphaNumeric(255);
+            String line1 = randomAlphaNumeric(255);
+            String line2 = randomAlphaNumeric(255);
+            String city = randomAlphaNumeric(255);
+            String postcode = randomAlphaNumeric(25);
             String country = "GB";
 
             app.givenSetup()
@@ -288,11 +274,11 @@ public class ChargesApiResourceCreatePrefilledCardholderDetailsIT {
 
         @Test
         void shouldReturn201_withPrefilledCardHolderDetailsFieldsAtMaximumLength() {
-            String cardholderName = randomAlphanumeric(255);
-            String line1 = randomAlphanumeric(255);
-            String line2 = randomAlphanumeric(255);
-            String city = randomAlphanumeric(255);
-            String postcode = randomAlphanumeric(25);
+            String cardholderName = randomAlphaNumeric(255);
+            String line1 = randomAlphaNumeric(255);
+            String line2 = randomAlphaNumeric(255);
+            String city = randomAlphaNumeric(255);
+            String postcode = randomAlphaNumeric(25);
             String country = "GB";
 
             app.givenSetup()

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
@@ -23,8 +23,6 @@ import java.time.ZonedDateTime;
 import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
-import static java.lang.String.format;
-import static java.time.temporal.ChronoUnit.SECONDS;
 import static jakarta.ws.rs.HttpMethod.GET;
 import static jakarta.ws.rs.HttpMethod.POST;
 import static jakarta.ws.rs.core.Response.Status;
@@ -32,9 +30,9 @@ import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
 import static jakarta.ws.rs.core.Response.Status.OK;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.lang.String.format;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -62,6 +60,7 @@ import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.a
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
 
 public class ChargesFrontendResourceIT {
     @RegisterExtension
@@ -70,10 +69,10 @@ public class ChargesFrontendResourceIT {
     public static final String AGREEMENT_ID = "12345678901234567890123456";
 
     private DatabaseTestHelper databaseTestHelper;
-    private String accountId = String.valueOf(nextLong());
+    private String accountId = String.valueOf(current().nextLong(0, Long.MAX_VALUE));
     private String description = "Test description";
     private String returnUrl = "http://whatever.com";
-    private String email = randomAlphabetic(242) + "@example.com";
+    private String email = randomAlphaNumeric(242) + "@example.com";
     private String serviceName = "a cool service";
     private String analyticsId = "test-123";
     private String type = "test";
@@ -237,7 +236,7 @@ public class ChargesFrontendResourceIT {
     @Test
     void getChargeShouldIncludeNetAmountIfFeeExists() {
         String externalChargeId = RandomIdGenerator.newId();
-        long chargeId = nextLong();
+        long chargeId = current().nextLong(0, Long.MAX_VALUE);
 
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
@@ -262,7 +261,7 @@ public class ChargesFrontendResourceIT {
     @Test
     void shouldReturnInternalChargeStatusIfStatusIsAuthorised() {
         String externalChargeId = RandomIdGenerator.newId();
-        Long chargeId = nextLong();
+        Long chargeId = current().nextLong(0, Long.MAX_VALUE);
 
         CardTypeEntity mastercardCredit = databaseTestHelper.getMastercardCreditCard();
 
@@ -285,7 +284,7 @@ public class ChargesFrontendResourceIT {
     @Test
     void shouldReturnEmptyCardBrandLabelIfStatusIsAuthorisedAndBrandUnknown() {
         String externalChargeId = RandomIdGenerator.newId();
-        Long chargeId = nextLong();
+        Long chargeId = current().nextLong(0, Long.MAX_VALUE);
 
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
@@ -305,7 +304,7 @@ public class ChargesFrontendResourceIT {
     @Test
     void shouldIncludeAuth3dsDataInResponse() {
         String externalChargeId = RandomIdGenerator.newId();
-        Long chargeId = nextLong();
+        Long chargeId = current().nextLong(0, Long.MAX_VALUE);
         String issuerUrl = "https://issuer.example.com/3ds";
         String paRequest = "test-pa-request";
 
@@ -332,7 +331,7 @@ public class ChargesFrontendResourceIT {
     @Test
     void shouldNotIncludeBillingAddress_whenNoAddressDetailsPresentInDB() {
         String externalChargeId = RandomIdGenerator.newId();
-        Long chargeId = nextLong();
+        Long chargeId = current().nextLong(0, Long.MAX_VALUE);
 
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
@@ -355,7 +354,7 @@ public class ChargesFrontendResourceIT {
     @Test
     void getChargeShouldIncludeExternalChargeStatus() {
         String externalChargeId = RandomIdGenerator.newId();
-        long chargeId = nextLong();
+        long chargeId = current().nextLong(0, Long.MAX_VALUE);
 
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
@@ -410,7 +409,7 @@ public class ChargesFrontendResourceIT {
     @Test
     void patchValidEmailOnChargeWithReplaceOp_shouldReturnOk() {
         String chargeId = postToCreateACharge(expectedAmount);
-        String email = randomAlphabetic(242) + "@example.com";
+        String email = randomAlphaNumeric(242) + "@example.com";
 
         String patchBody = createPatch("replace", "email", email);
 
@@ -441,7 +440,7 @@ public class ChargesFrontendResourceIT {
     @Test
     void patchTooLongEmailOnCharge_shouldReturnBadRequest() {
         String chargeId = postToCreateACharge(expectedAmount);
-        String tooLongEmail = randomAlphanumeric(243) + "@example.com";
+        String tooLongEmail = randomAlphaNumeric(243) + "@example.com";
         String patchBody = createPatch("replace", "email", tooLongEmail);
 
         ValidatableResponse response = connectorRestApi
@@ -506,7 +505,7 @@ public class ChargesFrontendResourceIT {
                 .body("return_url", is(returnUrl))
                 .body("email", is(email))
                 .body("created_date", is(notNullValue()))
-                .body("agreement_id",is(AGREEMENT_ID))
+                .body("agreement_id", is(AGREEMENT_ID))
                 .body("language", is("en"))
                 .body("delayed_capture", is(true))
                 .body("corporate_card_surcharge", is(nullValue()))
@@ -571,7 +570,7 @@ public class ChargesFrontendResourceIT {
                         ),
                         allOf(
                                 hasKey("id"),
-                                hasEntry("label","Visa"),
+                                hasEntry("label", "Visa"),
                                 hasEntry("type", "CREDIT"),
                                 hasEntry("brand", "visa")
                         )

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.resources;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,10 +17,11 @@ import java.util.List;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
-import static java.lang.String.format;
 import static jakarta.ws.rs.core.Response.Status.CONFLICT;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static jakarta.ws.rs.core.Response.Status.OK;
+import static java.lang.String.format;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -63,7 +63,7 @@ public class GatewayAccountResourceIT {
 
     @Nested
     class GetByServiceIdAndAccountType {
-        
+
         @Test
         void shouldReturnConflictWhenTryingToAddMultipleLiveGatewayAccounts() {
             String serviceId = randomUuid();
@@ -83,7 +83,7 @@ public class GatewayAccountResourceIT {
                     .then()
                     .statusCode(CONFLICT.getStatusCode());
         }
-        
+
         @Test
         void shouldReturnConflictWhenThereAreMultipleLiveGatewayAccounts() {
             String serviceId = randomUuid();
@@ -94,21 +94,21 @@ public class GatewayAccountResourceIT {
                                     "service_name", "Service Name",
                                     "type", "live")))
                     .post("/v1/api/accounts/");
-            
+
             //add another live gateway account directly into the database as it's not possible to add another via API 
             app.getDatabaseTestHelper().addGatewayAccount(
                     anAddGatewayAccountParams()
                             .withPaymentGateway("worldpay")
                             .withServiceId(serviceId)
-                            .withAccountId(String.valueOf(RandomUtils.nextInt()))
+                            .withAccountId(String.valueOf(current().nextInt(0, Integer.MAX_VALUE)))
                             .withServiceName("Service Name")
                             .withType(LIVE)
                             .build());
-            
+
             app.givenSetup().get(format("/v1/api/service/%s/account/live", serviceId))
                     .then().statusCode(CONFLICT.getStatusCode());
         }
-        
+
         @Test
         void shouldReturnStripeGatewayAccountWhenThereAreMultipleGatewayAccounts() {
             String serviceId = randomUuid();
@@ -167,7 +167,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnWorldpayAccountInformation() {
-            long accountId = RandomUtils.nextInt();
+            long accountId = current().nextInt(0, Integer.MAX_VALUE);
             AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider(WORLDPAY.getName())
                     .withGatewayAccountId(accountId)
@@ -280,7 +280,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnStripeAccountInformation() {
-            long accountId = RandomUtils.nextInt();
+            long accountId = current().nextInt(0, Integer.MAX_VALUE);
             AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider(STRIPE.getName())
                     .withGatewayAccountId(accountId)
@@ -387,7 +387,7 @@ public class GatewayAccountResourceIT {
                     aCreateGatewayAccountPayloadBuilder()
                             .withDescription("desc")
                             .withAnalyticsId("id")
-                                    .build());
+                            .build());
             app.givenSetup()
                     .get(ACCOUNTS_API_URL + gatewayAccountId)
                     .then()
@@ -416,7 +416,7 @@ public class GatewayAccountResourceIT {
                     aCreateGatewayAccountPayloadBuilder()
                             .withDescription("desc")
                             .build());
-            
+
             app.givenSetup()
                     .get(ACCOUNTS_API_URL + gatewayAccountId)
                     .then()
@@ -478,7 +478,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnAccountInformationForGetAccountById_withWorldpayCredentials() {
-            long accountId = RandomUtils.nextInt();
+            long accountId = current().nextInt(0, Integer.MAX_VALUE);
             AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider(WORLDPAY.getName())
                     .withGatewayAccountId(accountId)
@@ -582,7 +582,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnAccountInformationForGetAccountById_withStripeCredentials() {
-            long accountId = RandomUtils.nextInt();
+            long accountId = current().nextInt(0, Integer.MAX_VALUE);
             AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider(STRIPE.getName())
                     .withGatewayAccountId(accountId)
@@ -614,7 +614,7 @@ public class GatewayAccountResourceIT {
 
         @Test
         void shouldReturnAccountInformationForGetAccountById_withEpdqCredentials() {
-            long accountId = RandomUtils.nextInt();
+            long accountId = current().nextInt(0, Integer.MAX_VALUE);
             AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider(EPDQ.getName())
                     .withGatewayAccountId(accountId)
@@ -679,7 +679,7 @@ public class GatewayAccountResourceIT {
                 aCreateGatewayAccountPayloadBuilder()
                         .withProvider("worldpay")
                         .build());
-        
+
         app.getDatabaseTestHelper().insertWorldpay3dsFlexCredential(
                 Long.valueOf(gatewayAccountId2),
                 "macKey",
@@ -706,7 +706,7 @@ public class GatewayAccountResourceIT {
 
     @Test
     public void shouldReturnAccountInformationWhenSearchingByWorldpayMerchantCodeInOneOffPaymentCredentials() {
-        long accountId = RandomUtils.nextInt();
+        long accountId = current().nextInt(0, Integer.MAX_VALUE);
         AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                 .withPaymentProvider(WORLDPAY.getName())
                 .withGatewayAccountId(accountId)
@@ -739,7 +739,7 @@ public class GatewayAccountResourceIT {
 
     @Test
     public void shouldReturnAccountInformationWhenSearchingByWorldpayMerchantCodeInRecurringCustomerInitiatedCredentials() {
-        long accountId = RandomUtils.nextInt();
+        long accountId = current().nextInt(0, Integer.MAX_VALUE);
         AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                 .withPaymentProvider(WORLDPAY.getName())
                 .withGatewayAccountId(accountId)
@@ -769,7 +769,7 @@ public class GatewayAccountResourceIT {
                 .body("accounts[0].gateway_account_id", is(accountIdAsInt))
                 .body("accounts[0].payment_provider", is("worldpay"));
     }
-    
+
     @Test
     public void shouldSetApplePayEnabledByDefaultForSandboxAccount() {
         String gatewayAccountId1 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withProvider("sandbox").build());
@@ -808,7 +808,7 @@ public class GatewayAccountResourceIT {
         String serviceId = "aValidServiceId";
         String anotherServiceId = "anotherServiceId";
         String nonExistentServiceId = "nonExistentServiceId";
-        
+
         String gatewayAccountId1 = testHelpers.createGatewayAccount(
                 aCreateGatewayAccountPayloadBuilder()
                         .withServiceId(serviceId)
@@ -817,7 +817,7 @@ public class GatewayAccountResourceIT {
                 aCreateGatewayAccountPayloadBuilder()
                         .withServiceId(anotherServiceId)
                         .build());
-        
+
         app.givenSetup().accept(JSON)
                 .get(format("/v1/api/accounts?serviceIds=%s,%s", nonExistentServiceId, serviceId))
                 .then()
@@ -1025,7 +1025,7 @@ public class GatewayAccountResourceIT {
                 .body("code", Is.is(404))
                 .body("message", Is.is("HTTP 404 Not Found"));
     }
-    
+
     @Nested
     class Update3dsToggleByServiceIdAndAccountType {
 
@@ -1042,7 +1042,7 @@ public class GatewayAccountResourceIT {
 
             app.givenSetup().body(toJson(gatewayAccountRequest)).post(ACCOUNTS_API_URL);
         }
-        
+
         @Test
         void update3dsToggleSuccessfully() {
             app.givenSetup()
@@ -1062,7 +1062,7 @@ public class GatewayAccountResourceIT {
                     .then()
                     .statusCode(OK.getStatusCode())
                     .body("requires3ds", is(true));
-            
+
             app.givenSetup()
                     .body(toJson(Map.of("toggle_3ds", false)))
                     .patch(format("/v1/frontend/service/%s/account/test/3ds-toggle", serviceId))
@@ -1075,7 +1075,7 @@ public class GatewayAccountResourceIT {
                     .statusCode(OK.getStatusCode())
                     .body("requires3ds", is(false));
         }
-        
+
         @Test
         void setting3dsToggleToFalse_WhenA3dsCardTypeIsAccepted_returnsConflict() {
             app.givenSetup()
@@ -1099,10 +1099,11 @@ public class GatewayAccountResourceIT {
                     .statusCode(CONFLICT.getStatusCode());
         }
     }
-    
+
     @Nested
     class Update3dsToggleByGatewayAccountId {
         String gatewayAccountId;
+
         @BeforeEach
         void createGatewayAccount() {
             gatewayAccountId = testHelpers.createGatewayAccount(
@@ -1110,7 +1111,7 @@ public class GatewayAccountResourceIT {
                             .withProvider("worldpay")
                             .build());
         }
-        
+
         @Test
         void shouldToggle3dsToTrue() {
             app.givenSetup()
@@ -1162,7 +1163,7 @@ public class GatewayAccountResourceIT {
                     .statusCode(CONFLICT.getStatusCode());
         }
     }
-    
+
     @Test
     void shouldReturn3dsFlexCredentials_whenGatewayAccountHasCreds() {
         String gatewayAccountId = testHelpers.createGatewayAccount(

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeNotificationResourceIT.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.it.resources.stripe;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.restassured.response.Response;
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -22,7 +21,7 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.MediaType.TEXT_XML;
-import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
@@ -52,16 +51,16 @@ public class StripeNotificationResourceIT {
 
     private String accountId;
     private DatabaseTestHelper databaseTestHelper;
-    
+
     private WireMockServer wireMockServer;
 
     private StripeMockClient stripeMockClient;
 
     private AddGatewayAccountCredentialsParams accountCredentialsParams;
-    
+
     @BeforeEach
     void setup() {
-        accountId = String.valueOf(RandomUtils.nextInt());
+        accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
 
         databaseTestHelper = app.getDatabaseTestHelper();
         wireMockServer = app.getWireMockServer();
@@ -84,7 +83,7 @@ public class StripeNotificationResourceIT {
 
     @Test
     void shouldHandleAPaymentIntentAmountCapturableUpdatedNotification() {
-        String transactionId = "pi_123" + nextInt();
+        String transactionId = "pi_123" + current().nextInt(0, Integer.MAX_VALUE);
         String externalChargeId = createNewChargeWith(AUTHORISATION_3DS_REQUIRED, transactionId);
 
         String payload = sampleStripeNotification(STRIPE_NOTIFICATION_PAYMENT_INTENT,
@@ -102,7 +101,7 @@ public class StripeNotificationResourceIT {
 
     @Test
     void shouldHandleAPaymentIntentPaymentFailedNotification() {
-        String transactionId = "pi_123" + nextInt();
+        String transactionId = "pi_123" + current().nextInt(0, Integer.MAX_VALUE);
         String externalChargeId = createNewChargeWith(AUTHORISATION_3DS_REQUIRED, transactionId);
 
         String payload = sampleStripeNotification(STRIPE_NOTIFICATION_PAYMENT_INTENT,
@@ -134,7 +133,7 @@ public class StripeNotificationResourceIT {
 
     @Test
     void shouldFailAStripeNotification_whenSignatureIsInvalid() {
-        String transactionId = "transaction-id" + nextInt();
+        String transactionId = "transaction-id" + current().nextInt(0, Integer.MAX_VALUE);
         String externalChargeId = createNewChargeWith(AUTHORISATION_3DS_REQUIRED, transactionId);
 
         String payload = sampleStripeNotification(STRIPE_NOTIFICATION_PAYMENT_INTENT,
@@ -150,7 +149,7 @@ public class StripeNotificationResourceIT {
 
     @Test
     void shouldReturnForbiddenIfRequestComesFromUnexpectedIpAddress() {
-        String transactionId = "transaction-id" + nextInt();
+        String transactionId = "transaction-id" + current().nextInt(0, Integer.MAX_VALUE);
         createNewChargeWith(AUTHORISATION_3DS_REQUIRED, transactionId);
         stripeMockClient.mockCreatePaymentIntent();
 
@@ -164,7 +163,7 @@ public class StripeNotificationResourceIT {
 
     @Test
     void shouldHandleAPaymentIntent3DSVersion() {
-        String transactionId = "pi_123" + nextInt();
+        String transactionId = "pi_123" + current().nextInt(0, Integer.MAX_VALUE);
         String externalChargeId = createNewChargeWith(AUTHORISATION_3DS_REQUIRED, transactionId);
 
         String payload = sampleStripeNotification(STRIPE_NOTIFICATION_PAYMENT_INTENT,
@@ -218,7 +217,7 @@ public class StripeNotificationResourceIT {
     }
 
     protected String createNewChargeWith(ChargeStatus status, String gatewayTransactionId) {
-        long chargeId = RandomUtils.nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
 
         String externalChargeId = "charge-" + chargeId;
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static java.lang.String.format;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,6 +33,7 @@ import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccoun
 import static uk.gov.pay.connector.matcher.RefundsMatcher.aRefundMatching;
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomLong;
 
 public class WorldpayRefundsResourceIT {
@@ -51,7 +51,7 @@ public class WorldpayRefundsResourceIT {
                     CREDENTIALS_USERNAME, "test-user",
                     CREDENTIALS_PASSWORD, "test-password")
     );
-    
+
     @BeforeEach
     void setUpCharge() {
         gatewayAccountId = randomLong();
@@ -86,9 +86,9 @@ public class WorldpayRefundsResourceIT {
                 .withGatewayCredentialId(defaultCredentialsId)
                 .insert();
     }
-    
+
     @Nested
-    class ByAccountId {        
+    class ByAccountId {
 
         @Nested
         class GetRefund {
@@ -100,7 +100,7 @@ public class WorldpayRefundsResourceIT {
                         .aTestRefund()
                         .withTestCharge(defaultTestCharge)
                         .withType(RefundStatus.REFUND_SUBMITTED)
-                        .withGatewayTransactionId(randomAlphanumeric(10))
+                        .withGatewayTransactionId(randomAlphaNumeric(10))
                         .withChargeExternalId(defaultTestCharge.getExternalChargeId())
                         .insert();
 
@@ -172,7 +172,7 @@ public class WorldpayRefundsResourceIT {
             }
         }
     }
-    
+
     @Nested
     class ByServiceIdAndType {
         @Nested
@@ -190,7 +190,7 @@ public class WorldpayRefundsResourceIT {
                         .post(format("/v1/api/service/%s/account/%s/charges/%s/refunds", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId()))
                         .then().statusCode(202)
                         .extract().path("refund_id");
-                
+
                 // Attempt to retrieve refund
                 var response = app.givenSetup()
                         .get(format("/v1/api/service/%s/account/%s/charges/%s/refunds/%s", SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId(), refundExternalId))
@@ -199,7 +199,7 @@ public class WorldpayRefundsResourceIT {
                         .body("amount", is((int) defaultTestCharge.getAmount()))
                         .body("status", is("submitted"))
                         .body("created_date", is(notNullValue()));
-                
+
                 // Verify payment links in response
                 String paymentUrl = format("https://localhost:%s/v1/api/service/%s/account/%s/charges/%s",
                         app.getLocalPort(), SERVICE_ID, TEST, defaultTestCharge.getExternalChargeId());

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
@@ -6,11 +6,11 @@ import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 
 public class RefundEntityFixture {
 
-    private Long id = nextLong();
+    private Long id = current().nextLong(0, Long.MAX_VALUE);
     private Long amount = 500L;
     private RefundStatus status = RefundStatus.CREATED;
     private String reference = "reference";
@@ -74,7 +74,7 @@ public class RefundEntityFixture {
         this.externalId = externalId;
         return this;
     }
-    
+
     public RefundEntityFixture withGatewayTransactionId(String transactionId) {
         this.transactionId = transactionId;
         return this;

--- a/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
@@ -9,7 +9,6 @@ import au.com.dius.pact.provider.junit.target.HttpTarget;
 import au.com.dius.pact.provider.junit.target.Target;
 import au.com.dius.pact.provider.junit.target.TestTarget;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -30,7 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
@@ -52,14 +51,14 @@ public class FrontendContractTest {
 
     @ClassRule
     public static WireMockRule wireMockRule = new WireMockRule(app.getWireMockPort());
-    
+
     @TestTarget
     public static Target target;
     private static DatabaseTestHelper dbHelper;
-    
+
     private StripeMockClient stripeMockClient;
     private WorldpayMockClient worldpayMockClient;
-    
+
     @BeforeClass
     public static void setUp() {
         target = new HttpTarget(app.getLocalPort());
@@ -72,7 +71,7 @@ public class FrontendContractTest {
         stripeMockClient = new StripeMockClient(wireMockRule);
         worldpayMockClient = new WorldpayMockClient(wireMockRule);
     }
-    
+
     @State("an unused token testToken exists with external charge id chargeExternalId associated with it")
     public void anUnusedTokenExists() {
         long gatewayAccountId = 666L;
@@ -83,15 +82,15 @@ public class FrontendContractTest {
                 .withGatewayAccountId(String.valueOf(gatewayAccountId))
                 .build();
         dbHelper.addCharge(params);
-        
+
         dbHelper.addToken(params.chargeId(), "testToken", false);
     }
-    
+
     @State("a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.")
     public void aChargeExistsAwaitingAuthorisation() {
         long gatewayAccountId = 666L;
         setUpGatewayAccount(dbHelper, gatewayAccountId);
-        
+
         String chargeExternalId = "testChargeId";
 
         dbHelper.addCharge(anAddChargeParams()
@@ -130,7 +129,7 @@ public class FrontendContractTest {
                 .withDelayedCapture(false)
                 .build());
     }
-    
+
     @State("a sandbox account exists with a charge with id testChargeId and description ERROR that is in state ENTERING_CARD_DETAILS.")
     public void aChargeExistsAwaitingAuthorisationWithDescriptionError() {
         long gatewayAccountId = 666L;
@@ -186,7 +185,7 @@ public class FrontendContractTest {
                 .withCardTypeEntities(Collections.singletonList(dbHelper.getVisaDebitCard()))
                 .insert();
 
-        Long chargeId = nextLong();
+        Long chargeId = current().nextLong(0, Long.MAX_VALUE);
         String chargeExternalId = "testChargeId";
 
         dbHelper.insertWorldpay3dsFlexCredential(gatewayAccountId, "1A4rIZWXzXxqH7hZQUJ5aIUlFgPJFKLfrOGKxASaaV3YWMrcS616L7H86UhnTg5u", "an-issuer", "a-org-unit-id", 2L);
@@ -205,45 +204,45 @@ public class FrontendContractTest {
                 "a-payload",
                 "2.1.0");
     }
-    
+
     @State("a Worldpay account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.")
     public void aWorldpayChargeExistsAwaitingAuthorisation() {
         worldpayMockClient.mockAuthorisationSuccess();
         long gatewayAccountId = 666L;
-        int gatewayCredentialId = RandomUtils.nextInt();
+        int gatewayCredentialId = current().nextInt(0, Integer.MAX_VALUE);
         createGatewayAccount(gatewayAccountId, gatewayCredentialId, PaymentGatewayName.WORLDPAY);
         createChargeEnteringCardDetails("testChargeId", gatewayAccountId, gatewayCredentialId, PaymentGatewayName.WORLDPAY);
     }
-    
+
     @State("a Stripe account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.")
     public void aStripeChargeExistsAwaitingAuthorisation() {
         stripeMockClient.mockCreatePaymentIntent();
         long gatewayAccountId = 666L;
-        int gatewayCredentialId = RandomUtils.nextInt();
+        int gatewayCredentialId = current().nextInt(0, Integer.MAX_VALUE);
         createGatewayAccount(gatewayAccountId, gatewayCredentialId, PaymentGatewayName.STRIPE);
         createChargeEnteringCardDetails("testChargeId", gatewayAccountId, gatewayCredentialId, PaymentGatewayName.STRIPE);
     }
-    
+
     private void createGatewayAccount(Long gatewayAccountId, int gatewayCredentialId, PaymentGatewayName paymentProvider) {
         Map<String, Object> credentials;
-        switch(paymentProvider) {
-            case WORLDPAY: 
+        switch (paymentProvider) {
+            case WORLDPAY:
                 credentials = Map.of(
-                    ONE_OFF_CUSTOMER_INITIATED, Map.of(
-                            CREDENTIALS_MERCHANT_CODE, "merchant-id",
-                            CREDENTIALS_USERNAME, "test-user",
-                            CREDENTIALS_PASSWORD, "test-password")
+                        ONE_OFF_CUSTOMER_INITIATED, Map.of(
+                                CREDENTIALS_MERCHANT_CODE, "merchant-id",
+                                CREDENTIALS_USERNAME, "test-user",
+                                CREDENTIALS_PASSWORD, "test-password")
                 );
                 break;
-            case STRIPE: 
-                credentials = Map.of("stripe_account_id", RandomUtils.nextInt());
+            case STRIPE:
+                credentials = Map.of("stripe_account_id", current().nextInt(0, Integer.MAX_VALUE));
                 break;
             default:
                 throw new RuntimeException("This provider state only supports Worldpay and Stripe accounts");
         }
         createGatewayAccount(gatewayAccountId, gatewayCredentialId, paymentProvider, credentials);
     }
-    
+
     private void createGatewayAccount(Long gatewayAccountId, int gatewayCredentialId, PaymentGatewayName paymentProvider, Map<String, Object> credentials) {
         AddGatewayAccountCredentialsParams accountCredentialsParams = anAddGatewayAccountCredentialsParams()
                 .withId(gatewayCredentialId)
@@ -264,7 +263,7 @@ public class FrontendContractTest {
                 .withCardTypeEntities(List.of(visaCreditCard))
                 .insert();
     }
-     
+
     private void createChargeEnteringCardDetails(String externalChargeId, Long gatewayAccountId, int gatewayCredentialId, PaymentGatewayName paymentProvider) {
         dbHelper.addCharge(anAddChargeParams()
                 .withExternalChargeId(externalChargeId)
@@ -275,5 +274,5 @@ public class FrontendContractTest {
                 .withGatewayCredentialId(Long.valueOf(gatewayCredentialId))
                 .build());
     }
-    
+
 }

--- a/src/test/java/uk/gov/pay/connector/pact/event/ServiceArchivedEventIT.java
+++ b/src/test/java/uk/gov/pay/connector/pact/event/ServiceArchivedEventIT.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
@@ -41,7 +41,7 @@ public class ServiceArchivedEventIT {
 
 
     private byte[] currentMessage;
-    
+
     private String serviceExternalId = "service-external-id";
 
     @Pact(provider = "adminusers", consumer = "connector")
@@ -66,7 +66,7 @@ public class ServiceArchivedEventIT {
     @Test
     @PactVerification({"adminusers"})
     public void test() throws Exception {
-        long gatewayAccountId = nextLong();
+        long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
         String externalId = randomUuid();
         Map<String, Object> credMap = Map.of("some_payment_provider_account_id", String.valueOf(gatewayAccountId));
         app.getDatabaseTestHelper().addGatewayAccount(

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/CollectFeesForFailedPaymentsTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/CollectFeesForFailedPaymentsTaskHandlerIT.java
@@ -12,7 +12,7 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -31,7 +31,7 @@ public class CollectFeesForFailedPaymentsTaskHandlerIT {
 
     @Test
     void shouldPersistFees() throws Exception {
-        long chargeId = nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
         String chargeExternalId = RandomIdGenerator.newId();
         var paymentTaskData = new PaymentTaskData(chargeExternalId);
         app.getDatabaseTestHelper().addCharge(anAddChargeParams()
@@ -55,11 +55,11 @@ public class CollectFeesForFailedPaymentsTaskHandlerIT {
         assertThat(fees, hasSize(2));
         assertThat(fees, containsInAnyOrder(
                 allOf(
-                        hasEntry("fee_type", (Object)"radar"),
+                        hasEntry("fee_type", (Object) "radar"),
                         hasEntry("amount_collected", 5L)
                 ),
                 allOf(
-                        hasEntry("fee_type", (Object)"three_ds"),
+                        hasEntry("fee_type", (Object) "three_ds"),
                         hasEntry("amount_collected", 6L)
                 )
         ));

--- a/src/test/java/uk/gov/pay/connector/rules/PostgresTestDocker.java
+++ b/src/test/java/uk/gov/pay/connector/rules/PostgresTestDocker.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.rules;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer ;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -16,14 +16,14 @@ public class PostgresTestDocker {
     private static final String DB_NAME = "connector_test";
     private static final String DB_USERNAME = "test";
     private static final String DB_PASSWORD = "test";
-    private static PostgreSQLContainer<?> POSTGRES_CONTAINER;
+    private static PostgreSQLContainer POSTGRES_CONTAINER;
 
     public static void getOrCreate() {
         try {
             if (POSTGRES_CONTAINER == null) {
                 logger.info("Creating Postgres Container");
 
-                POSTGRES_CONTAINER = new PostgreSQLContainer<>("postgres:15.2")
+                POSTGRES_CONTAINER = new PostgreSQLContainer("postgres:15.2")
                         .withUsername(DB_USERNAME)
                         .withPassword(DB_PASSWORD);
 

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.time.ZonedDateTime.parse;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -96,7 +96,7 @@ public class ParityCheckServiceTest {
                 .withGatewayAccountEntity(defaultGatewayAccountEntity())
                 .withMoto(true)
                 .withSource(CARD_PAYMENT_LINK)
-                .withFee(Fee.of(null,10L))
+                .withFee(Fee.of(null, 10L))
                 .withCorporateSurcharge(25L)
                 .withWalletType(APPLE_PAY)
                 .withDelayedCapture(true)
@@ -155,7 +155,7 @@ public class ParityCheckServiceTest {
 
     @Test
     void parityCheckRefundForExpunger_shouldBackfillRefundIfParityCheckFails() {
-        LedgerTransaction transaction = from(nextLong(), refundEntity)
+        LedgerTransaction transaction = from(current().nextLong(0, Long.MAX_VALUE), refundEntity)
                 .withStatus(REFUND_ERROR.toExternal().getStatus()).build();
         when(mockLedgerService.getTransaction(refundEntity.getExternalId())).thenReturn(Optional.of(transaction));
 
@@ -173,7 +173,7 @@ public class ParityCheckServiceTest {
         when(mockRefundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(refundEntity.getExternalId(), RefundStatus.CREATED))
                 .thenReturn(Optional.of(refundHistory));
 
-        LedgerTransaction transaction = from(nextLong(), refundEntity).build();
+        LedgerTransaction transaction = from(current().nextLong(0, Long.MAX_VALUE), refundEntity).build();
         when(mockLedgerService.getTransaction(refundEntity.getExternalId())).thenReturn(Optional.of(transaction));
 
         boolean matchesWithLedger = parityCheckService.parityCheckRefundForExpunger(refundEntity);

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -15,7 +15,8 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
-import java.util.Random;
+
+import static java.util.concurrent.ThreadLocalRandom.current;
 
 public record AddChargeParams(
         Long chargeId,
@@ -54,7 +55,7 @@ public record AddChargeParams(
         AgreementPaymentType agreementPaymentType) {
 
     public static final class AddChargeParamsBuilder {
-        
+
         public AddChargeParams build() {
             List.of(amount, status, returnUrl, gatewayAccountId, description, reference, externalChargeId)
                     .forEach(Objects::requireNonNull);
@@ -66,13 +67,13 @@ public record AddChargeParams(
                     authorisationMode, updatedDate, paymentInstrumentId, canRetry, requires3ds, exemption3ds, exemption3dsType,
                     agreementPaymentType);
         }
-        
+
         private String agreementExternalId;
         private long amount = 1000;
         private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
         private Boolean canRetry;
         private CardType cardType;
-        private Long chargeId = new Random().nextLong();
+        private Long chargeId = current().nextLong(0, Long.MAX_VALUE);
         private Long corporateSurcharge;
         private Instant createdDate = Instant.now();
         private boolean delayedCapture = false;
@@ -102,7 +103,8 @@ public record AddChargeParams(
         private long version = 1;
         private AgreementPaymentType agreementPaymentType;
 
-        private AddChargeParamsBuilder() {}
+        private AddChargeParamsBuilder() {
+        }
 
         public static AddChargeParamsBuilder anAddChargeParams() {
             return new AddChargeParamsBuilder();

--- a/src/test/java/uk/gov/pay/connector/util/RandomAlphaNumericStringTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/RandomAlphaNumericStringTest.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.connector.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RandomAlphaNumericStringTest {
+
+    @Test
+    void randomAlphabetic_returnsRequestedLengthAndAlphabeticChars() {
+        int length = 10;
+        String s = RandomAlphaNumericString.randomAlphabetic(length);
+
+        assertThat(s.length(), is(length));
+        assertThat(s, matchesPattern("^[A-Za-z]{10}$"));
+    }
+
+    @Test
+    void randomAlphaNumeric_returnsRequestedLengthAndAlphaNumericChars() {
+        int length = 12;
+        String s = RandomAlphaNumericString.randomAlphaNumeric(length);
+
+        assertThat(s.length(), is(length));
+        assertThat(s, matchesPattern("^[A-Za-z0-9]{12}$"));
+    }
+
+    @Test
+    void zeroLength_returnsEmptyString() {
+        assertThat(RandomAlphaNumericString.randomAlphabetic(0), is(""));
+        assertThat(RandomAlphaNumericString.randomAlphaNumeric(0), is(""));
+    }
+
+    @Test
+    void negativeLength_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> RandomAlphaNumericString.randomAlphabetic(-1));
+        assertThrows(IllegalArgumentException.class, () -> RandomAlphaNumericString.randomAlphaNumeric(-5));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
_A brief description of the pull request:_
Changes Part 2/3:

- Removed unused import
- Reorganised imports
- Removed extra spaces
- Updating deprecated Hibernate NotEmpty to jakarta
- Updated deprecated StringUntil to Strings
- Updated deprecated nextLong and nextInt
- Updated deprecated getCredentials to getCredentialsObject
- Updated deprecated writeOnly = true to accessMode = WRITE_ONLY
- Updating deprecated Jwts from signingkey to verifywithf and parseclaimsjws to parsesignedclaims and get body to getpayload
- Removed and depreacated isSuccesful and isFailed and replaced with appropriate method
- get(0); to getFirst();
- Added new class for random numbers and alphabets + tests

No functional changes intended; behavior preserved.

## How to test

- How should it be reviewed?  Looks at the code changes and see no functional changes, see that tests pass 
- What feedback do you need? Comments

## Notes
NOTE: 

1. Custom code using pure java removes dependency and using ThreadLocalRandom is faster
2. nextLong(0, Long.MAX_VALUE) was used rather than nextLong() because it also includes negative number and it does not mimic the behaviour of the deprecated call
3. It was considered to use RandomStringUtils.insecure()next/nextNumeric/nextAlphanumeric however it returns a string and needs to be parsed and casting can throw overflow. it just makes the code longer.