### PR TITLE
PP-15084 Make CardAuthorisationGatewayRequest constructor private

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
@@ -4,9 +4,9 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 
 public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest {
-    private AuthCardDetails authCardDetails;
+    private final AuthCardDetails authCardDetails;
 
-    public CardAuthorisationGatewayRequest(ChargeEntity charge, AuthCardDetails authCardDetails) {
+    private CardAuthorisationGatewayRequest(ChargeEntity charge, AuthCardDetails authCardDetails) {
         super(charge);
         this.authCardDetails = authCardDetails;
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequestTest.java
@@ -16,7 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
                 .withAmount(2000L)
                 .withCorporateSurcharge(250L)
                 .build();
-        CardAuthorisationGatewayRequest gatewayRequest = new CardAuthorisationGatewayRequest(chargeEntity, null);
+        CardAuthorisationGatewayRequest gatewayRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, null);
         assertThat(gatewayRequest.getAmount(), is("2250"));
     }
     
@@ -25,7 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(2000L)
                 .build();
-        CardAuthorisationGatewayRequest gatewayRequest = new CardAuthorisationGatewayRequest(chargeEntity, null);
+        CardAuthorisationGatewayRequest gatewayRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, null);
         assertThat(gatewayRequest.getAmount(), is("2000"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseCredentialsHelperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseCredentialsHelperTest.java
@@ -56,7 +56,7 @@ class WorldpayAuthoriseCredentialsHelperTest {
                 .withGatewayAccountCredentialsEntity(gatewayAccountCredentialsEntity)
                 .build();
 
-        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = new CardAuthorisationGatewayRequest(chargeEntity, null);
+        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, null);
 
         WorldpayMerchantCodeCredentials expected = new WorldpayMerchantCodeCredentials(merchantCode, username, password);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseDescriptionHelperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseDescriptionHelperTest.java
@@ -28,7 +28,7 @@ class WorldpayAuthoriseDescriptionHelperTest {
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .build();
         
-        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = new CardAuthorisationGatewayRequest(chargeEntity, null);
+        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, null);
 
         String actual = descriptionHelper.getDescription(cardAuthorisationGatewayRequest);
         assertThat(actual, is(DESCRIPTION));
@@ -44,7 +44,7 @@ class WorldpayAuthoriseDescriptionHelperTest {
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .build();
 
-        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = new CardAuthorisationGatewayRequest(chargeEntity, null);
+        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, null);
 
         String actual = descriptionHelper.getDescription(cardAuthorisationGatewayRequest);
         assertThat(actual, is(REFERENCE));

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthoriseRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthoriseRequestFactoryTest.java
@@ -59,7 +59,7 @@ class WorldpayMotoAuthoriseRequestFactoryTest {
         
         AuthCardDetails authCardDetails = AuthCardDetails.of(authoriseRequest, chargeEntity, cardInformation);
 
-        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
+        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, authCardDetails);
         
         given(mockDescriptionHelper.getDescription(cardAuthorisationGatewayRequest)).willReturn(descriptionOrReference);
         given(mockCredentialsHelper.getOneOffCredentials(cardAuthorisationGatewayRequest)).willReturn(new WorldpayMerchantCodeCredentials(merchantCode, username, password));

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -87,7 +87,7 @@ public class SandboxPaymentProviderTest {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_SUCCESS_CARD_NUMBER);
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
+        GatewayResponse gatewayResponse = provider.authorise(CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails), charge);
 
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
@@ -141,7 +141,7 @@ public class SandboxPaymentProviderTest {
                 .withPaymentProvider(SANDBOX.getName())
                 .withCardDetails(ChargeEntityFixture.defaultCardDetails())
                 .build();
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
+        GatewayResponse gatewayResponse = provider.authorise(CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails), charge);
 
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
@@ -163,7 +163,7 @@ public class SandboxPaymentProviderTest {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_REJECTED_CARD_NUMBER);
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
+        GatewayResponse gatewayResponse = provider.authorise(CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails), charge);
 
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
@@ -184,7 +184,7 @@ public class SandboxPaymentProviderTest {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_ERROR_CARD_NUMBER);
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
+        GatewayResponse gatewayResponse = provider.authorise(CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails), charge);
 
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
@@ -202,7 +202,7 @@ public class SandboxPaymentProviderTest {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo("3456789987654567");
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(charge, authCardDetails), charge);
+        GatewayResponse gatewayResponse = provider.authorise(CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails), charge);
 
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeAuthoriseHandlerTest.java
@@ -23,7 +23,11 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.gateway.stripe.request.*;
+import uk.gov.pay.connector.gateway.stripe.request.StripeCustomerRequest;
+import uk.gov.pay.connector.gateway.stripe.request.StripePaymentIntentRequest;
+import uk.gov.pay.connector.gateway.stripe.request.StripePaymentMethodRequest;
+import uk.gov.pay.connector.gateway.stripe.request.StripePostRequest;
+import uk.gov.pay.connector.gateway.stripe.request.StripeTokenRequest;
 import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -677,11 +681,11 @@ public class StripeAuthoriseHandlerTest {
     }
 
     private CardAuthorisationGatewayRequest buildTestAuthorisationRequest(ChargeEntity chargeEntity) {
-        return new CardAuthorisationGatewayRequest(chargeEntity, buildTestAuthCardDetails());
+        return CardAuthorisationGatewayRequest.valueOf(chargeEntity, buildTestAuthCardDetails());
     }
 
     private CardAuthorisationGatewayRequest buildTestUsAuthorisationRequest(ChargeEntity chargeEntity) {
-        return new CardAuthorisationGatewayRequest(chargeEntity, buildTestUsAuthCardDetails());
+        return CardAuthorisationGatewayRequest.valueOf(chargeEntity, buildTestUsAuthCardDetails());
     }
 
     private AuthCardDetails buildTestAuthCardDetails() {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequestTest.java
@@ -70,7 +70,7 @@ class StripeAuthoriseRequestTest {
         when(charge.getAmount()).thenReturn(amount);
         when(charge.getGatewayAccountCredentialsEntity()).thenReturn(gatewayAccountCredentialsEntity);
 
-        authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, new AuthCardDetails());
+        authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, new AuthCardDetails());
 
         stripeAuthoriseRequest = StripeAuthoriseRequest.of(stripeSourceId, authorisationGatewayRequest, stripeGatewayConfig);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequestTest.java
