### PR TITLE
PP-15084 Authorise an Adyen payment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.github.netmikey.logunit</groupId>
+            <artifactId>logunit-logback</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
             <version>3.0.0</version>

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandler.java
@@ -1,0 +1,62 @@
+package uk.gov.pay.connector.gateway.adyen;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.adyen.model.AdyenAuthorisationRequest;
+import uk.gov.pay.connector.gateway.adyen.model.AdyenAuthoriseResponse;
+import uk.gov.pay.connector.gateway.adyen.model.AdyenPaymentResponse;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import java.net.URI;
+
+import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getBaseCheckoutUrl;
+
+public class AdyenAuthoriseHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(AdyenAuthoriseHandler.class);
+
+    private final GatewayClient gatewayClient;
+    private final AdyenGatewayConfig adyenGatewayConfig;
+    private final JsonObjectMapper jsonObjectMapper;
+    private final AdyenRequestFactory adyenRequestFactory;
+
+    public AdyenAuthoriseHandler(GatewayClient gatewayClient,
+                                 ConnectorConfiguration configuration,
+                                 JsonObjectMapper jsonObjectMapper) {
+        this.gatewayClient = gatewayClient;
+        this.adyenGatewayConfig = configuration.getAdyenGatewayConfig();
+        this.jsonObjectMapper = jsonObjectMapper;
+        this.adyenRequestFactory = new AdyenRequestFactory(configuration);
+    }
+
+    public GatewayResponse authorise(CardAuthorisationGatewayRequest request) throws
+            GatewayException.GatewayErrorException,
+            GatewayException.GenericGatewayException,
+            GatewayException.GatewayConnectionTimeoutException {
+        logger.info("Calling Adyen for authorisation of charge");
+        var authorisationRequest = new AdyenAuthorisationRequest(
+                getUrl(request),
+                adyenRequestFactory.createPaymentRequest(request),
+                jsonObjectMapper);
+
+        var jsonResponse = gatewayClient.postRequestFor(authorisationRequest).getEntity();
+
+        var paymentResponse = jsonObjectMapper.getObject(
+                jsonResponse,
+                AdyenPaymentResponse.class);
+
+        return GatewayResponse.GatewayResponseBuilder.responseBuilder()
+                .withResponse(AdyenAuthoriseResponse.of(paymentResponse))
+                .build();
+    }
+
+    private URI getUrl(CardAuthorisationGatewayRequest request) {
+        return URI.create(getBaseCheckoutUrl(adyenGatewayConfig, request.getGatewayAccount().isLive()) + "/payments");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
@@ -41,6 +41,7 @@ public class AdyenPaymentProvider implements PaymentProvider {
     private final GatewayClient client;
     private final AdyenGatewayConfig adyenGatewayConfig;
     private final ConnectorConfiguration connectorConfiguration;
+    private final AdyenAuthoriseHandler adyenAuthoriseHandler;
 
     @Inject
     public AdyenPaymentProvider(
@@ -52,6 +53,7 @@ public class AdyenPaymentProvider implements PaymentProvider {
         this.adyenGatewayConfig = connectorConfiguration.getAdyenGatewayConfig();
         this.connectorConfiguration = connectorConfiguration;
         this.client = gatewayClientFactory.createGatewayClient(ADYEN, environment.metrics());
+        adyenAuthoriseHandler = new AdyenAuthoriseHandler(client, connectorConfiguration, jsonObjectMapper);
     }
 
     @Override
@@ -66,7 +68,7 @@ public class AdyenPaymentProvider implements PaymentProvider {
 
     @Override
     public GatewayResponse authorise(CardAuthorisationGatewayRequest request, ChargeEntity charge) throws GatewayException {
-        throw new UnsupportedOperationException("Operation for Adyen is not Implemented yet");
+        return adyenAuthoriseHandler.authorise(request);
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandlerTest.java
@@ -1,0 +1,166 @@
+package uk.gov.pay.connector.gateway.adyen;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonassert.JsonAssert;
+import io.github.netmikey.logunit.api.LogCapturer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.event.Level;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.LinksConfig;
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.app.adyen.AdyenIds;
+import uk.gov.pay.connector.app.adyen.BaseUrls;
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+
+@ExtendWith(MockitoExtension.class)
+class AdyenAuthoriseHandlerTest {
+
+    public static final AdyenCredentials ADYEN_CREDENTIALS = new AdyenCredentials("legal_entity_id", "store_id");
+    public static final String LIVE_ADYEN_CHECKOUT_BASE_URL = "https://example.com/live/v71";
+    public static final String TEST_ADYEN_CHECKOUT_BASE_URL = "https://example.com/test/v71";
+    @Mock
+    private GatewayClient mockClient;
+    @Mock
+    private ConnectorConfiguration mockConfig;
+    private final JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(new ObjectMapper());
+    private AdyenAuthoriseHandler authoriseHandler;
+    @Mock
+    private GatewayClient.Response mockGatewayClientResponse;
+
+    @Captor
+    private ArgumentCaptor<GatewayClientPostRequest> captor;
+    @RegisterExtension
+    private final LogCapturer infoLogs = LogCapturer.create().captureForType(AdyenAuthoriseHandler.class, Level.INFO);
+
+    @BeforeEach
+    void setUp() {
+        when(mockConfig.getLinks()).thenReturn(new LinksConfig());
+
+        BaseUrls mockBaseUrls = mock(BaseUrls.class);
+        when(mockBaseUrls.checkout()).thenReturn(new BaseUrls.CheckoutUrls(TEST_ADYEN_CHECKOUT_BASE_URL, LIVE_ADYEN_CHECKOUT_BASE_URL));
+        AdyenGatewayConfig mockAdyenGatewayConfig = mock(AdyenGatewayConfig.class);
+        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
+        when(mockAdyenGatewayConfig.getBaseUrls()).thenReturn(mockBaseUrls);
+        when(mockConfig.getAdyenGatewayConfig()).thenReturn(mockAdyenGatewayConfig);
+
+        authoriseHandler = new AdyenAuthoriseHandler(mockClient, mockConfig, jsonObjectMapper);
+    }
+
+    @Test
+    void should_send_request_to_Adyen_with_full_billing_address() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        givenAdyenReturnsASuccessResponse();
+
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withAddress(makeFullBillingAddress())
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .build();
+        authoriseHandler.authorise(authoriseRequest);
+
+        then(mockClient).should().postRequestFor(captor.capture());
+        String payload = captor.getValue().getGatewayOrder().getPayload();
+        JsonAssert.with(payload).assertThat("$.billingAddress.houseNumberOrName", is("line1"));
+        JsonAssert.with(payload).assertThat("$.billingAddress.street", is("line2"));
+        JsonAssert.with(payload).assertThat("$.billingAddress.city", is("city"));
+        JsonAssert.with(payload).assertThat("$.billingAddress.postalCode", is("postcode"));
+        JsonAssert.with(payload).assertThat("$.billingAddress.country", is("country"));
+    }
+
+    @Test
+    void should_construct_correct_authorisation_URL() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        givenAdyenReturnsASuccessResponse();
+
+        var request = aCardAuthorisationGatewayRequest()
+                .withCredentials(ADYEN_CREDENTIALS)
+                .withGatewayAccount(aGatewayAccountEntity().withType(LIVE).build())
+                .build();
+        authoriseHandler.authorise(request);
+
+        then(mockClient).should()
+                .postRequestFor(captor.capture());
+
+        assertThat(captor.getValue().getUrl(), is(URI.create(LIVE_ADYEN_CHECKOUT_BASE_URL + "/payments")));
+                
+    }
+
+    @Test
+    void should_log_when_calling_Adyen_authorisation_of_charge() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        givenAdyenReturnsASuccessResponse();
+        var request = aCardAuthorisationGatewayRequest()
+                .withCredentials(ADYEN_CREDENTIALS)
+                .build();
+
+        authoriseHandler.authorise(request);
+
+        infoLogs.assertContains("Calling Adyen for authorisation of charge");
+    }
+
+    @Test
+    void should_return_a_GatewayResponse_for_successful_Authorisation() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        givenAdyenReturnsASuccessResponse();
+
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withAddress(makeFullBillingAddress())
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .build();
+        GatewayResponse<BaseAuthoriseResponse> response = authoriseHandler.authorise(authoriseRequest);
+        
+        assertThat(response.getBaseResponse().isPresent(), is(true));
+        assertThat(response.getBaseResponse().get(), hasProperty("transactionId", equalTo("adyen-PSP-reference")));
+        assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
+    }
+
+    private void givenAdyenReturnsASuccessResponse() throws GatewayException.GenericGatewayException, GatewayException.GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
+        when(mockGatewayClientResponse.getEntity()).thenReturn("""
+                {
+                  "pspReference": "adyen-PSP-reference",
+                  "resultCode": "Authorised",
+                  "merchantReference": "merchant-reference"
+                }
+                """);
+    }
+
+    private static Address makeFullBillingAddress() {
+        Address billingAddress = new Address();
+        billingAddress.setLine1("line1");
+        billingAddress.setLine2("line2");
+        billingAddress.setCity("city");
+        billingAddress.setCounty("county");
+        billingAddress.setPostcode("postcode");
+        billingAddress.setCountry("country");
+        return billingAddress;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
@@ -45,8 +45,10 @@ import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_ADYEN_LEGAL_ENTITY_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
@@ -162,6 +164,8 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     public void createCredentialParams() {
         if (paymentProvider.equals(STRIPE.getName())) {
             credentials = Map.of(CREDENTIALS_STRIPE_ACCOUNT_ID, "stripe-account-id");
+        } else if (paymentProvider.equals(ADYEN.getName())){
+            credentials = Map.of(CREDENTIALS_ADYEN_LEGAL_ENTITY_ID, "legal_entity_id");
         } else if (paymentProvider.equals(WORLDPAY.getName())) {
             credentials = Map.of(
                     ONE_OFF_CUSTOMER_INITIATED, Map.of(

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -1,0 +1,102 @@
+package uk.gov.pay.connector.it.resources.adyen;
+
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.it.base.ITestBaseExtension;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
+
+import java.util.Optional;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class AdyenCardResourceAuthoriseIT {
+
+    @RegisterExtension
+    static WireMockExtension wireMockExtension = WireMockExtension.newInstance()
+            .options(wireMockConfig().notifier(new ConsoleNotifier(true)).port(8081))
+            .configureStaticDsl(true)
+            .build();
+
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(
+            ConfigOverride.config("adyen.baseUrls.checkout.test", "http://localhost:8081/v71"));
+
+    @RegisterExtension
+    public static ITestBaseExtension testBaseExtension = new ITestBaseExtension(
+            "adyen", app.getLocalPort(), app.getDatabaseTestHelper());
+
+    private ChargeDao chargeDao;
+
+    @BeforeEach
+    void setUp() {
+        chargeDao = app.getInstanceFromGuiceContainer(ChargeDao.class);
+    }
+
+    @Test
+    void successful_authorisation_of_a_payment_with_a_billing_address() {
+        var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
+        var pspReferenceFromAdyen = "993617895215577D";
+        stubFor(post("/v71/payments")
+                .willReturn(aResponse().withBody("""
+                        {
+                          "pspReference": "%s",
+                          "resultCode": "Authorised",
+                          "merchantReference": "string"
+                        }""".formatted(pspReferenceFromAdyen))));
+
+        var authCardDetails = anAuthCardDetails()
+                .withCardNo("4444333322221111")
+                .withCardBrand("Visa")
+                .withCardHolder("John Doe")
+                .withCvc("737")
+                .withEndDate(CardExpiryDate.valueOf("03/30"))
+                .withAddress(new Address(
+                        "line1",
+                        "line2",
+                        "postcode",
+                        "city",
+                        "county",
+                        "country"
+                )).build();
+
+        app.givenSetup()
+                .body(authCardDetails)
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(200)
+                .body("status", is("AUTHORISATION SUCCESS"));
+
+        verify(postRequestedFor(urlEqualTo("/v71/payments"))
+                .withRequestBody(equalToJson(
+                        load(ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS)
+                                .formatted(chargeId))));
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
+        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -131,7 +131,8 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_SUBMIT_DISPUTE_EVIDENCE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/dispute_submit_evidence_response.json";
     public static final String STRIPE_SEARCH_TRANSFERS_FOR_CAPTURED_PAYMENT_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/search_transfers_for_captured_payment_response.json";
     public static final String STRIPE_SEARCH_TRANSFERS_EMPTY_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/search_transfers_empty_response.json";
-    
+
+    public static final String ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS = TEMPLATE_BASE_NAME + "/adyen/authorisation_request_with_full_billing_address.json";
 
     public static final String SQS_SEND_MESSAGE_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/send-message-response.json";
 

--- a/src/test/resources/templates/adyen/authorisation_request_with_full_billing_address.json
+++ b/src/test/resources/templates/adyen/authorisation_request_with_full_billing_address.json
@@ -1,0 +1,26 @@
+{
+  "amount": {
+    "currency": "GBP",
+    "value": 6234
+  },
+  "billingAddress": {
+    "houseNumberOrName": "line1",
+    "street": "line2",
+    "city": "city",
+    "country": "country",
+    "postalCode": "postcode"
+  },
+  "merchantAccount": "adyen-test-merchant-account-id",
+  "paymentMethod": {
+    "cvc": "737",
+    "expiryMonth": "03",
+    "expiryYear": "2030",
+    "holderName": "John Doe",
+    "number": "4444333322221111",
+    "type": "scheme"
+  },
+  "reference": "%s",
+  "returnUrl": "http://CardFrontend/",
+  "shopperInteraction": "Ecommerce",
+  "channel": "Web"
+}


### PR DESCRIPTION
## WHAT YOU DID

- Authorises an Adyen payment with minimal payload - only includes card details and billing address (doesn't include browser info required for 3DS payments).
- Doesn't handle unhappy paths or exceptions yet
- Introduces `logunit-logback` test dependency, which provides a custom JUnit extension and simplifies testing logging behaviour. It is also used in webhooks

