### PR TITLE
PP-14728 - Replace deprecated hibernate NotEmpty

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -181,14 +181,14 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5809
+        "line_number": 5812
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5820
+        "line_number": 5823
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-02T16:58:57Z"
+  "generated_at": "2025-12-15T12:52:05Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -5369,6 +5369,9 @@ components:
           type: string
           description: Only `ENTERING CARD DETAILS` is allowed
           example: ENTERING CARD DETAILS
+          minLength: 1
+      required:
+      - new_status
     Outcome:
       type: object
       description: Object containing information about the outcome of the 3ds exemption

--- a/src/main/java/uk/gov/pay/connector/charge/model/NewChargeStatusRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/NewChargeStatusRequest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.validation.ValidationMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.hibernate.validator.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 
 

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
@@ -64,7 +64,7 @@ class ChargesFrontendResourceTest {
         List<String> listOfErrors = (List) response.readEntity(Map.class).get("message");
         assertThat(listOfErrors.size(), is(2));
         assertThat(listOfErrors, hasItem("invalid new status"));
-        assertThat(listOfErrors, hasItem("may not be empty"));
+        assertThat(listOfErrors, hasItem("must not be empty"));
 
     }
 


### PR DESCRIPTION

## WHAT YOU DID
_A brief description of the pull request:_
PP-14728 - Replace deprecated org.hibernate.validator.constraints.NotEmpty to jakarta.validation.constraints.NotEmpty;

## How to test

- How should it be reviewed? Check code, Check PR pass Check Test Pass
- What feedback do you need?  PR Comments

