### PR TITLE
PP-15355 Validate adyen notification domain

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,70 +125,70 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "48ca4a65970b54002939b02e8d8c1b0167de7e4b",
         "is_verified": false,
-        "line_number": 1294
+        "line_number": 1296
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "7aaebcf1d5950305be73fbdda70fa0c55c6c8542",
         "is_verified": false,
-        "line_number": 1950
+        "line_number": 1952
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "313fa62b7b90790ca0e8c4b9752a0e3cf5d40421",
         "is_verified": false,
-        "line_number": 3466
+        "line_number": 3468
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 3510
+        "line_number": 3512
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 3995
+        "line_number": 3997
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4423
+        "line_number": 4425
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4459
+        "line_number": 4461
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 5391
+        "line_number": 5393
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5891
+        "line_number": 5893
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5902
+        "line_number": 5904
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1095,5 +1095,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-01T10:25:21Z"
+  "generated_at": "2026-05-05T12:03:14Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -1149,6 +1149,8 @@ paths:
       responses:
         "200":
           description: OK
+        "403":
+          description: Forbidden - notification rejected
         "405":
           description: Method Not Allowed - Unsupported HTTP method
         "415":

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.charge.service.Worldpay3dsFlexJwtService;
 import uk.gov.pay.connector.charge.util.JwtGenerator;
 import uk.gov.pay.connector.common.validator.RequestValidator;
