### PR TITLE
PP-15084: Update AdyenAuthorisationRequest to accept headers

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandler.java
@@ -13,9 +13,8 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
-import java.net.URI;
-
-import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getBaseCheckoutUrl;
+import static uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil.getAuthUrl;
+import static uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil.getHeaders;
 
 public class AdyenAuthoriseHandler {
 
@@ -41,7 +40,9 @@ public class AdyenAuthoriseHandler {
             GatewayException.GatewayConnectionTimeoutException {
         logger.info("Calling Adyen for authorisation of charge");
         var authorisationRequest = new AdyenAuthorisationRequest(
-                getUrl(request),
+                getAuthUrl(adyenGatewayConfig, request),
+                getHeaders(adyenGatewayConfig, request),
+                request.getGatewayAccount().getType(),
                 adyenRequestFactory.createPaymentRequest(request),
                 jsonObjectMapper);
 
@@ -54,9 +55,5 @@ public class AdyenAuthoriseHandler {
         return GatewayResponse.GatewayResponseBuilder.responseBuilder()
                 .withResponse(AdyenAuthoriseResponse.of(paymentResponse))
                 .build();
-    }
-
-    private URI getUrl(CardAuthorisationGatewayRequest request) {
-        return URI.create(getBaseCheckoutUrl(adyenGatewayConfig, request.getGatewayAccount().isLive()) + "/payments");
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
@@ -55,7 +55,7 @@ public class AdyenPaymentProvider implements PaymentProvider {
         this.client = gatewayClientFactory.createGatewayClient(ADYEN, environment.metrics());
         adyenAuthoriseHandler = new AdyenAuthoriseHandler(client, connectorConfiguration, jsonObjectMapper);
     }
-
+    
     @Override
     public PaymentGatewayName getPaymentGatewayName() {
         return ADYEN;

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/model/AdyenAuthorisationRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/model/AdyenAuthorisationRequest.java
@@ -13,7 +13,11 @@ import java.util.Map;
 
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 
-public record AdyenAuthorisationRequest(URI url, PaymentRequest requestPayload, JsonObjectMapper jsonObjectMapper) implements GatewayClientPostRequest {
+public record AdyenAuthorisationRequest(URI url,
+                                        Map<String, String> headers,
+                                        String gatewayAccountType,
+                                        PaymentRequest requestPayload,
+                                        JsonObjectMapper jsonObjectMapper) implements GatewayClientPostRequest {
     @Override
     public URI getUrl() {
         return url;
@@ -27,12 +31,12 @@ public record AdyenAuthorisationRequest(URI url, PaymentRequest requestPayload, 
 
     @Override
     public Map<String, String> getHeaders() {
-        return Map.of();
+        return headers;
     }
 
     @Override
     public String getGatewayAccountType() {
-        return "";
+        return gatewayAccountType;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.connector.gateway.adyen.utils;
+
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+
+import java.net.URI;
+import java.util.Map;
+
+import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getBaseCheckoutUrl;
+import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getCompanyApiKey;
+
+public class AdyenRequestUtil {
+
+    public static URI getAuthUrl(AdyenGatewayConfig adyenGatewayConfig, CardAuthorisationGatewayRequest request) {
+        return URI.create(getBaseCheckoutUrl(adyenGatewayConfig, request.getGatewayAccount().isLive()) + "/payments");
+    }
+
+    public static Map<String, String> getHeaders(AdyenGatewayConfig adyenGatewayConfig, CardAuthorisationGatewayRequest request) {
+        return Map.of("X-API-Key",
+                getCompanyApiKey(
+                        adyenGatewayConfig,
+                        request.getGatewayAccount().isLive()
+                ));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseHandlerTest.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.LinksConfig;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.app.adyen.AdyenIds;
+import uk.gov.pay.connector.app.adyen.ApiKeys;
 import uk.gov.pay.connector.app.adyen.BaseUrls;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayClient;
@@ -26,8 +27,6 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
-import java.net.URI;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
@@ -37,8 +36,6 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 
 @ExtendWith(MockitoExtension.class)
@@ -70,6 +67,12 @@ class AdyenAuthoriseHandlerTest {
         AdyenGatewayConfig mockAdyenGatewayConfig = mock(AdyenGatewayConfig.class);
         when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
         when(mockAdyenGatewayConfig.getBaseUrls()).thenReturn(mockBaseUrls);
+        
+        ApiKeys mockApiKeys = mock(ApiKeys.class);
+        ApiKeys.CompanyAccountApiKeys mockCompanyApiKeys = mock(ApiKeys.CompanyAccountApiKeys.class);
+        when(mockApiKeys.companyAccount()).thenReturn(mockCompanyApiKeys);
+        when(mockCompanyApiKeys.test()).thenReturn("test");
+        when(mockAdyenGatewayConfig.getApiKeys()).thenReturn(mockApiKeys);
         when(mockConfig.getAdyenGatewayConfig()).thenReturn(mockAdyenGatewayConfig);
 
         authoriseHandler = new AdyenAuthoriseHandler(mockClient, mockConfig, jsonObjectMapper);
@@ -97,20 +100,20 @@ class AdyenAuthoriseHandlerTest {
     }
 
     @Test
-    void should_construct_correct_authorisation_URL() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+    void should_send_request_to_Adyen_with_no_billing_address() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
         givenAdyenReturnsASuccessResponse();
 
-        var request = aCardAuthorisationGatewayRequest()
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withAddress(null)
+                        .build())
                 .withCredentials(ADYEN_CREDENTIALS)
-                .withGatewayAccount(aGatewayAccountEntity().withType(LIVE).build())
                 .build();
-        authoriseHandler.authorise(request);
+        authoriseHandler.authorise(authoriseRequest);
 
-        then(mockClient).should()
-                .postRequestFor(captor.capture());
-
-        assertThat(captor.getValue().getUrl(), is(URI.create(LIVE_ADYEN_CHECKOUT_BASE_URL + "/payments")));
-                
+        then(mockClient).should().postRequestFor(captor.capture());
+        String payload = captor.getValue().getGatewayOrder().getPayload();
+        JsonAssert.with(payload).assertNotDefined("$.billingAddress");
     }
 
     @Test
@@ -158,7 +161,7 @@ class AdyenAuthoriseHandlerTest {
                 .withCredentials(ADYEN_CREDENTIALS)
                 .build();
         GatewayResponse<BaseAuthoriseResponse> response = authoriseHandler.authorise(authoriseRequest);
-        
+
         assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(response.getBaseResponse().get(), hasProperty("transactionId", equalTo("adyen-PSP-reference")));
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/model/AdyenAuthorisationRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/model/AdyenAuthorisationRequestTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.gateway.adyen.model.json.PaymentRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import java.net.URI;
+import java.util.Map;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -59,6 +60,8 @@ class AdyenAuthorisationRequestTest {
         var paymentRequest = makePaymentRequestWithFullBillingAddress();
         return new AdyenAuthorisationRequest(
                 URI.create(TEST_URL),
+                Map.of("X-API-Key", "test-api-key"),
+                "test", 
                 paymentRequest,
                 jsonObjectMapper);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtilTest.java
@@ -10,9 +10,9 @@ import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.app.adyen.AdyenIds;
 import uk.gov.pay.connector.app.adyen.ApiKeys;
 import uk.gov.pay.connector.app.adyen.BaseUrls;
-import uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -49,7 +49,7 @@ class AdyenConfigUtilTest {
             String result =
                     AdyenConfigUtil.getCompanyApiKey(mockAdyenGatewayConfig, true);
 
-            assertThat(result).isEqualTo("live-api-key");
+            assertThat(result, is("live-api-key"));
         }
 
         @Test
@@ -58,7 +58,7 @@ class AdyenConfigUtilTest {
 
             String result = AdyenConfigUtil.getCompanyApiKey(mockAdyenGatewayConfig, false);
 
-            assertThat(result).isEqualTo("test-api-key");
+            assertThat(result, is("test-api-key"));
         }
     }
 
@@ -72,7 +72,7 @@ class AdyenConfigUtilTest {
 
             String result = AdyenConfigUtil.getBaseCheckoutUrl(mockAdyenGatewayConfig, true);
 
-            assertThat(result).isEqualTo("https://checkout-live.adyen.com");
+            assertThat(result, is("https://checkout-live.adyen.com"));
         }
 
         @Test
@@ -83,7 +83,7 @@ class AdyenConfigUtilTest {
 
             String result = AdyenConfigUtil.getBaseCheckoutUrl(mockAdyenGatewayConfig, false);
 
-            assertThat(result).isEqualTo("https://checkout-test.adyen.com");
+            assertThat(result, is("https://checkout-test.adyen.com"));
         }
     }
 
@@ -96,7 +96,7 @@ class AdyenConfigUtilTest {
 
             String result = AdyenConfigUtil.getMerchantAccountId(mockAdyenGatewayConfig, true);
 
-            assertThat(result).isEqualTo("live-merchant-123");
+            assertThat(result, is("live-merchant-123"));
 
             verify(mockMerchantAccountIds).live();
             verify(mockMerchantAccountIds, never()).test();
@@ -109,7 +109,7 @@ class AdyenConfigUtilTest {
 
             String result = AdyenConfigUtil.getMerchantAccountId(mockAdyenGatewayConfig, false);
 
-            assertThat(result).isEqualTo("test-merchant-123");
+            assertThat(result, is("test-merchant-123"));
 
             verify(mockMerchantAccountIds).test();
             verify(mockMerchantAccountIds, never()).live();

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.connector.gateway.adyen.utils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.app.adyen.AdyenIds;
+import uk.gov.pay.connector.app.adyen.ApiKeys;
+import uk.gov.pay.connector.app.adyen.BaseUrls;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+
+@ExtendWith(MockitoExtension.class)
+class AdyenRequestUtilTest {
+
+    @Mock
+    private AdyenGatewayConfig mockAdyenGatewayConfig;
+    public final AdyenCredentials adyenCredentials = new AdyenCredentials("legal_entity_id", "store_id");
+    private CardAuthorisationGatewayRequest mockAuthoriseRequest;
+
+    @BeforeEach
+    void setUp() {
+        mockAuthoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails().build())
+                .withCredentials(adyenCredentials)
+                .withGatewayAccount(aGatewayAccountEntity().withType(TEST).build())
+                .build();
+    }
+
+    @Test
+    void should_create_adyen_checkout_authorisation_url() {
+        BaseUrls mockBaseUrls = mock(BaseUrls.class);
+        when(mockBaseUrls.checkout()).thenReturn(new BaseUrls.CheckoutUrls("https://example.com/test/v71", "https://example.com/live/v71"));
+        when(mockAdyenGatewayConfig.getBaseUrls()).thenReturn(mockBaseUrls);
+
+        var testCheckoutUrl = AdyenRequestUtil.getAuthUrl(mockAdyenGatewayConfig, mockAuthoriseRequest).toString();
+        assertThat(testCheckoutUrl, is("https://example.com/test/v71/payments"));
+    }
+
+    @Test
+    void should_create_api_key_headers_for_checkout_url() {
+        ApiKeys mockApiKeys = mock(ApiKeys.class);
+        ApiKeys.CompanyAccountApiKeys mockCompanyApiKeys = mock(ApiKeys.CompanyAccountApiKeys.class);
+        when(mockApiKeys.companyAccount()).thenReturn(mockCompanyApiKeys);
+        when(mockCompanyApiKeys.test()).thenReturn("test");
+        when(mockAdyenGatewayConfig.getApiKeys()).thenReturn(mockApiKeys);
+
+        var headers = AdyenRequestUtil.getHeaders(mockAdyenGatewayConfig, mockAuthoriseRequest);
+        assertThat(headers, hasEntry("X-API-Key", "test"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.it.resources.adyen;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.dropwizard.testing.ConfigOverride;
@@ -18,7 +19,10 @@ import uk.gov.service.payments.commons.model.CardExpiryDate;
 import java.util.Optional;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -91,9 +95,58 @@ class AdyenCardResourceAuthoriseIT {
                 .body("status", is("AUTHORISATION SUCCESS"));
 
         verify(postRequestedFor(urlEqualTo("/v71/payments"))
+                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
                 .withRequestBody(equalToJson(
                         load(ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS)
                                 .formatted(chargeId))));
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
+        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+    }
+
+    @Test
+    void successful_authorisation_of_a_payment_without_a_billing_address() {
+        var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
+        var pspReferenceFromAdyen = "993617895215577D";
+        stubFor(post("/v71/payments")
+                .willReturn(aResponse().withBody("""
+                        {
+                          "pspReference": "%s",
+                          "resultCode": "Authorised",
+                          "merchantReference": "string"
+                        }""".formatted(pspReferenceFromAdyen))));
+
+        var authCardDetails = anAuthCardDetails()
+                .withCardNo("4444333322221111")
+                .withCardBrand("Visa")
+                .withCardHolder("John Doe")
+                .withCvc("737")
+                .withEndDate(CardExpiryDate.valueOf("03/30"))
+                .withAddress(null)
+                .build();
+
+        app.givenSetup()
+                .body(authCardDetails)
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(200)
+                .body("status", is("AUTHORISATION SUCCESS"));
+
+        verify(postRequestedFor(urlEqualTo("/v71/payments"))
+                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withRequestBody(WireMock.matchingJsonPath("$.billingAddress", absent()))
+                .withRequestBody(matchingJsonPath("$.paymentMethod",
+                        equalToJson(""" 
+                                {
+                                  "type": "scheme",
+                                  "number": "4444333322221111",
+                                  "expiryMonth": "03",
+                                  "expiryYear": "2030",
+                                  "cvc": "737",
+                                  "holderName": "John Doe"
+                                }"""))));
+
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));

--- a/src/test/java/uk/gov/pay/connector/webhook/resource/NotificationResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/webhook/resource/NotificationResourceTest.java
@@ -8,7 +8,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -29,7 +30,7 @@ class NotificationResourceTest {
         when(adyenNotificationService.handleNotificationFor(anyString(), eq(forwardedIpAddress))).thenReturn(true);
 
         try (Response response = notificationResource.authoriseAdyenPaymentsNotifications(rawNotification, forwardedIpAddress)) {
-            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.getStatus(), is(200));
         }
     }
 
@@ -40,7 +41,7 @@ class NotificationResourceTest {
         when(adyenNotificationService.handleNotificationFor(anyString(), eq(forwardedIpAddress))).thenReturn(false);
 
         try (Response response = notificationResource.authoriseAdyenPaymentsNotifications(rawNotification, forwardedIpAddress)) {
-            assertThat(response.getStatus()).isEqualTo(403);
+            assertThat(response.getStatus(), is(403));
         }
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Updated AuthorisationRequest to accept headers (X-API-Key, and so on) to pass on requests to Adyen
- Added AdyenRequestUtil to get headers/URL for requests to Adyen
- Additionally, added a missing integration test for authorisation without a billing address