### PR TITLE
PP-14844 store gateway rejection reason

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -787,9 +787,10 @@ public class ChargeService {
                                                           AuthCardDetails authCardDetails,
                                                           Map<String, String> recurringAuthToken,
                                                           Boolean canRetry,
-                                                          String rejectedReason) {
+                                                          String rejectedReason,
+                                                          String gatewayRejectionReason) {
         return updateChargeAndEmitEventPostAuthorisation(chargeExternalId, newStatus, authCardDetails, transactionId, auth3dsRequiredDetails, sessionIdentifier,
-                null, null, recurringAuthToken, canRetry, rejectedReason);
+                null, null, recurringAuthToken, canRetry, rejectedReason, gatewayRejectionReason);
 
     }
 
@@ -802,7 +803,7 @@ public class ChargeService {
                                                             String emailAddress,
                                                             Auth3dsRequiredEntity auth3dsRequiredDetails) {
         return updateChargeAndEmitEventPostAuthorisation(chargeExternalId, status, authCardDetails, transactionId, auth3dsRequiredDetails, sessionIdentifier,
-                walletType, emailAddress, null, null, null);
+                walletType, emailAddress, null, null, null, null);
     }
 
     private ChargeEntity updateChargeAndEmitEventPostAuthorisation(String chargeExternalId,
@@ -815,9 +816,10 @@ public class ChargeService {
                                                                    String emailAddress,
                                                                    Map<String, String> recurringAuthToken,
                                                                    Boolean canRetry,
-                                                                   String rejectedReason) {
+                                                                   String rejectedReason,
+                                                                   String gatewayRejectionReason) {
         updateChargePostAuthorisation(chargeExternalId, newStatus, authCardDetails, transactionId,
-                auth3dsRequiredDetails, sessionIdentifier, walletType, emailAddress, recurringAuthToken, canRetry, rejectedReason);
+                auth3dsRequiredDetails, sessionIdentifier, walletType, emailAddress, recurringAuthToken, canRetry, rejectedReason, gatewayRejectionReason);
         ChargeEntity chargeEntity = findChargeByExternalId(chargeExternalId);
         if (chargeEntity.getAuthorisationMode() == MOTO_API) {
             eventService.emitAndRecordEvent(PaymentDetailsSubmittedByAPI.from(chargeEntity));
@@ -845,13 +847,15 @@ public class ChargeService {
                                                       String emailAddress,
                                                       Map<String, String> recurringAuthToken,
                                                       Boolean canRetry,
-                                                      String rejectedReason) {
+                                                      String rejectedReason,
+                                                      String gatewayRejectionReason) {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
             setTransactionId(charge, transactionId);
             Optional.ofNullable(sessionIdentifier).map(ProviderSessionIdentifier::toString).ifPresent(charge::setProviderSessionId);
             Optional.ofNullable(auth3dsRequiredDetails).ifPresent(charge::set3dsRequiredDetails);
             Optional.ofNullable(walletType).ifPresent(charge::setWalletType);
             Optional.ofNullable(emailAddress).ifPresent(charge::setEmail);
+            Optional.ofNullable(gatewayRejectionReason).ifPresent(charge::setGatewayRejectionReason);
 
             CardDetailsEntity detailsEntity = authCardDetailsToCardDetailsEntityConverter.convert(authCardDetails);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseAuthoriseResponse.java
@@ -26,6 +26,14 @@ public interface BaseAuthoriseResponse extends BaseResponse {
                 .filter(authoriseStatus -> authoriseStatus == AuthoriseStatus.REJECTED)
                 .map(authoriseStatus -> MappedAuthorisationRejectedReason.UNCATEGORISED);
     }
+    
+    default Optional<String> getGatewayRejectionReason() {
+        return Optional.empty();
+    }
+    
+    default boolean isSoftDecline() {
+        return false;
+    }
 
     default Optional<Map<String, String>> getGatewayRecurringAuthToken() {
         return Optional.empty();

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
@@ -10,6 +10,7 @@ import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.util.Optional;
 import java.util.StringJoiner;
+import java.util.stream.Stream;
 
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.ERROR;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REJECTED;
@@ -59,11 +60,7 @@ public class StripeAuthorisationFailedResponse implements BaseAuthoriseResponse 
             return Optional.empty();
         }
 
-        var mappedAuthorisationRejectedReason = Optional.ofNullable(errorResponse)
-                .map(StripeErrorResponse::getError)
-                .flatMap(StripeErrorResponse.Error::getStripePaymentIntent)
-                .flatMap(StripePaymentIntent::getLastPaymentError)
-                .map(LastPaymentError::getDeclineCode)
+        var mappedAuthorisationRejectedReason = getGatewayRejectionReason()
                 .map(StripeAuthorisationRejectedCodeMapper::toMappedAuthorisationRejectionReason)
                 .orElse(MappedAuthorisationRejectedReason.UNCATEGORISED);
 
@@ -88,6 +85,15 @@ public class StripeAuthorisationFailedResponse implements BaseAuthoriseResponse 
     @Override
     public String getErrorMessage() {
         return null;
+    }
+    
+    @Override
+    public Optional<String> getGatewayRejectionReason() {
+        return  Optional.ofNullable(errorResponse)
+                .map(StripeErrorResponse::getError)
+                .flatMap(StripeErrorResponse.Error::getStripePaymentIntent)
+                .flatMap(StripePaymentIntent::getLastPaymentError)
+                .map(LastPaymentError::getDeclineCode);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
+import jakarta.xml.bind.annotation.XmlRootElement;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,7 +12,6 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseInquiryResponse;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
-import jakarta.xml.bind.annotation.XmlRootElement;
 import java.time.YearMonth;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static java.util.function.Predicate.not;
@@ -122,6 +123,7 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
         this.challengeAcsUrl = challengeAcsUrl != null ? challengeAcsUrl.trim() : null;
     }
 
+    @Override
     public boolean isSoftDecline() {
         return Optional.ofNullable(lastEvent).map("REFUSED"::equals).orElse(false)
                 && Optional.ofNullable(exemptionResponseResult).map(SOFT_DECLINE_EXEMPTION_RESPONSE_RESULTS::contains).orElse(false);
@@ -272,6 +274,13 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
                 .orElse(MappedAuthorisationRejectedReason.UNCATEGORISED);
 
         return Optional.of(mappedAuthorisationRejectedReason);
+    }
+
+    @Override
+    public Optional<String> getGatewayRejectionReason() {
+        return Stream.of(Optional.ofNullable(getRefusedReturnCode()), Optional.ofNullable(getRefusedReturnCodeDescription()))
+                .flatMap(Optional::stream)
+                .reduce((errorCode, errorMessage) -> errorCode + " " + errorMessage);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -30,6 +30,7 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
 import uk.gov.pay.connector.paymentprocessor.exception.AuthorisationExecutorTimedOutException;
@@ -43,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
 import static uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator.getCorporateCardSurchargeFor;
@@ -170,6 +172,7 @@ public class CardAuthoriseService {
                     authCardDetails,
                     null,
                     null,
+                    null,
                     null);
 
             LOGGER.info("Attempt to authorise charge synchronously timed out.");
@@ -219,6 +222,14 @@ public class CardAuthoriseService {
         Optional<String> mayBeRejectedReason = operationResponse.getBaseResponse()
                 .flatMap(baseAuthoriseResponse ->
                         baseAuthoriseResponse.getMappedAuthorisationRejectedReason().map(MappedAuthorisationRejectedReason::name));
+
+        Optional<String> gatewayRejectionReason = Optional.empty();
+        
+        if (newStatus == AUTHORISATION_REJECTED && 
+                !(operationResponse.getBaseResponse().map(BaseAuthoriseResponse::isSoftDecline).orElse(false))) {
+                gatewayRejectionReason = operationResponse.getBaseResponse().flatMap(BaseAuthoriseResponse::getGatewayRejectionReason);
+        }
+        
         ChargeEntity updatedCharge = chargeService.updateChargePostCardAuthorisation(
                 charge.getExternalId(),
                 newStatus,
@@ -228,7 +239,8 @@ public class CardAuthoriseService {
                 authCardDetails,
                 maybeToken.orElse(null),
                 mayBeCanRetry.orElse(null),
-                mayBeRejectedReason.orElse(null));
+                mayBeRejectedReason.orElse(null),
+                gatewayRejectionReason.orElse(null));
 
         var authorisationRequestSummary = generateAuthorisationRequestSummary(updatedCharge, authCardDetails);
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServicePostAuthorisationTest.java
@@ -151,7 +151,7 @@ class ChargeServicePostAuthorisationTest {
         when(mockChargeEventDao.persistChargeEventOf(chargeEntity, null)).thenReturn(mockChargeEventEntity);
         
         chargeService.updateChargePostCardAuthorisation(EXTERNAL_ID, AUTHORISATION_SUCCESS, TRANSACTION_ID, auth3dsRequiredEntity,
-                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, null, null);
+                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, null, null, null);
 
         assertThat(chargeEntity.getStatus(), is(AUTHORISATION_SUCCESS.toString()));
         assertThat(chargeEntity.getEmail(), is(EMAIL));
@@ -188,7 +188,7 @@ class ChargeServicePostAuthorisationTest {
         when(mockChargeEventDao.persistChargeEventOf(chargeEntity, null)).thenReturn(mockChargeEventEntity);
 
         chargeService.updateChargePostCardAuthorisation(EXTERNAL_ID, AUTHORISATION_SUCCESS, TRANSACTION_ID, auth3dsRequiredEntity,
-                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, true, null);
+                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, true, null, null);
 
         assertThat(chargeEntity.getStatus(), is(AUTHORISATION_SUCCESS.toString()));
         assertThat(chargeEntity.getEmail(), is(EMAIL));
@@ -232,7 +232,7 @@ class ChargeServicePostAuthorisationTest {
         when(mockChargeEventDao.persistChargeEventOf(chargeEntity, null)).thenReturn(mockChargeEventEntity);
 
         chargeService.updateChargePostCardAuthorisation(EXTERNAL_ID, AUTHORISATION_SUCCESS, TRANSACTION_ID, auth3dsRequiredEntity,
-                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, false, CLOSED_ACCOUNT.name());
+                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, false, CLOSED_ACCOUNT.name(), null);
 
         assertThat(chargeEntity.getStatus(), is(AUTHORISATION_SUCCESS.toString()));
         assertThat(chargeEntity.getEmail(), is(EMAIL));
@@ -285,7 +285,7 @@ class ChargeServicePostAuthorisationTest {
         when(mockChargeEventDao.persistChargeEventOf(chargeEntity, null)).thenReturn(mockChargeEventEntity);
 
         chargeService.updateChargePostCardAuthorisation(EXTERNAL_ID, AUTHORISATION_SUCCESS, TRANSACTION_ID, auth3dsRequiredEntity,
-                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, false, CLOSED_ACCOUNT.name());
+                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, false, CLOSED_ACCOUNT.name(), null);
 
         assertThat(chargeEntity.getStatus(), is(AUTHORISATION_SUCCESS.toString()));
         assertThat(chargeEntity.getEmail(), is(EMAIL));
@@ -309,10 +309,9 @@ class ChargeServicePostAuthorisationTest {
         when(mockPaymentInstrumentService.createPaymentInstrument(chargeEntity, TOKEN)).thenReturn(mockPaymentInstrumentEntity);
 
         chargeService.updateChargePostCardAuthorisation(EXTERNAL_ID, AUTHORISATION_SUCCESS, TRANSACTION_ID, auth3dsRequiredEntity,
-                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, null, null);
+                PROVIDER_SESSION_IDENTIFIER, authCardDetails, TOKEN, null, null, null);
 
         assertThat(chargeEntity.getPaymentInstrument().isPresent(), is(true));
         assertThat(chargeEntity.getPaymentInstrument().get(), is(mockPaymentInstrumentEntity));
     }
-
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponseTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -19,16 +20,19 @@ import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_CREATE_TOKEN_SUCCESS_RESPONSE_WITHOUT_TRANSACTION_IDENTIFIER;
@@ -152,12 +156,29 @@ class WorldpayOrderStatusResponseTest {
         verifyLogging(1, "Expiry date in Worldpay wallet payment authorisation response is in an unexpected format; month has 2 digits, year has 3 digits.");
     }
 
+    @ParameterizedTest
+    @CsvSource(useHeadersInDisplayName = true, nullValues = "null", textBlock = """
+        refusedReturnCodeDescription, refusedReturnCode, outcome, present
+        fraudulent, 42, 42 fraudulent, true
+        fraudulent, null, fraudulent, true
+        null, 42, 42, true
+        null, null, null, false
+    """)
+    void get_gateway_rejection_reason_should_return_reduced_values(String refusedReturnCodeDescription, String refusedReturnCode, String outcome, Boolean present)  throws Exception {
+        var response = spy(WorldpayOrderStatusResponse.class);
+        when(response.getRefusedReturnCode()).thenReturn(refusedReturnCode);
+        when(response.getRefusedReturnCodeDescription()).thenReturn(refusedReturnCodeDescription);
+        Optional<String> gatewayRejectionReason = response.getGatewayRejectionReason();
+        assertThat(gatewayRejectionReason.isPresent(), is(present));
+        if (present) {
+            assertThat(gatewayRejectionReason.get(), is(outcome));
+        }
+    }
+
     private void verifyLogging(int invocations, String logMessage) {
         ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(mockAppender, times(invocations)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
         assertThat(loggingEvents.stream().anyMatch(le -> le.getFormattedMessage().contains(logMessage)), is(true));
     }
-
-
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
@@ -327,7 +327,32 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.card_type", is("debit"))
                 .body("card_details.card_brand", is("Visa"))
                 .body("card_details.expiry_date", is("08/24"));
-        ;
+    }
+
+    @Test
+    void shouldRejectPayPayment_andSaveRejectionReason() {
+        app.getStripeMockClient().mockCreatePaymentMethod();
+        app.getStripeMockClient().mockCreatePaymentIntentAuthorisationRejectedNoRetry();
+        addGatewayAccount();
+
+        String externalChargeId = addCharge();
+
+        given().port(app.getLocalPort())
+                .contentType(JSON)
+                .body(validAuthorisationDetailsWithoutBillingAddress)
+                .post(testBaseExtension.authoriseChargeUrlFor(externalChargeId))
+                .then()
+                .statusCode(400);
+
+        app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/payment_methods"))
+                .withHeader("Content-Type", equalTo(APPLICATION_FORM_URLENCODED)));
+
+        app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/payment_intents"))
+                .withHeader("Content-Type", equalTo(APPLICATION_FORM_URLENCODED)));
+        
+        var charge = app.getDatabaseTestHelper().getChargeByExternalId(externalChargeId);
+
+        assertThat(charge.get("gateway_rejection_reason"), is("lost_card"));
     }
 
     @Test
@@ -383,7 +408,6 @@ public class StripeCardResourceAuthoriseIT {
                 .body("card_details.card_type", is("debit"))
                 .body("card_details.card_brand", is("Visa"))
                 .body("card_details.expiry_date", is("08/24"));
-        ;
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceIT.java
@@ -7,15 +7,20 @@ import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.it.base.ITestBaseExtension;
 import uk.gov.pay.connector.it.util.ChargeUtils;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.time.temporal.ChronoUnit.HOURS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY;
+import static uk.gov.pay.connector.it.base.AddChargeParameters.Builder.anAddChargeParameters;
 
 public class WorldpayCardAuthoriseServiceIT {
     @RegisterExtension
@@ -115,5 +120,26 @@ public class WorldpayCardAuthoriseServiceIT {
 
         var mergedCharge = app.getInstanceFromGuiceContainer(ChargeService.class).findChargeByExternalId(userNotPresentChargeId.toString());
         assertThat(mergedCharge.getRequires3ds(), is(nullValue()));
+    }
+
+    @Test
+    void shouldProcessFailedAuthorisationAndSetGatewayRejectionReason() {
+        String chargeId = testBaseExtension.addCharge(
+                anAddChargeParameters().withChargeStatus(ENTERING_CARD_DETAILS)
+                        .withCreatedDate(Instant.now().minus(1, HOURS))
+                        .withTransactionId("transaction-id-transition-it")
+                        .build());
+
+        app.getWorldpayMockClient().mockAuthorisationFailure();
+        
+        var authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
+
+        var failureResponse = app.getInstanceFromGuiceContainer(CardAuthoriseService.class).doAuthoriseWeb(chargeId, authCardDetails);
+        
+        assertThat(failureResponse.getAuthoriseStatus(), is(Optional.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED)));
+
+        var chargeUpdated = app.getDatabaseTestHelper().getChargeByExternalId(chargeId);
+
+        assertThat(chargeUpdated.get("gateway_rejection_reason"), is("5 REFUSED"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -23,6 +23,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHOR
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CUSTOMER_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_NO_RETRY_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CANCEL_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE;
@@ -68,7 +69,12 @@ public class StripeMockClient {
         String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_RESPONSE);
         setupResponse(payload, "/v1/payment_intents", 402);
     }
-
+    
+    public void mockCreatePaymentIntentAuthorisationRejectedNoRetry() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_NO_RETRY_RESPONSE);
+        setupResponse(payload, "/v1/payment_intents", 402);
+    }
+    
     public void mockCreatePaymentIntentAuthorisationError() {
         String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_ERROR_RESPONSE);
         setupResponse(payload, "/v1/payment_intents", 402);

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -108,6 +108,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CUSTOMER = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response_with_customer.json";
     public static final String STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_requires_3ds_response.json";
     public static final String STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_authorisation_rejected_response.json";
+    public static final String STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_NO_RETRY_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_authorisation_rejected_no_retry_response.json";
     public static final String STRIPE_PAYMENT_INTENT_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_error_response.json";
     public static final String STRIPE_PAYMENT_INTENT_CANCEL_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/payment_intent_cancel_response.json";
     public static final String STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/get_payment_intent_with_3ds_authorised_success_response.json";

--- a/src/test/resources/templates/stripe/create_payment_intent_authorisation_rejected_no_retry_response.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_authorisation_rejected_no_retry_response.json
@@ -1,0 +1,32 @@
+{
+  "error": {
+    "charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+    "code": "lost_card",
+    "decline_code": "lost_card",
+    "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+    "message": "Your card was declined.",
+    "payment_intent": {
+      "id": "pi_3N6AIYHj08j2jFuB1IozJAVc",
+      "object": "payment_intent",
+      "amount": 1000,
+      "payment_method": {
+        "id": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+        "card": {
+          "exp_month": 8,
+          "exp_year": 2024
+        }
+      },
+      "last_payment_error": {
+        "charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+        "code": "lost_card",
+        "decline_code": "lost_card",
+        "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+        "message": "Your card was declined.",
+        "type": "card_error"
+      },
+      "latest_charge": "ch_3N6AIYHj08j2jFuB1UoZ5O8H",
+      "livemode": false
+    },
+    "type": "card_error"
+  }
+}


### PR DESCRIPTION
## WHAT YOU DID

We want to store the unmapped rejection code and rejection message that we receive from the PSP, e.g. "fraudulent", into a new field in the charges DB table for Connector.