### PR TITLE
PP-14728 - Jwts replace deprecated setSigningKey and parseClaimsJws

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/util/JwtGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/JwtGenerator.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.charge.util;
 
 
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 
 import javax.crypto.spec.SecretKeySpec;
 import java.util.Map;
@@ -13,9 +12,9 @@ public class JwtGenerator {
         SecretKeySpec secret_key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
 
         return Jwts.builder()
-                .setHeaderParam("typ", "JWT")
-                .addClaims(claims)
-                .signWith(secret_key, SignatureAlgorithm.HS256)
+                .header().add("typ", "JWT").and()
+                .claims().add(claims).and()
+                .signWith(secret_key, Jwts.SIG.HS256)
                 .compact();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
@@ -105,9 +105,9 @@ class Worldpay3dsFlexJwtServiceTest {
         String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, paymentCreationTimeEpochSeconds19August2029, WORLDPAY.getName());
 
         Jws<Claims> jws = Jwts.parser()
-                .setSigningKey(new SecretKeySpec(VALID_CREDENTIALS.get("jwt_mac_id").getBytes(), "HmacSHA256"))
+                .verifyWith(new SecretKeySpec(VALID_CREDENTIALS.get("jwt_mac_id").getBytes(), "HmacSHA256"))
                 .build()
-                .parseClaimsJws(token);
+                .parseSignedClaims(token);
 
         assertThat(jws.getHeader().getAlgorithm(), is("HS256"));
         assertThat((Map<String, Object>) jws.getHeader(), hasEntry("typ", "JWT"));
@@ -169,9 +169,9 @@ class Worldpay3dsFlexJwtServiceTest {
         assertThat(maybeToken.isPresent(), is(true));
 
         Jws<Claims> jws = Jwts.parser()
-                .setSigningKey(new SecretKeySpec(VALID_CREDENTIALS.get("jwt_mac_id").getBytes(), "HmacSHA256"))
+                .verifyWith(new SecretKeySpec(VALID_CREDENTIALS.get("jwt_mac_id").getBytes(), "HmacSHA256"))
                 .build()
-                .parseClaimsJws(maybeToken.get());
+                .parseSignedClaims(maybeToken.get());
 
         assertThat(jws.getHeader().getAlgorithm(), is("HS256"));
         assertThat((Map<String, Object>) jws.getHeader(), hasEntry("typ", "JWT"));

--- a/src/test/java/uk/gov/pay/connector/charge/util/JwtGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/util/JwtGeneratorTest.java
@@ -24,9 +24,9 @@ public class JwtGeneratorTest {
         String token = jwtGenerator.createJwt(claims, secret);
 
         Jws<Claims> jws = Jwts.parser()
-                .setSigningKey(new SecretKeySpec(secret.getBytes(), "HmacSHA256"))
+                .verifyWith(new SecretKeySpec(secret.getBytes(), "HmacSHA256"))
                 .build()
-                .parseClaimsJws(token);
+                .parseSignedClaims(token);
 
         assertThat(jws.getHeader().getAlgorithm(), is("HS256"));
         assertThat(jws.getHeader().get("typ"), is("JWT"));


### PR DESCRIPTION


## WHAT YOU DID
_A brief description of the pull request:_

PP-14728 - Jwts replace deprecated setSigningKey with verifyWith and parseClaimsJws with parseSignedClaims

## How to test

- How should it be reviewed? Check code changed and PR passes and test passes
- What feedback do you need? PR comments
