### PR TITLE
PP-15197 Create Adyen gateway account in connector

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,56 +139,56 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 3393
+        "line_number": 3440
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 3437
+        "line_number": 3484
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3922
+        "line_number": 3969
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4350
+        "line_number": 4397
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4386
+        "line_number": 4433
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 5318
+        "line_number": 5365
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5818
+        "line_number": 5865
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5829
+        "line_number": 5876
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-01T18:20:49Z"
+  "generated_at": "2026-04-27T14:29:01Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3336,6 +3336,53 @@ components:
         postcode:
           type: string
           example: AB1 2CD
+    AdyenCredentials:
+      type: object
+      properties:
+        legal_entity_id:
+          type: string
+        store_id:
+          type: string
+    AdyenGatewayAccountRequest:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/GatewayAccountRequest"
+      - type: object
+        properties:
+          allow_apple_pay:
+            type: boolean
+            writeOnly: true
+          allow_google_pay:
+            type: boolean
+            writeOnly: true
+          analytics_id:
+            type: string
+            writeOnly: true
+          credentials:
+            $ref: "#/components/schemas/AdyenCredentials"
+          description:
+            type: string
+          payment_provider:
+            type: string
+            writeOnly: true
+          requires_3ds:
+            type: boolean
+            writeOnly: true
+          send_payer_email_to_gateway:
+            type: boolean
+            writeOnly: true
+          send_payer_ip_address_to_gateway:
+            type: boolean
+            writeOnly: true
+          service_id:
+            type: string
+            writeOnly: true
+          service_name:
+            type: string
+            writeOnly: true
+          type:
+            type: string
+            writeOnly: true
     AgreementCancelRequest:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentGatewayName.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentGatewayName.java