@@ -130,6 +131,11 @@ public class ConnectorModule extends AbstractModule {
     @Provides
     public StripeGatewayConfig stripeGatewayConfig(ConnectorConfiguration connectorConfiguration) {
         return connectorConfiguration.getStripeConfig();
+    }
+
+    @Provides
+    public AdyenGatewayConfig adyenGatewayConfig(ConnectorConfiguration connectorConfiguration) {
+        return connectorConfiguration.getAdyenGatewayConfig();
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/connector/app/adyen/AdyenGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/adyen/AdyenGatewayConfig.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.app.adyen;
 
 import io.dropwizard.core.Configuration;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import uk.gov.pay.connector.app.JerseyClientOverrides;
 
@@ -17,7 +17,7 @@ public class AdyenGatewayConfig extends Configuration {
     @Valid
     @NotNull
     private AdyenIds merchantAccountIds;
-    
+
     @Valid
     @NotNull
     private AdyenIds balancePlatformIds;
@@ -26,7 +26,7 @@ public class AdyenGatewayConfig extends Configuration {
     @NotNull
     private ApiKeys apiKeys;
 
-    @NotEmpty
+    @NotBlank
     private String notificationDomain;
 
     @Valid

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.gateway.adyen.webhook;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.util.IpDomainMatcher;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER;
+
+public class AdyenNotificationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdyenNotificationService.class);
+
+    private final AdyenGatewayConfig adyenGatewayConfig;
+    private final IpDomainMatcher ipDomainMatcher;
+    
+    @Inject
+    public AdyenNotificationService(AdyenGatewayConfig adyenGatewayConfig, IpDomainMatcher ipDomainMatcher) {
+        this.adyenGatewayConfig = adyenGatewayConfig;
+        this.ipDomainMatcher = ipDomainMatcher;
+    }
+
+    public boolean handleNotificationFor(String payload, String forwardedIpAddresses) {
+        if (isBlank(forwardedIpAddresses)) {
+            LOGGER.info("Adyen notification missing X-Forwarded-For header",
+                    kv(PROVIDER, PaymentGatewayName.ADYEN.getName()));
+            return false;
+        }
+
+        String notificationDomain = adyenGatewayConfig.getNotificationDomain();
+
+        if (!ipDomainMatcher.ipMatchesDomain(forwardedIpAddresses, notificationDomain)) {
+            LOGGER.info("Adyen notification from ip '{}' not matching configured domain '{}'",
+                    forwardedIpAddresses,
+                    notificationDomain,
+                    kv(PROVIDER, PaymentGatewayName.ADYEN.getName()),
+                    kv("notification_source", forwardedIpAddresses));
+            return false;
+        }
+
+        LOGGER.info("Processed adyen notification",
+                kv(PROVIDER, PaymentGatewayName.ADYEN.getName()),
+                kv("notification_source", forwardedIpAddresses),
+                kv("payload_length", payload == null ? 0 : payload.length()));
+
+        return true;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/webhook/resource/NotificationResource.java
+++ b/src/main/java/uk/gov/pay/connector/webhook/resource/NotificationResource.java
@@ -4,13 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.sandbox.SandboxNotificationService;
-import uk.gov.pay.connector.gateway.stripe.StripeNotificationService;
-import uk.gov.pay.connector.gateway.worldpay.WorldpayNotificationService;
-
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
@@ -18,6 +11,13 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
+import uk.gov.pay.connector.gateway.sandbox.SandboxNotificationService;
+import uk.gov.pay.connector.gateway.stripe.StripeNotificationService;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayNotificationService;
 
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -39,14 +39,18 @@ public class NotificationResource {
     private final WorldpayNotificationService worldpayNotificationService;
     private final SandboxNotificationService sandboxNotificationService;
     private final StripeNotificationService stripeNotificationService;
+    private final AdyenNotificationService adyenNotificationService;
 
     @Inject
     public NotificationResource(WorldpayNotificationService worldpayNotificationService,
                                 SandboxNotificationService sandboxNotificationService,
-                                StripeNotificationService stripeNotificationService) {
+                                StripeNotificationService stripeNotificationService,
+                                AdyenNotificationService adyenNotificationService
+    ) {
         this.worldpayNotificationService = worldpayNotificationService;
         this.sandboxNotificationService = sandboxNotificationService;
         this.stripeNotificationService = stripeNotificationService;
+        this.adyenNotificationService = adyenNotificationService;
     }
 
     @POST
@@ -138,6 +142,7 @@ public class NotificationResource {
             description = "Accepts Adyen payment webhooks as JSON and preserves the raw request body for signature verification.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "403", description = "Forbidden - notification rejected"),
                     @ApiResponse(responseCode = "405", description = "Method Not Allowed - Unsupported HTTP method"),
                     @ApiResponse(responseCode = "415", description = "Unsupported Media Type - Unsupported content type")
             }
@@ -145,7 +150,10 @@ public class NotificationResource {
     public Response authoriseAdyenPaymentsNotifications(String notification,
                                                         @Parameter(in = HEADER, example = "5.6.7.8")
                                                         @HeaderParam("X-Forwarded-For") String forwardedIpAddresses) {
-        
+        if (!adyenNotificationService.handleNotificationFor(notification, forwardedIpAddresses)) {
+            logRejectionMessage(forwardedIpAddresses, ADYEN);
+            return forbiddenErrorResponse();
+        }
         logResponseMessage("[accepted]", ADYEN);
         return Response.ok().build();
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.connector.gateway.adyen.webhook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.util.IpDomainMatcher;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdyenNotificationServiceTest {
+
+    private AdyenNotificationService adyenNotificationService;
+
+    @Mock
+    private AdyenGatewayConfig adyenGatewayConfig;
+
+    @Mock
+    private IpDomainMatcher ipDomainMatcher;
+
+    @BeforeEach
+    void setUp() {
+        adyenNotificationService = new AdyenNotificationService(adyenGatewayConfig, ipDomainMatcher);
+    }
+
+    @Test
+    void shouldAcceptNotificationWhenForwardedIpMatchesConfiguredDomain() {
+        when(adyenGatewayConfig.getNotificationDomain()).thenReturn("out.adyen.com.");
+        when(ipDomainMatcher.ipMatchesDomain("5.6.7.8", "out.adyen.com.")).thenReturn(true);
+
+        boolean result = adyenNotificationService.handleNotificationFor("{\"notificationItems\":[]}", "5.6.7.8");
+
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldRejectNotificationWhenForwardedIpHeaderIsMissing() {
+        boolean result = adyenNotificationService.handleNotificationFor("{\"notificationItems\":[]}", null);
+
+        assertFalse(result);
+        verifyNoInteractions(ipDomainMatcher);
+    }
+    
+
+    @Test
+    void shouldRejectNotificationWhenForwardedIpDoesNotMatchConfiguredDomain() {
+        when(adyenGatewayConfig.getNotificationDomain()).thenReturn("out.adyen.com.");
+        when(ipDomainMatcher.ipMatchesDomain("8.8.8.8", "out.adyen.com.")).thenReturn(false);
+
+        boolean result = adyenNotificationService.handleNotificationFor("{\"notificationItems\":[]}", "8.8.8.8");
+
+        assertFalse(result);
+    }
+}
+

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenNotificationResourceIT.java
@@ -1,30 +1,58 @@
 package uk.gov.pay.connector.it.resources.adyen;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.util.ConnectorAppWithCustomInjector;
+import uk.gov.pay.connector.util.DnsPointerResourceRecord;
+
+import java.util.Optional;
 
 import static io.restassured.RestAssured.given;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.MediaType.TEXT_XML;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.util.ConnectorModuleWithOverrides.reverseDnsLookup;
 
 public class AdyenNotificationResourceIT {
 
+
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(ConnectorAppWithCustomInjector.class);
 
     private static final String NOTIFICATION_PATH = "/v1/api/notifications/adyen/payments";
+    private static final String ADYEN_IP_ADDRESS = "192.168.0.1";
+    private static final String UNEXPECTED_IP_ADDRESS = "8.8.8.8";
+
+    @BeforeAll
+    static void before() {
+        when(reverseDnsLookup.lookup(new DnsPointerResourceRecord(ADYEN_IP_ADDRESS))).thenReturn(Optional.of(".adyen.com."));
+        when(reverseDnsLookup.lookup(new DnsPointerResourceRecord(UNEXPECTED_IP_ADDRESS))).thenReturn(Optional.of("dns.google."));
+    }
 
     @Test
     void shouldHandleAValidJsonNotification() {
         given()
                 .port(app.getLocalPort())
                 .body("{\"notificationItems\":[{\"NotificationRequestItem\":{\"eventCode\":\"AUTHORISATION\"}}]}")
-                .header("X-Forwarded-For", "5.6.7.8")
+                .header("X-Forwarded-For", ADYEN_IP_ADDRESS)
                 .contentType(APPLICATION_JSON)
                 .post(NOTIFICATION_PATH)
                 .then()
                 .statusCode(200);
+    }
+
+    @Test
+    void shouldRejectNotificationFromNonApprovedDomain() {
+        given()
+                .port(app.getLocalPort())
+                .body("{\"notificationItems\":[{\"NotificationRequestItem\":{\"eventCode\":\"AUTHORISATION\"}}]}")
+                .header("X-Forwarded-For", UNEXPECTED_IP_ADDRESS)
+                .contentType(APPLICATION_JSON)
+                .post(NOTIFICATION_PATH)
+                .then()
+                .statusCode(403);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
@@ -1,19 +1,15 @@
 package uk.gov.pay.connector.it.resources.worldpay;
 
-import io.dropwizard.core.setup.Environment;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.app.ConnectorModule;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.it.base.ITestBaseExtension;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.util.ConnectorAppWithCustomInjector;
 import uk.gov.pay.connector.util.DnsPointerResourceRecord;
 import uk.gov.pay.connector.util.RandomIdGenerator;
-import uk.gov.pay.connector.util.ReverseDnsLookup;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import java.time.ZonedDateTime;
@@ -28,21 +24,20 @@ import static jakarta.ws.rs.core.MediaType.TEXT_XML;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
+import static uk.gov.pay.connector.util.ConnectorModuleWithOverrides.reverseDnsLookup;
 import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.randomAlphanumeric;
 import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRandomLong;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_NOTIFICATION;
 
 public class WorldpayNotificationResourceIT {
-    private static final ReverseDnsLookup reverseDnsLookup = mock(ReverseDnsLookup.class);
 
     // App must be instantiated after mock is set
     @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(WorldpayNotificationResourceIT.ConnectorAppWithCustomInjector.class, config("worldpay.notificationDomain", ".worldpay.com"));
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(ConnectorAppWithCustomInjector.class, config("worldpay.notificationDomain", ".worldpay.com"));
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("worldpay", app.getLocalPort(), app.getDatabaseTestHelper());
 
@@ -253,23 +248,4 @@ public class WorldpayNotificationResourceIT {
         return externalChargeId;
     }
 
-    public static class ConnectorAppWithCustomInjector extends ConnectorApp {
-
-        @Override
-        protected ConnectorModule getModule(ConnectorConfiguration configuration, Environment environment) {
-            return new ConnectorModuleWithOverrides(configuration, environment);
-        }
-    }
-
-    private static class ConnectorModuleWithOverrides extends ConnectorModule {
-
-        public ConnectorModuleWithOverrides(ConnectorConfiguration configuration, Environment environment) {
-            super(configuration, environment);
-        }
-
-        @Override
-        protected ReverseDnsLookup getReverseDnsLookup() {
-            return reverseDnsLookup;
-        }
-    }
 }

--- a/src/test/java/uk/gov/pay/connector/util/ConnectorAppWithCustomInjector.java
+++ b/src/test/java/uk/gov/pay/connector/util/ConnectorAppWithCustomInjector.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.connector.util;
+
+import io.dropwizard.core.setup.Environment;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.ConnectorModule;
+
+public class ConnectorAppWithCustomInjector extends ConnectorApp {
+
+    @Override
+    protected ConnectorModule getModule(ConnectorConfiguration configuration, Environment environment) {
+        return new ConnectorModuleWithOverrides(configuration, environment);
+    }
+}
+

--- a/src/test/java/uk/gov/pay/connector/util/ConnectorModuleWithOverrides.java
+++ b/src/test/java/uk/gov/pay/connector/util/ConnectorModuleWithOverrides.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.util;
+
+import io.dropwizard.core.setup.Environment;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.ConnectorModule;
+
+import static org.mockito.Mockito.mock;
+
+public class ConnectorModuleWithOverrides extends ConnectorModule {
+
+    public static final ReverseDnsLookup reverseDnsLookup = mock(ReverseDnsLookup.class);
+
+    public ConnectorModuleWithOverrides(ConnectorConfiguration configuration, Environment environment) {
+        super(configuration, environment);
+    }
+
+    @Override
+    protected ReverseDnsLookup getReverseDnsLookup() {
+        return reverseDnsLookup;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/webhook/resource/NotificationResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/webhook/resource/NotificationResourceTest.java
@@ -4,23 +4,44 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationResourceTest {
-    
+
+    @Mock
+    AdyenNotificationService adyenNotificationService;
+
     @InjectMocks
     private NotificationResource notificationResource;
 
     @Test
-    void shouldHandleAdyenPaymentNotification() {
-        String rawNotification = "{\n  \"notificationItems\": [\n    {\"NotificationRequestItem\": {\"eventCode\": \"AUTHORISATION\"}}\n  ]\n}";
+    void shouldReturn200WhenAdyenNotificationSuccessfullyHandled() { 
+        String rawNotification = "{Adyen}";
         String forwardedIpAddress = "10.20.30.40";
-        
-        Response response = notificationResource.authoriseAdyenPaymentsNotifications(rawNotification, forwardedIpAddress);
+        when(adyenNotificationService.handleNotificationFor(anyString(), eq(forwardedIpAddress))).thenReturn(true);
+
+        try (Response response = notificationResource.authoriseAdyenPaymentsNotifications(rawNotification, forwardedIpAddress)) {
             assertThat(response.getStatus()).isEqualTo(200);
+        }
+    }
+
+    @Test
+    void shouldReturn403WhenAdyenNotificationValidationFails() {
+        String rawNotification = "{Adyen}";
+        String forwardedIpAddress = " ";
+        when(adyenNotificationService.handleNotificationFor(anyString(), eq(forwardedIpAddress))).thenReturn(false);
+
+        try (Response response = notificationResource.authoriseAdyenPaymentsNotifications(rawNotification, forwardedIpAddress)) {
+            assertThat(response.getStatus()).isEqualTo(403);
+        }
     }
 }
 


### PR DESCRIPTION
## WHAT YOU DID
- Validates Adyen notification IP address by doing reverse DNS lookup and matching the allowed notification domain.
- Minor improvements to inject AdyenGatewayConfig and extract custom ConnectorModule to use across tests

