### PR TITLE
PP-15127: Use XMLUnit for XML assertions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -551,7 +551,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 87
+        "line_number": 86
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-01T17:07:00Z"
+  "generated_at": "2026-04-01T18:20:49Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -542,7 +542,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 1188
+        "line_number": 1175
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-01T16:11:51Z"
+  "generated_at": "2026-04-01T16:59:04Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -512,7 +512,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java",
         "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 83
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-09T12:13:54Z"
+  "generated_at": "2026-04-01T16:11:51Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -542,7 +542,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 1175
+        "line_number": 1178
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-01T16:59:04Z"
+  "generated_at": "2026-04-01T17:07:00Z"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.xmlunit</groupId>
+                <artifactId>xmlunit-bom</artifactId>
+                <version>2.11.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -425,13 +432,11 @@
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-matchers</artifactId>
-            <version>2.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-assertj3</artifactId>
-            <version>2.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -428,6 +428,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-assertj3</artifactId>
+            <version>2.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>testing-dropwizard-5</artifactId>
             <version>${pay-java-commons.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>uk.gov.pay</groupId>
-    <version>0.1-SNAPSHOT</version>
     <artifactId>pay-connector</artifactId>
+    <version>0.1-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -54,7 +56,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <!-- Main dependencies that are imported from one of the BOMs specified
              in <dependencyManagement> so no explicit versions needed -->
@@ -440,6 +441,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
@@ -613,6 +615,7 @@
             </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>default</id>

--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-matchers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-assertj3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
@@ -427,16 +437,6 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>6.0.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-matchers</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-assertj3</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,12 @@
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-matchers</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>
@@ -392,12 +398,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>3.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
             <version>3.0.0</version>
@@ -420,6 +420,12 @@
             <artifactId>hamcrest-date</artifactId>
             <version>2.0.8</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+import org.xmlunit.assertj3.XmlAssert;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -109,7 +110,6 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITH_REFERENCE_IN_DESCRIPTION;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 import static uk.gov.pay.connector.util.XPathUtils.getNodeListFromExpression;
-import static wiremock.org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 
 @ExtendWith(MockitoExtension.class)
 class WorldpayAuthoriseHandlerTest {
@@ -177,8 +177,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS))
+                .areIdentical();
     }
 
     @Test
@@ -202,8 +203,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITH_IP_ADDRESS),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITH_IP_ADDRESS))
+                .areIdentical();
 
         ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
@@ -235,8 +237,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS))
+                .areIdentical();
 
         ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
@@ -291,7 +294,6 @@ class WorldpayAuthoriseHandlerTest {
 
     @Test
     void should_not_include_exemption_element() throws Exception {
-
         when(authorisationSuccessResponse.getEntity()).thenReturn(load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
@@ -318,7 +320,6 @@ class WorldpayAuthoriseHandlerTest {
 
     @Test
     void should_not_include_elements_when_worldpay_3ds_flex_ddc_result_is_not_present() throws Exception {
-
         gatewayAccountEntity.setRequires3ds(true);
 
         when(authorisationSuccessResponse.getEntity()).thenReturn(load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
@@ -349,7 +350,6 @@ class WorldpayAuthoriseHandlerTest {
 
     @Test
     void should_include_3DS2_flex_elements_when_worldpay_3ds_flex_ddc_result_is_present() throws Exception {
-
         when(authorisationSuccessResponse.getEntity()).thenReturn(load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
@@ -404,8 +404,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS))
+                .areIdentical();
     }
 
     @Test
@@ -430,8 +431,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITH_EMAIL),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITH_EMAIL))
+                .areIdentical();
 
         ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
@@ -464,8 +466,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS))
+                .areIdentical();
     }
 
     @Test
@@ -490,8 +493,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS))
+                .areIdentical();
     }
 
     @Test
@@ -516,8 +520,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS))
+                .areIdentical();
     }
 
     @Test
@@ -542,8 +547,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS))
+                .areIdentical();
     }
 
     @ParameterizedTest
@@ -577,8 +583,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(templatePath),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(templatePath))
+                .areIdentical();
     }
 
     @Test
@@ -607,8 +614,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_SETUP_AGREEMENT),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_SETUP_AGREEMENT))
+                .areIdentical();
     }
 
     @Test
@@ -637,8 +645,9 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_SETUP_AGREEMENT_WITH_EMAIL_AND_IP_ADDRESS),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_SETUP_AGREEMENT_WITH_EMAIL_AND_IP_ADDRESS))
+                .areIdentical();
     }
 
     @ParameterizedTest
@@ -676,9 +685,9 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-
-        assertXMLEqual(load(worldpayTemplate),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(worldpayTemplate))
+                .areIdentical();
     }
 
     @Test
@@ -714,9 +723,9 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER))
+                .areIdentical();
     }
 
     @Test
@@ -741,9 +750,10 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITH_REFERENCE_IN_DESCRIPTION)
-                        .replace("{{description}}", "service-payment-reference"),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITH_REFERENCE_IN_DESCRIPTION)
+                        .replace("{{description}}", "service-payment-reference"))
+                .areIdentical();
     }
 
     @Test
@@ -768,9 +778,10 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITH_REFERENCE_IN_DESCRIPTION)
-                        .replace("{{description}}", "This is a description"),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITH_REFERENCE_IN_DESCRIPTION)
+                        .replace("{{description}}", "This is a description"))
+                .areIdentical();
     }
 
     @Test
@@ -796,8 +807,9 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_REQUEST_3DS_FLEX_NON_JS),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_REQUEST_3DS_FLEX_NON_JS))
+                .areIdentical();
     }
 
     @Test
@@ -806,7 +818,7 @@ class WorldpayAuthoriseHandlerTest {
 
         var handlerWithRealJerseyClient = new WorldpayAuthoriseHandler(createGatewayClient(mockClient), GATEWAY_URL_MAP, new AcceptLanguageHeaderParser());
 
-        GatewayResponse response = handlerWithRealJerseyClient.authorise(getCardAuthorisationRequest(chargeEntityFixture.build()), DO_NOT_SEND_EXEMPTION_REQUEST);
+        GatewayResponse<WorldpayOrderStatusResponse> response = handlerWithRealJerseyClient.authorise(getCardAuthorisationRequest(chargeEntityFixture.build()), DO_NOT_SEND_EXEMPTION_REQUEST);
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getSessionIdentifier().isPresent());
     }
