### PR TITLE
PP-15351 Override dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,20 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>12.1.9</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.21.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
                 <version>5.0.1</version>


### PR DESCRIPTION
## WHAT YOU DID
- Overrides Jetty and Jackson dependencies due to vulnerable transitive dependencies, and the Dropwizard release with the latest versions of these libraries may take a while.
- Added BOM instead of overriding specific vulnerable dependencies to ensure all modules in the group are aligned to the overridden version.
