### PR TITLE
 PP-14781 Investigate and improve slow running tests

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -2,8 +2,6 @@ package uk.gov.pay.connector.it.dao;
 
 import com.google.common.collect.Lists;
 import jakarta.validation.ConstraintViolationException;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -105,11 +103,7 @@ public class ChargeDaoIT {
                 .build();
         gatewayAccountCredentialsEntity.setId(defaultTestAccount.getCredentials().getFirst().getId());
     }
-
-    @AfterEach
-    void clear() {
-        app.getDatabaseTestHelper().truncateAllData();
-    }
+    
 
     @Test
     void chargeEvents_shouldRecordTransactionIdWithEachStatusChange() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -117,18 +117,6 @@ public class ChargesApiResourceCreateIT {
                 .then()
                 .statusCode(201)
                 .extract().path("gateway_account_id");
-
-        liveGatewayAccountId = app.givenSetup()
-                .body(toJson(Map.of(
-                        "service_id", "a-service-id",
-                        "type", GatewayAccountType.LIVE,
-                        "payment_provider", PaymentGatewayName.WORLDPAY.getName(),
-                        "service_name", "my-test-service-name"
-                )))
-                .post("/v1/api/accounts")
-                .then()
-                .statusCode(201)
-                .extract().path("gateway_account_id");
     }
 
     @Nested
@@ -414,6 +402,11 @@ public class ChargesApiResourceCreateIT {
         @Nested
         class ReturnUnprocessableContent {
 
+            @BeforeEach
+            void setupLiveAccount() {
+                liveGatewayAccountId = createLiveWorldpayAccount();
+            }
+            
             @Test
             void when_return_url_is_not_https_when_gateway_account_is_live() {
                 app.givenSetup()
@@ -932,7 +925,12 @@ public class ChargesApiResourceCreateIT {
 
         @Nested
         class ReturnUnprocessableContent {
-
+           
+            @BeforeEach
+            void setupLiveAccount() {
+                liveGatewayAccountId = createLiveWorldpayAccount();
+            }
+            
             @Test
             void when_return_url_is_not_https_and_gateway_account_is_live() {
                 app.givenSetup()
@@ -1160,5 +1158,18 @@ by moving it back an hour which results in the assertion failing as it is now 1 
                 .replace("{accountId}", accountId)
                 .replace("{chargeId}", chargeId);
     }
-
+    
+    private String createLiveWorldpayAccount() {
+        return app.givenSetup()
+                .body(toJson(Map.of(
+                        "service_id", "a-service-id",
+                        "type", GatewayAccountType.LIVE,
+                        "payment_provider", PaymentGatewayName.WORLDPAY.getName(),
+                        "service_name", "my-test-service-name"
+                )))
+                .post("/v1/api/accounts")
+                .then()
+                .statusCode(201)
+                .extract().path("gateway_account_id");
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -1002,16 +1002,23 @@ public class DatabaseTestHelper {
     public void truncateEmittedEvents() {
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE emitted_events").execute());
     }
+    
 
     public void truncateAllData() {
-        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE gateway_accounts CASCADE").execute());
-        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE emitted_events CASCADE").execute());
-        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE tokens").execute());
-        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE refunds").execute());
-        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE refunds_history").execute());
-        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE agreements CASCADE").execute());
-        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE payment_instruments CASCADE").execute());
-        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE idempotency").execute());
+        jdbi.useHandle(h ->
+                h.createUpdate("""
+            TRUNCATE TABLE
+                gateway_accounts,
+                emitted_events,
+                tokens,
+                refunds,
+                refunds_history,
+                agreements,
+                payment_instruments,
+                idempotency
+            CASCADE
+        """).execute()
+        );
     }
 
     public void truncateAgreements() {


### PR DESCRIPTION
## Context: Connector unit and integration tests take about 8 minutes to run on GitHub Actions

## WHAT YOU DID
- refactored `AppWithPostgresAndSqsExtension` to ensure database migrations run only once per JVM
- moved WireMock request reset logic to use `resetRequests()` instead of `resetAll()`
- refactored `@AfterEach` in `ChargeDaoIT.java` as DB is truncate in the `AppWithPostgresAndSqsExtension`  class
- Use single TRUNCATE statement in `DatabaseTestHelper.truncateAllData()`
- Minor improvements / cleanup
