### PR TITLE
PP-14842 refactor to use new Ledger endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/service/LedgerService.java
@@ -63,7 +63,8 @@ public class LedgerService {
                                                                                         String gatewayTransactionId) {
         var uri = UriBuilder
                 .fromPath(ledgerUrl)
-                .path(format("/v1/transaction/gateway-transaction/%s", URLEncoder.encode(gatewayTransactionId, StandardCharsets.UTF_8)))
+                .path("/v1/transaction/gateway-transaction")
+                .queryParam("gateway_transaction_id", gatewayTransactionId)
                 .queryParam("payment_provider", paymentGatewayName);
         
         return getTransactionFromLedger(uri);

--- a/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
@@ -138,4 +138,19 @@ public class LedgerServiceConsumerTest {
 
         assertThat(response.getStatus(), is(202));
     }
+
+    @Test
+    @PactVerification("ledger")
+    @Pacts(pacts = {"connector-ledger-get-payment-transaction-by-gateway-transaction-id"})
+    public void getTransactionByGatewayTransactionId_shouldSerialiseLedgerPaymentTransactionCorrectly() {
+        String gatewayTransactionId = "gateway-tx-123456";
+        String paymentProvider = "sandbox";
+        
+        Optional<LedgerTransaction> mayBeTransaction = ledgerService.getTransactionForProviderAndGatewayTransactionId(paymentProvider, gatewayTransactionId);
+
+        assertThat(mayBeTransaction.isPresent(), is(true));
+        LedgerTransaction transaction = mayBeTransaction.get();
+        assertThat(transaction.getGatewayTransactionId(), is(gatewayTransactionId));
+        assertThat(transaction.getAmount(), is(100L));
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceTest.java
@@ -170,26 +170,4 @@ public class LedgerServiceTest {
 
         assertThrows(LedgerException.class, () -> ledgerService.getTransaction("transaction-id"));
     }
-
-    @Test
-    void getTransactionForProviderAndGatewayTransactionId_shouldEncodeCorrectly() {
-        var oddId = "an-id-with//some-weird-stuff-in-it";
-        LedgerTransaction ledgerTransaction = aValidLedgerTransaction()
-                .withPaymentProvider("worldpay")
-                .withGatewayTransactionId(oddId)
-                .build();
-        setupMocksForGetRequest();
-        when(mockResponse.getStatus()).thenReturn(SC_OK);
-        when(mockResponse.readEntity(LedgerTransaction.class)).thenReturn(ledgerTransaction);
-
-        var expectedPath = "/v1/transaction/gateway-transaction/an-id-with%2F%2Fsome-weird-stuff-in-it";
-        
-        Optional<LedgerTransaction> maybeTransaction = ledgerService.getTransactionForProviderAndGatewayTransactionId("worldpay", oddId);
-        verify(mockClient).target(argThat((UriBuilder arg) -> {
-            assertEquals(expectedPath, arg.build().getRawPath());
-            return true;
-        }));
-        assertThat(maybeTransaction.isPresent(), is(true));
-        assertThat(maybeTransaction.get(), is(ledgerTransaction));
-    }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/rules/LedgerStub.java
@@ -22,10 +22,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static java.lang.String.format;
-import static java.util.Objects.nonNull;
 import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static java.lang.String.format;
+import static java.util.Objects.nonNull;
 import static uk.gov.pay.connector.model.domain.RefundTransactionsForPaymentFixture.aValidRefundTransactionsForPayment;
 import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_INSTANT_MILLISECOND_PRECISION;
 
@@ -153,8 +153,9 @@ public class LedgerStub {
             responseDefBuilder.withBody(objectMapper.writeValueAsString(ledgerTransactionFields));
         }
         wireMockServer.stubFor(
-                get(urlPathEqualTo(format("/v1/transaction/gateway-transaction/%s", gatewayTransactionId)))
+                get(urlPathEqualTo("/v1/transaction/gateway-transaction"))
                         .withQueryParam("payment_provider", equalTo(paymentProvider))
+                        .withQueryParam("gateway_transaction_id", equalTo(gatewayTransactionId))
                         .willReturn(
                                 responseDefBuilder
                         )

--- a/src/test/resources/pacts/connector-ledger-get-payment-transaction-by-gateway-transaction-id.json
+++ b/src/test/resources/pacts/connector-ledger-get-payment-transaction-by-gateway-transaction-id.json
@@ -1,0 +1,90 @@
+{
+  "consumer": {
+    "name": "connector"
+  },
+  "provider": {
+    "name": "ledger"
+  },
+  "interactions": [
+    {
+      "description": "get a payment transaction by gateway transaction id request",
+      "providerStates": [
+        {
+          "name": "a transaction with a gateway transaction id exists",
+          "params": {
+            "account_id": "123456",
+            "charge_id": "ch_123abc456xyz",
+            "gateway_transaction_id": "gateway-tx-123456"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/transaction/gateway-transaction",
+        "query": {
+          "gateway_transaction_id": ["gateway-tx-123456"],
+          "payment_provider": ["sandbox"]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "amount": 100,
+          "state": {
+            "finished": false,
+            "status": "created"
+          },
+          "description": "Test description",
+          "reference": "aReference",
+          "language": "en",
+          "transaction_id": "ch_123abc456xyz",
+          "gateway_transaction_id": "gateway-tx-123456",
+          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "payment_provider": "sandbox",
+          "created_date": "2018-10-16T10:46:02.121Z",
+          "refund_summary": {
+            "status": "available",
+            "user_external_id": null,
+            "amount_available": 100,
+            "amount_submitted": 0
+          },
+          "settlement_summary": {
+            "capture_submit_time": null,
+            "captured_date": null
+          },
+          "delayed_capture": false
+        },
+        "matchingRules": {
+          "body": {
+            "$.reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            },
+            "$.refund_summary.amount_available": {
+              "matchers": [{"match": "type"}]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
## WHAT YOU DID

We introduced a new Ledger endpoint due to ambiguous path params are no longer allowed.

Refactor LedgerService to use the new endpoint with query params only.

Remove immaterial test.

