### PR TITLE
PP-14728 - Remove deprecated isSuccessful() and isFailed() 

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
@@ -30,16 +30,6 @@ public class GatewayResponse<T extends BaseResponse> {
         this.gatewayError = error;
     }
 
-    @Deprecated
-    public boolean isSuccessful() {
-        return baseResponse != null;
-    }
-
-    @Deprecated
-    public boolean isFailed() {
-        return gatewayError != null;
-    }
-
     public Optional<ProviderSessionIdentifier> getSessionIdentifier() {
         return Optional.ofNullable(sessionIdentifier);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/model/response/GatewayResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/response/GatewayResponseTest.java
@@ -22,8 +22,8 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
         GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
                 .withGatewayError(error)
                 .build();
-        assertThat(gatewayResponse.isFailed(), is(true));
-        assertThat(gatewayResponse.isSuccessful(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().get(), is(error));
@@ -37,8 +37,8 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
         GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
                 .withResponse(baseResponse)
                 .build();
-        assertThat(gatewayResponse.isFailed(), is(false));
-        assertThat(gatewayResponse.isSuccessful(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get(), is(baseResponse));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
@@ -51,8 +51,8 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
         GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
                 .withResponse(baseResponse)
                 .build();
-        assertThat(gatewayResponse.isFailed(), is(true));
-        assertThat(gatewayResponse.isSuccessful(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().get().getMessage(),

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -89,8 +89,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -119,8 +119,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().withPaymentInstrument(paymentInstrument).build();
         GatewayResponse gatewayResponse = provider.authoriseUserNotPresent(RecurringPaymentAuthorisationGatewayRequest.valueOf(charge));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -143,8 +143,8 @@ public class SandboxPaymentProviderTest {
                 .build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -165,8 +165,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -186,8 +186,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
 
@@ -204,8 +204,8 @@ public class SandboxPaymentProviderTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
 
@@ -234,8 +234,8 @@ public class SandboxPaymentProviderTest {
 
         GatewayResponse<BaseCancelResponse> gatewayResponse = provider.cancel(CancelGatewayRequest.valueOf(ChargeEntityFixture.aValidChargeEntity().build()));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
 

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/wallets/SandboxWalletAuthorisationHandlerTest.java
@@ -49,8 +49,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseApplePay(
                 new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription("whatever").build(), applePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -77,8 +77,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseApplePay(
                 new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription(magicValue.name()).build(), applePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -104,8 +104,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseApplePay(
                 new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription(SandboxWalletMagicValues.ERROR.name()).build(), applePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
 
@@ -126,8 +126,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseGooglePay(
                 new GooglePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription("whatever").build(), googlePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -154,8 +154,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseGooglePay(
                 new GooglePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription(magicValue.name()).build(), googlePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
@@ -181,8 +181,8 @@ class SandboxWalletAuthorisationHandlerTest {
         GatewayResponse gatewayResponse = sandboxWalletAuthorisationHandler.authoriseGooglePay(
                 new GooglePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().withDescription(SandboxWalletMagicValues.ERROR.name()).build(), googlePayAuthRequest));
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
@@ -70,7 +70,7 @@ class StripeCancelHandlerTest {
     void shouldCancelPaymentSuccessfully() throws Exception {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
         final GatewayResponse<BaseCancelResponse> response = stripeCancelHandler.cancel(request);
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         verify(client).postRequestFor(any(StripePaymentIntentCancelRequest.class));
     } 
     
@@ -87,7 +87,7 @@ class StripeCancelHandlerTest {
                 .withAmount(10000L)
                 .build());
         final GatewayResponse<BaseCancelResponse> response = stripeCancelHandler.cancel(request);
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         verify(client).postRequestFor(any(StripePaymentIntentCancelRequest.class));
     }
 
@@ -99,7 +99,7 @@ class StripeCancelHandlerTest {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), Is.is(true));
         assertThat(gatewayResponse.getGatewayError().get().getMessage(), Is.is("Unexpected HTTP status code 402 from gateway"));
         assertThat(gatewayResponse.getGatewayError().get().getErrorType(), Is.is(GATEWAY_ERROR));
@@ -113,7 +113,7 @@ class StripeCancelHandlerTest {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), Is.is(true));
         assertThat(gatewayResponse.getGatewayError().get().getMessage(), Is.is("Problem with Stripe servers"));
         assertThat(gatewayResponse.getGatewayError().get().getErrorType(), Is.is(GATEWAY_ERROR));
@@ -127,7 +127,7 @@ class StripeCancelHandlerTest {
         CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
-        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
     }
 
     private GatewayAccountEntity buildGatewayAccountEntity() {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeAuthoriseHandlerTest.java
@@ -126,7 +126,7 @@ public class StripeAuthoriseHandlerTest {
             GatewayResponse<BaseAuthoriseResponse> response = handler.authorise(buildTestAuthorisationRequest(charge));
             
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().isPresent(), is(true));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().get().getTwoDigitMonth(), is("08"));
@@ -146,7 +146,7 @@ public class StripeAuthoriseHandlerTest {
             GatewayResponse<BaseAuthoriseResponse> response = handler.authorise(buildTestUsAuthorisationRequest(charge));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
         }
 
@@ -176,7 +176,7 @@ public class StripeAuthoriseHandlerTest {
             assertThat(response.getBaseResponse().get().getGatewayRecurringAuthToken().get().get(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY), is("cus_4QFOF3xrvBT3nU"));
             assertThat(response.getBaseResponse().get().getGatewayRecurringAuthToken().get().get(STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY), is("pm_1FHESdEZsufgnuO0bzghQoZ2"));
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
         }
 
@@ -193,7 +193,7 @@ public class StripeAuthoriseHandlerTest {
             GatewayResponse<BaseAuthoriseResponse> response = handler.authorise(buildTestAuthorisationRequest(charge));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_123")); // id from templates/stripe/create_payment_intent_requires_3ds_response.json
 
             Optional<Stripe3dsRequiredParams> stripeParamsFor3ds = (Optional<Stripe3dsRequiredParams>) response.getBaseResponse().get().getGatewayParamsFor3ds();
@@ -212,7 +212,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestCharge();
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertEquals("jakarta.ws.rs.ProcessingException: java.io.IOException",
                     authoriseResponse.getGatewayError().get().getMessage());
@@ -303,7 +303,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestCharge();
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -320,7 +320,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestCharge();
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -337,7 +337,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestChargeToSetUpAgreement(buildTestGatewayAccountEntity(), "agreement description");
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -356,7 +356,7 @@ public class StripeAuthoriseHandlerTest {
             ChargeEntity charge = buildTestChargeToSetUpAgreement(buildTestGatewayAccountEntity(), "agreement description");
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authorise(buildTestAuthorisationRequest(charge));
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -382,7 +382,7 @@ public class StripeAuthoriseHandlerTest {
             assertThat(paymentIntentRequest.getPaymentMethodId(), is(PAYMENT_METHOD_ID));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
         }
 
@@ -413,7 +413,7 @@ public class StripeAuthoriseHandlerTest {
             RecurringPaymentAuthorisationGatewayRequest authRequest = RecurringPaymentAuthorisationGatewayRequest.valueOf(charge);
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authoriseUserNotPresent(authRequest);
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                     containsString("There was an internal server error"));
@@ -429,7 +429,7 @@ public class StripeAuthoriseHandlerTest {
             RecurringPaymentAuthorisationGatewayRequest authRequest = RecurringPaymentAuthorisationGatewayRequest.valueOf(charge);
             GatewayResponse<BaseAuthoriseResponse> authoriseResponse = handler.authoriseUserNotPresent(authRequest);
 
-            assertThat(authoriseResponse.isFailed(), is(true));
+            assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
             assertEquals("jakarta.ws.rs.ProcessingException: java.io.IOException",
                     authoriseResponse.getGatewayError().get().getMessage());
@@ -456,7 +456,7 @@ public class StripeAuthoriseHandlerTest {
             var paymentIntentRequest = (StripePaymentIntentRequest) allRequests.get(1);
             assertThat(paymentIntentRequest.getTokenId(), is("tok_1NrjK3Hj08j2jFuBm3LGVHYe"));
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().isPresent(), is(true));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().get().getTwoDigitMonth(), is("08"));
@@ -534,7 +534,7 @@ public class StripeAuthoriseHandlerTest {
             assertThat(paymentIntentRequest.getTokenId(), is(TOKEN_ID));
 
             assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
-            assertTrue(response.isSuccessful());
+            assertTrue(response.getBaseResponse().isPresent());
             assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_1FHESeEZsufgnuO08A2FUSPy"));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().isPresent(), is(true));
             assertThat(response.getBaseResponse().get().getCardExpiryDate().get().getTwoDigitMonth(), is("08"));
@@ -553,7 +553,7 @@ public class StripeAuthoriseHandlerTest {
         GatewayResponse<BaseAuthoriseResponse> response = handler.authoriseGooglePay(buildGooglePayAuthorisationRequest(charge));
 
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS));
-        assertTrue(response.isSuccessful());
+        assertTrue(response.getBaseResponse().isPresent());
         assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_123"));
 
         Optional<Stripe3dsRequiredParams> stripeParamsFor3ds = (Optional<Stripe3dsRequiredParams>) response.getBaseResponse().get().getGatewayParamsFor3ds();

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -814,7 +814,7 @@ class WorldpayAuthoriseHandlerTest {
         var handlerWithRealJerseyClient = new WorldpayAuthoriseHandler(createGatewayClient(mockClient), GATEWAY_URL_MAP, new AcceptLanguageHeaderParser());
 
         GatewayResponse response = handlerWithRealJerseyClient.authorise(getCardAuthorisationRequest(chargeEntityFixture.build()), DO_NOT_SEND_EXEMPTION_REQUEST);
-        assertTrue(response.isSuccessful());
+        assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getSessionIdentifier().isPresent());
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -100,7 +100,7 @@ public class StripePaymentProviderTest {
     @Test
     public void createCharge() {
         GatewayResponse gatewayResponse = authorise();
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -113,7 +113,7 @@ public class StripePaymentProviderTest {
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class StripePaymentProviderTest {
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -151,7 +151,7 @@ public class StripePaymentProviderTest {
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request, charge);
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -165,7 +165,7 @@ public class StripePaymentProviderTest {
 
         StripeAuthorisationResponse response = gatewayResponse.getBaseResponse().get();
 
-        assertTrue(gatewayResponse.isSuccessful());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
         assertThat(response.getGatewayRecurringAuthToken().isPresent(), is(true));
         assertThat(response.getGatewayRecurringAuthToken().get(), hasKey(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY));
         assertThat(response.getGatewayRecurringAuthToken().get(), hasKey(STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY));
@@ -192,7 +192,7 @@ public class StripePaymentProviderTest {
         ChargeEntity chargeEntity = getCharge();
         chargeEntity.setGatewayTransactionId(gatewayResponse.getBaseResponse().get().getTransactionId());
         GatewayResponse<BaseCancelResponse> cancelResponse = stripePaymentProvider.cancel(CancelGatewayRequest.valueOf(chargeEntity));
-        assertTrue(cancelResponse.isSuccessful());
+        assertTrue(cancelResponse.getBaseResponse().isPresent());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -258,7 +258,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
 
@@ -294,7 +294,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse<BaseAuthoriseResponse> response = walletAuthoriseService.authorise(charge.getExternalId(), authorisationData);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
 
@@ -330,7 +330,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse<BaseAuthoriseResponse> response = walletAuthoriseService.authorise(charge.getExternalId(), authorisationData);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
 
@@ -363,7 +363,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
@@ -378,7 +378,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
 
         ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
@@ -404,7 +404,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_ERROR.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
@@ -419,7 +419,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_CANCELLED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
@@ -436,7 +436,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
         
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_ERROR.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
@@ -548,7 +548,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_TIMEOUT.getValue()));
 
         verify(mockEventService, never()).emitAndRecordEvent(any(GatewayDoesNotRequire3dsAuthorisation.class));
@@ -560,7 +560,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
 
         GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_UNEXPECTED_ERROR.getValue()));
 
         verify(mockEventService, never()).emitAndRecordEvent(any(GatewayDoesNotRequire3dsAuthorisation.class));


### PR DESCRIPTION

## WHAT YOU DID
_A brief description of the pull request:_
removing deprecated isSuccessful() and .isFailed() and replacing with getGatewayError().isPresent() and getBaseResponse().isPresent()

## How to test

- How should it be reviewed?  make sure the replaced method is correct and the build and tests pass
- What feedback do you need? PR comment