@@ -49,8 +49,8 @@ class StripeCustomerRequestTest {
         var charge = aValidChargeEntity()
                 .withGatewayAccountCredentialsEntity(gatewayAccountCredentialsEntity)
                 .build();
-        
-        var authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+
+        var authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         var agreementEntity = anAgreementEntity()
                 .withExternalId(AGREEMENT_EXTERNAL_ID)
                 .withDescription(AGREEMENT_DESCRIPTION)

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
@@ -139,7 +139,7 @@ class StripePaymentIntentRequestTest {
 
     @Test
     void shouldIncludeCustomerIdAndSetupFutureUsageFlagForSetupFutureUsageRequest() {
-        var authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, new AuthCardDetails());
+        var authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, new AuthCardDetails());
         var stripePaymentIntentRequest = StripePaymentIntentRequest.createPaymentIntentRequestWithSetupFutureUsage(
                 authorisationGatewayRequest, paymentMethodId, customerId, stripeGatewayConfig, frontendUrl);
         String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
@@ -192,7 +192,7 @@ class StripePaymentIntentRequestTest {
     }
 
     private StripePaymentIntentRequest createOneOffStripePaymentIntentRequest() {
-        var authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, new AuthCardDetails());
+        var authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, new AuthCardDetails());
         return StripePaymentIntentRequest.createOneOffPaymentIntentRequest(authorisationGatewayRequest, paymentMethodId, stripeGatewayConfig, frontendUrl);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
@@ -81,7 +81,7 @@ class StripePaymentMethodRequestTest {
         authCardDetails.setCvc(cvc);
         authCardDetails.setEndDate(CardExpiryDate.valueOf(endMonth + "/" + endYear));
 
-        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
 
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
     }
