### PR TITLE
PP-15083 Validate Adyen webhook HMAC signature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,11 @@
             <version>1.0.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.adyen</groupId>
+            <artifactId>adyen-java-api-library</artifactId>
+            <version>41.1.1</version>
+        </dependency>
 
         <!-- Test dependencies that are imported from one of the BOMs specified
              in <dependencyManagement> so no explicit versions needed -->

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtil.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.adyen.utils;
 
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
 
 public class AdyenConfigUtil {
 
@@ -34,5 +35,18 @@ public class AdyenConfigUtil {
             merchantAccountId = adyenGatewayConfig.getMerchantAccountIds().test();
         }
         return merchantAccountId;
+    }
+
+    public static String getHmacKey(AdyenGatewayConfig adyenGatewayConfig, boolean live) {
+        WebhookHmacKeys webhookHmacKeys;
+
+        if (live) {
+            webhookHmacKeys = adyenGatewayConfig.getHmacKeys().payments().live();
+        } else {
+            webhookHmacKeys = adyenGatewayConfig.getHmacKeys().payments().test();
+        }
+
+        return webhookHmacKeys.getPrimary()
+                .orElseThrow(() -> new IllegalStateException("Missing primary Adyen HMAC key"));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
@@ -1,15 +1,24 @@
 package uk.gov.pay.connector.gateway.adyen.webhook;
 
+import com.adyen.model.notification.NotificationRequest;
+import com.adyen.model.notification.NotificationRequestItem;
+import com.adyen.notification.WebhookHandler;
+import com.adyen.util.HMACValidator;
 import com.google.inject.Inject;
-import com.google.inject.persist.Transactional;
+import jakarta.ws.rs.WebApplicationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil;
+import uk.gov.pay.connector.gateway.exception.AdyenNotificationException;
 import uk.gov.pay.connector.util.IpDomainMatcher;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.security.SignatureException;
+import java.util.List;
+
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER;
 
 public class AdyenNotificationService {
@@ -18,11 +27,13 @@ public class AdyenNotificationService {
 
     private final AdyenGatewayConfig adyenGatewayConfig;
     private final IpDomainMatcher ipDomainMatcher;
-    
+    private final HMACValidator hmacValidator;
+
     @Inject
     public AdyenNotificationService(AdyenGatewayConfig adyenGatewayConfig, IpDomainMatcher ipDomainMatcher) {
         this.adyenGatewayConfig = adyenGatewayConfig;
         this.ipDomainMatcher = ipDomainMatcher;
+        this.hmacValidator = new HMACValidator();
     }
 
     public boolean handleNotificationFor(String payload, String forwardedIpAddresses) {
@@ -43,11 +54,65 @@ public class AdyenNotificationService {
             return false;
         }
 
-        LOGGER.info("Processed adyen notification",
+        try {
+            NotificationRequest notificationRequest = deserialisePayloadToNotificationRequest(payload);
+            List<NotificationRequestItem> items = extractNotificationItem(notificationRequest);
+
+            boolean live = "true".equalsIgnoreCase(notificationRequest.getLive());
+
+            String hmacKey = AdyenConfigUtil.getHmacKey(adyenGatewayConfig, live);
+
+            for (NotificationRequestItem item : items) {
+                if (!isValidHmac(item, hmacKey)) {
+                    return false;
+                }
+            }
+        } catch (AdyenNotificationException e) {
+            LOGGER.error("Failed to validate Adyen notification payload", e);
+            return false;
+        }
+
+        LOGGER.info("Processed Adyen notification",
                 kv(PROVIDER, PaymentGatewayName.ADYEN.getName()),
-                kv("notification_source", forwardedIpAddresses),
-                kv("payload_length", payload == null ? 0 : payload.length()));
+                kv("notification_source", forwardedIpAddresses));
 
         return true;
+    }
+
+    private NotificationRequest deserialisePayloadToNotificationRequest(String rawAdyenJson) {
+        try {
+            WebhookHandler webhookHandler = new WebhookHandler();
+            return webhookHandler.handleNotificationJson(rawAdyenJson);
+        } catch (Exception e) {
+            LOGGER.info("Error deserialising Adyen notification payload", e);
+            throw new WebApplicationException("Error deserialising webhook Json", e);
+        }
+    }
+
+    private List<NotificationRequestItem> extractNotificationItem(NotificationRequest notificationRequest) {
+        if (notificationRequest == null ||
+                (notificationRequest.getNotificationItems() == null || notificationRequest.getNotificationItems().isEmpty())) {
+            LOGGER.info("Adyen notification request is empty or missing items");
+            throw new AdyenNotificationException("Notification request is empty");
+        }
+        return notificationRequest.getNotificationItems();
+    }
+
+    private boolean isValidHmac(NotificationRequestItem item, String hmacKey) {
+        try {
+            boolean validSignature = hmacValidator.validateHMAC(item, hmacKey);
+
+            if (!validSignature) {
+                LOGGER.error("Invalid HMAC signature in the payload for Adyen notification",
+                        kv("pspReference", item.getPspReference()),
+                        kv("eventCode", item.getEventCode()));
+            }
+            return validSignature;
+        } catch (IllegalArgumentException | SignatureException e) {
+            LOGGER.info("Failed to validate HMAC signature",
+                    kv("pspReference", item.getPspReference()),
+                    kv("eventCode", item.getEventCode()));
+            throw new AdyenNotificationException("Failed to validate HMAC signature", e);
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/exception/AdyenNotificationException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/exception/AdyenNotificationException.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.gateway.exception;
+
+public class AdyenNotificationException extends RuntimeException{
+    public AdyenNotificationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AdyenNotificationException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtilTest.java
@@ -10,9 +10,14 @@ import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.app.adyen.AdyenIds;
 import uk.gov.pay.connector.app.adyen.ApiKeys;
 import uk.gov.pay.connector.app.adyen.BaseUrls;
+import uk.gov.pay.connector.app.adyen.HmacKeys;
+import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
+
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -113,6 +118,62 @@ class AdyenConfigUtilTest {
 
             verify(mockMerchantAccountIds).test();
             verify(mockMerchantAccountIds, never()).live();
+        }
+    }
+
+    @Nested
+    class TestGetsHmacKeys {
+
+        @Mock
+        private HmacKeys mockHmacKeys;
+        @Mock
+        private HmacKeys.WebhookHmacKeyPair mockKeyPair;
+        @Mock
+        private WebhookHmacKeys mockLiveKeys;
+        @Mock
+        private WebhookHmacKeys mockTestKeys;
+
+        @Test
+        void shouldReturnLiveHmacKeyWhenLiveIsTrue() {
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(mockHmacKeys);
+            when(mockHmacKeys.payments()).thenReturn(mockKeyPair);
+            when(mockKeyPair.live()).thenReturn(mockLiveKeys);
+            when(mockLiveKeys.getPrimary()).thenReturn(Optional.of("live-hmac-key"));
+
+            String result = AdyenConfigUtil.getHmacKey(mockAdyenGatewayConfig, true);
+
+            assertThat(result, is("live-hmac-key"));
+
+            verify(mockKeyPair).live();
+            verify(mockKeyPair, never()).test();
+        }
+
+        @Test
+        void shouldReturnTestHmacKeyWhenLiveIsFalse() {
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(mockHmacKeys);
+            when(mockHmacKeys.payments()).thenReturn(mockKeyPair);
+            when(mockKeyPair.test()).thenReturn(mockTestKeys);
+            when(mockTestKeys.getPrimary()).thenReturn(Optional.of("test-hmac-key"));
+
+            String result = AdyenConfigUtil.getHmacKey(mockAdyenGatewayConfig, false);
+
+            assertThat(result, is("test-hmac-key"));
+
+            verify(mockKeyPair).test();
+            verify(mockKeyPair, never()).live();
+        }
+
+        @Test
+        void shouldThrowWhenPrimaryHmacKeyIsMissingForTest() {
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(mockHmacKeys);
+            when(mockHmacKeys.payments()).thenReturn(mockKeyPair);
+            when(mockKeyPair.test()).thenReturn(mockTestKeys);
+            when(mockTestKeys.getPrimary()).thenReturn(Optional.empty());
+
+            var exception = assertThrows(IllegalStateException.class, () ->
+                    AdyenConfigUtil.getHmacKey(mockAdyenGatewayConfig, false));
+
+            assertThat(exception.getMessage(), is("Missing primary Adyen HMAC key"));
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
@@ -1,22 +1,50 @@
 package uk.gov.pay.connector.gateway.adyen.webhook;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import jakarta.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.app.adyen.HmacKeys;
+import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
 import uk.gov.pay.connector.util.IpDomainMatcher;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_NOTIFICATION;
 
 @ExtendWith(MockitoExtension.class)
 class AdyenNotificationServiceTest {
 
     private AdyenNotificationService adyenNotificationService;
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
 
     @Mock
     private AdyenGatewayConfig adyenGatewayConfig;
@@ -24,17 +52,26 @@ class AdyenNotificationServiceTest {
     @Mock
     private IpDomainMatcher ipDomainMatcher;
 
+    private String validHmacSigniture = "coqCmt/IZ4E3CzPvMY8zTjQVL5hYJUiBRg8UU+iCWo0="; // pragma: allowlist secret
+
     @BeforeEach
     void setUp() {
         adyenNotificationService = new AdyenNotificationService(adyenGatewayConfig, ipDomainMatcher);
+        Logger root = (Logger) LoggerFactory.getLogger(AdyenNotificationService.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
     }
 
     @Test
     void shouldAcceptNotificationWhenForwardedIpMatchesConfiguredDomain() {
         when(adyenGatewayConfig.getNotificationDomain()).thenReturn("out.adyen.com.");
         when(ipDomainMatcher.ipMatchesDomain("5.6.7.8", "out.adyen.com.")).thenReturn(true);
+        when(adyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
 
-        boolean result = adyenNotificationService.handleNotificationFor("{\"notificationItems\":[]}", "5.6.7.8");
+        String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
+                .replace("{{HMAC_SIGNATURE}}", validHmacSigniture);
+
+        boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
 
         assertTrue(result);
     }
@@ -46,7 +83,6 @@ class AdyenNotificationServiceTest {
         assertFalse(result);
         verifyNoInteractions(ipDomainMatcher);
     }
-    
 
     @Test
     void shouldRejectNotificationWhenForwardedIpDoesNotMatchConfiguredDomain() {
@@ -57,5 +93,141 @@ class AdyenNotificationServiceTest {
 
         assertFalse(result);
     }
-}
 
+    @Nested
+    class TestValidateNotification {
+        @BeforeEach
+        void setUp() {
+            when(adyenGatewayConfig.getNotificationDomain()).thenReturn("out.adyen.com.");
+            when(ipDomainMatcher.ipMatchesDomain("5.6.7.8", "out.adyen.com.")).thenReturn(true);
+        }
+
+        @Test
+        void shouldReturnTrueForValidHmacKey() {
+            when(adyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+
+            String payload = TestTemplateResourceLoader
+                    .load(ADYEN_NOTIFICATION)
+                    .replace("{{HMAC_SIGNATURE}}", validHmacSigniture);
+
+            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
+
+            assertTrue(result);
+        }
+
+        @Test
+        void shouldReturnFalseWhenHmacSignatureIsInvalid() {
+            when(adyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+
+            String payload = TestTemplateResourceLoader
+                    .load(ADYEN_NOTIFICATION)
+                    .replace("{{HMAC_SIGNATURE}}", "WrongSignature");
+
+            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
+
+            assertFalse(result);
+            verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .stream()
+                    .anyMatch(event -> event
+                            .getFormattedMessage()
+                            .equals("Invalid HMAC signature in the payload for Adyen notification")), is(true));
+        }
+
+        @Test
+        void shouldReturnFalseWhenHmacKeyIsInvalid() {
+            when(adyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys("invalid-hmac-key"));
+
+            String payload = TestTemplateResourceLoader
+                    .load(ADYEN_NOTIFICATION)
+                    .replace("{{HMAC_SIGNATURE}}", validHmacSigniture);
+
+            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
+
+            assertFalse(result);
+
+            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .getFirst()
+                    .getFormattedMessage(), is("Failed to validate HMAC signature"));
+            assertThat(loggingEvents
+                    .get(1)
+                    .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
+        }
+
+        @Test
+        void shouldThrowWebApplicationExceptionWhenPayloadIsInvalidJson() {
+
+            assertThrows(WebApplicationException.class,
+                    () -> adyenNotificationService.handleNotificationFor("not-json", "5.6.7.8"));
+
+            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .stream()
+                    .anyMatch(event -> event
+                            .getFormattedMessage()
+                            .equals("Error deserialising Adyen notification payload")), is(true));
+        }
+
+        @Test
+        void shouldReturnFalseWhenPayloadIsValidJsonAndNotificationIsNull() {
+            String validJsonButMissingExpectedFields = """ 
+                    {
+                        "live": false
+                    }
+                    """;
+            boolean result = adyenNotificationService.handleNotificationFor(validJsonButMissingExpectedFields,
+                    "5.6.7.8");
+
+            assertFalse(result);
+
+            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .getFirst()
+                    .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
+            assertThat(loggingEvents
+                    .get(1)
+                    .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
+        }
+
+        @Test
+        void shouldReturnFalseWhenPayloadIsValidJsonAndNotificationRequestItemsIsEmpty() {
+            String validJsonButMissingExpectedFields = """ 
+                    {
+                        "live": false,
+                        "notificationItems": [
+                        ]
+                    }
+                    """;
+            boolean result = adyenNotificationService.handleNotificationFor(validJsonButMissingExpectedFields,
+                    "5.6.7.8");
+
+            assertFalse(result);
+            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .getFirst()
+                    .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
+            assertThat(loggingEvents
+                    .get(1)
+                    .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
+        }
+    }
+
+    private HmacKeys getHmacKeys(String... testKey) {
+        String exampleLiveKey = "exampleLiveKey";
+        String validTestKey = "44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056"; // pragma: allowlist secret
+        WebhookHmacKeys liveKeys = new WebhookHmacKeys(exampleLiveKey, null);
+        WebhookHmacKeys testKeys = testKey == null || testKey.length == 0 ? new WebhookHmacKeys(validTestKey,
+                null) : new WebhookHmacKeys(testKey[0], null);
+
+        HmacKeys.WebhookHmacKeyPair pair = new HmacKeys.WebhookHmacKeyPair(testKeys, liveKeys);
+
+        return new HmacKeys(pair);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenNotificationResourceIT.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.util.ConnectorAppWithCustomInjector;
 import uk.gov.pay.connector.util.DnsPointerResourceRecord;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import java.util.Optional;
 
@@ -14,9 +15,9 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.MediaType.TEXT_XML;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.util.ConnectorModuleWithOverrides.reverseDnsLookup;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_NOTIFICATION;
 
 public class AdyenNotificationResourceIT {
-
 
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(ConnectorAppWithCustomInjector.class);
@@ -33,9 +34,12 @@ public class AdyenNotificationResourceIT {
 
     @Test
     void shouldHandleAValidJsonNotification() {
+        String validHmacSignature = "coqCmt/IZ4E3CzPvMY8zTjQVL5hYJUiBRg8UU+iCWo0="; // pragma: allowlist secret
+        String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
+                .replace("{{HMAC_SIGNATURE}}", validHmacSignature);
         given()
                 .port(app.getLocalPort())
-                .body("{\"notificationItems\":[{\"NotificationRequestItem\":{\"eventCode\":\"AUTHORISATION\"}}]}")
+                .body(payload)
                 .header("X-Forwarded-For", ADYEN_IP_ADDRESS)
                 .contentType(APPLICATION_JSON)
                 .post(NOTIFICATION_PATH)
@@ -73,5 +77,18 @@ public class AdyenNotificationResourceIT {
                 .post(NOTIFICATION_PATH)
                 .then()
                 .statusCode(415);
+    }
+
+    @Test
+    void shouldReturn500WhenInvalidJsonPayload() {
+        String payload = "not-json";
+        given()
+                .port(app.getLocalPort())
+                .body(payload)
+                .header("X-Forwarded-For", ADYEN_IP_ADDRESS)
+                .contentType(APPLICATION_JSON)
+                .post(NOTIFICATION_PATH)
+                .then()
+                .statusCode(500);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -133,6 +133,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_SEARCH_TRANSFERS_EMPTY_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/search_transfers_empty_response.json";
 
     public static final String ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS = TEMPLATE_BASE_NAME + "/adyen/authorisation_request_with_full_billing_address.json";
+    public static final String ADYEN_NOTIFICATION = TEMPLATE_BASE_NAME + "/adyen/notification.json";
 
     public static final String SQS_SEND_MESSAGE_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/send-message-response.json";
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -63,7 +63,7 @@ adyen:
   hmacKeys:
     payments:
       test:
-        primary: adyen-test-payments-hmac-primary
+        primary: 44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056 # pragma: allowlist secret
         secondary: ""
       live:
         primary: adyen-live-payments-hmac-primary

--- a/src/test/resources/templates/adyen/notification.json
+++ b/src/test/resources/templates/adyen/notification.json
@@ -1,0 +1,21 @@
+{
+  "live": "false",
+  "notificationItems": [
+    {
+      "NotificationRequestItem": {
+        "pspReference": "7914073381342284",
+        "merchantAccountCode": "TestMerchant",
+        "merchantReference": "TestPayment-1407325143704",
+        "eventCode": "AUTHORISATION",
+        "success": "true",
+        "amount": {
+          "value": 1130,
+          "currency": "EUR"
+        },
+        "additionalData": {
+          "hmacSignature": "{{HMAC_SIGNATURE}}"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## WHAT YOU DID
- Validates HMAC signature in Adyen's notification and throws exceptions for invalid signature or deserialization errors
- Introduces Adyen library to use Adyen's functionality to validate HMAC signature