### PR TITLE
PP-14778 - Deprecated and warnings 3/3

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -181,14 +181,14 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5809
+        "line_number": 5812
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5820
+        "line_number": 5823
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-02T16:58:57Z"
+  "generated_at": "2025-12-11T09:09:04Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -5369,6 +5369,9 @@ components:
           type: string
           description: Only `ENTERING CARD DETAILS` is allowed
           example: ENTERING CARD DETAILS
+          minLength: 1
+      required:
+      - new_status
     Outcome:
       type: object
       description: Object containing information about the outcome of the 3ds exemption

--- a/src/main/java/uk/gov/pay/connector/charge/model/NewChargeStatusRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/NewChargeStatusRequest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.validation.ValidationMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.hibernate.validator.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 
 

--- a/src/main/java/uk/gov/pay/connector/charge/util/JwtGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/JwtGenerator.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.charge.util;
 
 
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 
 import javax.crypto.spec.SecretKeySpec;
 import java.util.Map;
@@ -13,9 +12,9 @@ public class JwtGenerator {
         SecretKeySpec secret_key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
 
         return Jwts.builder()
-                .setHeaderParam("typ", "JWT")
-                .addClaims(claims)
-                .signWith(secret_key, SignatureAlgorithm.HS256)
+                .header().add("typ", "JWT").and()
+                .claims().add(claims).and()
+                .signWith(secret_key, Jwts.SIG.HS256)
                 .compact();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
@@ -30,15 +30,7 @@ public class GatewayResponse<T extends BaseResponse> {
         this.gatewayError = error;
     }
 
-    @Deprecated
-    public boolean isSuccessful() {
-        return baseResponse != null;
-    }
 
-    @Deprecated
-    public boolean isFailed() {
-        return gatewayError != null;
-    }
 
     public Optional<ProviderSessionIdentifier> getSessionIdentifier() {
         return Optional.ofNullable(sessionIdentifier);

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReason.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReason.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -12,18 +12,18 @@ public enum StripeTransferMetadataReason {
     TRANSFER_REFUND_AMOUNT,
     TRANSFER_PAYMENT_AMOUNT,
     TRANSFER_DISPUTE_AMOUNT;
-    
+
     @Override
     public String toString() {
         return name().toLowerCase((Locale.ENGLISH));
     }
-    
+
     public static StripeTransferMetadataReason fromString(String value) {
         if (value == null) {
             return NOT_DEFINED;
         }
         return Arrays.stream(StripeTransferMetadataReason.values())
-                .filter(stripeTransferMetadataReason -> StringUtils.equalsIgnoreCase(stripeTransferMetadataReason.name(), value))
+                .filter(stripeTransferMetadataReason -> stripeTransferMetadataReason.name().equalsIgnoreCase(value))
                 .findFirst()
                 .orElse(UNRECOGNISED);
     }

--- a/src/main/java/uk/gov/pay/connector/healthcheck/resource/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/connector/healthcheck/resource/HealthCheckResource.java
@@ -8,15 +8,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
 
@@ -74,7 +75,7 @@ public class HealthCheckResource {
                 .collect(Collectors.toMap(Map.Entry::getKey,
                                 healthCheck -> ImmutableMap.of(
                                         "healthy", healthCheck.getValue().isHealthy(),
-                                        "message", defaultString(healthCheck.getValue().getMessage(), "Healthy"))
+                                        "message", Objects.toString(healthCheck.getValue().getMessage(), "Healthy"))
                         )
                 );
 

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -1,13 +1,6 @@
 package uk.gov.pay.connector.refund.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.eclipse.persistence.annotations.Customizer;
-import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
-import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
-import uk.gov.pay.connector.common.model.domain.HistoryCustomizer;
-import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
-import uk.gov.pay.connector.util.RandomIdGenerator;
-
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
@@ -23,14 +16,20 @@ import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.SqlResultSetMapping;
 import jakarta.persistence.Table;
+import org.eclipse.persistence.annotations.Customizer;
+import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
+import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
+import uk.gov.pay.connector.common.model.domain.HistoryCustomizer;
+import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
 import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 
+import static com.google.common.base.Ascii.equalsIgnoreCase;
 import static java.time.temporal.ChronoUnit.MICROS;
-import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @SqlResultSetMapping(
@@ -43,7 +42,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
                         @ColumnResult(name = "amount", type = Long.class),
                         @ColumnResult(name = "status", type = String.class),
                         @ColumnResult(name = "created_date", type = Timestamp.class),
-                        @ColumnResult(name = "version", type=Long.class),
+                        @ColumnResult(name = "version", type = Long.class),
                         @ColumnResult(name = "history_start_date", type = Timestamp.class),
                         @ColumnResult(name = "history_end_date", type = Timestamp.class),
                         @ColumnResult(name = "user_external_id", type = String.class),
@@ -60,7 +59,7 @@ public class RefundEntity extends AbstractVersionedEntity {
 
     @Id
     @SequenceGenerator(name = "refundsSequence", sequenceName = "refunds_id_seq", allocationSize = 1)
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator="refundsSequence")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "refundsSequence")
     @JsonIgnore
     private Long id;
 
@@ -73,7 +72,7 @@ public class RefundEntity extends AbstractVersionedEntity {
 
     @Column(name = "user_external_id")
     private String userExternalId;
-    
+
     @Column(name = "user_email")
     private String userEmail;
 
@@ -111,8 +110,8 @@ public class RefundEntity extends AbstractVersionedEntity {
     public String getExternalId() {
         return externalId;
     }
-    
-    public String getGatewayTransactionId() { 
+
+    public String getGatewayTransactionId() {
         return gatewayTransactionId;
     }
 
@@ -143,8 +142,8 @@ public class RefundEntity extends AbstractVersionedEntity {
     public void setExternalId(String externalId) {
         this.externalId = externalId;
     }
-    
-    public void setGatewayTransactionId(String gatewayTransactionId) { 
+
+    public void setGatewayTransactionId(String gatewayTransactionId) {
         this.gatewayTransactionId = gatewayTransactionId;
     }
 

--- a/src/main/java/uk/gov/pay/connector/util/ConnectorSessionCustomiser.java
+++ b/src/main/java/uk/gov/pay/connector/util/ConnectorSessionCustomiser.java
@@ -1,8 +1,8 @@
 package uk.gov.pay.connector.util;
 
-import org.eclipse.persistence.config.SessionCustomizer;
 import org.eclipse.persistence.sessions.DatabaseLogin;
 import org.eclipse.persistence.sessions.Session;
+import org.eclipse.persistence.sessions.SessionCustomizer;
 
 public class ConnectorSessionCustomiser implements SessionCustomizer {
 

--- a/src/main/java/uk/gov/pay/connector/util/RandomAlphaNumericString.java
+++ b/src/main/java/uk/gov/pay/connector/util/RandomAlphaNumericString.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.connector.util;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.util.concurrent.ThreadLocalRandom.current;
+
+public final class RandomAlphaNumericString {
+
+    private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final String NUMS = "0123456789";
+    private static final String ALPHA_NUM = CHARS + NUMS;
+
+    private RandomAlphaNumericString() {
+        // utility class - prevent instantiation
+    }
+
+    public static String randomAlphabetic(int length) {
+        return randomFromCharset(CHARS, length);
+    }
+
+
+    public static String randomAlphaNumeric(int length) {
+        return randomFromCharset(ALPHA_NUM, length);
+    }
+
+    private static String randomFromCharset(String charset, int length) {
+        if (length < 0) {
+            throw new IllegalArgumentException("length must be non-negative");
+        }
+        ThreadLocalRandom rnd = current();
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(charset.charAt(rnd.nextInt(charset.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceValidationTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesApiResourceValidationTest.java
@@ -25,17 +25,17 @@ import java.util.Map;
 import java.util.stream.IntStream;
 
 import static java.util.stream.Collectors.joining;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphabetic;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class ChargesApiResourceValidationTest {
-    
+
     public static ResourceExtension chargesApiResource = ResourceExtension.builder()
             .addResource(new ChargesApiResource(null, null, null, null))
             .setRegisterDefaultExceptionMappers(false)
@@ -49,7 +49,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 400 if fields are missing")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -69,7 +69,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 422 if fields exceed maximum length")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -80,7 +80,7 @@ public class ChargesApiResourceValidationTest {
                 "description", randomAlphabetic(256),
                 "email", randomAlphabetic(256),
                 "return_url", "https://service.example/success-page/");
-        
+
         try (Response response = chargesApiResource
                 .target(url)
                 .request()
@@ -103,7 +103,7 @@ public class ChargesApiResourceValidationTest {
                 "description", "Test description",
                 "email", "test@example.com",
                 "return_url", "https://service.example/success-page/");
-        
+
         try (Response response = chargesApiResource
                 .target("/v1/api/accounts/invalidAccountId/charges")
                 .request()
@@ -116,7 +116,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 400 if language is not supported")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -127,7 +127,7 @@ public class ChargesApiResourceValidationTest {
                 "description", "Test description",
                 "return_url", "https://service.example/success-page/",
                 "language", "not a supported language");
-        
+
         try (Response response = chargesApiResource
                 .target(url)
                 .request()
@@ -139,7 +139,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 422 if metadata is correct type but invalid values")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -151,7 +151,7 @@ public class ChargesApiResourceValidationTest {
         metadata.put("key3", "");
         metadata.put("key4", IntStream.rangeClosed(1, ExternalMetadata.MAX_VALUE_LENGTH + 1).mapToObj(i -> "v").collect(joining()));
         metadata.put(IntStream.rangeClosed(1, ExternalMetadata.MAX_KEY_LENGTH + 1).mapToObj(i -> "k").collect(joining()), "This is valid");
-       
+
         var payload = Map.of(
                 "amount", 6234L,
                 "reference", "Test reference",
@@ -159,7 +159,7 @@ public class ChargesApiResourceValidationTest {
                 "return_url", "https://service.example/success-page/",
                 "metadata", metadata
         );
-        
+
         try (Response response = chargesApiResource
                 .target(url)
                 .request()
@@ -178,7 +178,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 400 if metadata is a string")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -190,7 +190,7 @@ public class ChargesApiResourceValidationTest {
                 "return_url", "https://service.example/success-page/",
                 "metadata", "metadata cannot be a string"
         );
-        
+
         try (Response response = chargesApiResource
                 .target(url)
                 .request()
@@ -202,7 +202,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 400 if metadata is an array")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -214,11 +214,11 @@ public class ChargesApiResourceValidationTest {
                 "return_url", "https://service.example/success-page/",
                 "metadata", new Object[1]
         );
-        
+
         try (Response response = chargesApiResource
-                    .target(url)
-                    .request()
-                    .post(Entity.json(payload))) {
+                .target(url)
+                .request()
+                .post(Entity.json(payload))) {
 
             assertGenericErrorResponse(response, 400, "Field [metadata] must be an object of JSON key-value pairs");
         }
@@ -226,7 +226,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 400 if authorisation mode is invalid")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -250,7 +250,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 400 if authorisation_payment_type is invalid for initial payment")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -276,7 +276,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 400 if authorisation_payment_type is invalid for subsequent payment")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -298,10 +298,10 @@ public class ChargesApiResourceValidationTest {
             assertGenericErrorResponse(response, 400, "Cannot deserialize value of type `uk.gov.service.payments.commons.model.AgreementPaymentType`");
         }
     }
-    
+
     @DisplayName("Should return 422 if idempotency key is above maximum length")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -319,14 +319,14 @@ public class ChargesApiResourceValidationTest {
                 .request()
                 .header("Idempotency-Key", "a".repeat(256))
                 .post(Entity.json(payload))) {
-            
+
             assertGenericErrorResponse(response, 422, "Header [Idempotency-Key] can have a size between 1 and 255");
         }
     }
 
     @DisplayName("Should return 422 if idempotency key is empty")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -351,7 +351,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 422 if return url is missing")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -376,7 +376,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 422 if return url is an empty string")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -402,7 +402,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 422 if return url is not a valid format")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -428,7 +428,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 422 if return url is present and authorisation mode is moto api")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -455,7 +455,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 400 if source value is invalid")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -481,7 +481,7 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 400 if source type is invalid")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
@@ -507,18 +507,18 @@ public class ChargesApiResourceValidationTest {
 
     @DisplayName("Should return 422 if prefilled cardholder details exceed maximum length]")
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "/v1/api/accounts/1234/charges",
             "/v1/api/service/my-service-id/account/test/charges"
     })
     void shouldReturn422IfPrefilledCardHolderDetailsExceedMaximumLength(String url) {
-        String cardholderName = randomAlphanumeric(256);
-        String line1 = randomAlphanumeric(256);
-        String line2 = randomAlphanumeric(256);
-        String city = randomAlphanumeric(256);
-        String postcode = randomAlphanumeric(26);
+        String cardholderName = randomAlphaNumeric(256);
+        String line1 = randomAlphaNumeric(256);
+        String line2 = randomAlphaNumeric(256);
+        String city = randomAlphaNumeric(256);
+        String postcode = randomAlphaNumeric(26);
         String country = "GB";
-        
+
         String payload = toJson(Map.of(
                 "amount", 6234L,
                 "reference", "Test reference",
@@ -550,7 +550,7 @@ public class ChargesApiResourceValidationTest {
             assertTrue(errorMessages.contains("Field [postcode] can have a size between 0 and 25"));
         }
     }
-    
+
     private static void assertGenericErrorResponse(Response response, int status, String errorMessage) {
         ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
         assertThat(response.getStatus(), is(status));

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
@@ -64,7 +64,7 @@ class ChargesFrontendResourceTest {
         List<String> listOfErrors = (List) response.readEntity(Map.class).get("message");
         assertThat(listOfErrors.size(), is(2));
         assertThat(listOfErrors, hasItem("invalid new status"));
-        assertThat(listOfErrors, hasItem("may not be empty"));
+        assertThat(listOfErrors, hasItem("must not be empty"));
 
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
@@ -24,7 +24,7 @@ import uk.gov.pay.connector.paymentprocessor.service.QueryService;
 
 import java.util.Optional;
 
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -62,9 +62,9 @@ class ChargeCancelServiceTest {
     private ChargeCancelService chargeCancelService;
 
     @Test
-   void doSystemCancel_shouldCancel_withStatusThatDoesNotNeedCancellationInGatewayProvider() {
+    void doSystemCancel_shouldCancel_withStatusThatDoesNotNeedCancellationInGatewayProvider() {
         String externalChargeId = "external-charge-id";
-        Long gatewayAccountId = nextLong();
+        Long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withExternalId(externalChargeId)
                 .withStatus(ChargeStatus.ENTERING_CARD_DETAILS)
@@ -76,8 +76,9 @@ class ChargeCancelServiceTest {
 
         verify(chargeService).transitionChargeState(externalChargeId, SYSTEM_CANCELLED);
     }
+
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "AUTHORISATION 3DS REQUIRED",
             "AUTHORISATION 3DS READY",
             "AUTHORISATION READY"
@@ -86,7 +87,7 @@ class ChargeCancelServiceTest {
         var status = ChargeStatus.fromString(chargeStatus);
 
         String externalChargeId = "external-charge-id";
-        Long gatewayAccountId = nextLong();
+        Long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withExternalId(externalChargeId)
                 .withTransactionId("transaction-id")
@@ -103,7 +104,7 @@ class ChargeCancelServiceTest {
 
 
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "AUTHORISATION 3DS REQUIRED",
             "AUTHORISATION 3DS READY",
             "AUTHORISATION SUCCESS"
@@ -112,7 +113,7 @@ class ChargeCancelServiceTest {
         var status = ChargeStatus.fromString(chargeStatus);
 
         String externalChargeId = "external-charge-id";
-        Long gatewayAccountId = nextLong();
+        Long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withExternalId(externalChargeId)
                 .withTransactionId("transaction-id")
@@ -139,7 +140,7 @@ class ChargeCancelServiceTest {
     @Test
     void doSystemCancel_chargeStatusAfterAuthorisation_cancelledWithProvider() throws Exception {
         String externalChargeId = "external-charge-id";
-        Long gatewayAccountId = nextLong();
+        Long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withExternalId(externalChargeId)
                 .withTransactionId("transaction-id")
@@ -165,7 +166,7 @@ class ChargeCancelServiceTest {
     void doSystemCancel_shouldFail_whenChargeNotFound() {
 
         String externalChargeId = "external-charge-id";
-        Long gatewayAccountId = nextLong();
+        Long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
 
         when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId)).thenReturn(Optional.empty());
 
@@ -190,7 +191,7 @@ class ChargeCancelServiceTest {
 
 
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "AUTHORISATION 3DS REQUIRED",
             "AUTHORISATION 3DS READY",
             "AUTHORISATION READY"
@@ -215,7 +216,7 @@ class ChargeCancelServiceTest {
 
 
     @ParameterizedTest
-    @ValueSource( strings = {
+    @ValueSource(strings = {
             "AUTHORISATION 3DS REQUIRED",
             "AUTHORISATION 3DS READY",
             "AUTHORISATION SUCCESS"
@@ -283,7 +284,7 @@ class ChargeCancelServiceTest {
     @Test
     void doSystemCancel_shouldCancelWorldPayCharge_withStatus_awaitingCaptureRequest() throws Exception {
         String externalChargeId = "external-charge-id";
-        Long gatewayAccountId = nextLong();
+        Long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withExternalId(externalChargeId)
                 .withTransactionId("transaction-id")

--- a/src/test/java/uk/gov/pay/connector/dao/ChargeEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/dao/ChargeEventDaoIT.java
@@ -186,7 +186,7 @@ public class ChargeEventDaoIT {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText(String.format("does not contain [%s]", (Object) expectedStatuses));
+                description.appendText(String.format("does not contain [%s]", asList(expectedStatuses)));
             }
         };
     }

--- a/src/test/java/uk/gov/pay/connector/dao/ChargeEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/dao/ChargeEventDaoIT.java
@@ -22,8 +22,8 @@ import java.util.List;
 
 import static java.time.ZonedDateTime.now;
 import static java.util.Arrays.asList;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -60,7 +60,7 @@ public class ChargeEventDaoIT {
         Long chargeId = app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withTransactionId(TRANSACTION_ID)
                 .insert()
@@ -98,7 +98,7 @@ public class ChargeEventDaoIT {
         Long chargeId = app.getDatabaseFixtures()
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withChargeId(nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalChargeId(RandomIdGenerator.newId())
                 .withTransactionId(TRANSACTION_ID)
                 .withDelayedCapture(true)
@@ -186,7 +186,7 @@ public class ChargeEventDaoIT {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText(String.format("does not contain [%s]", expectedStatuses));
+                description.appendText(String.format("does not contain [%s]", (Object) expectedStatuses));
             }
         };
     }

--- a/src/test/java/uk/gov/pay/connector/filters/SchemeRewriteFilterTest.java
+++ b/src/test/java/uk/gov/pay/connector/filters/SchemeRewriteFilterTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.core.Is.is;
 
 class SchemeRewriteFilterTest {
 
-    private SchemeRewriteFilter schemeRewriteFilter = new SchemeRewriteFilter();
+    private final SchemeRewriteFilter schemeRewriteFilter = new SchemeRewriteFilter();
 
     @Test
     void filter_shouldRewriteSchemeInBaseUriAndRequestUriToHttps() {
@@ -24,8 +24,7 @@ class SchemeRewriteFilterTest {
         URI baseUri = URI.create("tcp://pay.gov.uk");
         URI requestUri = URI.create("tcp://pay.gov.uk/hey/you");
 
-        ContainerRequest request = new ContainerRequest(baseUri, requestUri, "tcp", securityContextMock, propertiesDelegateMock);
-
+        ContainerRequest request = new ContainerRequest(baseUri, requestUri, "tcp", securityContextMock, propertiesDelegateMock, null);
         schemeRewriteFilter.filter(request);
 
         assertThat(request.getBaseUri(), is(URI.create("https://pay.gov.uk")));

--- a/src/test/java/uk/gov/pay/connector/gateway/model/response/GatewayResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/response/GatewayResponseTest.java
@@ -22,8 +22,8 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
         GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
                 .withGatewayError(error)
                 .build();
-        assertThat(gatewayResponse.isFailed(), is(true));
-        assertThat(gatewayResponse.isSuccessful(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().get(), is(error));
@@ -37,8 +37,8 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
         GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
                 .withResponse(baseResponse)
                 .build();
-        assertThat(gatewayResponse.isFailed(), is(false));
-        assertThat(gatewayResponse.isSuccessful(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get(), is(baseResponse));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
@@ -51,8 +51,8 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
         GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
                 .withResponse(baseResponse)
                 .build();
-        assertThat(gatewayResponse.isFailed(), is(true));
-        assertThat(gatewayResponse.isSuccessful(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().get().getMessage(),

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -89,8 +89,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -119,8 +119,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().withPaymentInstrument(paymentInstrument).build();
         GatewayResponse gatewayResponse = provider.authoriseUserNotPresent(RecurringPaymentAuthorisationGatewayRequest.valueOf(charge));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -143,8 +143,8 @@ public class SandboxPaymentProviderTest {
                 .build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -165,8 +165,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -186,8 +186,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
 
@@ -204,8 +204,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
 
@@ -234,8 +234,8 @@ public class SandboxPaymentProviderTest {
 
         GatewayResponse<BaseCancelResponse> gatewayResponse = provider.cancel(CancelGatewayRequest.valueOf(ChargeEntityFixture.aValidChargeEntity().build()));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
 

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletAuthorisationHandlerTest.java
@@ -49,8 +49,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseApplePay(
                 new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription("whatever").build(), applePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -77,8 +77,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseApplePay(
                 new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription(magicValue.name()).build(), applePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -104,8 +104,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseApplePay(
                 new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription(SandboxWalletMagicValues.ERROR.name()).build(), applePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
 
@@ -126,8 +126,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseGooglePay(
                 new GooglePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription("whatever").build(), googlePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -154,8 +154,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseGooglePay(
                 new GooglePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription(magicValue.name()).build(), googlePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -181,8 +181,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseGooglePay(
                 new GooglePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription(SandboxWalletMagicValues.ERROR.name()).build(), googlePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
@@ -70,7 +70,7 @@ class StripeCancelHandlerTest {
     void shouldCancelPaymentSuccessfully() throws Exception {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
         final GatewayResponse<BaseCancelResponse> response = stripeCancelHandler.cancel(request);
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         verify(client).postRequestFor(any(StripePaymentIntentCancelRequest.class));
     } 
     
@@ -87,7 +87,7 @@ class StripeCancelHandlerTest {
                 .withAmount(10000L)
                 .build());
         final GatewayResponse<BaseCancelResponse> response = stripeCancelHandler.cancel(request);
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         verify(client).postRequestFor(any(StripePaymentIntentCancelRequest.class));
     }
 
@@ -99,7 +99,7 @@ class StripeCancelHandlerTest {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), Is.is(true));
         assertThat(gatewayResponse.getGatewayError().get().getMessage(), Is.is("Unexpected HTTP status code 402 from gateway"));
         assertThat(gatewayResponse.getGatewayError().get().getErrorType(), Is.is(GATEWAY_ERROR));
@@ -113,7 +113,7 @@ class StripeCancelHandlerTest {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), Is.is(true));
         assertThat(gatewayResponse.getGatewayError().get().getMessage(), Is.is("Problem with Stripe servers"));
         assertThat(gatewayResponse.getGatewayError().get().getErrorType(), Is.is(GATEWAY_ERROR));
@@ -127,7 +127,7 @@ class StripeCancelHandlerTest {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
     }
 
     private GatewayAccountEntity buildGatewayAccountEntity() {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeAuthoriseHandlerTest.java
@@ -126,7 +126,7 @@ public class StripeAuthoriseHandlerTest {
             GatewayResponse<BaseAuthoriseResponse> response = handler.authorise(buildTestAuthorisationRequest(charge));
             
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().isPresent(), is(true));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().get().getTwoDigitMonth(), is("08"));
@@ -146,7 +146,7 @@ public class StripeAuthoriseHandlerTest {
             GatewayResponse<BaseAuthoriseResponse> response = handler.authorise(buildTestUsAuthorisationRequest(charge));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
         }
 
@@ -176,7 +176,7 @@ public class StripeAuthoriseHandlerTest {
             assertThat(response.getBaseResponse().get().getGatewayRecurringAuthToken().get().get(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY), is("cus_4QFOF3xrvBT3nU"));
             assertThat(response.getBaseResponse().get().getGatewayRecurringAuthToken().get().get(STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY), is("pm_1FHESdEZsufgnuO0bzghQoZ2"));
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
         }
 
@@ -193,7 +193,7 @@ public class StripeAuthoriseHandlerTest {
             GatewayResponse<BaseAuthoriseResponse> response = handler.authorise(buildTestAuthorisationRequest(charge));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_123")); // id from templates/stripe/create_payment_intent_requires_3ds_response.json
 
             Optional<Stripe3dsRequiredParams> stripeParamsFor3ds = (Optional<Stripe3dsRequiredParams>) response.getBaseResponse().get().getGatewayParamsFor3ds();
@@ -212,7 +212,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestCharge();
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertEquals("jakarta.ws.rs.ProcessingException: java.io.IOException",
                     authoriseResponse.getGatewayError().get().getMessage());
@@ -303,7 +303,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestCharge();
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -320,7 +320,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestCharge();
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -337,7 +337,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestChargeToSetUpAgreement(buildTestGatewayAccountEntity(), "agreement description");
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -356,7 +356,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestChargeToSetUpAgreement(buildTestGatewayAccountEntity(), "agreement description");
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -382,7 +382,7 @@ public class StripeAuthoriseHandlerTest {
             assertThat(paymentIntentRequest.getPaymentMethodId(), is(PAYMENT_METHOD_ID));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
         }
 
@@ -413,7 +413,7 @@ public class StripeAuthoriseHandlerTest {
             RecurringPaymentAuthorisationGatewayRequest authRequest = RecurringPaymentAuthorisationGatewayRequest.valueOf(charge);
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authoriseUserNotPresent(authRequest);
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -429,7 +429,7 @@ public class StripeAuthoriseHandlerTest {
             RecurringPaymentAuthorisationGatewayRequest authRequest = RecurringPaymentAuthorisationGatewayRequest.valueOf(charge);
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authoriseUserNotPresent(authRequest);
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertEquals("jakarta.ws.rs.ProcessingException: java.io.IOException",
                     authoriseResponse.getGatewayError().get().getMessage());
@@ -456,7 +456,7 @@ public class StripeAuthoriseHandlerTest {
             var paymentIntentRequest = (StripePaymentIntentRequest) allRequests.get(1);
             assertThat(paymentIntentRequest.getTokenId(), is("tok_1NrjK3Hj08j2jFuBm3LGVHYe"));
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().isPresent(), is(true));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().get().getTwoDigitMonth(), is("08"));
@@ -534,7 +534,7 @@ public class StripeAuthoriseHandlerTest {
             assertThat(paymentIntentRequest.getTokenId(), is(TOKEN_ID));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().isPresent(), is(true));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().get().getTwoDigitMonth(), is("08"));
@@ -553,7 +553,7 @@ public class StripeAuthoriseHandlerTest {
         GatewayResponse<BaseAuthoriseResponse> response = handler.authoriseGooglePay(buildGooglePayAuthorisationRequest(charge));
 
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS));
-        assertTrue(response.isSuccessful());
+        assertTrue(response.getBaseResponse().isPresent());
         assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_123"));
 
         Optional<Stripe3dsRequiredParams> stripeParamsFor3ds = (Optional<Stripe3dsRequiredParams>) response.getBaseResponse().get().getGatewayParamsFor3ds();

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.RuntimeDelegate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -814,7 +815,7 @@ class WorldpayAuthoriseHandlerTest {
         var handlerWithRealJerseyClient = new WorldpayAuthoriseHandler(createGatewayClient(mockClient), GATEWAY_URL_MAP, new AcceptLanguageHeaderParser());
 
         GatewayResponse response = handlerWithRealJerseyClient.authorise(getCardAuthorisationRequest(chargeEntityFixture.build()), DO_NOT_SEND_EXEMPTION_REQUEST);
-        assertTrue(response.isSuccessful());
+        assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getSessionIdentifier().isPresent());
     }
 
@@ -987,7 +988,7 @@ class WorldpayAuthoriseHandlerTest {
         when(mockBuilder.header(anyString(), anyString())).thenReturn(mockBuilder);
 
         Map<String, NewCookie> responseCookies =
-                Collections.singletonMap(WORLDPAY_MACHINE_COOKIE_NAME, NewCookie.valueOf("value-from-worldpay"));
+                Collections.singletonMap(WORLDPAY_MACHINE_COOKIE_NAME, RuntimeDelegate.getInstance().createHeaderDelegate(NewCookie.class).fromString("value-from-worldpay"));
 
         Response response = mock(Response.class);
         when(response.readEntity(String.class)).thenReturn(responsePayload);

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsHistoryDaoIT.java
@@ -11,7 +11,7 @@ import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials
 
 import java.util.Map;
 
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
@@ -38,7 +38,7 @@ public class GatewayAccountCredentialsHistoryDaoIT {
         gatewayAccountDao = app.getInstanceFromGuiceContainer(GatewayAccountDao.class);
         gatewayAccountCredentialsHistoryDao = app.getInstanceFromGuiceContainer(GatewayAccountCredentialsHistoryDao.class);
     }
-    
+
     @Test
     void deleteGatewayAccountCredentialsHistory() {
         String serviceId = "archived-service-id";
@@ -46,7 +46,7 @@ public class GatewayAccountCredentialsHistoryDaoIT {
         // delete credentials history as DatabaseTestHelper creates some by default
         gatewayAccountCredentialsHistoryDao.delete(serviceId);
         persistTwoGatewayAccountCredentialsHistoryRows(gatewayAccountEntity, serviceId);
-        
+
         var anotherGatewayAccountEntity = createAGatewayAccount(serviceId);
         persistTwoGatewayAccountCredentialsHistoryRows(anotherGatewayAccountEntity, serviceId);
 
@@ -54,19 +54,19 @@ public class GatewayAccountCredentialsHistoryDaoIT {
         assertThat(app.getDatabaseTestHelper().getGatewayAccountCredentialsHistoryForAccount(gatewayAccountEntity.getId()).isEmpty(), is(true));
         assertThat(app.getDatabaseTestHelper().getGatewayAccountCredentialsHistoryForAccount(anotherGatewayAccountEntity.getId()).isEmpty(), is(true));
     }
-    
+
     private GatewayAccountEntity createAGatewayAccount(String serviceId) {
-        long gatewayAccountId = nextLong();
+        long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
         app.getDatabaseTestHelper()
                 .addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId))
-                .withServiceId(serviceId)
-                .build());
+                        .withAccountId(String.valueOf(gatewayAccountId))
+                        .withServiceId(serviceId)
+                        .build());
         return gatewayAccountDao.findById(gatewayAccountId).get();
     }
 
     private void persistTwoGatewayAccountCredentialsHistoryRows(GatewayAccountEntity gatewayAccountEntity, String serviceId) {
-        Map<String, Object> credentials = Map.of(ONE_OFF_CUSTOMER_INITIATED, 
+        Map<String, Object> credentials = Map.of(ONE_OFF_CUSTOMER_INITIATED,
                 Map.of(CREDENTIALS_MERCHANT_CODE, "a-merchant-code-1", CREDENTIALS_USERNAME, "a-merchant-code-1", CREDENTIALS_PASSWORD, "passw0rd1"));
         String externalCredentialId = randomUuid();
         var gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpay3dsFlexIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceWorldpay3dsFlexIT.java
@@ -27,7 +27,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
@@ -96,7 +96,7 @@ public class GatewayAccountCredentialsResourceWorldpay3dsFlexIT {
 
             @Test
             void forAccountSwitchingToWorldpay_withValidCredentials_shouldReturn200_withResultValid() throws Exception {
-                var anAccountId = nextLong(2, 10000);
+                var anAccountId = current().nextLong(2, 10000);
                 var credentials = List.of(
                         createGatewayAccountCredentialsParams(anAccountId, "stripe", ACTIVE),
                         createGatewayAccountCredentialsParams(anAccountId, "worldpay", CREATED)
@@ -151,7 +151,7 @@ public class GatewayAccountCredentialsResourceWorldpay3dsFlexIT {
 
             @Test
             void forAccountSwitchingToWorldpay_shouldSet3dsFlexCredentials_andReturn200() throws Exception {
-                var anAccountId = nextLong(2, 10000);
+                var anAccountId = current().nextLong(2, 10000);
                 var credentials = List.of(
                         createGatewayAccountCredentialsParams(anAccountId, "stripe", ACTIVE),
                         createGatewayAccountCredentialsParams(anAccountId, "worldpay", CREATED)
@@ -319,7 +319,7 @@ public class GatewayAccountCredentialsResourceWorldpay3dsFlexIT {
 
             @Test
             void forAccountSwitchingToWorldpay_shouldReturn200_andUpdateCredentials() {
-                var anAccountId = nextLong(2, 10000);
+                var anAccountId = current().nextLong(2, 10000);
                 var anAccount = addGatewayAccountAndCredential(anAccountId, LIVE, SERVICE_ID, List.of(
                         createGatewayAccountCredentialsParams(anAccountId, "stripe", ACTIVE),
                         createGatewayAccountCredentialsParams(anAccountId, "worldpay", CREATED)
@@ -493,7 +493,7 @@ public class GatewayAccountCredentialsResourceWorldpay3dsFlexIT {
 
     private DatabaseFixtures.TestAccount addGatewayAccountAndCredential(String paymentProvider, GatewayAccountCredentialState state,
                                                                         GatewayAccountType gatewayAccountType, String serviceId) {
-        long accountId = nextLong(2, 10000);
+        long accountId = current().nextLong(2, 10000);
         return addGatewayAccountAndCredential(accountId,
                 gatewayAccountType,
                 serviceId,

--- a/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.it.contract;
 
 import io.dropwizard.core.setup.Environment;
-import org.apache.commons.lang3.RandomUtils;
+import jakarta.ws.rs.client.ClientBuilder;
 import org.apache.http.HttpStatus;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -17,13 +17,13 @@ import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
-import jakarta.ws.rs.client.ClientBuilder;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_XML_TYPE;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -65,7 +65,7 @@ public class GooglePayForWorldpayTest {
         String payload = load("templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml")
                 .replace("${amount}", "100")
                 .replace("${merchantCode}", merchantCode)
-                .replace("${transactionId?xml}", Integer.toString(RandomUtils.nextInt()))
+                .replace("${transactionId?xml}", Integer.toString(current().nextInt(0, Integer.MAX_VALUE)))
                 .replace("${walletAuthorisationData.encryptedPaymentData.signature?xml}", signature)
                 .replace("${walletAuthorisationData.encryptedPaymentData.protocolVersion?xml}", protocolVersion)
                 .replace("${walletAuthorisationData.encryptedPaymentData.signedMessage?xml}", signedMessage);
@@ -73,7 +73,7 @@ public class GooglePayForWorldpayTest {
         GatewayClient authoriseClient = getGatewayClient();
 
         GatewayOrder gatewayOrder = new GatewayOrder(OrderRequestType.AUTHORISE, payload, APPLICATION_XML_TYPE);
-        WorldpayCredentials credentials = (WorldpayCredentials)gatewayAccount.getGatewayAccountCredentialsEntity(WORLDPAY.getName()).getCredentialsObject();
+        WorldpayCredentials credentials = (WorldpayCredentials) gatewayAccount.getGatewayAccountCredentialsEntity(WORLDPAY.getName()).getCredentialsObject();
         GatewayClient.Response response = authoriseClient.postRequestFor(
                 URI.create("https://secure-test.worldpay.com/jsp/merchant/xml/paymentService.jsp"),
                 WORLDPAY,

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -100,7 +100,7 @@ public class StripePaymentProviderTest {
     @Test
     public void createCharge() {
         GatewayResponse gatewayResponse = authorise();
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -113,7 +113,7 @@ public class StripePaymentProviderTest {
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class StripePaymentProviderTest {
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -151,7 +151,7 @@ public class StripePaymentProviderTest {
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -165,7 +165,7 @@ public class StripePaymentProviderTest {
 
         StripeAuthorisationResponse response = gatewayResponse.getBaseResponse().get();
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
         assertThat(response.getGatewayRecurringAuthToken().isPresent(), is(true));
         assertThat(response.getGatewayRecurringAuthToken().get(), hasKey(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY));
         assertThat(response.getGatewayRecurringAuthToken().get(), hasKey(STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY));
@@ -192,7 +192,7 @@ public class StripePaymentProviderTest {
         ChargeEntity chargeEntity = getCharge();
         chargeEntity.setGatewayTransactionId(gatewayResponse.getBaseResponse().get().getTransactionId());
         GatewayResponse<BaseCancelResponse> cancelResponse = stripePaymentProvider.cancel(CancelGatewayRequest.valueOf(chargeEntity));
-        assertTrue(cancelResponse.isSuccessful());
+        assertTrue(cancelResponse.getBaseResponse().isPresent());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/AgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/AgreementDaoIT.java
@@ -1,8 +1,8 @@
 package uk.gov.pay.connector.it.dao;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
@@ -12,13 +12,13 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 
 import java.util.Optional;
 
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 
 public class AgreementDaoIT {
-    
+
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     private static final String AGREEMENT_EXTERNAL_ID_ONE = "12345678901234567890123456";
@@ -26,7 +26,7 @@ public class AgreementDaoIT {
     private static final String SERVICE_ID = "a-valid-service-id";
     private AgreementDao agreementDao;
     private GatewayAccountEntity gatewayAccount1, gatewayAccount2;
-    
+
     @BeforeEach
     void setUp() {
         agreementDao = app.getInstanceFromGuiceContainer(AgreementDao.class);
@@ -42,7 +42,7 @@ public class AgreementDaoIT {
 
     @Nested
     class FindAgreementByExternalId {
-        
+
         @Test
         void shouldFindAnAgreementEntity() {
             insertTestAgreement(AGREEMENT_EXTERNAL_ID_ONE, gatewayAccount1.getId());
@@ -57,10 +57,10 @@ public class AgreementDaoIT {
             assertThat(agreement.isPresent(), is(false));
         }
     }
-    
+
     @Nested
     class FindAgreementByExternalIdAndGatewayAccountId {
-        
+
         @Test
         void shouldFindAnAgreementEntity() {
             insertTestAgreement(AGREEMENT_EXTERNAL_ID_ONE, gatewayAccount1.getId());
@@ -83,10 +83,10 @@ public class AgreementDaoIT {
             assertThat(agreement.isPresent(), is(false));
         }
     }
-    
+
     @Nested
     class FindAgreementByExternalIdAndServiceIdAndAccountType {
-        
+
         @Test
         void shouldFindAnAgreementEntity() {
             insertTestAgreement(AGREEMENT_EXTERNAL_ID_ONE, gatewayAccount1.getId());
@@ -101,7 +101,7 @@ public class AgreementDaoIT {
             Optional<AgreementEntity> agreement = agreementDao.findByExternalIdAndServiceIdAndAccountType(AGREEMENT_EXTERNAL_ID_ONE, SERVICE_ID, GatewayAccountType.TEST);
             assertThat(agreement.isPresent(), is(false));
         }
-        
+
         @Test
         void shouldNotFindAnAgreementEntity_forADifferentService() {
             insertTestAgreement(AGREEMENT_EXTERNAL_ID_ONE, gatewayAccount1.getId());
@@ -116,11 +116,11 @@ public class AgreementDaoIT {
             assertThat(agreement.isPresent(), is(false));
         }
     }
-    
+
     private void insertTestAgreement(String agreementExternalId, long gatewayAccountId) {
         app.getDatabaseFixtures()
                 .aTestAgreement()
-                .withAgreementId(nextLong())
+                .withAgreementId(current().nextLong())
                 .withExternalId(agreementExternalId)
                 .withReference("ref9876")
                 .withGatewayAccountId(gatewayAccountId)
@@ -132,7 +132,7 @@ public class AgreementDaoIT {
     private DatabaseFixtures.TestAccount insertTestAccount() {
         return app.getDatabaseFixtures()
                 .aTestAccount()
-                .withAccountId(nextLong())
+                .withAccountId(current().nextLong())
                 .withServiceId(SERVICE_ID)
                 .insert();
     }

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.dao;
 
-import org.apache.commons.lang3.RandomUtils;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
@@ -25,7 +24,6 @@ import uk.gov.service.payments.commons.model.SupportedLanguage;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -34,6 +32,7 @@ import java.util.UUID;
 
 import static java.time.ZonedDateTime.now;
 import static java.time.temporal.ChronoUnit.MICROS;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
@@ -329,7 +328,7 @@ public class DatabaseFixtures {
     }
 
     public class TestAccount {
-        long accountId = RandomUtils.nextLong(1, 99999);
+        long accountId = current().nextLong(1, 99999);
         String externalId = randomUuid();
         private String paymentProvider = "sandbox";
         private Map<String, Object> credentialsMap = Map.of();
@@ -421,8 +420,14 @@ public class DatabaseFixtures {
         public boolean isAllowTelephonePaymentNotifications() {
             return allowTelephonePaymentNotifications;
         }
-        public boolean isRequires3ds() { return requires3ds; }
-        public void setRequires3ds(boolean requires3ds) { this.requires3ds = requires3ds; }
+
+        public boolean isRequires3ds() {
+            return requires3ds;
+        }
+
+        public void setRequires3ds(boolean requires3ds) {
+            this.requires3ds = requires3ds;
+        }
 
         public boolean isRecurringEnabled() {
             return recurringEnabled;
@@ -554,7 +559,7 @@ public class DatabaseFixtures {
             this.requires3ds = requires3ds;
             return this;
         }
-        
+
         public TestAccount withRecurringEnabled(boolean recurringEnabled) {
             this.recurringEnabled = recurringEnabled;
             return this;
@@ -569,12 +574,12 @@ public class DatabaseFixtures {
             this.providerSwitchEnabled = providerSwitchEnabled;
             return this;
         }
-        
+
         public TestAccount withSendPayerEmailToGateway(boolean sendPayerEmailToGateway) {
             this.sendPayerEmailToGateway = sendPayerEmailToGateway;
             return this;
         }
-        
+
         public TestAccount withSendPayerIpAddressToGateway(boolean sendPayerIpAddressToGateway) {
             this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
             return this;
@@ -627,8 +632,8 @@ public class DatabaseFixtures {
     }
 
     public class TestAgreement {
-        Long agreementId = RandomUtils.nextLong();
-        Long gatewayAccountId = RandomUtils.nextLong();
+        Long agreementId = current().nextLong(0, Long.MAX_VALUE);
+        Long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
         String externalId = "externalIDxxxyz";
         String reference = "AgreementReference";
         String description = "A valid description";
@@ -742,7 +747,7 @@ public class DatabaseFixtures {
     }
 
     public class TestCharge {
-        Long chargeId = RandomUtils.nextLong();
+        Long chargeId = current().nextLong(0, Long.MAX_VALUE);
         String email = "alice.111@mail.test";
         String externalChargeId = RandomIdGenerator.newId();
         long amount = 101L;
@@ -923,7 +928,7 @@ public class DatabaseFixtures {
             this.authorisationMode = authorisationMode;
             return this;
         }
-        
+
         public TestCharge withServiceId(String serviceId) {
             this.serviceId = serviceId;
             return this;
@@ -1005,7 +1010,9 @@ public class DatabaseFixtures {
             return requires3ds;
         }
 
-        public String getServiceId() { return serviceId; }
+        public String getServiceId() {
+            return serviceId;
+        }
     }
 
     public class TestToken {
@@ -1291,7 +1298,7 @@ public class DatabaseFixtures {
     }
 
     public class TestPaymentInstrument {
-        Long paymentInstrumentId = RandomUtils.nextLong();
+        Long paymentInstrumentId = current().nextLong(0, Long.MAX_VALUE);
         ;
         Map<String, String> recurringAuthToken;
         Instant createdDate = Instant.now();

--- a/src/test/java/uk/gov/pay/connector/it/dao/PaymentInstrumentDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/PaymentInstrumentDaoIT.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
@@ -22,9 +22,9 @@ public class PaymentInstrumentDaoIT {
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     private PaymentInstrumentDao paymentInstrumentDao;
-    
+
     private static final String PAYMENT_INSTRUMENT_EXTERNAL_ID_ONE = "12345678901234567890123456";
-   
+
     @BeforeEach
     void setUp() {
         paymentInstrumentDao = app.getInstanceFromGuiceContainer(PaymentInstrumentDao.class);
@@ -51,31 +51,31 @@ public class PaymentInstrumentDaoIT {
         insertAgreement(agreementExternalId);
         insertAgreement(otherAgreementExternalId);
 
-        insertTestPaymentInstrument("payment-instrument-1", agreementExternalId, 
+        insertTestPaymentInstrument("payment-instrument-1", agreementExternalId,
                 PaymentInstrumentStatus.ACTIVE);
-        insertTestPaymentInstrument("payment-instrument-2", agreementExternalId, 
+        insertTestPaymentInstrument("payment-instrument-2", agreementExternalId,
                 PaymentInstrumentStatus.ACTIVE);
-        insertTestPaymentInstrument("payment-instrument-3", agreementExternalId, 
+        insertTestPaymentInstrument("payment-instrument-3", agreementExternalId,
                 PaymentInstrumentStatus.CREATED);
-        insertTestPaymentInstrument("payment-instrument-4", otherAgreementExternalId, 
+        insertTestPaymentInstrument("payment-instrument-4", otherAgreementExternalId,
                 PaymentInstrumentStatus.ACTIVE);
         List<PaymentInstrumentEntity> paymentInstruments = paymentInstrumentDao.findPaymentInstrumentsByAgreementAndStatus(
                 agreementExternalId, PaymentInstrumentStatus.ACTIVE);
-        
+
         assertThat(paymentInstruments, hasSize(2));
         List<String> returnedPaymentInstrumentExternalIds = paymentInstruments.stream()
                 .map(PaymentInstrumentEntity::getExternalId).collect(Collectors.toList());
         assertThat(returnedPaymentInstrumentExternalIds, containsInAnyOrder("payment-instrument-1", "payment-instrument-2"));
     }
-    
+
     private void insertTestPaymentInstrument(String paymentInstrumentExternalId) {
         app.getDatabaseFixtures()
                 .aTestPaymentInstrument()
-                .withPaymentInstrumentId(nextLong())
+                .withPaymentInstrumentId(current().nextLong(0, Long.MAX_VALUE))
                 .withExternalId(paymentInstrumentExternalId)
                 .insert();
     }
-    
+
     private void insertTestPaymentInstrument(String externalId, String agreementExternalId, PaymentInstrumentStatus status) {
         app.getDatabaseFixtures()
                 .aTestPaymentInstrument()

--- a/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
@@ -62,7 +62,7 @@ public class StateTransitionsIT {
         assertThat(messages.size(), is(2));
 
         JsonObject cancelledMessage = messages.stream()
-                .map(m -> new JsonParser().parse(m.body()).getAsJsonObject())
+                .map(m -> JsonParser.parseString(m.body()).getAsJsonObject())
                 .filter(e -> e.get("event_type").getAsString().equals("CANCELLED_BY_EXTERNAL_SERVICE"))
                 .findFirst().get();
 
@@ -72,7 +72,7 @@ public class StateTransitionsIT {
         assertThat(cancelledMessage.get("live").getAsBoolean(), is(false));
 
         Optional<JsonObject> refundMessage = messages.stream()
-                .map(m -> new JsonParser().parse(m.body()).getAsJsonObject())
+                .map(m -> JsonParser.parseString(m.body()).getAsJsonObject())
                 .filter(e -> e.get("event_type").getAsString().equals("REFUND_AVAILABILITY_UPDATED"))
                 .findFirst();
         assertThat(refundMessage.isPresent(), is(true));
@@ -80,7 +80,7 @@ public class StateTransitionsIT {
     }
 
     @Test
-    void shouldEmitCorrectRefundEvents() throws Exception{
+    void shouldEmitCorrectRefundEvents() throws Exception {
         String chargeId = testBaseExtension.addCharge(
                 anAddChargeParameters().withChargeStatus(CAPTURED)
                         .withCreatedDate(Instant.now().minus(1, HOURS))
@@ -103,13 +103,13 @@ public class StateTransitionsIT {
         Thread.sleep(500L);
 
         String refundId = response.extract().response().jsonPath().get("refund_id");
-        
+
         List<Message> messages = readMessagesFromEventQueue();
 
         assertThat(messages.size(), is(4));
 
         JsonObject message1 = messages.stream()
-                .map(m -> new JsonParser().parse(m.body()).getAsJsonObject())
+                .map(m -> JsonParser.parseString(m.body()).getAsJsonObject())
                 .filter(m -> "REFUND_CREATED_BY_SERVICE".equals(m.get("event_type").getAsString()))
                 .findFirst().get();
         assertThat(message1.get("event_type").getAsString(), is("REFUND_CREATED_BY_SERVICE"));
@@ -120,7 +120,7 @@ public class StateTransitionsIT {
         assertThat(message1.get("event_details").getAsJsonObject().get("amount").getAsInt(), is(50));
 
         JsonObject message2 = messages.stream()
-                .map(m -> new JsonParser().parse(m.body()).getAsJsonObject())
+                .map(m -> JsonParser.parseString(m.body()).getAsJsonObject())
                 .filter(m -> "REFUND_AVAILABILITY_UPDATED".equals(m.get("event_type").getAsString()))
                 .findFirst().get();
         assertThat(message2.get("event_type").getAsString(), is("REFUND_AVAILABILITY_UPDATED"));
@@ -132,7 +132,7 @@ public class StateTransitionsIT {
         assertThat(message2.get("event_details").getAsJsonObject().get("refund_status").getAsString(), is("available"));
 
         JsonObject message3 = messages.stream()
-                .map(m -> new JsonParser().parse(m.body()).getAsJsonObject())
+                .map(m -> JsonParser.parseString(m.body()).getAsJsonObject())
                 .filter(m -> "REFUND_SUBMITTED".equals(m.get("event_type").getAsString()))
                 .findFirst().get();
         assertThat(message3.get("event_type").getAsString(), is("REFUND_SUBMITTED"));
@@ -141,7 +141,7 @@ public class StateTransitionsIT {
         assertThat(message3.get("live").getAsBoolean(), is(false));
 
         JsonObject message4 = messages.stream()
-                .map(m -> new JsonParser().parse(m.body()).getAsJsonObject())
+                .map(m -> JsonParser.parseString(m.body()).getAsJsonObject())
                 .filter(m -> "REFUND_SUCCEEDED".equals(m.get("event_type").getAsString()))
                 .findFirst().get();
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
@@ -2,8 +2,7 @@ package uk.gov.pay.connector.it.resources;
 
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.apache.commons.lang3.RandomUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
@@ -25,6 +24,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -309,7 +309,7 @@ public class CardResourceAuthoriseIT {
 
     @Test
     void shouldPersistCorporateSurcharge() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         long corporateCreditCardSurchargeAmount = 2222L;
         var gatewayAccountParams = anAddGatewayAccountParams()
                 .withAccountId(accountId)
@@ -479,7 +479,7 @@ public class CardResourceAuthoriseIT {
 
     @Test
     void shouldUseActivePaymentProviderWhenMultipleCredentials() {
-        long accountId = RandomUtils.nextInt();
+        long accountId = current().nextInt(0, Integer.MAX_VALUE);
         AddGatewayAccountCredentialsParams stripeCredentialsParams = anAddGatewayAccountCredentialsParams()
                 .withPaymentProvider(STRIPE.getName())
                 .withGatewayAccountId(accountId)
@@ -564,6 +564,6 @@ public class CardResourceAuthoriseIT {
     }
 
     private Long getLongChargeId(String externalChargeId) {
-        return Long.valueOf(StringUtils.removeStart(externalChargeId, "charge-"));
+        return Long.valueOf(Strings.CS.removeStart(externalChargeId, "charge-"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateAgreementIT.java
@@ -5,7 +5,6 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -29,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_CONFLICT;
 import static org.apache.http.HttpStatus.SC_CREATED;
@@ -72,7 +72,7 @@ public class ChargesApiResourceCreateAgreementIT {
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
-    
+
     private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
 
@@ -83,7 +83,7 @@ public class ChargesApiResourceCreateAgreementIT {
     private static final String JSON_TOO_LONG_AGREEMENT_ID_VALUE = "123456789012345678901234567890";
     private static final String JSON_AUTH_MODE_AGREEMENT = "agreement";
     private static final String JSON_AGREEMENT_PAYMENT_TYPE = "agreement_payment_type";
-    
+
     @BeforeEach
     void setUpLogger() {
         Logger root = (Logger) LoggerFactory.getLogger(TaskQueue.class);
@@ -158,7 +158,7 @@ public class ChargesApiResourceCreateAgreementIT {
     @Test
     void shouldCreatePaymentWithAgreementIdAndAuthorisationModeAgreementAndNoExplicitAgreementPaymentType() {
         app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testBaseExtension.getAccountId()));
-        Long paymentInstrumentId = RandomUtils.nextLong();
+        Long paymentInstrumentId = current().nextLong(0, Long.MAX_VALUE);
 
         AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)
@@ -205,7 +205,7 @@ public class ChargesApiResourceCreateAgreementIT {
     void shouldCreatePaymentWithAgreementIdAndAuthorisationModeAgreementAndExplicitAgreementPaymentType(
             String requestAgreementPaymentType, AgreementPaymentType expectedAgreementPaymentType) {
         app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testBaseExtension.getAccountId()));
-        Long paymentInstrumentId = RandomUtils.nextLong();
+        Long paymentInstrumentId = current().nextLong(0, Long.MAX_VALUE);
 
         AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)
@@ -259,7 +259,7 @@ public class ChargesApiResourceCreateAgreementIT {
                 .withExternalAgreementId(JSON_VALID_AGREEMENT_ID_VALUE)
                 .build();
         app.getDatabaseTestHelper().addAgreement(agreementParams);
-    
+
         String postBody = toJson(Map.of(
                 JSON_AMOUNT_KEY, AMOUNT,
                 JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
@@ -304,27 +304,27 @@ public class ChargesApiResourceCreateAgreementIT {
                 .body("message", contains("Unexpected attribute: agreement_payment_type"))
                 .body("error_identifier", is(ErrorIdentifier.UNEXPECTED_ATTRIBUTE.toString()));
     }
-    
+
     @ParameterizedTest
     @EnumSource(AgreementPaymentType.class)
     void shouldReturn422WhenAgreementPaymentTypeUsedWithoutAuthorisationModeAgreement(AgreementPaymentType agreementPaymentType) {
         String requestAgreementPaymentType = agreementPaymentType.getName();
 
         app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testBaseExtension.getAccountId()));
-        Long paymentInstrumentId = RandomUtils.nextLong();
-    
+        Long paymentInstrumentId = current().nextLong(0, Long.MAX_VALUE);
+
         AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)
                 .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE).build();
         app.getDatabaseTestHelper().addPaymentInstrument(paymentInstrumentParams);
-    
+
         AddAgreementParams agreementParams = anAddAgreementParams()
                 .withGatewayAccountId(testBaseExtension.getAccountId())
                 .withExternalAgreementId(JSON_VALID_AGREEMENT_ID_VALUE)
                 .withPaymentInstrumentId(paymentInstrumentId)
                 .build();
         app.getDatabaseTestHelper().addAgreement(agreementParams);
-    
+
         String postBody = toJson(Map.of(
                 JSON_AMOUNT_KEY, AMOUNT,
                 JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
@@ -346,7 +346,7 @@ public class ChargesApiResourceCreateAgreementIT {
         String idempotencyKey = "an-idempotency-key";
 
         app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testBaseExtension.getAccountId()));
-        Long paymentInstrumentId = RandomUtils.nextLong();
+        Long paymentInstrumentId = current().nextLong(0, Long.MAX_VALUE);
 
         AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)
@@ -391,7 +391,7 @@ public class ChargesApiResourceCreateAgreementIT {
         String idempotencyKey = "an-idempotency-key";
 
         app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testBaseExtension.getAccountId()));
-        Long paymentInstrumentId = RandomUtils.nextLong();
+        Long paymentInstrumentId = current().nextLong(0, Long.MAX_VALUE);
 
         AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)
@@ -441,7 +441,7 @@ public class ChargesApiResourceCreateAgreementIT {
         String idempotencyKey = "an-idempotency-key";
 
         app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testBaseExtension.getAccountId()));
-        Long paymentInstrumentId = RandomUtils.nextLong();
+        Long paymentInstrumentId = current().nextLong(0, Long.MAX_VALUE);
 
         AddPaymentInstrumentParams paymentInstrumentParams = anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)
@@ -457,7 +457,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
         String existingChargeExternalId = testBaseExtension.addCharge(
                 anAddChargeParameters().withChargeStatus(CREATED).build());
-        
+
         Map<String, Object> previousRequestBodyMap = Map.of(
                 JSON_AMOUNT_KEY, AMOUNT,
                 JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
@@ -485,7 +485,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn400WhenSavePaymentInstrumentToAgreementIsTrueButNoAgreementId() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -512,7 +512,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn400WhenSavePaymentInstrumentToAgreementTrueAndAgreementNotFound() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -538,7 +538,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn422WhenAuthorisationModeAgreementButNoAgreementId() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -563,7 +563,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn422WhenAuthorisationModeAgreementAndReturnUrlProvided() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("sandbox")
                 .withAccountId(accountId)
@@ -589,7 +589,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn422WhenAuthorisationModeAgreementAndMotoTrue() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("sandbox")
                 .withAccountId(accountId)
@@ -617,7 +617,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn422WhenAuthorisationModeAgreementAndEmailProvided() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("sandbox")
                 .withAccountId(accountId)
@@ -644,7 +644,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn422WhenAuthorisationModeAgreementAndPrefilledCardholderDetailsProvided() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("sandbox")
                 .withAccountId(accountId)
@@ -671,7 +671,7 @@ public class ChargesApiResourceCreateAgreementIT {
         ));
 
         testBaseExtension.getConnectorRestApiClient()
-                .postCreateCharge(postBody,accountId)
+                .postCreateCharge(postBody, accountId)
                 .statusCode(SC_UNPROCESSABLE_ENTITY)
                 .contentType(JSON)
                 .body("message", contains("Unexpected attribute: prefilled_cardholder_details"))
@@ -680,7 +680,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn400WhenAuthorisationModeIsAgreementAndAgreementNotFound() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -705,7 +705,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn400WhenAuthorisationModeIsAgreementAndPaymentInstrumentNotFound() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -736,7 +736,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn400WhenAuthorisationModeIsAgreementAndPaymentInstrumentIsNotActive() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -777,7 +777,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn422WhenAuthorisationModeMotoApiAndAgreementId() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -807,7 +807,7 @@ public class ChargesApiResourceCreateAgreementIT {
     void shouldReturn422WhenAuthorisationModeMotoApiAndAgreementPaymentType(AgreementPaymentType agreementPaymentType) {
         String requestAgreementPaymentType = agreementPaymentType.getName();
 
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -834,7 +834,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn400WhenSavePaymentInstrumentToAgreementTrueAuthorisationModeAgreementAndAgreementId() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -861,7 +861,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn422WhenAgreementIdIsProvidedButNotSavePaymentInstrumentToAgreementNorAuthorisationModeAgreement() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -889,8 +889,8 @@ public class ChargesApiResourceCreateAgreementIT {
     void shouldReturn422WhenAgreementIdAndAgreementPaymentTypeIsProvidedButNotSavePaymentInstrumentToAgreementNorAuthorisationModeAgreement(
             AgreementPaymentType agreementPaymentType) {
         String requestAgreementPaymentType = agreementPaymentType.getName();
-        
-        String accountId = String.valueOf(RandomUtils.nextInt());
+
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -916,7 +916,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn422WhenAgreementIdIsProvidedButSavePaymentInstrumentToAgreementFalse() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -942,7 +942,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn422WhenAgreementIdExceeds26Characters() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)
@@ -972,7 +972,7 @@ public class ChargesApiResourceCreateAgreementIT {
 
     @Test
     void shouldReturn422WhenAgreementIdFewerThan26Characters() {
-        String accountId = String.valueOf(RandomUtils.nextInt());
+        String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
                 .withPaymentGateway("worldpay")
                 .withAccountId(accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateProviderCredentialsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateProviderCredentialsIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.it.resources;
 
-import org.apache.commons.lang3.RandomUtils;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -12,12 +12,12 @@ import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.pay.connector.util.AddGatewayAccountParams;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
-import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
@@ -31,13 +31,13 @@ public class ChargesApiResourceCreateProviderCredentialsIT {
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("sandbox", app.getLocalPort(), app.getDatabaseTestHelper());
     private static final String VALID_SERVICE_ID = "a-valid-service-id";
-    
+
     @Nested
     class ByGatewayAccountId {
         @Test
         void shouldCreateChargeForCredentialIdProvided() {
             //set up a Worldpay to Worldpay PSP switch scenario in the database (as described in PP-10958)
-            String accountId = String.valueOf(RandomUtils.nextInt());
+            String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
             AddGatewayAccountCredentialsParams credentialsToUse = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider("worldpay")
                     .withState(GatewayAccountCredentialState.ENTERED)
@@ -79,7 +79,7 @@ public class ChargesApiResourceCreateProviderCredentialsIT {
         @Test
         void shouldReturn400WhenCredentialsNotFoundForCredentialIdProvided() {
             //set up an account with valid credentials in the database
-            String accountId = String.valueOf(RandomUtils.nextInt());
+            String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
             AddGatewayAccountCredentialsParams credentials = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider("worldpay")
                     .withState(GatewayAccountCredentialState.ACTIVE)
@@ -111,7 +111,7 @@ public class ChargesApiResourceCreateProviderCredentialsIT {
 
         @Test
         void shouldReturn400WhenNoCredentialsAreInUsableState() {
-            String accountId = String.valueOf(RandomUtils.nextInt());
+            String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
             AddGatewayAccountCredentialsParams credentials = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider("worldpay")
                     .withState(GatewayAccountCredentialState.RETIRED)
@@ -144,7 +144,7 @@ public class ChargesApiResourceCreateProviderCredentialsIT {
 
         @Test
         void shouldReturn400WhenCredentialsInCreatedState() {
-            String accountId = String.valueOf(RandomUtils.nextInt());
+            String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
             AddGatewayAccountCredentialsParams credentials = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider("worldpay")
                     .withState(GatewayAccountCredentialState.CREATED)
@@ -181,7 +181,7 @@ public class ChargesApiResourceCreateProviderCredentialsIT {
         @Test
         void shouldCreateChargeForCredentialIdProvided() {
             //set up a Worldpay to Worldpay PSP switch scenario in the database (as described in PP-10958)
-            String accountId = String.valueOf(RandomUtils.nextInt());
+            String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
             AddGatewayAccountCredentialsParams credentialsToUse = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider("worldpay")
                     .withState(GatewayAccountCredentialState.ENTERED)
@@ -224,7 +224,7 @@ public class ChargesApiResourceCreateProviderCredentialsIT {
         @Test
         void shouldReturn400WhenCredentialsNotFoundForCredentialIdProvided() {
             //set up an account with valid credentials in the database
-            String accountId = String.valueOf(RandomUtils.nextInt());
+            String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
             AddGatewayAccountCredentialsParams credentials = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider("worldpay")
                     .withState(GatewayAccountCredentialState.ACTIVE)
@@ -257,7 +257,7 @@ public class ChargesApiResourceCreateProviderCredentialsIT {
 
         @Test
         void shouldReturn400WhenNoCredentialsAreInUsableState() {
-            String accountId = String.valueOf(RandomUtils.nextInt());
+            String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
             AddGatewayAccountCredentialsParams credentials = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider("worldpay")
                     .withState(GatewayAccountCredentialState.RETIRED)
@@ -291,7 +291,7 @@ public class ChargesApiResourceCreateProviderCredentialsIT {
 
         @Test
         void shouldReturn400WhenCredentialsInCreatedState() {
-            String accountId = String.valueOf(RandomUtils.nextInt());
+            String accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
             AddGatewayAccountCredentialsParams credentials = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider("worldpay")
                     .withState(GatewayAccountCredentialState.CREATED)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.it.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -20,15 +19,13 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.now;
 import static java.time.ZonedDateTime.parse;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
@@ -40,6 +37,7 @@ import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
 import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.service.payments.commons.model.SupportedLanguage.ENGLISH;
 
@@ -64,13 +62,13 @@ public class ExpungeResourceIT {
         this.defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
-                .withAccountId(nextLong())
+                .withAccountId(current().nextLong(0, Long.MAX_VALUE))
                 .insert();
     }
 
     @Test
     void shouldExpungeCharge() throws JsonProcessingException {
-        var chargedId = ThreadLocalRandom.current().nextLong();
+        var chargedId = current().nextLong(0, Long.MAX_VALUE);
         expungeableCharge1 = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withChargeId(chargedId)
@@ -110,7 +108,7 @@ public class ExpungeResourceIT {
 
     @Test
     void shouldUpdateTheParityCheckedDateOfNonCriteriaMatchedCharge() throws JsonProcessingException {
-        var chargedId = ThreadLocalRandom.current().nextLong();
+        var chargedId = current().nextLong(0, Long.MAX_VALUE);
         var date = parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC).minusDays(91))).toInstant();
         expungeableCharge1 = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -136,7 +134,7 @@ public class ExpungeResourceIT {
 
     @Test
     void shouldNotExpungeChargeThatIsNotOldEnoughToBeExpunged() throws JsonProcessingException {
-        var chargedId = ThreadLocalRandom.current().nextLong();
+        var chargedId = current().nextLong(0, Long.MAX_VALUE);
         expungeableCharge1 = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withChargeId(chargedId)
@@ -168,7 +166,7 @@ public class ExpungeResourceIT {
 
     @Test
     void shouldExpungeChargesMeetingCriteriaButNotThoseThatDont() throws JsonProcessingException {
-        var chargedId = ThreadLocalRandom.current().nextLong();
+        var chargedId = current().nextLong(0, Long.MAX_VALUE);
 
         expungeableCharge1 = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -189,7 +187,7 @@ public class ExpungeResourceIT {
         insertChargeEvent(expungeableCharge1);
         app.getLedgerStub().returnLedgerTransaction("external_charge_id_10", expungeableCharge1, null);
 
-        var chargedId2 = ThreadLocalRandom.current().nextLong();
+        var chargedId2 = current().nextLong(0, Long.MAX_VALUE);
 
         var nonExpungeableCharge1 = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -210,7 +208,7 @@ public class ExpungeResourceIT {
         insertChargeEvent(nonExpungeableCharge1);
         app.getLedgerStub().returnLedgerTransaction("external_charge_id_11", nonExpungeableCharge1, null);
 
-        var chargedId3 = ThreadLocalRandom.current().nextLong();
+        var chargedId3 = current().nextLong(0, Long.MAX_VALUE);
 
         var expungeableCharge2 = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -231,7 +229,7 @@ public class ExpungeResourceIT {
         insertChargeEvent(expungeableCharge2);
         app.getLedgerStub().returnLedgerTransaction("external_charge_id_12", expungeableCharge2, null);
 
-        var chargedId4 = ThreadLocalRandom.current().nextLong();
+        var chargedId4 = current().nextLong(0, Long.MAX_VALUE);
 
         var nonExpungeableCharge2 = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -270,7 +268,7 @@ public class ExpungeResourceIT {
 
     @Test
     void shouldExpungeAuxiliaryTables_whenTheyExistAndReferenceAChargeForExpunging() throws JsonProcessingException {
-        var chargedId = ThreadLocalRandom.current().nextLong();
+        var chargedId = current().nextLong(0, Long.MAX_VALUE);
 
         expungeableCharge1 = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -301,7 +299,7 @@ public class ExpungeResourceIT {
         emittedEventDao.persist(anEmittedEventEntity()
                 .withResourceExternalId(expungeableCharge1.getExternalChargeId())
                 .withResourceType("payment")
-                .withId(RandomUtils.nextLong())
+                .withId(current().nextLong(0, Long.MAX_VALUE))
                 .build());
 
         app.getLedgerStub().returnLedgerTransaction("external_charge_id", expungeableCharge1, testFee);
@@ -325,7 +323,7 @@ public class ExpungeResourceIT {
 
     @Test
     void shouldExpungeRefundEligibleAndRelatedRecords() throws JsonProcessingException {
-        String chargeExternalId = randomAlphanumeric(26);
+        String chargeExternalId = randomAlphaNumeric(26);
         RefundEntity refundToBeExpunged1 = createAndStubRefund(chargeExternalId, 91, REFUNDED, true);
         RefundEntity refundToBeExpunged2 = createAndStubRefund(chargeExternalId, 91, REFUND_SUBMITTED, true);
 
@@ -348,14 +346,14 @@ public class ExpungeResourceIT {
 
     @Test
     void shouldNotExpungeRefundsNotMeetingCriteria() throws JsonProcessingException {
-        String chargeExternalId = randomAlphanumeric(26);
-        RefundEntity nonExpungeableRefund1 = createAndStubRefund(randomAlphanumeric(26), 1, REFUNDED, true);
-        RefundEntity nonExpungeableRefund2 = createAndStubRefund(randomAlphanumeric(26), 1, REFUND_SUBMITTED, true);
+        String chargeExternalId = randomAlphaNumeric(26);
+        RefundEntity nonExpungeableRefund1 = createAndStubRefund(randomAlphaNumeric(26), 1, REFUNDED, true);
+        RefundEntity nonExpungeableRefund2 = createAndStubRefund(randomAlphaNumeric(26), 1, REFUND_SUBMITTED, true);
         RefundEntity parityCheckFailedRefund = createAndStubRefund(chargeExternalId, 91, REFUNDED, false);
 
         var chargeToStub = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
-                .withChargeId(ThreadLocalRandom.current().nextLong())
+                .withChargeId(current().nextLong(0, Long.MAX_VALUE))
                 .withTestAccount(defaultTestAccount);
         app.getLedgerStub().returnLedgerTransaction(chargeExternalId, chargeToStub, null);
         var containsEmittedEvents = databaseTestHelper.containsEmittedEventWithExternalId(parityCheckFailedRefund.getExternalId());
@@ -386,7 +384,7 @@ public class ExpungeResourceIT {
     private RefundEntity createAndStubRefund(String chargeExternalId, int createdBeforeDays, RefundStatus refundStatus,
                                              boolean stubForMatchingLedgerTransaction) throws JsonProcessingException {
         RefundEntity refundEntity = new RefundEntity(100L, userExternalId, userEmail, chargeExternalId);
-        refundEntity.setGatewayTransactionId(randomAlphanumeric(20));
+        refundEntity.setGatewayTransactionId(randomAlphaNumeric(20));
         refundEntity.setStatus(RefundStatus.CREATED);
         refundEntity.setCreatedDate(now(UTC).minusDays(createdBeforeDays));
         refundDao.persist(refundEntity);

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.resources;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
@@ -11,6 +10,7 @@ import java.util.List;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.ws.rs.core.Response.Status.OK;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -41,7 +41,7 @@ public class GatewayCleanupResourceIT {
         // add a non-Worldpay charge that shouldn't be picked up
         var sandboxAccount = withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aTestAccount()
-                .withAccountId(RandomUtils.nextLong())
+                .withAccountId(current().nextLong(0, Long.MAX_VALUE))
                 .withPaymentProvider(SANDBOX.getName())
                 .insert();
 
@@ -67,7 +67,7 @@ public class GatewayCleanupResourceIT {
         String chargeStatus2 = app.getDatabaseTestHelper().getChargeStatusByExternalId(chargeId2);
         String chargeStatus3 = app.getDatabaseTestHelper().getChargeStatusByExternalId(chargeId3);
         String chargeStatus4 = app.getDatabaseTestHelper().getChargeStatusByExternalId(chargeId4);
-        
+
         assertThat(chargeStatus1, is(AUTHORISATION_REJECTED.getValue()));
         assertThat(chargeStatus2, is(AUTHORISATION_ERROR_CANCELLED.getValue()));
         assertThat(chargeStatus3, is(AUTHORISATION_ERROR_CANCELLED.getValue()));

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceCancelIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceCancelIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.resources.stripe;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -22,9 +21,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.lang.String.format;
-import static java.util.stream.Collectors.joining;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static java.lang.String.format;
+import static java.util.concurrent.ThreadLocalRandom.current;
+import static java.util.stream.Collectors.joining;
 import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
@@ -49,9 +49,9 @@ public class StripeResourceCancelIT {
 
     @BeforeEach
     void setup() {
-        stripeAccountId = String.valueOf(RandomUtils.nextInt());
+        stripeAccountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
         databaseTestHelper = app.getDatabaseTestHelper();
-        accountId = String.valueOf(RandomUtils.nextInt());
+        accountId = String.valueOf(current().nextInt(0, Integer.MAX_VALUE));
 
         accountCredentialsParams = anAddGatewayAccountCredentialsParams()
                 .withPaymentProvider(paymentProvider)
@@ -66,9 +66,9 @@ public class StripeResourceCancelIT {
 
         addGatewayAccount();
 
-        String transactionId = "stripe-" + RandomUtils.nextInt();
+        String transactionId = "stripe-" + current().nextInt(0, Integer.MAX_VALUE);
         app.getStripeMockClient().mockCancelPaymentIntent(transactionId);
-        
+
         String externalChargeId = addChargeWithStatusAndTransactionId(AUTHORISATION_SUCCESS, transactionId);
 
         given().port(app.getLocalPort())
@@ -89,7 +89,7 @@ public class StripeResourceCancelIT {
 
         addGatewayAccount();
 
-        String transactionId = "stripe-" + RandomUtils.nextInt();
+        String transactionId = "stripe-" + current().nextInt(0, Integer.MAX_VALUE);
         app.getStripeMockClient().mockCancelPaymentIntent(transactionId);
 
         String externalChargeId = addChargeWithStatusAndTransactionId(AUTHORISATION_SUCCESS, transactionId);
@@ -108,7 +108,7 @@ public class StripeResourceCancelIT {
     }
 
     private String addChargeWithStatusAndTransactionId(ChargeStatus chargeStatus, String transactionId) {
-        long chargeId = RandomUtils.nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
         String externalChargeId = "charge-" + chargeId;
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)

--- a/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
@@ -1,13 +1,13 @@
 package uk.gov.pay.connector.it.util;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang3.RandomUtils;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.util.Map;
 
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static uk.gov.pay.connector.it.resources.ChargesFrontendResourceIT.AGREEMENT_ID;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
@@ -51,7 +51,7 @@ public class ChargeUtils {
         return createNewChargeWithAccountId(status, RandomIdGenerator.newId(), gatewayAccountId, databaseTestHelper, "email@fake.test", paymentProvider);
     }
 
-    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String gatewayAccountId, 
+    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String gatewayAccountId,
                                                                 DatabaseTestHelper databaseTestHelper, String paymentProvider) {
         return createNewChargeWithAccountId(status, gatewayTransactionId, gatewayAccountId, databaseTestHelper, "email@fake.test", paymentProvider);
     }
@@ -63,7 +63,7 @@ public class ChargeUtils {
 
     public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String gatewayAccountId,
                                                                 DatabaseTestHelper databaseTestHelper, String emailAddress, String paymentProvider, String description) {
-        long chargeId = RandomUtils.nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
         ExternalChargeId externalChargeId = ExternalChargeId.fromChargeId(chargeId);
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
@@ -82,7 +82,7 @@ public class ChargeUtils {
     public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId,
                                                                 String gatewayAccountId, DatabaseTestHelper databaseTestHelper,
                                                                 String paymentProvider, Long gatewayCredentialId) {
-        long chargeId = RandomUtils.nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
         ExternalChargeId externalChargeId = ExternalChargeId.fromChargeId(chargeId);
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)

--- a/src/test/java/uk/gov/pay/connector/pact/ChargeEventEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ChargeEventEntityFixture.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.fee.model.Fee;
 
 import java.time.ZonedDateTime;
 
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity.ChargeEventEntityBuilder.aChargeEventEntity;
 
@@ -15,7 +16,7 @@ public class ChargeEventEntityFixture {
     private ChargeStatus chargeStatus = ChargeStatus.CAPTURED;
     private ZonedDateTime updated = ZonedDateTime.now();
     private ZonedDateTime gatewayEventDate;
-    private Long id = RandomUtils.nextLong();
+    private Long id = current().nextLong(0, Long.MAX_VALUE);
     private ChargeEntity charge = aValidChargeEntity()
             .withFee(Fee.of(null, 42L))
             .build();

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -6,7 +6,6 @@ import au.com.dius.pact.provider.junit.target.Target;
 import au.com.dius.pact.provider.junit.target.TestTarget;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang3.RandomStringUtils;
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -79,6 +78,7 @@ import static uk.gov.pay.connector.events.model.payout.PayoutCreated.from;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 import static uk.gov.pay.connector.pact.ChargeEventEntityFixture.aValidChargeEventEntity;
 import static uk.gov.pay.connector.pact.RefundHistoryEntityFixture.aValidRefundHistoryEntity;
+import static uk.gov.pay.connector.util.RandomAlphaNumericString.randomAlphaNumeric;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.EXTERNAL;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 import static uk.gov.service.payments.commons.model.Source.CARD_API;
@@ -242,7 +242,7 @@ public class QueueMessageContractTest {
 
     @PactVerifyProvider("a refund succeeded message")
     public String verifyRefundedEvent() throws JsonProcessingException {
-        String gatewayTransactionId = RandomStringUtils.randomAlphanumeric(14);
+        String gatewayTransactionId = randomAlphaNumeric(14);
         ChargeEntity chargeEntity = aValidChargeEntity().build();
         Charge charge = Charge.from(chargeEntity);
         RefundHistory refundHistory = aValidRefundHistoryEntity()

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceIT.java
@@ -13,7 +13,7 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -33,7 +33,7 @@ public class CardCaptureServiceIT {
 
     @Test
     void shouldPersistFeesForStripeV2Charge() {
-        long chargeId = nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
         String externalChargeId = RandomIdGenerator.newId();
 
         app.getDatabaseTestHelper().addCharge(anAddChargeParams()
@@ -58,15 +58,15 @@ public class CardCaptureServiceIT {
         assertThat(listOfFees, hasSize(3));
         assertThat(listOfFees, containsInAnyOrder(
                 allOf(
-                        hasEntry("fee_type", (Object)"radar"),
+                        hasEntry("fee_type", (Object) "radar"),
                         hasEntry("amount_collected", 10L)
                 ),
                 allOf(
-                        hasEntry("fee_type", (Object)"three_ds"),
+                        hasEntry("fee_type", (Object) "three_ds"),
                         hasEntry("amount_collected", 20L)
                 ),
                 allOf(
-                        hasEntry("fee_type", (Object)"transaction"),
+                        hasEntry("fee_type", (Object) "transaction"),
                         hasEntry("amount_collected", 480L)
                 )
         ));

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/QueryAndUpdatePaymentInSubmittedStateTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/QueryAndUpdatePaymentInSubmittedStateTaskHandlerIT.java
@@ -12,7 +12,7 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
@@ -29,7 +29,7 @@ class QueryAndUpdatePaymentInSubmittedStateTaskHandlerIT {
 
     @Test
     void shouldQueryAndUpdateChargeInSubmittedStateToCaptured() {
-        long chargeId = nextInt();
+        long chargeId = current().nextInt(0, Integer.MAX_VALUE);
         String chargeExternalId = RandomIdGenerator.newId();
         var paymentTaskData = new PaymentTaskData(chargeExternalId);
 

--- a/src/test/java/uk/gov/pay/connector/tasks/service/RefundParityCheckerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/service/RefundParityCheckerTest.java
@@ -18,7 +18,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static java.time.ZoneOffset.UTC;
-import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
@@ -36,7 +36,7 @@ class RefundParityCheckerTest {
     private RefundDao mockRefundDao;
     @InjectMocks
     RefundParityChecker refundParityChecker;
-    private Long gatewayAccountId = nextLong();
+    private Long gatewayAccountId = current().nextLong(0, Long.MAX_VALUE);
     private RefundEntity refundEntity;
 
     @BeforeEach

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountCredentialsParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountCredentialsParams.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.connector.util;
 
-import org.apache.commons.lang3.RandomUtils;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 
 import java.time.Instant;
 import java.util.Map;
 
+import static java.util.concurrent.ThreadLocalRandom.current;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
@@ -63,7 +63,7 @@ public class AddGatewayAccountCredentialsParams {
     }
 
     public static final class AddGatewayAccountCredentialsParamsBuilder {
-        private long id = RandomUtils.nextLong(2, 1000000);
+        private long id = current().nextLong(2, 1000000);
         private Instant createdDate = Instant.now();
         private Instant activeStartDate = null;
         private Instant activeEndDate = null;

--- a/src/test/java/uk/gov/pay/connector/util/RandomIdGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/RandomIdGeneratorTest.java
@@ -13,8 +13,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.pay.connector.util.RandomIdGenerator.newId;
 import static uk.gov.pay.connector.util.RandomIdGenerator.idFromExternalId;
+import static uk.gov.pay.connector.util.RandomIdGenerator.newId;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 class RandomIdGeneratorTest {
@@ -24,9 +24,9 @@ class RandomIdGeneratorTest {
     @Test
     void shouldGenerateUniqueRandomIds() {
         Set<String> randomIds = IntStream.range(0, 100)
-            .parallel()
-            .mapToObj(value -> newId())
-            .collect(Collectors.toSet());
+                .parallel()
+                .mapToObj(value -> newId())
+                .collect(Collectors.toSet());
 
         assertEquals(100, randomIds.size());
     }
@@ -34,18 +34,18 @@ class RandomIdGeneratorTest {
     @Test
     void shouldGenerateRandomIdsInBase32() {
         IntStream.range(0, 100)
-            .parallel()
-            .mapToObj(value -> newId())
-            .map(id -> asList(id.toCharArray()))
-            .forEach(idArray -> assertTrue(BASE32_DICTIONARY.containsAll(idArray)));
+                .parallel()
+                .mapToObj(value -> newId())
+                .map(id -> asList(id.toCharArray()))
+                .forEach(idArray -> assertTrue(BASE32_DICTIONARY.containsAll(idArray)));
     }
 
     @Test
     void shouldGenerateIdsOf26CharsInLength() {
         IntStream.range(0, 100)
-            .parallel()
-            .mapToObj(value -> newId())
-            .forEach(id -> assertEquals(26, id.length()));
+                .parallel()
+                .mapToObj(value -> newId())
+                .forEach(id -> assertEquals(26, id.length()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -258,7 +258,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
 
@@ -294,7 +294,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse<BaseAuthoriseResponse> response = walletAuthoriseService.authorise(charge.getExternalId(), authorisationData);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
 
@@ -330,7 +330,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse<BaseAuthoriseResponse> response = walletAuthoriseService.authorise(charge.getExternalId(), authorisationData);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
 
@@ -363,7 +363,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
@@ -378,7 +378,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
 
         ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
@@ -404,7 +404,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_ERROR.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
@@ -419,7 +419,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_CANCELLED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
@@ -436,7 +436,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
         
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_ERROR.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
@@ -548,7 +548,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_TIMEOUT.getValue()));
 
         verify(mockEventService, never()).emitAndRecordEvent(any(GatewayDoesNotRequire3dsAuthorisation.class));
@@ -560,7 +560,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_UNEXPECTED_ERROR.getValue()));
 
         verify(mockEventService, never()).emitAndRecordEvent(any(GatewayDoesNotRequire3dsAuthorisation.class));


### PR DESCRIPTION
## WHAT YOU DID
_A brief description of the pull request:_
Changes Part 3/3:

- Removed unused import
- Reorganised imports
- Removed extra spaces
- Updated deprecated StringUntil to Strings
- Updating deprecated Hibernate NotEmpty to jakarta
- Updating deprecated Jwts header and claim 
- Removed and depreacated isSuccesful and isFailed and replaced with appropriate method
- Added new class for random numbers and alphabets
- Updated validation error message 
- Updated deprecated nextLong and nextInt 
- Updated deprecated jsonparser with new
- Updated deprecated getCredentials to getCredentialsObject

No functional changes intended; behavior preserved.

## How to test

- How should it be reviewed?  Looks at the code changes and see no functional changes, see that tests pass 
- What feedback do you need? Comments

## Notes
NOTE: 
1. Custom code using pure java removes dependency and using ThreadLocalRandom is faster
2. nextLong(0, Long.MAX_VALUE) was used rather than nextLong() because it also includes negative number and it does not mimic the behaviour of the deprecated call
3. It was considered to use RandomStringUtils.insecure()next/nextNumeric/nextAlphanumeric however it returns a string and needs to be parsed. it just makes the code longer. ThreadLocalRandom