### PR TITLE
PP-14728 - Replaced deprecated assertThat with suggested

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/ClientFactoryIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/ClientFactoryIT.java
@@ -30,7 +30,7 @@ import static java.lang.String.format;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;


### PR DESCRIPTION
## WHAT YOU DID
_A brief description of the pull request:_
PP-14728 - Replaced deprecated assertThat from org.junit.Assert.assertThat; to org.hamcrest.MatcherAssert.assertThat; as suggested in the doc

## How to test

- How should it be reviewed? Check code, check PR, make sure tests pass
- What feedback do you need? PR Comment 