@@ -875,8 +887,9 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER))
+                .areIdentical();
     }
 
     @Test
@@ -916,8 +929,9 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        assertXMLEqual(load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER))
+                .areIdentical();
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -23,7 +23,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
 import org.xmlunit.assertj3.XmlAssert;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
@@ -48,13 +47,10 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.util.AcceptLanguageHeaderParser;
-import uk.gov.pay.connector.util.XPathUtils;
 import uk.gov.service.payments.commons.model.AgreementPaymentType;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathFactory;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Collections;
@@ -62,9 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -109,7 +103,6 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_SETUP_AGREEMENT_WITH_EMAIL_AND_IP_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITH_REFERENCE_IN_DESCRIPTION;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
-import static uk.gov.pay.connector.util.XPathUtils.getNodeListFromExpression;
 
 @ExtendWith(MockitoExtension.class)
 class WorldpayAuthoriseHandlerTest {
@@ -286,10 +279,13 @@ class WorldpayAuthoriseHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        Document document = XPathUtils.getDocumentXmlString(gatewayOrderArgumentCaptor.getValue().getPayload());
-        XPath xPath = XPathFactory.newInstance().newXPath();
-        assertThat(xPath.evaluate("/paymentService/submit/order/exemption/@type", document), is(expectedExemptionType));
-        assertThat(xPath.evaluate("/paymentService/submit/order/exemption/@placement", document), is(expectedExemptionPlacement));
+        String payload = gatewayOrderArgumentCaptor.getValue().getPayload();
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/exemption/@type")
+                .isEqualTo(expectedExemptionType);
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/exemption/@placement")
+                .isEqualTo(expectedExemptionPlacement);
     }
 
     @Test
@@ -313,9 +309,9 @@ class WorldpayAuthoriseHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        Document document = XPathUtils.getDocumentXmlString(gatewayOrderArgumentCaptor.getValue().getPayload());
-        assertThat(getNodeListFromExpression(document, "/paymentService/submit/order/exemption").getLength(),
-                is(0));
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .valueByXPath("/paymentService/submit/order/exemption")
+                .isEmpty();
     }
 
     @Test
@@ -336,16 +332,19 @@ class WorldpayAuthoriseHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        Document document = XPathUtils.getDocumentXmlString(gatewayOrderArgumentCaptor.getValue().getPayload());
-        XPath xPath = XPathFactory.newInstance().newXPath();
-        assertThat(getNodeListFromExpression(document, "/paymentService/submit/order/additional3DSData").getLength(),
-                is(0));
-        assertThat(xPath.evaluate("/paymentService/submit/order/paymentDetails/session/@id", document),
-                not(emptyString()));
-        assertThat(xPath.evaluate("/paymentService/submit/order/shopper/browser/acceptHeader", document),
-                not(emptyString()));
-        assertThat(xPath.evaluate("/paymentService/submit/order/shopper/browser/userAgentHeader", document),
-                not(emptyString()));
+        String payload = gatewayOrderArgumentCaptor.getValue().getPayload();
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/additional3DSData")
+                .isEmpty();
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/paymentDetails/session/@id")
+                .isNotEmpty();
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/shopper/browser/acceptHeader")
+                .isNotEmpty();
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/shopper/browser/userAgentHeader")
+                .isNotEmpty();
     }
 
     @Test
