### PR TITLE
PP-15084 Handle Adyen authorisation gateway exceptions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthorisationRequestSummary.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.connector.gateway.adyen;
+
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
+public class AdyenAuthorisationRequestSummary implements AuthorisationRequestSummary {
+
+    private final Presence billingAddress;
+    private final String ipAddress;
+    private final boolean isCorporateCard;
+
+    private Presence isSetUpAgreement;
+
+    public AdyenAuthorisationRequestSummary(AuthCardDetails authCardDetails, boolean isSetUpAgreement) {
+        billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
+        ipAddress = authCardDetails.getIpAddress().orElse(null);
+        isCorporateCard = authCardDetails.isCorporateCard();
+        this.isSetUpAgreement = isSetUpAgreement ? PRESENT : NOT_PRESENT;
+    }
+
+    @Override
+    public Presence billingAddress() {
+        return billingAddress;
+    }
+
+    @Override
+    public String ipAddress() {
+        return ipAddress;
+    }
+
+    @Override
+    public Presence setUpAgreement() {
+        return isSetUpAgreement;
+    }
+
+    @Override
+    public boolean corporateCard() {
+        return isCorporateCard;
+    }
+
+    @Override
+    public Presence email() {
+        return NOT_PRESENT;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandler.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.gateway.adyen.model.AdyenAuthorisationRequest;
 import uk.gov.pay.connector.gateway.adyen.model.AdyenAuthoriseResponse;
 import uk.gov.pay.connector.gateway.adyen.model.AdyenPaymentResponse;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
@@ -38,6 +39,11 @@ public class AdyenAuthoriseHandler {
             GatewayException.GatewayErrorException,
             GatewayException.GenericGatewayException,
             GatewayException.GatewayConnectionTimeoutException {
+
+        GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse
+                .GatewayResponseBuilder
+                .responseBuilder();
+
         logger.info("Calling Adyen for authorisation of charge");
         var authorisationRequest = new AdyenAuthorisationRequest(
                 getAuthUrl(adyenGatewayConfig, request),
@@ -46,14 +52,20 @@ public class AdyenAuthoriseHandler {
                 adyenRequestFactory.createPaymentRequest(request),
                 jsonObjectMapper);
 
-        var jsonResponse = gatewayClient.postRequestFor(authorisationRequest).getEntity();
+        try {
+            var jsonResponse = gatewayClient.postRequestFor(authorisationRequest).getEntity();
+            var paymentResponse = jsonObjectMapper.getObject(
+                    jsonResponse,
+                    AdyenPaymentResponse.class);
 
-        var paymentResponse = jsonObjectMapper.getObject(
-                jsonResponse,
-                AdyenPaymentResponse.class);
-
-        return GatewayResponse.GatewayResponseBuilder.responseBuilder()
-                .withResponse(AdyenAuthoriseResponse.of(paymentResponse))
-                .build();
+            return responseBuilder
+                    .withResponse(AdyenAuthoriseResponse.of(paymentResponse))
+                    .build();
+        } catch (GatewayException.GatewayConnectionTimeoutException
+                 | GatewayException.GenericGatewayException
+                 | GatewayException.GatewayErrorException e) {
+            logger.error("GatewayException occurred, error:\n {0}", e);
+            return responseBuilder.withGatewayError(e.toGatewayError()).build();
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
@@ -17,7 +17,6 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -112,12 +111,10 @@ public class AdyenPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public AuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity,
-                                                                           AuthCardDetails authCardDetails,
-                                                                           boolean isSetUpAgreement) {
-        return new AuthorisationRequestSummary() {
-            // TODO: Implement AdyenAuthorisationRequestSummary
-        };
+    public AdyenAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity,
+                                                                                AuthCardDetails authCardDetails,
+                                                                                boolean isSetUpAgreement) {
+        return new AdyenAuthorisationRequestSummary(authCardDetails, isSetUpAgreement);
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthorisationRequestSummaryTest.java
@@ -1,0 +1,84 @@
+package uk.gov.pay.connector.gateway.adyen;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
+@ExtendWith(MockitoExtension.class)
+class AdyenAuthorisationRequestSummaryTest {
+
+    @Mock
+    private AuthCardDetails mockAuthCardDetails;
+
+    @Test
+    void billingAddressPresent() {
+        given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
+        var adyenAuthorisationRequestSummary = new AdyenAuthorisationRequestSummary(mockAuthCardDetails, false);
+        assertThat(adyenAuthorisationRequestSummary.billingAddress(), is(PRESENT));
+    }
+
+    @Test
+    void billingAddressNotPresent() {
+        given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
+        var adyenAuthorisationRequestSummary = new AdyenAuthorisationRequestSummary(mockAuthCardDetails, false);
+        assertThat(adyenAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
+    }
+
+    @Test
+    void dataFor3dsAlwaysNotApplicable() {
+        var adyenAuthorisationRequestSummary = new AdyenAuthorisationRequestSummary(mockAuthCardDetails, false);
+        assertThat(adyenAuthorisationRequestSummary.dataFor3ds(), is(NOT_APPLICABLE));
+    }
+
+    @Test
+    void dataFor3ds2AlwaysNotApplicable() {
+        var adyenAuthorisationRequestSummary = new AdyenAuthorisationRequestSummary(mockAuthCardDetails, false);
+        assertThat(adyenAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
+    }
+
+    @Test
+    void deviceDataCollectionResultAlwaysNotApplicable() {
+        var adyenAuthorisationRequestSummary = new AdyenAuthorisationRequestSummary(mockAuthCardDetails, false);
+        assertThat(adyenAuthorisationRequestSummary.deviceDataCollectionResult(), is(NOT_APPLICABLE));
+    }
+
+    @Test
+    void isSetUpAgreementPresent() {
+        var adyenAuthorisationRequestSummary = new AdyenAuthorisationRequestSummary(mockAuthCardDetails, true);
+        assertThat(adyenAuthorisationRequestSummary.setUpAgreement(), is(PRESENT));
+    }
+
+    @Test
+    void isSetUpAgreementNotPresent() {
+        var adyenAuthorisationRequestSummary = new AdyenAuthorisationRequestSummary(mockAuthCardDetails, false);
+        assertThat(adyenAuthorisationRequestSummary.setUpAgreement(), is(NOT_PRESENT));
+    }
+
+    @Test
+    void corporateCardUsed() {
+        given(mockAuthCardDetails.isCorporateCard()).willReturn(true);
+        var adyenAuthorisationRequestSummary = new AdyenAuthorisationRequestSummary(mockAuthCardDetails, false);
+        assertThat(adyenAuthorisationRequestSummary.corporateCard(), is(true));
+    }
+
+    @Test
+    void corporateCardNotUsed() {
+        given(mockAuthCardDetails.isCorporateCard()).willReturn(false);
+        var adyenAuthorisationRequestSummary = new AdyenAuthorisationRequestSummary(mockAuthCardDetails, false);
+        assertThat(adyenAuthorisationRequestSummary.corporateCard(), is(false));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandlerTest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.adyen;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonassert.JsonAssert;
 import io.github.netmikey.logunit.api.LogCapturer;
+import org.hamcrest.core.Is;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +28,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
@@ -35,6 +37,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 
@@ -167,6 +170,24 @@ class AdyenAuthoriseHandlerTest {
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
     }
 
+    @Test
+    void should_not_authorise_when_payment_provider_returns_unexpected_status_code() throws Exception {
+        givenAdyenReturnsAnUnexpectedResponse();
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withAddress(makeFullBillingAddress())
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .build();
+
+        GatewayResponse<BaseAuthoriseResponse> response = authoriseHandler.authorise(authoriseRequest);
+
+        assertThat(response.getGatewayError().isPresent(), Is.is(true));
+        assertThat(response.getGatewayError().get().getMessage(),
+                containsString("server error"));
+        assertThat(response.getGatewayError().get().getErrorType(), Is.is(GATEWAY_ERROR));
+    }
+
     private void givenAdyenReturnsASuccessResponse() throws GatewayException.GenericGatewayException, GatewayException.GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
         when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
         when(mockGatewayClientResponse.getEntity()).thenReturn("""
@@ -176,6 +197,19 @@ class AdyenAuthoriseHandlerTest {
                   "merchantReference": "merchant-reference"
                 }
                 """);
+    }
+
+    private void givenAdyenReturnsAnUnexpectedResponse() throws GatewayException.GenericGatewayException, GatewayException.GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockClient.postRequestFor(any()))
+                .thenThrow(new GatewayException.GatewayErrorException("server error", """
+                        {
+                           "status": 500,
+                           "errorCode": "905",
+                           "message": "Payment details are not supported",
+                           "errorType": "configuration",
+                           "pspReference": "adyen-PSP-reference"
+                         }
+                        """, 500));
     }
 
     private static Address makeFullBillingAddress() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -152,4 +152,63 @@ class AdyenCardResourceAuthoriseIT {
         assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
         assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
     }
+
+    @Test
+    void declined_authorisation() {
+        var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
+        var pspReferenceFromAdyen = "883617895215577D";
+        stubFor(post("/v71/payments")
+                .willReturn(aResponse().withBody("""
+                        {
+                          "pspReference": "%s",
+                          "refusalReason": "Expired Card",
+                          "resultCode": "Refused",
+                          "refusalReasonCode": "6"
+                        }""".formatted(pspReferenceFromAdyen))));
+
+
+        var response = app.givenSetup()
+                .body(anAuthCardDetails().build())
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId);
+
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION REJECTED"));
+        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+
+        response.then()
+                .statusCode(400)
+                .body("error_identifier", is("GENERIC"))
+                .body("message[0]", is("This transaction was declined."));
+    }
+
+
+    @Test
+    void unknown_error_from_Adyen() {
+        var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
+        var pspReferenceFromAdyen = "851563882585825A";
+        stubFor(post("/v71/payments")
+                .willReturn(aResponse().withBody("""
+                        {
+                          "pspReference": "%s",
+                          "refusalReason": "Acquirer Error",
+                          "resultCode": "Error",
+                          "refusalReasonCode": "4"
+                        }""".formatted(pspReferenceFromAdyen))));
+
+
+        var response = app.givenSetup()
+                .body(anAuthCardDetails().build())
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId);
+
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION ERROR"));
+        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+
+        response.then()
+                .statusCode(402)
+                .body("error_identifier", is("GENERIC"))
+                .body("message[0]", is("There was an error authorising the transaction."));
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenPaymentAuthorisationTimeoutIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenPaymentAuthorisationTimeoutIT.java
@@ -1,0 +1,105 @@
+package uk.gov.pay.connector.it.resources.adyen;
+
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.google.inject.Provides;
+import io.dropwizard.core.setup.Environment;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.ConnectorModule;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.gateway.ClientFactory;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
+import uk.gov.pay.connector.it.base.ITestBaseExtension;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class AdyenPaymentAuthorisationTimeoutIT {
+
+    @RegisterExtension
+    static WireMockExtension wireMockExtension = WireMockExtension.newInstance()
+            .options(wireMockConfig().notifier(new ConsoleNotifier(true)).port(8081))
+            .configureStaticDsl(true)
+            .build();
+
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(
+            CustomConnectorApp.class,
+            ConfigOverride.config("adyen.baseUrls.checkout.test", "http://localhost:8081/v71"));
+
+    @RegisterExtension
+    public static ITestBaseExtension testBaseExtension = new ITestBaseExtension(
+            "adyen", app.getLocalPort(), app.getDatabaseTestHelper());
+
+    private ChargeDao chargeDao;
+
+    @BeforeEach
+    void setUp() {
+        chargeDao = app.getInstanceFromGuiceContainer(ChargeDao.class);
+    }
+
+    @Test
+    void timed_out_authorisation() {
+        var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
+
+        app.givenSetup()
+                .body(anAuthCardDetails().build())
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(402)
+                .body("error_identifier", is("GENERIC"))
+                .body("message[0]", is("Gateway connection timeout error"));
+
+
+        var charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION TIMEOUT"));
+    }
+
+    public static class CustomConnectorApp extends ConnectorApp {
+        @Override
+        protected ConnectorModule getModule(ConnectorConfiguration configuration, Environment environment) {
+            return new ConnectorModuleWithCustomGatewayClientThrowingException(configuration, environment);
+        }
+    }
+
+    private static class ConnectorModuleWithCustomGatewayClientThrowingException extends ConnectorModule {
+        public ConnectorModuleWithCustomGatewayClientThrowingException(ConnectorConfiguration configuration, Environment environment) {
+            super(configuration, environment);
+        }
+
+        @Provides
+        public GatewayClientFactory provideGatewayClientFactory(ClientFactory clientFactory) {
+            return new GatewayClientFactory(clientFactory) {
+                @Override
+                public GatewayClient createGatewayClient(PaymentGatewayName gateway, MetricRegistry metricRegistry) {
+                    return new GatewayClient(null, null) {
+                        @Override
+                        public Response postRequestFor(GatewayClientPostRequest request) throws GatewayException.GatewayConnectionTimeoutException {
+                            throw new GatewayException.GatewayConnectionTimeoutException("Gateway connection timeout error");
+                        }
+                    };
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- Handles Gateway exceptions during payment authorisation with Adyen, and added tests for authorisation declines
- For payment declines or errors on Adyen's end, Adyen responds with a 200 HTTP status code and the status code is mapped to an internal status.
- Generates and returns AuthorisationSummary for logging based on the current data included in the authorisation request.