@@ -5,13 +5,16 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public enum PaymentGatewayName {
-    SANDBOX("sandbox"), SMARTPAY("smartpay"), WORLDPAY("worldpay"), EPDQ("epdq"), STRIPE("stripe");
+    ADYEN("adyen"), EPDQ("epdq"), SANDBOX("sandbox"), SMARTPAY("smartpay"), STRIPE("stripe"), WORLDPAY("worldpay");
 
     private final String gatewayName;
-    
+
     private static final Set<String> UNSUPPORTED = Set.of(SMARTPAY.gatewayName, EPDQ.gatewayName);
 
-    private static final Set<String> PAYMENT_GATEWAY_NAMES = EnumSet.allOf(PaymentGatewayName.class).stream().map(x -> x.gatewayName).collect(Collectors.toSet());
+    private static final Set<String> PAYMENT_GATEWAY_NAMES = EnumSet.allOf(PaymentGatewayName.class)
+            .stream()
+            .map(x -> x.gatewayName)
+            .collect(Collectors.toSet());
 
     PaymentGatewayName(String gatewayName) {
         this.gatewayName = gatewayName;
@@ -20,21 +23,26 @@ public enum PaymentGatewayName {
     public String getName() {
         return gatewayName;
     }
-    
+
     public static boolean isUnsupported(String gatewayName) {
         return UNSUPPORTED.contains(gatewayName);
     }
 
     public static class Unsupported extends RuntimeException {
-        public Unsupported() { super(); }
-        public Unsupported(String msg) { super(msg); }
+        public Unsupported() {
+            super();
+        }
+
+        public Unsupported(String msg) {
+            super(msg);
+        }
     }
 
     public static boolean isValidPaymentGateway(String name) {
         try {
             valueFrom(name);
             return true;
-        } catch (Unsupported e){
+        } catch (Unsupported _) {
             return false;
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/AdyenCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/AdyenCredentials.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import java.util.Map;
+
+public record AdyenCredentials(@JsonView({Views.Api.class}) String legalEntityId,
+                               @JsonView({Views.Api.class}) String storeId) implements GatewayCredentials {
+
+    public static final String ADYEN_LEGAL_ENTITY_ID = "legal_entity_id";
+    public static final String ADYEN_STORE_ID = "store_id";
+
+    public Map<String, String> toMap() {
+        return Map.of(
+                ADYEN_LEGAL_ENTITY_ID, legalEntityId,
+                ADYEN_STORE_ID, storeId
+        );
+    }
+
+    @Override
+    public boolean hasCredentials() {
+        return legalEntityId != null;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/AdyenGatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/AdyenGatewayAccountRequest.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class AdyenGatewayAccountRequest extends GatewayAccountRequest {
+
+    private final AdyenCredentials credentials;
+
+    public AdyenGatewayAccountRequest(@JsonProperty("type") String providerAccountType,
+                                      @JsonProperty("payment_provider") String paymentProvider,
+                                      @JsonProperty("service_name") String serviceName,
+                                      @JsonProperty("service_id") String serviceId,
+                                      @JsonProperty("description") String description,
+                                      @JsonProperty("analytics_id") String analyticsId,
+                                      @JsonProperty("credentials") AdyenCredentials credentials,
+                                      @JsonProperty("requires_3ds") boolean requires3ds,
+                                      @JsonProperty("allow_apple_pay") boolean allowApplePay,
+                                      @JsonProperty("allow_google_pay") boolean allowGooglePay,
+                                      @JsonProperty("send_payer_email_to_gateway") boolean sendPayerEmailToGateway,
+                                      @JsonProperty("send_payer_ip_address_to_gateway") boolean sendPayerIPAddressToGateway
+    ) {
+        super(providerAccountType,
+                paymentProvider,
+                serviceName,
+                serviceId,
+                description,
+                analyticsId,
+                requires3ds,
+                allowApplePay,
+                allowGooglePay,
+                sendPayerEmailToGateway,
+                sendPayerIPAddressToGateway);
+        this.credentials = credentials;
+    }
+
+    @Override
+    public Map<String, String> getCredentialsAsMap() {
+        return Optional.ofNullable(credentials)
+                .map(AdyenCredentials::toMap)
+                .orElse(Map.of());
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.dropwizard.validation.ValidationMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 
-import jakarta.validation.constraints.NotBlank;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -22,7 +22,8 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
         visible = true,
         defaultImpl = GatewayAccountRequest.class)
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = StripeGatewayAccountRequest.class, name = "stripe")
+        @JsonSubTypes.Type(value = StripeGatewayAccountRequest.class, name = "stripe"),
+        @JsonSubTypes.Type(value = AdyenGatewayAccountRequest.class, name = "adyen")
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GatewayAccountRequest {
@@ -49,16 +50,16 @@ public class GatewayAccountRequest {
 
     @JsonIgnore
     private boolean requires3ds;
-    
+
     @JsonIgnore
     private boolean allowApplePay;
-    
+
     @JsonIgnore
     private boolean allowGooglePay;
-    
+
     @JsonIgnore
     private boolean sendPayerEmailToGateway;
-    
+
     @JsonIgnore
     private boolean sendPayerIpAddressToGateway;
 
@@ -99,7 +100,7 @@ public class GatewayAccountRequest {
         try {
             GatewayAccountType.fromString(providerAccountType);
             return true;
-        } catch (IllegalArgumentException iae) {
+        } catch (IllegalArgumentException _) {
             return false;
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -6,6 +6,7 @@ import org.eclipse.persistence.annotations.Customizer;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
 import uk.gov.pay.connector.common.model.domain.HistoryCustomizer;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.EpdqCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
@@ -100,18 +101,13 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     
     public GatewayCredentials getCredentialsObject() {
         Map<String, Object> credentialsMap = Optional.ofNullable(credentials).orElse(Map.of());
-        switch (PaymentGatewayName.valueFrom(paymentProvider)) {
-            case WORLDPAY:
-                return objectMapper.convertValue(credentialsMap, WorldpayCredentials.class);
-            case STRIPE:
-                return objectMapper.convertValue(credentialsMap, StripeCredentials.class);
-            case EPDQ:
-                return objectMapper.convertValue(credentialsMap, EpdqCredentials.class);
-            case SMARTPAY:
-            case SANDBOX:
-            default:
-                return objectMapper.convertValue(credentialsMap, SandboxCredentials.class);
-        }
+        return switch (PaymentGatewayName.valueFrom(paymentProvider)) {
+            case WORLDPAY -> objectMapper.convertValue(credentialsMap, WorldpayCredentials.class);
+            case STRIPE -> objectMapper.convertValue(credentialsMap, StripeCredentials.class);
+            case ADYEN ->  objectMapper.convertValue(credentialsMap, AdyenCredentials.class);
+            case EPDQ -> objectMapper.convertValue(credentialsMap, EpdqCredentials.class);
+            default -> objectMapper.convertValue(credentialsMap, SandboxCredentials.class);
+        };
     }
 
     public GatewayAccountCredentialState getState() {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/AdyenCredentialsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/AdyenCredentialsFixture.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+public class AdyenCredentialsFixture {
+
+    private String legalEntityId = "legal-entity-id";
+    private String storeId = "store-id";
+
+    static AdyenCredentialsFixture anAdyenCredentials() {
+        return new AdyenCredentialsFixture();
+    }
+
+    public AdyenCredentials build() {
+        return new AdyenCredentials(legalEntityId, storeId);
+    }
+
+    public AdyenCredentialsFixture withLegalEntityId(String legalEntityId) {
+        this.legalEntityId = legalEntityId;
+        return this;
+    }
+
+    public AdyenCredentialsFixture withStoreId(String storeId) {
+        this.storeId = storeId;
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/AdyenCredentialsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/AdyenCredentialsTest.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AdyenCredentialsTest {
+
+    @Test
+    void should_have_credentials_if_legal_entity_ID_is_not_null() {
+        var adyenCredentialsWithCredentials = new AdyenCredentials("legal-entity-ID", null);
+
+        assertTrue(adyenCredentialsWithCredentials.hasCredentials());
+    }
+
+    @Test
+    void should_NOT_have_credentials_if_legal_entity_ID_is_null() {
+        var adyenCredentialsWithoutCredentials = new AdyenCredentials(null, null);
+
+        assertFalse(adyenCredentialsWithoutCredentials.hasCredentials());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/AdyenGatewayAccountRequestFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/AdyenGatewayAccountRequestFixture.java
@@ -1,0 +1,98 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+public class AdyenGatewayAccountRequestFixture {
+
+    private String providerAccountType;
+    private String paymentProvider;
+    private String serviceName;
+    private String serviceId;
+    private String description;
+    private String analyticsId;
+    private AdyenCredentials credentials;
+    private boolean requires3ds;
+    private boolean allowApplePay;
+    private boolean allowGooglePay;
+    private boolean sendPayerEmailToGateway;
+    private boolean sendPayerIPAddressToGateway;
+
+    static AdyenGatewayAccountRequestFixture anAdyenGatewayAccountRequest() {
+        return new AdyenGatewayAccountRequestFixture();
+    }
+
+    public AdyenGatewayAccountRequestFixture withProviderAccountType(String providerAccountType) {
+        this.providerAccountType = providerAccountType;
+        return this;
+    }
+
+    public AdyenGatewayAccountRequestFixture withPaymentProvider(String paymentProvider) {
+        this.paymentProvider = paymentProvider;
+        return this;
+    }
+
+    public AdyenGatewayAccountRequestFixture withServiceName(String serviceName) {
+        this.serviceName = serviceName;
+        return this;
+    }
+
+    public AdyenGatewayAccountRequestFixture withServiceId(String serviceId) {
+        this.serviceId = serviceId;
+        return this;
+    }
+
+    public AdyenGatewayAccountRequestFixture withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public AdyenGatewayAccountRequestFixture withAnalyticsId(String analyticsId) {
+        this.analyticsId = analyticsId;
+        return this;
+    }
+
+    public AdyenGatewayAccountRequestFixture withCredentials(AdyenCredentials credentials) {
+        this.credentials = credentials;
+        return this;
+    }
+
+    public AdyenGatewayAccountRequestFixture withRequires3ds(boolean requires3ds) {
+        this.requires3ds = requires3ds;
+        return this;
+    }
+
+    public AdyenGatewayAccountRequestFixture withAllowApplePay(boolean allowApplePay) {
+        this.allowApplePay = allowApplePay;
+        return this;
+    }
+
+    public AdyenGatewayAccountRequestFixture withAllowGooglePay(boolean allowGooglePay) {
+        this.allowGooglePay = allowGooglePay;
+        return this;
+    }
+
+    public AdyenGatewayAccountRequestFixture withSendPayerEmailToGateway(boolean sendPayerEmailToGateway) {
+        this.sendPayerEmailToGateway = sendPayerEmailToGateway;
+        return this;
+    }
+
+    AdyenGatewayAccountRequestFixture withSendPayerIPAddressToGateway(boolean sendPayerIPAddressToGateway) {
+        this.sendPayerIPAddressToGateway = sendPayerIPAddressToGateway;
+        return this;
+    }
+
+    public AdyenGatewayAccountRequest build() {
+        return new AdyenGatewayAccountRequest(
+                providerAccountType,
+                paymentProvider,
+                serviceName,
+                serviceId,
+                description,
+                analyticsId,
+                credentials,
+                requires3ds,
+                allowApplePay,
+                allowGooglePay,
+                sendPayerEmailToGateway,
+                sendPayerIPAddressToGateway
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/AdyenGatewayAccountRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/AdyenGatewayAccountRequestTest.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials.ADYEN_LEGAL_ENTITY_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials.ADYEN_STORE_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenCredentialsFixture.anAdyenCredentials;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenGatewayAccountRequestFixture.anAdyenGatewayAccountRequest;
+
+class AdyenGatewayAccountRequestTest {
+
+    @Test
+    void should_get_credentials_as_map() {
+        var request = anAdyenGatewayAccountRequest()
+                .withCredentials(
+                        anAdyenCredentials()
+                                .withLegalEntityId("LEM0000000000000001")
+                                .withStoreId("ST00000000000000000000001")
+                                .build())
+                .build();
+
+        assertThat(request.getCredentialsAsMap().get(ADYEN_LEGAL_ENTITY_ID), is("LEM0000000000000001"));
+        assertThat(request.getCredentialsAsMap().get(ADYEN_STORE_ID), is("ST00000000000000000000001"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonassert.JsonAssert;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.dropwizard.jackson.Jackson.newObjectMapper;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials.ADYEN_LEGAL_ENTITY_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials.ADYEN_STORE_ID;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
+
+class GatewayAccountCredentialsTest {
+
+    private static final ObjectMapper MAPPER = newObjectMapper();
+
+    @Test
+    void should_serialise_to_JSON_with_Adyen_credentials() throws JsonProcessingException {
+        var legalEntityId = "LEM0000000000000001";
+        var storeId = "ST00000000000000000000001";
+        var adyenGatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider("adyen")
+                .withGatewayAccountEntity(GatewayAccountEntityFixture.aGatewayAccountEntity().build())
+                .withCredentials(Map.of(
+                        ADYEN_LEGAL_ENTITY_ID, legalEntityId,
+                        ADYEN_STORE_ID, storeId
+                )).build();
+        var credentials = new GatewayAccountCredentials(adyenGatewayAccountCredentialsEntity);
+
+        var json = MAPPER.writeValueAsString(credentials);
+
+        JsonAssert.with(json)
+                .assertThat("$.credentials.legal_entity_id", is(legalEntityId))
+                .assertThat("$.credentials.store_id", is(storeId));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequestTest.java
@@ -1,0 +1,124 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static io.dropwizard.jackson.Jackson.newObjectMapper;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenCredentialsFixture.anAdyenCredentials;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenGatewayAccountRequestFixture.anAdyenGatewayAccountRequest;
+
+class GatewayAccountRequestTest {
+
+    private static final ObjectMapper MAPPER = newObjectMapper();
+
+    @Test
+    void should_deserialize_from_JSON() throws JsonProcessingException {
+        // language=JSON
+        String requestJson = """
+                {
+                  "provider_account_type": "test",
+                  "payment_provider": "payment-provider",
+                  "service_name": "service-name",
+                  "service_id": "service-id",
+                  "description": "description",
+                  "analytics_id": "analytics-id",
+                  "requires_3ds": true,
+                  "allow_apple_pay": true,
+                  "allow_google_pay": true,
+                  "send_payer_email_to_gateway": true,
+                  "send_payer_ip_address_to_gateway": true
+                }""";
+
+        var deserializedRequest = MAPPER.readValue(requestJson, GatewayAccountRequest.class);
+
+        var expectedRequest = new GatewayAccountRequest(
+                "test",
+                "payment-provider",
+                "service-name",
+                "service-id",
+                "description",
+                "analytics-id",
+                true,
+                true,
+                true,
+                true,
+                true
+        );
+
+        assertDeserializedRequest(deserializedRequest, expectedRequest);
+    }
+
+    @Test
+    void should_deserialize_from_JSON_with_Stripe_credentials() throws JsonProcessingException {
+        // language=JSON
+        String requestJson = """
+                {
+                  "payment_provider": "stripe",
+                  "credentials": {
+                    "stripe_account_id": "stripe-account-id"
+                  }
+                }""";
+
+        var deserializedRequest = MAPPER.readValue(requestJson, StripeGatewayAccountRequest.class);
+
+        var credentials = new StripeCredentials();
+        credentials.setStripeAccountId("stripe-account-id");
+        var expectedRequest = new StripeGatewayAccountRequest(
+                null,
+                "stripe",
+                null,
+                null,
+                null,
+                null,
+                credentials,
+                false,
+                false,
+                false,
+                false,
+                false
+        );
+        assertDeserializedRequest(deserializedRequest, expectedRequest);
+    }
+
+    @Test
+    void should_deserialize_from_JSON_with_Adyen_credentials() throws JsonProcessingException {
+        // language=JSON
+        String requestJson = """
+                {
+                  "payment_provider": "adyen",
+                  "credentials": {
+                    "legal_entity_id": "LEM0000000000000001",
+                    "store_id": "ST00000000000000000000001"
+                  }
+                }""";
+
+        var deserializedRequest = MAPPER.readValue(requestJson, AdyenGatewayAccountRequest.class);
+
+        var credentials = anAdyenCredentials()
+                .withLegalEntityId("LEM0000000000000001")
+                .withStoreId("ST00000000000000000000001")
+                .build();
+        var expectedRequest = anAdyenGatewayAccountRequest()
+                .withPaymentProvider("adyen")
+                .withCredentials(credentials)
+                .build();
+        assertDeserializedRequest(deserializedRequest, expectedRequest);
+    }
+
+    private static void assertDeserializedRequest(GatewayAccountRequest deserializedRequest, GatewayAccountRequest expectedRequest) {
+        assertThat(deserializedRequest.getProviderAccountType(), is(expectedRequest.getProviderAccountType()));
+        assertThat(deserializedRequest.getPaymentProvider(), is(expectedRequest.getPaymentProvider()));
+        assertThat(deserializedRequest.getServiceName(), is(expectedRequest.getServiceName()));
+        assertThat(deserializedRequest.getServiceId(), is(expectedRequest.getServiceId()));
+        assertThat(deserializedRequest.getDescription(), is(expectedRequest.getDescription()));
+        assertThat(deserializedRequest.getAnalyticsId(), is(expectedRequest.getAnalyticsId()));
+        assertThat(deserializedRequest.isRequires3ds(), is(expectedRequest.isRequires3ds()));
+        assertThat(deserializedRequest.isAllowApplePay(), is(expectedRequest.isAllowApplePay()));
+        assertThat(deserializedRequest.isAllowGooglePay(), is(expectedRequest.isAllowGooglePay()));
+        assertThat(deserializedRequest.isSendPayerEmailToGateway(), is(expectedRequest.isSendPayerEmailToGateway()));
+        assertThat(deserializedRequest.isSendPayerIpAddressToGateway(), is(expectedRequest.isSendPayerIpAddressToGateway()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
@@ -4,15 +4,20 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.common.validator.RequestValidator;
+import uk.gov.pay.connector.gatewayaccount.model.CreateGatewayAccountResponse;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.rules.ResourceTestRuleWithCustomExceptionMappersBuilder;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,17 +25,27 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class GatewayAccountResourceValidationTest {
 
-    private static ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    private static final GatewayAccountService gatewayAccountServiceStub = mock(GatewayAccountService.class);
     private static final ResourceExtension resources = ResourceTestRuleWithCustomExceptionMappersBuilder
             .getBuilder()
-            .addResource(new GatewayAccountResource(null,null,
-                    new GatewayAccountRequestValidator(new RequestValidator()), null,null))
+            .addResource(new GatewayAccountResource(gatewayAccountServiceStub, null,
+                    new GatewayAccountRequestValidator(new RequestValidator()), null, null))
             .build();
+
+    @BeforeAll
+    static void setUpGatewayAccountServiceStub() {
+        when(gatewayAccountServiceStub.createGatewayAccount(any(), any()))
+                .thenReturn(new CreateGatewayAccountResponse.GatewayAccountResponseBuilder().build());
+    }
 
     @Test
     void shouldReturn422_whenEverythingMissing() {
@@ -75,18 +90,35 @@ class GatewayAccountResourceValidationTest {
 
     @Test
     void shouldReturn422_whenPaymentProviderIsInvalid() {
+        var payload = Map.of(
+                "service_id", "a-valid-service-id",
+                "payment_provider", "blockchain");
 
-        Map<String, Object> payload = Map.of("service_id", "a-valid-service-id", "payment_provider", "blockchain");
-
-        Response response = resources.client()
+        var response = resources.client()
                 .target("/v1/api/accounts")
                 .request()
                 .post(Entity.json(payload));
 
         assertThat(response.getStatus(), is(422));
-
-        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
+        var errorMessage = response.readEntity(JsonNode.class)
+                .get("message")
+                .get(0)
+                .textValue();
         assertThat(errorMessage, is("Unsupported payment provider value."));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"sandbox", "smartpay", "worldpay", "epdq", "stripe", "adyen"})
+    void shouldReturn201_whenPaymentProviderIsValid(String paymentProvider) {
+        var payload = Map.of(
+                "service_id", "a-valid-service-id",
+                "payment_provider", paymentProvider);
+
+        var response = resources.target("/v1/api/accounts")
+                .request()
+                .post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(201));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityTest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gatewayaccountcredentials.model;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.EpdqCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.SandboxCredentials;
@@ -12,17 +13,22 @@ import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.isA;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials.ADYEN_LEGAL_ENTITY_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials.ADYEN_STORE_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.ONE_OFF_CUSTOMER_INITIATED;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeCredentials.STRIPE_ACCOUNT_ID_KEY;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
@@ -84,6 +90,39 @@ class GatewayAccountCredentialsEntityTest {
         StripeCredentials stripeCredentials = (StripeCredentials) credentials;
         assertThat(stripeCredentials.hasCredentials(), is(true));
         assertThat(stripeCredentials.getStripeAccountId(), is(stripeAccountId));
+    }
+
+    @Test
+    void getCredentialsObject_shouldReturnEmptyAdyenCredentials_whenCredentialsEmpty() {
+        var credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(ADYEN.getName())
+                .withCredentials(Map.of())
+                .build();
+
+        var credentials = credentialsEntity.getCredentialsObject();
+
+        assertThat(credentials, instanceOf(AdyenCredentials.class));
+        assertNull(((AdyenCredentials) credentials).legalEntityId());
+        assertNull(((AdyenCredentials) credentials).storeId());
+    }
+
+    @Test
+    void getCredentialsObject_shouldReturnPopulatedAdyenCredentials() {
+        var legalEntityId = "a-legal-entity-id";
+        var storeId = "a-store-id";
+        var credentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(ADYEN.getName())
+                .withCredentials(Map.of(
+                        ADYEN_LEGAL_ENTITY_ID, legalEntityId,
+                        ADYEN_STORE_ID, storeId)
+                ).build();
+
+        var credentials = credentialsEntity.getCredentialsObject();
+
+        assertThat(credentials, instanceOf(AdyenCredentials.class));
+        AdyenCredentials adyenCredentials = (AdyenCredentials) credentials;
+        assertThat(adyenCredentials.legalEntityId(), is(legalEntityId));
+        assertThat(adyenCredentials.storeId(), is(storeId));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
@@ -1,20 +1,16 @@
 package uk.gov.pay.connector.it.resources;
 
-import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.SandboxCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -26,7 +22,9 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_API_URL;
@@ -35,21 +33,23 @@ import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class GatewayAccountResourceCreateIT {
+
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+
     GatewayAccountDao gatewayAccountDao;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         gatewayAccountDao = app.getInstanceFromGuiceContainer(GatewayAccountDao.class);
     }
 
     @Nested
     class Degateway {
-        @Test
-        public void shouldNotAllowMultipleGatewayAccountsWhenQueryStringIsIncluded() {
 
-            Map<String, String> requestForAccountPayload = aCreateGatewayAccountPayloadBuilder()
+        @Test
+        void shouldNotAllowMultipleGatewayAccountsWhenQueryStringIsIncluded() {
+            var requestForAccountPayload = aCreateGatewayAccountPayloadBuilder()
                     .withProvider("worldpay")
                     .withServiceId("my-service-id")
                     .withDescription("my test service")
@@ -58,7 +58,7 @@ public class GatewayAccountResourceCreateIT {
                     .withSendPayerEmailToGateway(true)
                     .build();
 
-            Map<String, String> requestForSecondAccountPayload = aCreateGatewayAccountPayloadBuilder()
+            var requestForSecondAccountPayload = aCreateGatewayAccountPayloadBuilder()
                     .withProvider("worldpay")
                     .withServiceId("my-service-id")
                     .withDescription("my extra test service")
@@ -67,7 +67,7 @@ public class GatewayAccountResourceCreateIT {
                     .withSendPayerIpAddressToGateway(true)
                     .build();
 
-            ValidatableResponse response = app.givenSetup()
+            var response = app.givenSetup()
                     .body(requestForAccountPayload)
                     .post(ACCOUNTS_API_URL + "?degatewayification=true")
                     .then()
@@ -80,9 +80,16 @@ public class GatewayAccountResourceCreateIT {
                     .then()
                     .statusCode(409)
                     .contentType(JSON)
-                    .body("message", contains("Gateway account with service id my-service-id and account type 'test' already exists."));
+                    .body("message",
+                            contains("Gateway account with service id my-service-id and account type 'test' already exists."));
 
-            assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, true, true);
+            assertCorrectCreateResponse(response,
+                    TEST,
+                    "my test service",
+                    "analytics",
+                    null,
+                    true,
+                    true);
         }
     }
 
@@ -90,9 +97,8 @@ public class GatewayAccountResourceCreateIT {
     class PreDegateway {
 
         @Test
-        public void shouldAllowMultipleGatewayAccounts() {
-
-            Map<String, String> requestForAccountPayload = aCreateGatewayAccountPayloadBuilder()
+        void shouldAllowMultipleGatewayAccounts() {
+            var requestForAccountPayload = aCreateGatewayAccountPayloadBuilder()
                     .withProvider("worldpay")
                     .withServiceId("my-service-id")
                     .withDescription("my test service")
@@ -101,7 +107,7 @@ public class GatewayAccountResourceCreateIT {
                     .withSendPayerIpAddressToGateway(true)
                     .build();
 
-            Map<String, String> requestForSecondAccountPayload = aCreateGatewayAccountPayloadBuilder()
+            var requestForSecondAccountPayload = aCreateGatewayAccountPayloadBuilder()
                     .withProvider("worldpay")
                     .withServiceId("my-service-id")
                     .withDescription("my extra test service")
@@ -126,60 +132,148 @@ public class GatewayAccountResourceCreateIT {
         }
 
         @Test
-        public void createASandboxGatewayAccount() {
-            Map<String, Object> payload = Map.of("payment_provider", "sandbox", "service_id", "a-valid-service-id", "description", "my test service",
-                    "analytics_id", "analytics", "send_payer_email_to_gateway", true, "send_payer_ip_address_to_gateway", true);
-            ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
-            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, true, true);
+        void createASandboxGatewayAccount() {
+            var payload = Map.of("payment_provider", "sandbox",
+                    "service_id", "a-valid-service-id",
+                    "description", "my test service",
+                    "analytics_id", "analytics",
+                    "send_payer_email_to_gateway", true,
+                    "send_payer_ip_address_to_gateway", true);
+            var response = app.givenSetup()
+                    .body(payload)
+                    .post(ACCOUNTS_API_URL)
+                    .then()
+                    .statusCode(201)
+                    .contentType(JSON);
+
+            assertCorrectCreateResponse(response,
+                    TEST,
+                    "my test service",
+                    "analytics",
+                    null,
+                    true,
+                    true);
         }
 
         @Test
-        public void createAWorldpaySandboxGatewayAccount() {
-            Map<String, Object> payload = Map.of("payment_provider", "worldpay", "service_id", "a-valid-service-id", "description", "my test service",
-                    "analytics_id", "analytics", "send_payer_email_to_gateway", true, "send_payer_ip_address_to_gateway", true);
-            ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
-            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, true, true);
+        void createAWorldpaySandboxGatewayAccount() {
+            var payload = Map.of("payment_provider", "worldpay",
+                    "service_id", "a-valid-service-id",
+                    "description", "my test service",
+                    "analytics_id", "analytics",
+                    "send_payer_email_to_gateway", true,
+                    "send_payer_ip_address_to_gateway", true);
+            var response = app.givenSetup()
+                    .body(payload)
+                    .post(ACCOUNTS_API_URL)
+                    .then()
+                    .statusCode(201)
+                    .contentType(JSON);
+
+            assertCorrectCreateResponse(response,
+                    TEST,
+                    "my test service",
+                    "analytics",
+                    null,
+                    true,
+                    true);
         }
 
         @Test
-        public void createAWorldpayStripeGatewayAccount() {
-            Map<String, Object> payload = Map.of("payment_provider", "stripe", "service_id", "a-valid-service-id", "description", "my test service",
-                    "analytics_id", "analytics", "send_payer_email_to_gateway", false, "send_payer_ip_address_to_gateway", false);
-            ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON);
-            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, TEST, "my test service", "analytics", null, false, false);
-        }
-
-        @Test
-        public void shouldCreateAccountWithServiceIdAndDefaultsForOtherProperties() {
-            Map<String, Object> payload = Map.of("service_id", "some-special-service-id");
-            ValidatableResponse response = app.givenSetup().body(toJson(payload)).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON).body("gateway_account_id", not(emptyString())).body("type", is("test")).body("requires_3ds", is(false));
-
-            app.givenSetup().get(response.extract().header("Location").replace("https", "http")) //Scheme on links back are forced to be https
-                    .then().statusCode(200).contentType(JSON).body("payment_provider", is("sandbox")).body("gateway_account_id", is(notNullValue())).body("type", is("test")).body("requires3ds", is(false)).body("allow_apple_pay", is(true)).body("allow_google_pay", is(false)).body("corporate_credit_card_surcharge_amount", is(0)).body("corporate_debit_card_surcharge_amount", is(0)).body("corporate_prepaid_debit_card_surcharge_amount", is(0));
-        }
-
-        @Test
-        public void shouldCreateAccountWithAllConfigurationOptions() {
-            Map<String, Object> payload = Map.of("service_id", "some-special-service-id", "service_name", "a-service-name", "type", "live", "payment_provider", "stripe", "description", "a-description", "analytics_id", "an-analytics-id", "requires_3ds", true, "allow_apple_pay", true, "allow_google_pay", true);
-            ValidatableResponse response = app.givenSetup().body(toJson(payload)).post(ACCOUNTS_API_URL).then().statusCode(201).contentType(JSON).body("gateway_account_id", not(emptyString())).body("service_name", is("a-service-name")).body("type", is("live")).body("requires_3ds", is(true)).body("analytics_id", is("an-analytics-id")).body("description", is("a-description"));
-
-            app.givenSetup().get(response.extract().header("Location").replace("https", "http")) //Scheme on links back are forced to be https
-                    .then().statusCode(200).contentType(JSON).body("payment_provider", is("stripe")).body("gateway_account_id", is(notNullValue())).body("service_name", is("a-service-name")).body("service_id", is("some-special-service-id")).body("type", is("live")).body("analytics_id", is("an-analytics-id")).body("description", is("a-description")).body("requires3ds", is(true)).body("allow_apple_pay", is(true)).body("allow_google_pay", is(true));
-        }
-
-        @Test
-        public void createStripeGatewayAccountWithoutCredentials() {
-            Map<String, Object> payload = Map.of(
-                    "type", "test",
-                    "payment_provider", "stripe",
-                    "service_name", "My shiny new stripe service",
-                    "service_id", "a-valid-service-id");
-            app.givenSetup()
+        void shouldCreateAccountWithServiceIdAndDefaultsForOtherProperties() {
+            var payload = Map.of("service_id", "some-special-service-id");
+            var response = app.givenSetup()
                     .body(toJson(payload))
                     .post(ACCOUNTS_API_URL)
                     .then()
                     .statusCode(201)
                     .contentType(JSON)
+                    .body("gateway_account_id", not(emptyString()))
+                    .body("type", is("test"))
+                    .body("requires_3ds", is(false));
+
+            app.givenSetup()
+                    .get(response.extract()
+                            .header("Location")
+                            .replace("https", "http")) //Scheme on links back are forced to be https
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("payment_provider", is("sandbox"))
+                    .body("gateway_account_id", is(notNullValue()))
+                    .body("type", is("test"))
+                    .body("requires3ds", is(false))
+                    .body("allow_apple_pay", is(true))
+                    .body("allow_google_pay", is(false))
+                    .body("corporate_credit_card_surcharge_amount", is(0))
+                    .body("corporate_debit_card_surcharge_amount", is(0))
+                    .body("corporate_prepaid_debit_card_surcharge_amount", is(0));
+        }
+
+        @Test
+        void shouldCreateAccountWithAllConfigurationOptions() {
+            var payload = Map.of("service_id", "some-special-service-id",
+                    "service_name", "a-service-name",
+                    "type", "live",
+                    "payment_provider", "stripe",
+                    "description", "a-description",
+                    "analytics_id", "an-analytics-id",
+                    "requires_3ds", true,
+                    "allow_apple_pay", true,
+                    "allow_google_pay", true);
+            var response = app.givenSetup()
+                    .body(toJson(payload))
+                    .post(ACCOUNTS_API_URL)
+                    .then()
+                    .statusCode(201)
+                    .contentType(JSON)
+                    .body("gateway_account_id", not(emptyString()))
+                    .body("service_name", is("a-service-name"))
+                    .body("type", is("live"))
+                    .body("requires_3ds", is(true))
+                    .body("analytics_id", is("an-analytics-id"))
+                    .body("description", is("a-description"));
+
+            app.givenSetup()
+                    .get(response.extract()
+                            .header("Location")
+                            .replace("https", "http")) //Scheme on links back are forced to be https
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("payment_provider", is("stripe"))
+                    .body("gateway_account_id", is(notNullValue()))
+                    .body("service_name", is("a-service-name"))
+                    .body("service_id", is("some-special-service-id"))
+                    .body("type", is("live"))
+                    .body("analytics_id", is("an-analytics-id"))
+                    .body("description", is("a-description"))
+                    .body("requires3ds", is(true))
+                    .body("allow_apple_pay", is(true))
+                    .body("allow_google_pay", is(true));
+        }
+
+        @Test
+        void createStripeGatewayAccountWithoutCredentials() {
+            var payload = Map.of(
+                    "type", "test",
+                    "payment_provider", "stripe",
+                    "service_name", "My shiny new stripe service",
+                    "service_id", "a-valid-service-id",
+                    "description", "my test service",
+                    "analytics_id", "analytics",
+                    "send_payer_email_to_gateway", false,
+                    "send_payer_ip_address_to_gateway", false);
+            app.givenSetup()
+                    .body(payload)
+                    .post(ACCOUNTS_API_URL)
+                    .then()
+                    .statusCode(201)
+                    .contentType(JSON)
+                    .body("description", is("my test service"))
+                    .body("analytics_id", is("analytics"))
+                    .body("send_payer_email_to_gateway", is(false))
+                    .body("send_payer_ip_address_to_gateway", is(false))
                     .body("gateway_account_id", not(emptyString()))
                     .body("service_name", is("My shiny new stripe service"))
                     .body("type", is("test"))
@@ -190,15 +284,15 @@ public class GatewayAccountResourceCreateIT {
         }
 
         @Test
-        public void createStripeGatewayAccountWithCredentials() {
-            String stripeAccountId = "abc";
-            Map<String, Object> payload = Map.of(
+        void createStripeGatewayAccountWithCredentials() {
+            var stripeAccountId = "abc";
+            var payload = Map.of(
                     "type", "test",
                     "payment_provider", "stripe",
                     "service_name", "My shiny new stripe service",
                     "service_id", "a-valid-service-id",
                     "credentials", Map.of("stripe_account_id", stripeAccountId));
-            String gatewayAccountId = app.givenSetup()
+            var gatewayAccountId = app.givenSetup()
                     .body(toJson(payload))
                     .post(ACCOUNTS_API_URL)
                     .then()
@@ -215,12 +309,12 @@ public class GatewayAccountResourceCreateIT {
                     .body()
                     .jsonPath()
                     .getString("gateway_account_id");
-            Optional<GatewayAccountEntity> gatewayAccount = gatewayAccountDao.findById(Long.valueOf(gatewayAccountId));
+            var gatewayAccount = gatewayAccountDao.findById(Long.valueOf(gatewayAccountId));
             assertThat(gatewayAccount.isPresent(), is(true));
 
-            List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsList = gatewayAccount.get().getGatewayAccountCredentials();
+            var gatewayAccountCredentialsList = gatewayAccount.get().getGatewayAccountCredentials();
             assertThat(gatewayAccountCredentialsList.size(), is(1));
-            GatewayCredentials credentialsObject = gatewayAccountCredentialsList.getFirst().getCredentialsObject();
+            var credentialsObject = gatewayAccountCredentialsList.getFirst().getCredentialsObject();
             assertThat(credentialsObject, isA(StripeCredentials.class));
             assertThat(((StripeCredentials) credentialsObject).getStripeAccountId(), is(stripeAccountId));
             assertThat(gatewayAccountCredentialsList.getFirst().getState(), is(ACTIVE));
@@ -229,17 +323,125 @@ public class GatewayAccountResourceCreateIT {
         }
 
         @Test
-        public void createGatewayAccountWithoutPaymentProviderDefaultsToSandbox() {
-            String payload = toJson(Map.of("name", "test account", "type", "test", "service_id", "a-valid-service-id",
-                    "send_payer_email_to_gateway", true, "send_payer_ip_address_to_gateway", true));
+        void should_create_Adyen_gateway_account_without_credentials() {
+            // language=JSON
+            var requestBodyWithoutCredentials = """
+                    {
+                      "payment_provider": "adyen",
+                      "type": "test",
+                      "service_name": "new service",
+                      "service_id": "service-external-id"
+                    }""";
 
-            ValidatableResponse response = app.givenSetup().body(payload).post(ACCOUNTS_API_URL).then().statusCode(201);
+            var accountId = app.givenSetup()
+                    .body(requestBodyWithoutCredentials)
+                    .post(ACCOUNTS_API_URL)
+                    .then()
+                    .statusCode(201)
+                    .body("gateway_account_id", not(emptyString()))
+                    .body("external_id", not(emptyString()))
+                    .body("type", is("test"))
+                    .body("service_name", is("new service"))
+                    .body("description", nullValue())
+                    .body("analytics_id", nullValue())
+                    .body("links[0].method", is("GET"))
+                    .body("links[0].href", matchesPattern("https://localhost:[0-9]*/v1/api/accounts/[0-9]*"))
+                    .body("links[0].rel", is("self"))
+                    .body("requires_3ds", is(false))
+                    .body("send_payer_email_to_gateway", is(false))
+                    .body("send_payer_ip_address_to_gateway", is(false))
+                    .extract()
+                    .body()
+                    .jsonPath()
+                    .getString("gateway_account_id");
 
-            assertCorrectCreateResponse(response, TEST);
+            var gatewayAccount = gatewayAccountDao.findById(Long.valueOf(accountId));
+            assertTrue(gatewayAccount.isPresent());
+
+            Optional<GatewayAccountCredentialsEntity> gatewayAccountCredentials = 
+                    gatewayAccount.get().getGatewayAccountCredentials().stream().findFirst();
+            assertTrue(gatewayAccountCredentials.isPresent());
+            assertThat(gatewayAccountCredentials.get().getPaymentProvider(), is("adyen"));
+        }
+
+        @Test
+        void should_create_Adyen_gateway_account_with_credentials() {
+            // language=JSON
+            var requestBodyWithoutCredentials = """
+                    {
+                       "payment_provider": "adyen",
+                       "type": "test",
+                       "service_name": "My new service",
+                       "service_id": "service-ext-id-2",
+                       "credentials": {
+                         "legal_entity_id": "LEM0000000000000001",
+                         "store_id": "ST00000000000000000000001"
+                       }
+                     }""";
+
+            var accountId = app.givenSetup()
+                    .body(requestBodyWithoutCredentials)
+                    .post(ACCOUNTS_API_URL)
+                    .then()
+                    .statusCode(201)
+                    .body("gateway_account_id", not(emptyString()))
+                    .body("external_id", not(emptyString()))
+                    .body("type", is("test"))
+                    .body("service_name", is("My new service"))
+                    .body("description", nullValue())
+                    .body("analytics_id", nullValue())
+                    .body("links[0].method", is("GET"))
+                    .body("links[0].href", matchesPattern("https://localhost:[0-9]*/v1/api/accounts/[0-9]*"))
+                    .body("links[0].rel", is("self"))
+                    .body("requires_3ds", is(false))
+                    .body("send_payer_email_to_gateway", is(false))
+                    .body("send_payer_ip_address_to_gateway", is(false))
+                    .extract()
+                    .body()
+                    .jsonPath()
+                    .getString("gateway_account_id");
+
+            var gatewayAccount = gatewayAccountDao.findById(Long.valueOf(accountId));
+
+            assertTrue(gatewayAccount.isPresent());
+
+            Optional<GatewayAccountCredentialsEntity> gatewayAccountCredentials =
+                    gatewayAccount.get().getGatewayAccountCredentials().stream().findFirst();
+            assertTrue(gatewayAccountCredentials.isPresent());
+            assertThat(gatewayAccountCredentials.get().getPaymentProvider(), is("adyen"));
+
+            AdyenCredentials credentialsObject = (AdyenCredentials) gatewayAccountCredentials.get().getCredentialsObject();
+            assertThat(credentialsObject.legalEntityId(), is("LEM0000000000000001"));
+            assertThat(credentialsObject.storeId(), is("ST00000000000000000000001"));
+        }
+
+        @Test
+        void createGatewayAccountWithoutPaymentProviderDefaultsToSandbox() {
+            var payload = toJson(Map.of("name", "test account",
+                    "type", "test",
+                    "service_id", "a-valid-service-id",
+                    "send_payer_email_to_gateway", true,
+                    "send_payer_ip_address_to_gateway", true));
+
+            var response = app.givenSetup()
+                    .body(payload)
+                    .post(ACCOUNTS_API_URL)
+                    .then()
+                    .statusCode(201);
+
+            assertCorrectCreateResponse(response,
+                    TEST,
+                    null,
+                    null,
+                    null,
+                    true,
+                    true);
 
             app.givenSetup()
                     .contentType(JSON)
-                    .get(response.extract().header("Location").replace("https", "http")) //Scheme on links back are forced to be https
+                    .get(response.extract()
+                            .header("Location")
+                            .replace("https", "http")) //Scheme on links back are forced to be https
                     .then()
                     .statusCode(200)
                     .contentType(JSON)
@@ -247,24 +449,18 @@ public class GatewayAccountResourceCreateIT {
                     .body("gateway_account_id", is(notNullValue()))
                     .body("type", is("test"));
 
-            String gatewayAccountId = response.extract().body().jsonPath().getString("gateway_account_id");
-            Optional<GatewayAccountEntity> gatewayAccount = gatewayAccountDao.findById(Long.valueOf(gatewayAccountId));
+            var gatewayAccountId = response.extract().body().jsonPath().getString("gateway_account_id");
+            var gatewayAccount = gatewayAccountDao.findById(Long.valueOf(gatewayAccountId));
             assertThat(gatewayAccount.isPresent(), is(true));
 
-            List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsList = gatewayAccount.get().getGatewayAccountCredentials();
+            var gatewayAccountCredentialsList = gatewayAccount.get().getGatewayAccountCredentials();
             assertThat(gatewayAccountCredentialsList.size(), is(1));
             assertThat(gatewayAccountCredentialsList.getFirst().getState(), is(ACTIVE));
             assertThat(gatewayAccountCredentialsList.getFirst().getPaymentProvider(), is("sandbox"));
 
-            GatewayCredentials credentialsObj = gatewayAccountCredentialsList.getFirst().getCredentialsObject();
+            var credentialsObj = gatewayAccountCredentialsList.getFirst().getCredentialsObject();
             assertThat(credentialsObj, isA(SandboxCredentials.class));
-            //hasCredentials in SandboxCredentials.class is hardcoded to true
             assertThat(credentialsObj.hasCredentials(), is(true));
         }
-
-        private void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountType type) {
-            GatewayAccountResourceITHelpers.assertCorrectCreateResponse(response, type, null, null, null, true, true);
-        }
     }
-
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -28,9 +28,12 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials.ADYEN_LEGAL_ENTITY_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials.ADYEN_STORE_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
@@ -44,6 +47,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.RECURRING
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.resource.GatewayAccountCredentialsRequestValidator.FIELD_GATEWAY_MERCHANT_ID;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_API_SERVICE_ID_URL;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.ACCOUNTS_API_URL;
@@ -52,8 +56,8 @@ import static uk.gov.pay.connector.it.resources.GatewayAccountResourceITHelpers.
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
-import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRandomInt;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRandomInt;
 
 public class GatewayAccountResourceIT {
     @RegisterExtension
@@ -477,7 +481,7 @@ public class GatewayAccountResourceIT {
         }
 
         @Test
-        void shouldReturnAccountInformationForGetAccountById_withWorldpayCredentials() {
+        void shouldReturnAccountInformation_withWorldpayCredentials() {
             long accountId = secureRandomInt();
             AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider(WORLDPAY.getName())
@@ -581,7 +585,7 @@ public class GatewayAccountResourceIT {
         }
 
         @Test
-        void shouldReturnAccountInformationForGetAccountById_withStripeCredentials() {
+        void shouldReturnAccountInformation_withStripeCredentials() {
             long accountId = secureRandomInt();
             AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider(STRIPE.getName())
@@ -613,7 +617,43 @@ public class GatewayAccountResourceIT {
         }
 
         @Test
-        void shouldReturnAccountInformationForGetAccountById_withEpdqCredentials() {
+        void shouldReturnAccountInformation_withAdyenCredentials() {
+            var accountId = secureRandomInt();
+            var gatewayAccountCredentialsExternalId = String.valueOf(secureRandomInt());
+            var storeId = "ST00000000000000000000001";
+            var legalEntityId = "LEM0000000000000001";
+            var params = anAddGatewayAccountCredentialsParams()
+                    .withExternalId(gatewayAccountCredentialsExternalId)
+                    .withPaymentProvider(ADYEN.getName())
+                    .withGatewayAccountId(accountId)
+                    .withState(CREATED)
+                    .withCredentials(Map.of(
+                            ADYEN_STORE_ID, storeId,
+                            ADYEN_LEGAL_ENTITY_ID, legalEntityId
+                    )).build();
+            DatabaseFixtures.withDatabaseTestHelper(app.getDatabaseTestHelper())
+                    .aTestAccount()
+                    .withAccountId(accountId)
+                    .withPaymentProvider(ADYEN.getName())
+                    .withGatewayAccountCredentials(List.of(params))
+                    .insert();
+
+            app.givenSetup()
+                    .get(ACCOUNTS_API_URL + accountId)
+                    .then()
+                    .statusCode(200)
+                    .body("gateway_account_credentials.size()", is(1))
+                    .body("gateway_account_credentials[0].external_id", is(gatewayAccountCredentialsExternalId))
+                    .body("gateway_account_credentials[0].payment_provider", is("adyen"))
+                    .body("gateway_account_credentials[0].credentials",
+                            hasEntry(ADYEN_STORE_ID, storeId))
+                    .body("gateway_account_credentials[0].credentials",
+                            hasEntry(ADYEN_LEGAL_ENTITY_ID, legalEntityId))
+                    .body("gateway_account_credentials[0].state", is("CREATED"));
+        }
+
+        @Test
+        void shouldReturnAccountInformation_withEpdqCredentials() {
             long accountId = secureRandomInt();
             AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                     .withPaymentProvider(EPDQ.getName())
@@ -705,7 +745,7 @@ public class GatewayAccountResourceIT {
     }
 
     @Test
-    public void shouldReturnAccountInformationWhenSearchingByWorldpayMerchantCodeInOneOffPaymentCredentials() {
+    void shouldReturnAccountInformationWhenSearchingByWorldpayMerchantCodeInOneOffPaymentCredentials() {
         long accountId = secureRandomInt();
         AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                 .withPaymentProvider(WORLDPAY.getName())
@@ -738,7 +778,7 @@ public class GatewayAccountResourceIT {
     }
 
     @Test
-    public void shouldReturnAccountInformationWhenSearchingByWorldpayMerchantCodeInRecurringCustomerInitiatedCredentials() {
+    void shouldReturnAccountInformationWhenSearchingByWorldpayMerchantCodeInRecurringCustomerInitiatedCredentials() {
         long accountId = secureRandomInt();
         AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
                 .withPaymentProvider(WORLDPAY.getName())
@@ -771,7 +811,7 @@ public class GatewayAccountResourceIT {
     }
 
     @Test
-    public void shouldSetApplePayEnabledByDefaultForSandboxAccount() {
+    void shouldSetApplePayEnabledByDefaultForSandboxAccount() {
         String gatewayAccountId1 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withProvider("sandbox").build());
         String gatewayAccountId2 = testHelpers.createGatewayAccount(aCreateGatewayAccountPayloadBuilder().withProvider("worldpay").build());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTest.java
@@ -2,62 +2,100 @@ package uk.gov.pay.connector.it.resources;
 
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
+import jakarta.ws.rs.client.Entity;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.common.exception.ConstraintViolationExceptionMapper;
 import uk.gov.pay.connector.common.exception.ValidationExceptionMapper;
-import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.pay.connector.gatewayaccount.model.CreateGatewayAccountResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountRequest;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountResource;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
-import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
-import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountSwitchPaymentProviderService;
-
-import jakarta.ws.rs.core.GenericType;
-import jakarta.ws.rs.core.Response;
-import java.util.HashMap;
-import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
+@ExtendWith(MockitoExtension.class)
 class GatewayAccountResourceTest {
 
     private static final GatewayAccountService gatewayAccountService = mock(GatewayAccountService.class);
-    private static final CardTypeDao cardTypeDao = mock(CardTypeDao.class);
-    private static final GatewayAccountRequestValidator gatewayAccountRequestValidator = mock(GatewayAccountRequestValidator.class);
-    private static final GatewayAccountServicesFactory gatewayAccountServicesFactory = mock(GatewayAccountServicesFactory.class);
-    private static final GatewayAccountSwitchPaymentProviderService gatewayAccountSwitchPaymentProviderService = mock(GatewayAccountSwitchPaymentProviderService.class);
 
-    public static ResourceExtension resources = ResourceExtension.builder()
+    private static final ResourceExtension resources = ResourceExtension.builder()
             .addResource(new GatewayAccountResource(
                     gatewayAccountService,
-                    cardTypeDao,
-                    gatewayAccountRequestValidator,
-                    gatewayAccountServicesFactory,
-                    gatewayAccountSwitchPaymentProviderService
+                    null,
+                    null,
+                    null,
+                    null
             ))
             .setRegisterDefaultExceptionMappers(false)
             .addProvider(ConstraintViolationExceptionMapper.class)
             .addProvider(ValidationExceptionMapper.class)
             .build();
 
+    @Captor
+    ArgumentCaptor<GatewayAccountRequest> gatewayAccountRequestCaptor;
+
     @Test
     void searchGatewayAccount_invalidAccountIdsList_shouldReturn422() {
-        Response response = resources.target("/v1/api/accounts")
-                .queryParam("accountIds", "123,abc")
+        var invalidAccountIdsList = "123,abc";
+
+        var response = resources.target("/v1/api/accounts")
+                .queryParam("accountIds", invalidAccountIdsList)
                 .request()
                 .get();
 
         assertThat(response.getStatus(), is(422));
-        assertThat(extractErrorMessagesFromResponse(response).getFirst(), is("Parameter [accountIds] must be a comma separated list of numbers"));
+
+        assertTrue(response.readEntity(ErrorResponse.class).messages()
+                .contains("Parameter [accountIds] must be a comma separated list of numbers"));
     }
 
-    private List extractErrorMessagesFromResponse(Response response) {
-        var responseBody = response.readEntity(new GenericType<HashMap>() {
-        });
-        return (List) responseBody.get("message");
+    @Test
+    void should_create_gateway_account_on_create_gateway_account_request() {
+        given(gatewayAccountService.createGatewayAccount(any(), any()))
+                .willReturn(new CreateGatewayAccountResponse.GatewayAccountResponseBuilder().build());
+
+        resources.target("/v1/api/accounts")
+                .request()
+                .post(Entity.json("""
+                        {
+                          "payment_provider": "stripe",
+                          "type": "test",
+                          "service_name": "new service",
+                          "service_id": "service-external-id",
+                          "analytics_id": "analytics-id",
+                          "requires_3ds": true,
+                          "allow_apple_pay": true,
+                          "allow_google_pay": true,
+                          "send_payer_email_to_gateway": true,
+                          "send_payer_ip_address_to_gateway": true
+                        }
+                        """));
+
+        then(gatewayAccountService).should()
+                .createGatewayAccount(gatewayAccountRequestCaptor.capture(), any());
+        GatewayAccountRequest gatewayAccountRequest = gatewayAccountRequestCaptor.getValue();
+
+        assertThat(gatewayAccountRequest.getPaymentProvider(), is("stripe"));
+        assertThat(gatewayAccountRequest.getProviderAccountType(), is("test"));
+        assertThat(gatewayAccountRequest.getServiceName(), is("new service"));
+        assertThat(gatewayAccountRequest.getServiceId(), is("service-external-id"));
+        assertThat(gatewayAccountRequest.getAnalyticsId(), is("analytics-id"));
+        assertTrue(gatewayAccountRequest.isRequires3ds());
+        assertTrue(gatewayAccountRequest.isAllowApplePay());
+        assertTrue(gatewayAccountRequest.isAllowGooglePay());
+        assertTrue(gatewayAccountRequest.isSendPayerEmailToGateway());
+        assertTrue(gatewayAccountRequest.isSendPayerIpAddressToGateway());
     }
 }


### PR DESCRIPTION
## WHAT YOU DID

- Enables creating Adyen gateway accounts in Connector.
- Accepts `legal_entity_id` (Organisation ID) and `store_id` (to use to associate service to payments) as part of credentials. These are not mandatory