@@ -95,7 +95,7 @@ class StripePaymentMethodRequestTest {
         address.setCountry(country);
         address.setPostcode(postcode);
         authCardDetails.setAddress(address);
-        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
 
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
 
@@ -121,7 +121,7 @@ class StripePaymentMethodRequestTest {
         address.setCountry("CA");
         address.setPostcode("X0A0A0");
         authCardDetails.setAddress(address);
-        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
 
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
 
@@ -141,7 +141,7 @@ class StripePaymentMethodRequestTest {
         address.setCountry("US");
         address.setPostcode("90210");
         authCardDetails.setAddress(address);
-        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
 
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
 
@@ -154,7 +154,7 @@ class StripePaymentMethodRequestTest {
 
     @Test
     void shouldHaveCorrectParametersWithoutAddress() {
-        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
         
         String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
@@ -174,7 +174,7 @@ class StripePaymentMethodRequestTest {
         address.setCountry(null);
         address.setPostcode(null);
         authCardDetails.setAddress(address);
-        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
 
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -268,7 +268,8 @@ class WorldpayAuthoriseHandlerTest {
 
         AuthCardDetails authCardDetails = getValidTestCard(UUID.randomUUID().toString());
 
-        worldpayAuthoriseHandler.authorise(new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), authCardDetails),
+        ChargeEntity charge = chargeEntityFixture.build();
+        worldpayAuthoriseHandler.authorise(CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails),
                 sendCorporateExemptionRequest);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
@@ -299,7 +300,8 @@ class WorldpayAuthoriseHandlerTest {
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
 
-        worldpayAuthoriseHandler.authorise(new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), getValidTestCard()), DO_NOT_SEND_EXEMPTION_REQUEST);
+        ChargeEntity charge = chargeEntityFixture.build();
+        worldpayAuthoriseHandler.authorise(CardAuthorisationGatewayRequest.valueOf(charge, getValidTestCard()), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
 
@@ -322,7 +324,8 @@ class WorldpayAuthoriseHandlerTest {
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
 
-        worldpayAuthoriseHandler.authorise(new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), getValidTestCard()), DO_NOT_SEND_EXEMPTION_REQUEST);
+        ChargeEntity charge = chargeEntityFixture.build();
+        worldpayAuthoriseHandler.authorise(CardAuthorisationGatewayRequest.valueOf(charge, getValidTestCard()), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
 
@@ -355,7 +358,8 @@ class WorldpayAuthoriseHandlerTest {
 
         AuthCardDetails authCardDetails = getValidTestCard(UUID.randomUUID().toString());
 
-        worldpayAuthoriseHandler.authorise(new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), authCardDetails), DO_NOT_SEND_EXEMPTION_REQUEST);
+        ChargeEntity charge = chargeEntityFixture.build();
+        worldpayAuthoriseHandler.authorise(CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
 
@@ -404,7 +408,7 @@ class WorldpayAuthoriseHandlerTest {
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
 
-        worldpayAuthoriseHandler.authorise((new CardAuthorisationGatewayRequest(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
+        worldpayAuthoriseHandler.authorise((CardAuthorisationGatewayRequest.valueOf(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
@@ -431,7 +435,7 @@ class WorldpayAuthoriseHandlerTest {
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
 
-        worldpayAuthoriseHandler.authorise((new CardAuthorisationGatewayRequest(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
+        worldpayAuthoriseHandler.authorise((CardAuthorisationGatewayRequest.valueOf(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
@@ -466,7 +470,7 @@ class WorldpayAuthoriseHandlerTest {
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
 
-        worldpayAuthoriseHandler.authorise((new CardAuthorisationGatewayRequest(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
+        worldpayAuthoriseHandler.authorise((CardAuthorisationGatewayRequest.valueOf(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
@@ -493,7 +497,7 @@ class WorldpayAuthoriseHandlerTest {
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
 
-        worldpayAuthoriseHandler.authorise((new CardAuthorisationGatewayRequest(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
+        worldpayAuthoriseHandler.authorise((CardAuthorisationGatewayRequest.valueOf(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
@@ -520,7 +524,7 @@ class WorldpayAuthoriseHandlerTest {
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
 
-        worldpayAuthoriseHandler.authorise((new CardAuthorisationGatewayRequest(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
+        worldpayAuthoriseHandler.authorise((CardAuthorisationGatewayRequest.valueOf(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
@@ -547,7 +551,7 @@ class WorldpayAuthoriseHandlerTest {
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
 
-        worldpayAuthoriseHandler.authorise((new CardAuthorisationGatewayRequest(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
+        worldpayAuthoriseHandler.authorise((CardAuthorisationGatewayRequest.valueOf(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
@@ -614,7 +618,7 @@ class WorldpayAuthoriseHandlerTest {
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
 
-        worldpayAuthoriseHandler.authorise((new CardAuthorisationGatewayRequest(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
+        worldpayAuthoriseHandler.authorise((CardAuthorisationGatewayRequest.valueOf(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
@@ -749,7 +753,7 @@ class WorldpayAuthoriseHandlerTest {
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
 
-        worldpayAuthoriseHandler.authorise((new CardAuthorisationGatewayRequest(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
+        worldpayAuthoriseHandler.authorise((CardAuthorisationGatewayRequest.valueOf(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
@@ -777,7 +781,7 @@ class WorldpayAuthoriseHandlerTest {
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
 
-        worldpayAuthoriseHandler.authorise((new CardAuthorisationGatewayRequest(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
+        worldpayAuthoriseHandler.authorise((CardAuthorisationGatewayRequest.valueOf(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
@@ -806,7 +810,7 @@ class WorldpayAuthoriseHandlerTest {
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(authorisationSuccessResponse);
 
-        worldpayAuthoriseHandler.authorise((new CardAuthorisationGatewayRequest(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
+        worldpayAuthoriseHandler.authorise((CardAuthorisationGatewayRequest.valueOf(chargeEntity, getValidTestCard())), DO_NOT_SEND_EXEMPTION_REQUEST);
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
@@ -1028,7 +1032,7 @@ class WorldpayAuthoriseHandlerTest {
     private CardAuthorisationGatewayRequest getCardAuthorisationRequest(ChargeEntity chargeEntity, String ipAddress) {
         AuthCardDetails authCardDetails = getValidTestCard();
         authCardDetails.setIpAddress(ipAddress);
-        return new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
+        return CardAuthorisationGatewayRequest.valueOf(chargeEntity, authCardDetails);
     }
 
     private AuthCardDetails getValidTestCard() {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -232,7 +232,7 @@ class WorldpayPaymentProviderTest {
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
         ChargeEntity chargeEntity = chargeEntityFixture.build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().build());
 
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, SEND_EXEMPTION_ENGINE_REQUEST))
                 .thenReturn(responseBuilder().withGatewayError(gatewayConnectionError("connetion problemo")).build());
@@ -251,7 +251,7 @@ class WorldpayPaymentProviderTest {
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
 
         ChargeEntity chargeEntity = chargeEntityFixture.build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().build());
 
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, DO_NOT_SEND_EXEMPTION_REQUEST))
                 .thenReturn(getGatewayResponse(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
@@ -327,7 +327,7 @@ class WorldpayPaymentProviderTest {
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
 
         ChargeEntity chargeEntity = chargeEntityFixture.build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().build());
 
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, DO_NOT_SEND_EXEMPTION_REQUEST))
                 .thenReturn(getGatewayResponse(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
@@ -358,7 +358,7 @@ class WorldpayPaymentProviderTest {
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
 
         ChargeEntity chargeEntity = chargeEntityFixture.build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().build());
 
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, DO_NOT_SEND_EXEMPTION_REQUEST))
                 .thenReturn(getGatewayResponse(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
@@ -391,7 +391,7 @@ class WorldpayPaymentProviderTest {
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
 
         ChargeEntity chargeEntity = chargeEntityFixture.build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().withCorporateCard(false).build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().withCorporateCard(false).build());
 
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, DO_NOT_SEND_EXEMPTION_REQUEST))
                 .thenReturn(getGatewayResponse(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE));
@@ -422,7 +422,7 @@ class WorldpayPaymentProviderTest {
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
         ChargeEntity chargeEntity = chargeEntityFixture.build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().build());
 
         when(chargeDao.merge(chargeEntity)).thenReturn(chargeEntity);
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, SEND_EXEMPTION_ENGINE_REQUEST))
@@ -453,7 +453,7 @@ class WorldpayPaymentProviderTest {
         ChargeEntity chargeEntity = chargeEntityFixture
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().withCorporateCard(true).build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().withCorporateCard(true).build());
 
         when(chargeDao.merge(chargeEntity)).thenReturn(chargeEntity);
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, DO_NOT_SEND_EXEMPTION_REQUEST))
@@ -484,7 +484,7 @@ class WorldpayPaymentProviderTest {
         ChargeEntity chargeEntity = chargeEntityFixture
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().withCorporateCard(true).build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().withCorporateCard(true).build());
 
         when(chargeDao.merge(chargeEntity)).thenReturn(chargeEntity);
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, SEND_CORPORATE_EXEMPTION_REQUEST))
@@ -519,7 +519,7 @@ class WorldpayPaymentProviderTest {
         ChargeEntity chargeEntity = chargeEntityFixture
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails()
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails()
                 .withCorporateCard(true).build());
 
         when(chargeDao.merge(chargeEntity)).thenReturn(chargeEntity);
@@ -553,7 +553,7 @@ class WorldpayPaymentProviderTest {
         ChargeEntity chargeEntity = chargeEntityFixture
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails()
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails()
                 .withCorporateCard(true).build());
 
         when(chargeDao.merge(chargeEntity)).thenReturn(chargeEntity);
@@ -585,7 +585,7 @@ class WorldpayPaymentProviderTest {
         ChargeEntity chargeEntity = chargeEntityFixture
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails()
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails()
                 .withCorporateCard(false).build());
 
         when(chargeDao.merge(chargeEntity)).thenReturn(chargeEntity);
@@ -619,7 +619,7 @@ class WorldpayPaymentProviderTest {
         ChargeEntity chargeEntity = chargeEntityFixture
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails()
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails()
                 .withCorporateCard(true).build());
 
         when(chargeDao.merge(chargeEntity)).thenReturn(chargeEntity);
@@ -651,7 +651,7 @@ class WorldpayPaymentProviderTest {
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
         ChargeEntity chargeEntity = chargeEntityFixture.build();
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().build());
 
         when(chargeDao.merge(any(ChargeEntity.class))).thenReturn(chargeEntity);
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, SEND_EXEMPTION_ENGINE_REQUEST))
@@ -699,7 +699,7 @@ class WorldpayPaymentProviderTest {
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
         ChargeEntity chargeEntity = chargeEntityFixture.build();
 
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().build());
 
         when(chargeDao.merge(any(ChargeEntity.class))).thenReturn(chargeEntity);
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, SEND_EXEMPTION_ENGINE_REQUEST)).thenReturn(getGatewayResponse(worldpayXmlResponse));
@@ -720,7 +720,7 @@ class WorldpayPaymentProviderTest {
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
         ChargeEntity chargeEntity = chargeEntityFixture.build();
 
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().build());
 
         when(chargeDao.merge(chargeEntity)).thenReturn(chargeEntity);
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, SEND_EXEMPTION_ENGINE_REQUEST))
@@ -747,7 +747,7 @@ class WorldpayPaymentProviderTest {
         chargeEntityFixture.withGatewayTransactionId(gatewayTransactionId);
         ChargeEntity chargeEntity = chargeEntityFixture.build();
 
-        var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
+        var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().build());
 
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, SEND_EXEMPTION_ENGINE_REQUEST))
                 .thenReturn(getGatewayResponse(WORLDPAY_EXEMPTION_REQUEST_SOFT_DECLINE_RESULT_REJECTED_RESPONSE));

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -310,7 +310,7 @@ public class StripePaymentProviderTest {
     private ChargeEntity setUpAgreement() {
         AuthCardDetails authCardDetails = anAuthCardDetails().withEndDate(CardExpiryDate.valueOf(validCardExpiryDate)).build();
         ChargeEntity setUpAgreementCharge = getChargeWithAgreement();
-        var request = new CardAuthorisationGatewayRequest(setUpAgreementCharge, authCardDetails);
+        var request = CardAuthorisationGatewayRequest.valueOf(setUpAgreementCharge, authCardDetails);
         GatewayResponse<StripeAuthorisationResponse> setUpAgreementResponse = stripePaymentProvider.authorise(request, setUpAgreementCharge);
 
         Map<String, String> recurringAuthToken = setUpAgreementResponse.getBaseResponse().get().getGatewayRecurringAuthToken().get();

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.core.setup.Environment;
+import jakarta.ws.rs.client.ClientBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -53,10 +54,8 @@ import uk.gov.pay.connector.util.AcceptLanguageHeaderParser;
 import uk.gov.pay.connector.wallets.applepay.ApplePayDecrypter;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
-import jakarta.ws.rs.client.ClientBuilder;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.time.Clock;
 import java.time.InstantSource;
 import java.util.List;
@@ -205,7 +204,7 @@ class WorldpayPaymentProviderTest {
                 .withWorldpay3dsFlexDdcResult(UUID.randomUUID().toString())
                 .build();
         ChargeEntity charge = createChargeEntity();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getBaseResponse().get().getLastEvent().isPresent());
@@ -227,7 +226,7 @@ class WorldpayPaymentProviderTest {
                 .withWorldpay3dsFlexDdcResult(UUID.randomUUID().toString())
                 .build();
         ChargeEntity charge = createChargeEntity();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getBaseResponse().get().getLastEvent().isPresent());
@@ -246,7 +245,7 @@ class WorldpayPaymentProviderTest {
                 .withWorldpay3dsFlexDdcResult(UUID.randomUUID().toString())
                 .build();
         ChargeEntity charge = createChargeEntity();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
     }
@@ -261,7 +260,7 @@ class WorldpayPaymentProviderTest {
                 .withWorldpay3dsFlexDdcResult(UUID.randomUUID().toString())
                 .build();
         ChargeEntity charge = createChargeEntity();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
         response.getBaseResponse().ifPresent(res -> {
@@ -279,7 +278,7 @@ class WorldpayPaymentProviderTest {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         AuthCardDetails authCardDetails = anAuthCardDetails().withCardNo(cardNumber).build();
         ChargeEntity charge = createChargeEntity();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
     }
@@ -290,7 +289,7 @@ class WorldpayPaymentProviderTest {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         AuthCardDetails authCardDetails = anAuthCardDetails().withCardNo(cardNumber).withAddress(null).build();
         ChargeEntity charge = createChargeEntity();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
     }
@@ -307,7 +306,7 @@ class WorldpayPaymentProviderTest {
         usAddress.setCountry("US");
         AuthCardDetails authCardDetails = anAuthCardDetails().withCardNo(cardNumber).withAddress(usAddress).build();
         ChargeEntity charge = createChargeEntity();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
     }
@@ -324,7 +323,7 @@ class WorldpayPaymentProviderTest {
         canadaAddress.setCountry("CA");
         AuthCardDetails authCardDetails = anAuthCardDetails().withCardNo(cardNumber).withAddress(canadaAddress).build();
         ChargeEntity charge = createChargeEntity();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
     }
@@ -339,7 +338,7 @@ class WorldpayPaymentProviderTest {
                 .build();
 
         ChargeEntity charge = createChargeWithRequires3ds();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
 
         assertTrue(response.getBaseResponse().isPresent());
@@ -359,7 +358,7 @@ class WorldpayPaymentProviderTest {
         ChargeEntity charge = createChargeEntity();
         charge.setSavePaymentInstrumentToAgreement(true);
         charge.setAgreementEntity(anAgreementEntity().build());
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getBaseResponse().get().getGatewayRecurringAuthToken().isPresent());
@@ -414,7 +413,7 @@ class WorldpayPaymentProviderTest {
                 .build();
 
         ChargeEntity charge = createChargeWithRequires3ds();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
 
         assertTrue(response.getBaseResponse().isPresent());
@@ -445,7 +444,7 @@ class WorldpayPaymentProviderTest {
                 .withCardHolder(MAGIC_CARDHOLDER_NAME_THAT_MAKES_WORLDPAY_TEST_REQUIRE_3DS)
                 .build();
 
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
 
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
 
@@ -480,7 +479,7 @@ class WorldpayPaymentProviderTest {
                 .withWorldpay3dsFlexDdcResult(null)
                 .build();
 
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
 
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
 
@@ -512,7 +511,7 @@ class WorldpayPaymentProviderTest {
         AuthCardDetails authCardDetails = anAuthCardDetails().build();
 
         ChargeEntity charge = createChargeEntity();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
         String transactionId = response.getBaseResponse().get().getTransactionId();
 
@@ -537,7 +536,7 @@ class WorldpayPaymentProviderTest {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         AuthCardDetails authCardDetails = anAuthCardDetails().build();
         ChargeEntity charge = createChargeEntity();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request, charge);
 
         assertThat(response.getBaseResponse().isPresent(), is(true));
@@ -580,7 +579,7 @@ class WorldpayPaymentProviderTest {
                 .withGatewayAccountCredentialsEntity(gatewayAccountCredentialsEntity)
                 .build();
         AuthCardDetails authCardDetails = anAuthCardDetails().build();
-        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         assertFalse(paymentProvider.authorise(request, charge).getBaseResponse().isPresent());
     }
 
@@ -675,7 +674,7 @@ class WorldpayPaymentProviderTest {
         ChargeEntity setUpAgreementCharge = createChargeEntity();
         setUpAgreementCharge.setSavePaymentInstrumentToAgreement(true);
         setUpAgreementCharge.setAgreementEntity(agreement);
-        var request = new CardAuthorisationGatewayRequest(setUpAgreementCharge, authCardDetails);
+        var request = CardAuthorisationGatewayRequest.valueOf(setUpAgreementCharge, authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> setUpAgreementResponse = paymentProvider.authorise(request, setUpAgreementCharge);
 
         Map<String, String> recurringAuthToken = setUpAgreementResponse.getBaseResponse().get().getGatewayRecurringAuthToken().get();


### PR DESCRIPTION
## WHAT YOU DID
- The constructor was public to be used only by tests, now tests use the static factory method, and the constructor is private