@@ -366,20 +365,25 @@ class WorldpayAuthoriseHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        Document document = XPathUtils.getDocumentXmlString(gatewayOrderArgumentCaptor.getValue().getPayload());
-        XPath xPath = XPathFactory.newInstance().newXPath();
-        assertThat(xPath.evaluate("/paymentService/submit/order/additional3DSData/@dfReferenceId", document),
-                is(authCardDetails.getWorldpay3dsFlexDdcResult().get()));
-        assertThat(xPath.evaluate("/paymentService/submit/order/additional3DSData/@challengeWindowSize", document),
-                is("390x400"));
-        assertThat(xPath.evaluate("/paymentService/submit/order/additional3DSData/@challengePreference", document),
-                is("noPreference"));
-        assertThat(xPath.evaluate("/paymentService/submit/order/paymentDetails/session/@id", document),
-                not(emptyString()));
-        assertThat(xPath.evaluate("/paymentService/submit/order/shopper/browser/acceptHeader", document),
-                not(emptyString()));
-        assertThat(xPath.evaluate("/paymentService/submit/order/shopper/browser/userAgentHeader", document),
-                not(emptyString()));
+        String payload = gatewayOrderArgumentCaptor.getValue().getPayload();
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/additional3DSData/@dfReferenceId")
+                .isEqualTo(authCardDetails.getWorldpay3dsFlexDdcResult().get());
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/additional3DSData/@challengeWindowSize")
+                .isEqualTo("390x400");
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/additional3DSData/@challengePreference")
+                .isEqualTo("noPreference");
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/paymentDetails/session/@id")
+                .isNotEmpty();
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/shopper/browser/acceptHeader")
+                .isNotEmpty();
+        XmlAssert.assertThat(payload)
+                .valueByXPath("/paymentService/submit/order/shopper/browser/userAgentHeader")
+                .isNotEmpty();
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -114,8 +114,8 @@ import static wiremock.org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 @ExtendWith(MockitoExtension.class)
 class WorldpayAuthoriseHandlerTest {
 
-    private final URI WORLDPAY_URL = URI.create("http://worldpay.url");
-    private final Map<String, URI> GATEWAY_URL_MAP = Map.of(TEST.toString(), WORLDPAY_URL);
+    private static final URI WORLDPAY_URL = URI.create("http://worldpay.url");
+    private static final Map<String, URI> GATEWAY_URL_MAP = Map.of(TEST.toString(), WORLDPAY_URL);
 
     @Mock
     private GatewayClient authoriseClient;
@@ -126,7 +126,6 @@ class WorldpayAuthoriseHandlerTest {
 
     private ChargeEntityFixture chargeEntityFixture;
     private GatewayAccountEntity gatewayAccountEntity;
-    private GatewayAccountCredentialsEntity creds;
     private WorldpayAuthoriseHandler worldpayAuthoriseHandler;
 
     @BeforeEach
@@ -134,7 +133,7 @@ class WorldpayAuthoriseHandlerTest {
         worldpayAuthoriseHandler = new WorldpayAuthoriseHandler(authoriseClient, GATEWAY_URL_MAP, new AcceptLanguageHeaderParser());
 
         gatewayAccountEntity = aServiceAccount();
-        creds = aGatewayAccountCredentialsEntity()
+        GatewayAccountCredentialsEntity creds = aGatewayAccountCredentialsEntity()
                 .withCredentials(Map.of(
                         ONE_OFF_CUSTOMER_INITIATED, Map.of(
                                 CREDENTIALS_MERCHANT_CODE, "MERCHANTCODE",
@@ -983,7 +982,7 @@ class WorldpayAuthoriseHandlerTest {
         Map<String, NewCookie> responseCookies =
                 Collections.singletonMap(
                         WORLDPAY_MACHINE_COOKIE_NAME,
-                        new NewCookie(WORLDPAY_MACHINE_COOKIE_NAME, "value-from-worldpay")
+                        new NewCookie.Builder(WORLDPAY_MACHINE_COOKIE_NAME).value("value-from-worldpay").build()
                 );
 
         Response response = mock(Response.class);
@@ -996,14 +995,12 @@ class WorldpayAuthoriseHandlerTest {
     }
 
     private GatewayAccountEntity aServiceAccount() {
-        GatewayAccountEntity gatewayAccount = GatewayAccountEntityFixture
+        return GatewayAccountEntityFixture
                 .aGatewayAccountEntity()
                 .withId(1L)
                 .withGatewayName(WORLDPAY.getName())
                 .withRequires3ds(false)
                 .build();
-
-        return gatewayAccount;
     }
 
     private CardAuthorisationGatewayRequest getCardAuthorisationRequest(ChargeEntity chargeEntity) {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -160,7 +160,7 @@ class WorldpayCaptureHandlerTest {
                 is(String.valueOf(chargeEntity.getAmount() + chargeEntity.getCorporateSurcharge().orElse(0L))));
     }
 
-    private class TestResponse extends GatewayClient.Response {
+    private static class TestResponse extends GatewayClient.Response {
 
         protected TestResponse(Response delegate) {
             super(delegate);

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.w3c.dom.Document;
+import org.xmlunit.assertj3.XmlAssert;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
@@ -19,10 +19,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.util.XPathUtils;
 
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathFactory;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -117,15 +114,13 @@ class WorldpayCaptureHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        Document document = XPathUtils.getDocumentXmlString(gatewayOrderArgumentCaptor.getValue().getPayload());
-        XPath xPath = XPathFactory.newInstance().newXPath();
-        assertThat(xPath.evaluate("/paymentService/modify/orderModification/capture/amount/@value", document),
-                is(String.valueOf(chargeEntity.getAmount() + chargeEntity.getCorporateSurcharge().orElse(0L))));
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .valueByXPath("/paymentService/modify/orderModification/capture/amount/@value")
+                .isEqualTo(chargeEntity.getAmount() + chargeEntity.getCorporateSurcharge().orElse(0L));
     }
 
     @Test
     void shouldCaptureARecurringPaymentSuccessfully() throws Exception {
-
         when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
         when(response.readEntity(String.class)).thenReturn(load("templates/worldpay/capture-success-response.xml"));
         GatewayClient.Response response = new TestResponse(this.response);
@@ -154,10 +149,9 @@ class WorldpayCaptureHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        Document document = XPathUtils.getDocumentXmlString(gatewayOrderArgumentCaptor.getValue().getPayload());
-        XPath xPath = XPathFactory.newInstance().newXPath();
-        assertThat(xPath.evaluate("/paymentService/modify/orderModification/capture/amount/@value", document),
-                is(String.valueOf(chargeEntity.getAmount() + chargeEntity.getCorporateSurcharge().orElse(0L))));
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .valueByXPath("/paymentService/modify/orderModification/capture/amount/@value")
+                .isEqualTo(chargeEntity.getAmount() + chargeEntity.getCorporateSurcharge().orElse(0L));
     }
 
     private static class TestResponse extends GatewayClient.Response {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
 import com.google.common.collect.ImmutableMap;
+import jakarta.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,6 @@ import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.util.XPathUtils;
 
-import jakarta.ws.rs.core.Response;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathFactory;
 import java.net.URI;
@@ -70,9 +70,9 @@ class WorldpayCaptureHandlerTest {
     );
 
     Map<String, Object> recurringCredentials = Map.of(
-            RECURRING_CUSTOMER_INITIATED, Map.of( CREDENTIALS_MERCHANT_CODE, "CIT-MERCHANTCODE",
-            CREDENTIALS_USERNAME, "cit-username",
-            CREDENTIALS_PASSWORD, "cit-password"),
+            RECURRING_CUSTOMER_INITIATED, Map.of(CREDENTIALS_MERCHANT_CODE, "CIT-MERCHANTCODE",
+                    CREDENTIALS_USERNAME, "cit-username",
+                    CREDENTIALS_PASSWORD, "cit-password"),
             RECURRING_MERCHANT_INITIATED, Map.of(
                     CREDENTIALS_MERCHANT_CODE, "MIT-MERCHANTCODE",
                     CREDENTIALS_USERNAME, "mit-password",
@@ -86,8 +86,8 @@ class WorldpayCaptureHandlerTest {
     }
 
     @ParameterizedTest
-    @ValueSource( strings = {"250"})
-    void shouldCaptureAPaymentSuccessfully( Long corporateSurchargeAmount) throws Exception {
+    @ValueSource(strings = {"250"})
+    void shouldCaptureAPaymentSuccessfully(Long corporateSurchargeAmount) throws Exception {
         when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
         when(response.readEntity(String.class)).thenReturn(load("templates/worldpay/capture-success-response.xml"));
         GatewayClient.Response response = new TestResponse(this.response);

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.gateway.worldpay;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.xml.sax.SAXException;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -18,10 +17,10 @@ import uk.gov.pay.connector.wallets.googlepay.api.GooglePayPaymentInfo;
 import uk.gov.service.payments.commons.model.AgreementPaymentType;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
-import java.io.IOException;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.xmlunit.assertj3.XmlAssert.assertThat;
 import static uk.gov.pay.connector.gateway.worldpay.SendWorldpayExemptionRequest.DO_NOT_SEND_EXEMPTION_REQUEST;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpay3dsResponseAuthOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseApplePayOrderRequestBuilder;
@@ -55,7 +54,6 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CAPTURE_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_DELETE_TOKEN_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST;
-import static wiremock.org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 
 class WorldpayOrderRequestBuilderTest {
 
@@ -86,8 +84,7 @@ class WorldpayOrderRequestBuilderTest {
     );
 
     @Test
-    void shouldGenerateValidAuthoriseOrderRequestForAddressWithMinimumFields() throws Exception {
-
+    void shouldGenerateValidAuthoriseOrderRequestForAddressWithMinimumFields() {
         Address minAddress = new Address("123 My Street", null, "SW8URR", "London", null, "GB");
 
         AuthCardDetails authCardDetails = getValidTestCard(minAddress);
@@ -103,12 +100,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseRecurringOrderRequestWithSchemeIdentifier() throws Exception {
+    void shouldGenerateValidAuthoriseRecurringOrderRequestWithSchemeIdentifier() {
         GatewayOrder actualRequest = aWorldpayAuthoriseRecurringOrderRequestBuilder()
                 .withPaymentTokenId("test-payment-token-123456")
                 .withSchemeTransactionIdentifier("test-transaction-id-999999")
@@ -120,12 +119,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseRecurringOrderRequestWithOutSchemeIdentifier() throws Exception {
+    void shouldGenerateValidAuthoriseRecurringOrderRequestWithOutSchemeIdentifier() {
         GatewayOrder actualRequest = aWorldpayAuthoriseRecurringOrderRequestBuilder()
                 .withPaymentTokenId("test-payment-token-123456")
                 .withAgreementId("test-agreement-123456")
@@ -136,13 +137,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseOrderRequestForAddressWithMinimumFieldsWhen3dsEnabled() throws Exception {
-
+    void shouldGenerateValidAuthoriseOrderRequestForAddressWithMinimumFieldsWhen3dsEnabled() {
         Address minAddress = new Address("123 My Street", null, "SW8URR", "London", null, "GB");
 
         AuthCardDetails authCardDetails = getValidTestCard(minAddress);
@@ -160,13 +162,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseOrderRequestForAddressWithState() throws Exception {
-
+    void shouldGenerateValidAuthoriseOrderRequestForAddressWithState() {
         Address usAddress = new Address("10 WCB", null, "20500", "Washington D.C.", null, "US");
 
         AuthCardDetails authCardDetails = getValidTestCard(usAddress);
@@ -182,13 +185,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseOrderRequestForAddressWithStateWhen3dsEnabled() throws Exception {
-
+    void shouldGenerateValidAuthoriseOrderRequestForAddressWithStateWhen3dsEnabled() {
         Address usAddress = new Address("10 WCB", null, "20500", "Washington D.C.", null, "US");
 
         AuthCardDetails authCardDetails = getValidTestCard(usAddress);
@@ -206,13 +210,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseOrderRequestForAddressWithAllFields() throws Exception {
-
+    void shouldGenerateValidAuthoriseOrderRequestForAddressWithAllFields() {
         Address fullAddress = new Address("123 My Street", "This road", "SW8URR", "London", "London county", "GB");
 
         AuthCardDetails authCardDetails = getValidTestCard(fullAddress);
@@ -228,13 +233,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseOrderRequestWhenSpecialCharactersInUserInput() throws Exception {
-
+    void shouldGenerateValidAuthoriseOrderRequestWhenSpecialCharactersInUserInput() {
         Address address = new Address("123 & My Street", "This road -->", "SW8 > URR", "London !>", null, "GB");
 
         AuthCardDetails authCardDetails = getValidTestCard(address);
@@ -250,12 +256,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseOrderRequestWhenAddressIsMissing() throws Exception {
+    void shouldGenerateValidAuthoriseOrderRequestWhenAddressIsMissing() {
         AuthCardDetails authCardDetails = getValidTestCard(null);
 
         GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
@@ -269,12 +277,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuth3dsResponseOrderRequest() throws Exception {
+    void shouldGenerateValidAuth3dsResponseOrderRequest() {
         GatewayOrder actualRequest = aWorldpay3dsResponseAuthOrderRequestBuilder()
                 .withPaResponse3ds("I am an opaque 3D Secure PA response from the card issuer")
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
@@ -282,12 +292,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withMerchantCode("MERCHANTCODE")
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE_3DS, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseApplePayOrderRequest() throws Exception {
+    void shouldGenerateValidAuthoriseApplePayOrderRequest() {
         GatewayOrder actualRequest = aWorldpayAuthoriseApplePayOrderRequestBuilder()
                 .withAppleDecryptedPaymentData(validApplePayData)
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
@@ -299,12 +311,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE_APPLE_PAY, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseApplePayOrderRequest_withMinData() throws Exception {
+    void shouldGenerateValidAuthoriseApplePayOrderRequest_withMinData() {
         AppleDecryptedPaymentData validData =
                 anApplePayDecryptedPaymentData()
                         .withEciIndicator(null)
@@ -324,12 +338,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE_APPLE_PAY, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseGooglePayOrderRequest() throws Exception {
+    void shouldGenerateValidAuthoriseGooglePayOrderRequest() {
         GooglePayPaymentInfo googlePayPaymentInfo = aGooglePayPaymentInfo().build();
         GooglePayAuthRequest validGooglePayData = new GooglePayAuthRequest(googlePayPaymentInfo, GOOGLE_PAY_ENCRYPTED_PAYMENT_DATA);
 
@@ -341,12 +357,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseGooglePay3dsOrderRequestWithoutIpAddress() throws Exception {
+    void shouldGenerateValidAuthoriseGooglePay3dsOrderRequestWithoutIpAddress() {
         GooglePayAuthRequest validGooglePay3dsData = new GooglePayAuthRequest(googlePayWalletPaymentInfoFor3ds, GOOGLE_PAY_ENCRYPTED_PAYMENT_DATA);
 
         GatewayOrder actualRequest = aWorldpayAuthoriseGooglePayOrderRequestBuilder()
@@ -361,12 +379,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseGooglePay3dsOrderRequestWithIpAddress() throws Exception {
+    void shouldGenerateValidAuthoriseGooglePay3dsOrderRequestWithIpAddress() {
         GooglePayAuthRequest validGooglePay3dsData = new GooglePayAuthRequest(googlePayWalletPaymentInfoFor3ds, GOOGLE_PAY_ENCRYPTED_PAYMENT_DATA);
 
         GatewayOrder actualRequest = aWorldpayAuthoriseGooglePayOrderRequestBuilder()
@@ -382,12 +402,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidAuthoriseGooglePay3dsOrderRequestWhen3dsDisabled() throws Exception {
+    void shouldGenerateValidAuthoriseGooglePay3dsOrderRequestWhen3dsDisabled() {
         GooglePayAuthRequest validGooglePay3dsData = new GooglePayAuthRequest(googlePayWalletPaymentInfoFor3ds, GOOGLE_PAY_ENCRYPTED_PAYMENT_DATA);
 
         GatewayOrder actualRequest = aWorldpayAuthoriseGooglePayOrderRequestBuilder()
@@ -400,12 +422,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidCaptureOrderRequest() throws Exception {
+    void shouldGenerateValidCaptureOrderRequest() {
         var date = LocalDate.of(2013, 2, 23);
 
         GatewayOrder actualRequest = aWorldpayCaptureOrderRequestBuilder()
@@ -415,12 +439,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withTransactionId("MyUniqueTransactionId!")
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_CAPTURE_WORLDPAY_REQUEST), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_CAPTURE_WORLDPAY_REQUEST))
+                .areIdentical();
         assertEquals(OrderRequestType.CAPTURE, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidCaptureOrderRequestWithSpecialCharactersInStrings() throws Exception {
+    void shouldGenerateValidCaptureOrderRequestWithSpecialCharactersInStrings() {
         var date = LocalDate.of(2013, 2, 23);
 
         GatewayOrder actualRequest = aWorldpayCaptureOrderRequestBuilder()
@@ -430,13 +456,14 @@ class WorldpayOrderRequestBuilderTest {
                 .withTransactionId("MyUniqueTransactionId <!-- & > ")
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_SPECIAL_CHAR_VALID_CAPTURE_WORLDPAY_REQUEST), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(WORLDPAY_SPECIAL_CHAR_VALID_CAPTURE_WORLDPAY_REQUEST))
+                .areIdentical();
         assertEquals(OrderRequestType.CAPTURE, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidCancelOrderRequest() throws Exception {
-
+    void shouldGenerateValidCancelOrderRequest() {
         GatewayOrder actualRequest = aWorldpayCancelOrderRequestBuilder()
                 .withMerchantCode("MERCHANTCODE")
                 .withTransactionId("MyUniqueTransactionId!")
@@ -446,13 +473,14 @@ class WorldpayOrderRequestBuilderTest {
                 .replace("{{merchantCode}}", "MERCHANTCODE")
                 .replace("{{transactionId}}", "MyUniqueTransactionId!");
 
-        assertXMLEqual(expectedRequestBody, actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(expectedRequestBody)
+                .areIdentical();
         assertEquals(OrderRequestType.CANCEL, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidRefundOrderRequest() throws Exception {
-
+    void shouldGenerateValidRefundOrderRequest() {
         GatewayOrder actualRequest = aWorldpayRefundOrderRequestBuilder()
                 .withReference("reference")
                 .withAmount("200")
@@ -466,12 +494,14 @@ class WorldpayOrderRequestBuilderTest {
                 .replace("{{refundReference}}", "reference")
                 .replace("{{amount}}", "200");
 
-        assertXMLEqual(expectedRequestBody, actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(expectedRequestBody)
+                .areIdentical();
         assertEquals(OrderRequestType.REFUND, actualRequest.getOrderRequestType());
     }
 
     @Test
-    void shouldGenerateValidDeleteTokenRequest() throws Exception {
+    void shouldGenerateValidDeleteTokenRequest() {
         GatewayOrder actualRequest = aWorldpayDeleteTokenOrderRequestBuilder()
                 .withAgreementId("test-agreement-123")
                 .withPaymentTokenId("test-paymentToken-789")
@@ -483,7 +513,9 @@ class WorldpayOrderRequestBuilderTest {
                 .replace("{{agreementId}}", "test-agreement-123")
                 .replace("{{paymentTokenId}}", "test-paymentToken-789");
 
-        assertXMLEqual(expectedRequestBody, actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(expectedRequestBody)
+                .areIdentical();
         assertEquals(OrderRequestType.DELETE_STORED_PAYMENT_DETAILS, actualRequest.getOrderRequestType());
     }
 
@@ -496,8 +528,7 @@ class WorldpayOrderRequestBuilderTest {
             """)
     void shouldGenerateValidAuthoriseOrderRequestAndIncludeCorrectExemptionResponse(SendWorldpayExemptionRequest sendExemptionRequest,
                                                                                     String testTemplatePath,
-                                                                                    Boolean isCorporateCard) throws Exception {
-
+                                                                                    Boolean isCorporateCard) {
         Address minAddress = new Address("123 My Street", null, "SW8URR", "London", null, "GB");
 
         AuthCardDetails authCorporateCardDetails = getValidTestCard(minAddress);
@@ -516,10 +547,12 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCorporateCardDetails)
                 .build();
 
-        assertXMLEqual(TestTemplateResourceLoader.load(testTemplatePath), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(testTemplatePath))
+                .areIdentical();
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
-    
+
     @ParameterizedTest
     @CsvSource(useHeadersInDisplayName = true, nullValues = "null", textBlock = """
             3ds_enabled, send_payer_ip_address_to_gateway, send_payer_email_to_gateway, email_address, template_path
@@ -529,8 +562,7 @@ class WorldpayOrderRequestBuilderTest {
             true, false, false, citizen@example.org, templates/worldpay/valid-authorise-worldpay-request-including-3ds.xml
             false, true, true, null, templates/worldpay/valid-authorise-worldpay-request-excluding-3ds.xml
             """)
-    void testVariationsOfSendPayerEmailAndSendPayerIPAddress(boolean is3dsEnabled, boolean sendIPAddress, boolean sendEmail, String emailAddress, String testTemplatePath) throws IOException, SAXException {
-        
+    void testVariationsOfSendPayerEmailAndSendPayerIPAddress(boolean is3dsEnabled, boolean sendIPAddress, boolean sendEmail, String emailAddress, String testTemplatePath) {
         Address minAddress = new Address("123 My Street", "This road", "SW8URR", "London", null, "GB");
 
         AuthCardDetails authCardDetails = getValidTestCard(minAddress);
@@ -541,28 +573,30 @@ class WorldpayOrderRequestBuilderTest {
                 .withAcceptHeader("text/html")
                 .withUserAgentHeader("Mozilla/5.0")
                 .withRequestExemption(DO_NOT_SEND_EXEMPTION_REQUEST);
-                
-                builder
+
+        builder
                 .withTransactionId("transaction-id")
                 .withMerchantCode("MERCHANTCODE")
                 .withDescription("This is a description")
                 .withAmount("500")
                 .withAuthorisationDetails(authCardDetails);
-        
+
         if (sendEmail) {
             builder.withPayerEmail(emailAddress);
         }
-        
+
         if (sendIPAddress) {
             builder.withPayerIpAddress("127.0.0.1");
         }
 
-        GatewayOrder actualRequest =  builder.build();
+        GatewayOrder actualRequest = builder.build();
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
 
-        assertXMLEqual(TestTemplateResourceLoader.load(testTemplatePath), actualRequest.getPayload());
+        assertThat(actualRequest.getPayload())
+                .and(TestTemplateResourceLoader.load(testTemplatePath))
+                .areIdentical();
     }
-    
+
     private AuthCardDetails getValidTestCard(Address address) {
         return AuthCardDetailsFixture.anAuthCardDetails()
                 .withCardHolder("Mr. Payment")

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -15,6 +15,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
+import org.xmlunit.assertj3.XmlAssert;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
@@ -134,7 +135,6 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_DELETE_TOKEN_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
-import static wiremock.org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 
 @ExtendWith(MockitoExtension.class)
 class WorldpayPaymentProviderTest {
@@ -883,8 +883,9 @@ class WorldpayPaymentProviderTest {
                 anyList(),
                 anyMap());
 
-        assertXMLEqual(load(WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST))
+                .areIdentical();
     }
 
     @Test
@@ -909,8 +910,9 @@ class WorldpayPaymentProviderTest {
                 anyList(),
                 anyMap());
 
-        assertXMLEqual(load(WORLDPAY_VALID_3DS_FLEX_RESPONSE_AUTH_WORLDPAY_REQUEST),
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(load(WORLDPAY_VALID_3DS_FLEX_RESPONSE_AUTH_WORLDPAY_REQUEST))
+                .areIdentical();
     }
 
     @Test
@@ -936,8 +938,9 @@ class WorldpayPaymentProviderTest {
                 .replace("{{agreementId}}", agreement.getExternalId())
                 .replace("{{paymentTokenId}}", token);
 
-        assertXMLEqual(expectedRequestBody,
-                gatewayOrderArgumentCaptor.getValue().getPayload());
+        XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                .and(expectedRequestBody)
+                .areIdentical();
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -215,7 +215,7 @@ class WorldpayPaymentProviderTest {
                                         CREDENTIALS_MERCHANT_CODE, ONE_OFF_MERCHANT_CODE,
                                         CREDENTIALS_USERNAME, ONE_OFF_USERNAME,
                                         CREDENTIALS_PASSWORD, ONE_OFF_PASSWORD)
-                                ))
+                        ))
                         .build())
                 .withGatewayAccountEntity(gatewayAccountEntity);
 
@@ -296,7 +296,7 @@ class WorldpayPaymentProviderTest {
             return loggingEvent.getFormattedMessage().contains(log);
         }));
     }
-    
+
     private void verifyLoggingTypeOf3dsExemption(Exemption3dsType exemption3dsType, String externalId) {
         ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(mockAppender, atLeast(1)).doAppend(loggingEventArgumentCaptor.capture());
@@ -395,9 +395,9 @@ class WorldpayPaymentProviderTest {
         gatewayAccountEntity.setRequires3ds(true);
         gatewayAccountEntity.setIntegrationVersion3ds(1);
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity()
-                        .withExemptionEngine(false)
-                        .withCorporateExemptions(true)
-                        .build());
+                .withExemptionEngine(false)
+                .withCorporateExemptions(true)
+                .build());
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
 
         ChargeEntity chargeEntity = chargeEntityFixture.build();
@@ -510,11 +510,11 @@ class WorldpayPaymentProviderTest {
         verifyLoggingWithExemptionReason(EXEMPTION_REJECTED, "HIGH_RISK", chargeEntity.getExternalId(), 3);
 
         var exemptionRejectedEvent = new Gateway3dsExemptionResultObtainedEvent(
-                chargeEntity.getServiceId(), 
-                chargeEntity.getGatewayAccount().isLive(), 
-                chargeEntity.getGatewayAccount().getId(), 
-                chargeEntity.getExternalId(), 
-                new Gateway3dsExemptionResultObtainedEventDetails(EXEMPTION_REJECTED.toString()), 
+                chargeEntity.getServiceId(),
+                chargeEntity.getGatewayAccount().isLive(),
+                chargeEntity.getGatewayAccount().getId(),
+                chargeEntity.getExternalId(),
+                new Gateway3dsExemptionResultObtainedEventDetails(EXEMPTION_REJECTED.toString()),
                 instantSource.instant());
         verify(eventService).emitAndRecordEvent(exemptionRejectedEvent);
     }
@@ -849,11 +849,11 @@ class WorldpayPaymentProviderTest {
         verifyLoggingWithOutExemptionReason(EXEMPTION_REJECTED, chargeEntity.getExternalId(), 2);
 
         var exemptionRejectedEvent = new Gateway3dsExemptionResultObtainedEvent(
-                chargeEntity.getServiceId(), 
-                chargeEntity.getGatewayAccount().isLive(), 
-                chargeEntity.getGatewayAccount().getId(), 
-                chargeEntity.getExternalId(), 
-                new Gateway3dsExemptionResultObtainedEventDetails(EXEMPTION_REJECTED.toString()), 
+                chargeEntity.getServiceId(),
+                chargeEntity.getGatewayAccount().isLive(),
+                chargeEntity.getGatewayAccount().getId(),
+                chargeEntity.getExternalId(),
+                new Gateway3dsExemptionResultObtainedEventDetails(EXEMPTION_REJECTED.toString()),
                 instantSource.instant());
         verify(eventService).emitAndRecordEvent(exemptionRejectedEvent);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -307,16 +307,6 @@ class WorldpayPaymentProviderTest {
         }));
     }
 
-    private void verifyLoggingTypeOf3dsExemption(Exemption3dsType exemption3dsType, String externalId, int timesLoggingCalled) {
-        ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
-        verify(mockAppender, times(timesLoggingCalled)).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> logs = loggingEventArgumentCaptor.getAllValues();
-        assertTrue(logs.stream().anyMatch(loggingEvent -> {
-            String log = format("Requesting %s exemption - charge_external_id=%s", exemption3dsType.name(), externalId);
-            return loggingEvent.getFormattedMessage().contains(log);
-        }));
-    }
-
     private void verifyLoggingWithOutExemptionReason(Exemption3ds exemption3ds, String externalId, int timesLoggingCalled) {
         ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(mockAppender, times(timesLoggingCalled)).doAppend(loggingEventArgumentCaptor.capture());
@@ -731,7 +721,6 @@ class WorldpayPaymentProviderTest {
         ChargeEntity chargeEntity = chargeEntityFixture.build();
 
         var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
-        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
 
         when(chargeDao.merge(chargeEntity)).thenReturn(chargeEntity);
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, SEND_EXEMPTION_ENGINE_REQUEST))
@@ -1072,7 +1061,7 @@ class WorldpayPaymentProviderTest {
     }
 
     @Test
-    void should_throw_exception_when_using_recurring_payment_and_no_creds() throws Exception {
+    void should_throw_exception_when_using_recurring_payment_and_no_creds() {
         String providerSessionId = "provider-session-id";
         AgreementEntity agreementEntity = anAgreementEntity().build();
         ChargeEntity mockChargeEntity = chargeEntityFixture
@@ -1087,9 +1076,8 @@ class WorldpayPaymentProviderTest {
                         .build())
                 .build();
 
-        assertThrows(MissingCredentialsForRecurringPaymentException.class, () -> {
-            worldpayPaymentProvider.authorise3dsResponse(get3dsResponseGatewayRequest(mockChargeEntity));
-        });
+        assertThrows(MissingCredentialsForRecurringPaymentException.class, () ->
+                worldpayPaymentProvider.authorise3dsResponse(get3dsResponseGatewayRequest(mockChargeEntity)));
     }
 
     @Test
@@ -1161,9 +1149,8 @@ class WorldpayPaymentProviderTest {
 
         ChargeQueryGatewayRequest chargeQueryGatewayRequest = ChargeQueryGatewayRequest.valueOf(Charge.from(chargeEntity), chargeEntity.getGatewayAccount(), chargeEntity.getGatewayAccountCredentialsEntity());
 
-        assertThrows(WebApplicationException.class, () -> {
-            worldpayPaymentProvider.queryPaymentStatus(chargeQueryGatewayRequest);
-        });
+        assertThrows(WebApplicationException.class, () ->
+                worldpayPaymentProvider.queryPaymentStatus(chargeQueryGatewayRequest));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -83,8 +83,8 @@ class WorldpayWalletAuthorisationHandlerTest {
 
     private static final URI WORLDPAY_URL = URI.create("http://worldpay.test");
     private static final String GOOGLE_PAY_3DS_WITHOUT_IP_ADDRESS = "uniqueSessionId";
-    private static final String username = "worldpay-username";
-    private static final String password = "password";
+    private static final String USERNAME = "worldpay-username";
+    private static final String PASSWORD = "password";
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
@@ -98,8 +98,8 @@ class WorldpayWalletAuthorisationHandlerTest {
                 .withCredentials(Map.of(
                         ONE_OFF_CUSTOMER_INITIATED, Map.of(
                                 CREDENTIALS_MERCHANT_CODE, "MERCHANTCODE",
-                                CREDENTIALS_USERNAME, username,
-                                CREDENTIALS_PASSWORD, password)
+                                CREDENTIALS_USERNAME, USERNAME,
+                                CREDENTIALS_PASSWORD, PASSWORD)
                 ))
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .withPaymentProvider(WORLDPAY.getName())
@@ -121,12 +121,12 @@ class WorldpayWalletAuthorisationHandlerTest {
         when(mockApplePayDecrypter.performDecryptOperation(any(ApplePayAuthRequest.class))).thenReturn(getAppleDecryptedPaymentData());
         try {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -137,12 +137,12 @@ class WorldpayWalletAuthorisationHandlerTest {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(true));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -153,12 +153,12 @@ class WorldpayWalletAuthorisationHandlerTest {
         gatewayAccountEntity.setSendPayerEmailToGateway(false);
         try {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(true));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -169,12 +169,12 @@ class WorldpayWalletAuthorisationHandlerTest {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -185,7 +185,7 @@ class WorldpayWalletAuthorisationHandlerTest {
         gatewayAccountEntity.setSendReferenceToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
@@ -196,12 +196,12 @@ class WorldpayWalletAuthorisationHandlerTest {
     void shouldSendGooglePayRequestWhenGooglePayDetailsArePresent() throws Exception {
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -211,12 +211,12 @@ class WorldpayWalletAuthorisationHandlerTest {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(true));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -226,7 +226,7 @@ class WorldpayWalletAuthorisationHandlerTest {
         gatewayAccountEntity.setSendReferenceToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
@@ -238,12 +238,12 @@ class WorldpayWalletAuthorisationHandlerTest {
         gatewayAccountEntity.setSendPayerEmailToGateway(false);
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(true));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -253,12 +253,12 @@ class WorldpayWalletAuthorisationHandlerTest {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -267,12 +267,12 @@ class WorldpayWalletAuthorisationHandlerTest {
     void shouldSendGooglePay3dsRequestWithDDCResultWhenWorldpay3dsFlexResultIsAvailable() throws Exception {
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, true, false, true));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_GOOGLE_PAY_3DS_REQUEST_WITH_DDC_RESULT),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -281,12 +281,12 @@ class WorldpayWalletAuthorisationHandlerTest {
     void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithoutIpAddressArePresent() throws Exception {
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, false, false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -295,11 +295,11 @@ class WorldpayWalletAuthorisationHandlerTest {
     void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithIpAddressArePresent() throws Exception {
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, true, false, false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS), gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -308,11 +308,11 @@ class WorldpayWalletAuthorisationHandlerTest {
     void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithout3dsEnabledArePresent() throws Exception {
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(false, true, false, false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST), gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -322,12 +322,12 @@ class WorldpayWalletAuthorisationHandlerTest {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, true, false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_EMAIL),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -337,12 +337,12 @@ class WorldpayWalletAuthorisationHandlerTest {
         gatewayAccountEntity.setSendPayerEmailToGateway(false);
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, true, false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }
@@ -352,12 +352,12 @@ class WorldpayWalletAuthorisationHandlerTest {
         gatewayAccountEntity.setSendPayerEmailToGateway(true);
         try {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, false, false));
-        } catch (GatewayErrorException e) {
+        } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
                     gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+            String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
         }
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -373,7 +373,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             throws IOException {
         String fixturePath = withDDCResult ? "googlepay/example-3ds-auth-request-with-ddc.json" :
                 withPayerEmail ? "googlepay/example-3ds-auth-request.json" :
-                        "googlepay/example-3ds-auth-request-without-email.json";
+                "googlepay/example-3ds-auth-request-without-email.json";
         GooglePayAuthRequest googlePayAuthRequest = objectMapper.readValue(load(fixturePath), GooglePayAuthRequest.class);
         chargeEntity.getGatewayAccount().setRequires3ds(isRequires3ds);
         chargeEntity.getGatewayAccount().setSendPayerIpAddressToGateway(withIpAddress);

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -8,6 +8,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.xmlunit.assertj3.XmlAssert;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.gateway.GatewayClient;
@@ -15,7 +16,6 @@ import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.applepay.ApplePayDecrypter;
@@ -63,7 +63,6 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
-import static wiremock.org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 
 @ExtendWith(MockitoExtension.class)
 class WorldpayWalletAuthorisationHandlerTest {
@@ -123,8 +122,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -139,8 +139,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(true));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -155,8 +156,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(true));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -171,8 +173,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -187,8 +190,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION))
+                    .areIdentical();
         }
     }
 
@@ -198,8 +202,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -213,8 +218,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(true));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -228,8 +234,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION))
+                    .areIdentical();
         }
     }
 
@@ -240,8 +247,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(true));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -255,8 +263,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -269,8 +278,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, true, false, true));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_GOOGLE_PAY_3DS_REQUEST_WITH_DDC_RESULT),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_GOOGLE_PAY_3DS_REQUEST_WITH_DDC_RESULT))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -283,8 +293,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, false, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -297,7 +308,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, true, false, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS), gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -310,7 +323,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(false, true, false, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST), gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -324,8 +339,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, true, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_EMAIL),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_EMAIL))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -339,8 +355,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, true, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -354,8 +371,9 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, false, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
-                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            XmlAssert.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS))
+                    .areIdentical();
             assertThat(headers.getValue().size(), is(1));
             String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
             assertThat(headers.getValue(), hasEntry(AUTHORIZATION, expectedHeader));
@@ -417,5 +435,4 @@ class WorldpayWalletAuthorisationHandlerTest {
                         "7")
         );
     }
-
 }

--- a/src/test/resources/templates/worldpay/valid-capture-worldpay-request.xml
+++ b/src/test/resources/templates/worldpay/valid-capture-worldpay-request.xml
@@ -6,7 +6,7 @@
         <orderModification orderCode="MyUniqueTransactionId!">
             <capture>
                 <date dayOfMonth="23" month="02" year="2013"/>
-                <amount value="500" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+                <amount value="500" currencyCode="GBP" exponent="2"/>
             </capture>
         </orderModification>
     </modify>


### PR DESCRIPTION
## WHAT YOU DID
1. Ran `mvn tidy:pom`, i.e the `pom` goal of the [Tidy Maven Plugin](https://www.mojohaus.org/tidy-maven-plugin/) to ensure that the POM conforms to the [POM Code Convention](https://maven.apache.org/developers/conventions/code.html#POM_Code_Convention). In practice this has:
* Added an XML declaration
* Updated the schema location to the modern form
* Formatted the artifact coordinates according to convention
* Added empty lines between sections

2. Added the `xmlunit-assertj3` dependency in `test` scope. This [XMLUnit](https://www.xmlunit.org/) dependency adds a custom AssertJ assertion, for expressive fluent assertions and excellent failure messages, enabling an automated diff view in IntelliJ.

3. Replaced test assertions that previously used `wiremock.org.custommonkey.xmlunit.XMLAssert.assertXMLEqual` from a transitive dependency with explicit, modern, XMLUnit assertions. Running XML assertions does not now call out to fetch the Worldpay XML schema on every run, and has speeded up these tests.

4. Reformatted the files and made small fixes suggested by IntelliJ

Note that I have changed one fixture. This is because the comparison here is more rigorous than the previous XML string comparison. The test `WorldpayOrderRequestBuilderTest#shouldGenerateValidCaptureOrderRequest` failed when rewritten because we expect the `amount` element to look like this:

```xml
<amount currencyCode="GBP" debitCreditIndicator="credit" exponent="2" value="500"/>
```
but we, in fact, produce this:

```xml
<amount currencyCode="GBP" exponent="2" value="500"/>
```
Installing the Worldpay schema in IntelliJ and examining `src/test/resources/templates/worldpay/valid-capture-worldpay-request.xml` showed that the default value of the `debitCreditIndicator` attribute in this case is `"credit"`, and so it is redundant. I have removed it.

An example of a failure message using the old assertion:

```
junit.framework.AssertionFailedError: wiremock.org.custommonkey.xmlunit.Diff
[different] Expected attribute value 'transaction-id' but was 'DIFFERENCE!' - comparing <order orderCode="transaction-id"...> at /paymentService[1]/submit[1]/order[1]/@orderCode to <order orderCode="DIFFERENCE!"...> at /paymentService[1]/submit[1]/order[1]/@orderCode
```
and with the AssertJ-enabled XMLUnit (I have abbreviated the pretty-printed XML):

```
Expecting:
 <control instance> and <test instance> to be identical
Expected attribute value 'transaction-id' but was 'DIFFERENCE!' - comparing <order orderCode="transaction-id"...> at /paymentService[1]/submit[1]/order[1]/@orderCode to <order orderCode="DIFFERENCE!"...> at /paymentService[1]/submit[1]/order[1]/@orderCode
expected:<<order orderCode="transaction-id">
            ...
        </order>> but was:<<order orderCode="DIFFERENCE!">
           ...
        </order>>>
Comparison Failure: 
<Click to see difference>
```
The diff window can then be viewed by clicking on the link.

The tests could still be improved, making use of XMLUnit's features, but I have not attempted this here.

## How to test

The tests should be like-for-like and not be obscured or weakened.
