### PR TITLE
PP-15101 pin eclipse persistence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
         # Stripe SDK 22.x needs refactoring on our end
         versions:
           - ">= 22"
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.jpa"
+        # org.eclipse.persistence.jpa 5 is incompatible with Guice 7, needs a lot of work on our end
+        versions:
+          - ">= 5"
     open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
## WHAT YOU DID

Pin eclipse persistence to v4.x.x. org.eclipse.persistence.jpa 5 is incompatible with Guice 7 out of the box, needs a lot of work on our end.
