### PR TITLE
PP-15262 Add Adyen Capture Webhook Notification To Task Queue

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
@@ -12,6 +12,9 @@ import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil;
 import uk.gov.pay.connector.gateway.exception.AdyenNotificationException;
+import uk.gov.pay.connector.queue.tasks.TaskQueueService;
+import uk.gov.pay.connector.queue.tasks.TaskType;
+import uk.gov.pay.connector.queue.tasks.model.Task;
 import uk.gov.pay.connector.util.IpDomainMatcher;
 
 import java.security.SignatureException;
@@ -28,11 +31,13 @@ public class AdyenNotificationService {
     private final AdyenGatewayConfig adyenGatewayConfig;
     private final IpDomainMatcher ipDomainMatcher;
     private final HMACValidator hmacValidator;
+    private final TaskQueueService taskQueueService;
 
     @Inject
-    public AdyenNotificationService(AdyenGatewayConfig adyenGatewayConfig, IpDomainMatcher ipDomainMatcher) {
+    public AdyenNotificationService(AdyenGatewayConfig adyenGatewayConfig, IpDomainMatcher ipDomainMatcher, TaskQueueService taskQueueService) {
         this.adyenGatewayConfig = adyenGatewayConfig;
         this.ipDomainMatcher = ipDomainMatcher;
+        this.taskQueueService = taskQueueService;
         this.hmacValidator = new HMACValidator();
     }
 
@@ -66,6 +71,13 @@ public class AdyenNotificationService {
                 if (!isValidHmac(item, hmacKey)) {
                     return false;
                 }
+                if (!"CAPTURE".equals(item.getEventCode())) {
+                    LOGGER.info("Ignored Adyen notification",
+                            kv("originalReference", item.getOriginalReference()),
+                            kv("eventCode", item.getEventCode()));
+                    continue;
+                }
+                addNotificationToTaskQueue(payload, item);
             }
         } catch (AdyenNotificationException e) {
             LOGGER.error("Failed to validate Adyen notification payload", e);
@@ -77,6 +89,20 @@ public class AdyenNotificationService {
                 kv("notification_source", forwardedIpAddresses));
 
         return true;
+    }
+
+    private void addNotificationToTaskQueue(String payload, NotificationRequestItem item) {
+        try {
+            taskQueueService.add(new Task(payload, TaskType.HANDLE_ADYEN_WEBHOOK_NOTIFICATION));
+        } catch (Exception e) {
+            LOGGER.error("Error sending Adyen webhook notification to task SQS queue",
+                    kv("pspReference", item.getPspReference()),
+                    kv("eventCode", item.getEventCode()),
+                    e);
+            throw new WebApplicationException(
+                    "Error sending message to task SQS queue",
+                    e);
+        }
     }
 
     private NotificationRequest deserialisePayloadToNotificationRequest(String rawAdyenJson) {

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum TaskType {
     COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT("collect_fee_for_stripe_failed_payment"),
     HANDLE_STRIPE_WEBHOOK_NOTIFICATION("handle_stripe_webhook_notification"),
+    HANDLE_ADYEN_WEBHOOK_NOTIFICATION("handle_adyen_webhook_notification"),
     AUTHORISE_WITH_USER_NOT_PRESENT("authorise_with_user_not_present"),
     DELETE_STORED_PAYMENT_DETAILS("delete_stored_payment_details"),
     RETRY_FAILED_PAYMENT_OR_REFUND_EMAIL("retry_failed_payment_or_refund_email"), 

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
@@ -5,6 +5,10 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
+import com.adyen.model.notification.NotificationRequest;
+import com.adyen.model.notification.NotificationRequestItem;
+import com.adyen.notification.WebhookHandler;
+import com.adyen.util.HMACValidator;
 import jakarta.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -18,9 +22,14 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.app.adyen.HmacKeys;
 import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
+import uk.gov.pay.connector.queue.tasks.TaskQueueService;
+import uk.gov.pay.connector.queue.tasks.TaskType;
+import uk.gov.pay.connector.queue.tasks.model.Task;
 import uk.gov.pay.connector.util.IpDomainMatcher;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
+import java.io.IOException;
+import java.security.SignatureException;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,7 +37,10 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -47,8 +59,11 @@ class AdyenNotificationServiceTest {
     private Appender<ILoggingEvent> mockAppender;
 
     @Mock
-    private AdyenGatewayConfig adyenGatewayConfig;
-
+    private AdyenGatewayConfig mockAdyenGatewayConfig;
+    
+    @Mock
+    private TaskQueueService mockTaskQueueService;
+    
     @Mock
     private IpDomainMatcher ipDomainMatcher;
 
@@ -56,7 +71,7 @@ class AdyenNotificationServiceTest {
 
     @BeforeEach
     void setUp() {
-        adyenNotificationService = new AdyenNotificationService(adyenGatewayConfig, ipDomainMatcher);
+        adyenNotificationService = new AdyenNotificationService(mockAdyenGatewayConfig, ipDomainMatcher, mockTaskQueueService);
         Logger root = (Logger) LoggerFactory.getLogger(AdyenNotificationService.class);
         root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
@@ -64,9 +79,9 @@ class AdyenNotificationServiceTest {
 
     @Test
     void shouldAcceptNotificationWhenForwardedIpMatchesConfiguredDomain() {
-        when(adyenGatewayConfig.getNotificationDomain()).thenReturn("out.adyen.com.");
+        when(mockAdyenGatewayConfig.getNotificationDomain()).thenReturn("out.adyen.com.");
         when(ipDomainMatcher.ipMatchesDomain("5.6.7.8", "out.adyen.com.")).thenReturn(true);
-        when(adyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
 
         String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
                 .replace("{{HMAC_SIGNATURE}}", validHmacSigniture);
@@ -86,7 +101,7 @@ class AdyenNotificationServiceTest {
 
     @Test
     void shouldRejectNotificationWhenForwardedIpDoesNotMatchConfiguredDomain() {
-        when(adyenGatewayConfig.getNotificationDomain()).thenReturn("out.adyen.com.");
+        when(mockAdyenGatewayConfig.getNotificationDomain()).thenReturn("out.adyen.com.");
         when(ipDomainMatcher.ipMatchesDomain("8.8.8.8", "out.adyen.com.")).thenReturn(false);
 
         boolean result = adyenNotificationService.handleNotificationFor("{\"notificationItems\":[]}", "8.8.8.8");
@@ -98,13 +113,13 @@ class AdyenNotificationServiceTest {
     class TestValidateNotification {
         @BeforeEach
         void setUp() {
-            when(adyenGatewayConfig.getNotificationDomain()).thenReturn("out.adyen.com.");
+            when(mockAdyenGatewayConfig.getNotificationDomain()).thenReturn("out.adyen.com.");
             when(ipDomainMatcher.ipMatchesDomain("5.6.7.8", "out.adyen.com.")).thenReturn(true);
         }
 
         @Test
         void shouldReturnTrueForValidHmacKey() {
-            when(adyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
 
             String payload = TestTemplateResourceLoader
                     .load(ADYEN_NOTIFICATION)
@@ -117,7 +132,7 @@ class AdyenNotificationServiceTest {
 
         @Test
         void shouldReturnFalseWhenHmacSignatureIsInvalid() {
-            when(adyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
 
             String payload = TestTemplateResourceLoader
                     .load(ADYEN_NOTIFICATION)
@@ -138,7 +153,7 @@ class AdyenNotificationServiceTest {
 
         @Test
         void shouldReturnFalseWhenHmacKeyIsInvalid() {
-            when(adyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys("invalid-hmac-key"));
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys("invalid-hmac-key"));
 
             String payload = TestTemplateResourceLoader
                     .load(ADYEN_NOTIFICATION)
@@ -217,6 +232,74 @@ class AdyenNotificationServiceTest {
                     .get(1)
                     .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
         }
+        
+        @Test
+        void shouldAddTaskToQueueWhenValidCaptureNotificationIsReceived() {
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+
+            String payload = getNotificationWithValidHmacSignature("CAPTURE");
+
+            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
+
+            assertTrue(result);
+
+            ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
+            verify(mockTaskQueueService).add(taskCaptor.capture());
+
+            Task task = taskCaptor.getValue();
+            assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_WEBHOOK_NOTIFICATION));
+            assertThat(task.getData(), is(payload));
+        }
+        
+        @Test
+        void shouldIgnoreNonCaptureWebhookNotificationsAndNotAddToTaskQue() {
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+            String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
+
+            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
+            
+            assertTrue(result);
+
+            verify(mockTaskQueueService, never()).add(any(Task.class));
+            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents.getFirst()
+                    .getFormattedMessage(), is("Ignored Adyen notification"));
+            assertThat(loggingEvents.get(1).getFormattedMessage(), is("Processed Adyen notification"));
+        }
+        
+        @Test
+        void ShouldNotAddToTaskQueWhenHmacSignatureIsInvalid() {
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+
+            String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
+                    .replace("{{HMAC_SIGNATURE}}", "WrongSignature");
+
+            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
+
+            assertFalse(result);
+            verify(mockTaskQueueService,never()).add(any(Task.class));
+        }
+        
+        @Test
+        void shouldThrowWebApplicationExceptionWhenSendingCaptureNotificationToTaskQueueFails() {
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+
+            String payload = getNotificationWithValidHmacSignature("CAPTURE");
+
+            doThrow(new RuntimeException("SQS unavailable")).when(mockTaskQueueService).add(any(Task.class));
+
+            WebApplicationException exception = assertThrows(WebApplicationException.class, () ->
+                    adyenNotificationService.handleNotificationFor(payload, "5.6.7.8"));
+
+            verify(mockTaskQueueService).add(any(Task.class));
+            assertThat(exception.getResponse().getStatus(), is(500));
+            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents.getFirst()
+                    .getFormattedMessage(), is("Error sending Adyen webhook notification to task SQS queue"));
+        }
+        
     }
 
     private HmacKeys getHmacKeys(String... testKey) {
@@ -229,5 +312,27 @@ class AdyenNotificationServiceTest {
         HmacKeys.WebhookHmacKeyPair pair = new HmacKeys.WebhookHmacKeyPair(testKeys, liveKeys);
 
         return new HmacKeys(pair);
+    }
+
+    private String getNotificationWithValidHmacSignature(String eventCode) {
+        try {
+            String template = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
+                    .replace("\"AUTHORISATION\"", "\"" + eventCode + "\"");
+
+            String unsignedPayload = template.replace("{{HMAC_SIGNATURE}}", "");
+
+            NotificationRequest request = new WebhookHandler().handleNotificationJson(unsignedPayload);
+            NotificationRequestItem item = request.getNotificationItems().getFirst();
+
+            String hmacKey = "44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056"; // pragma: allowlist secret
+
+            String signature = new HMACValidator().calculateHMAC(item, hmacKey); // pragma: allowlist secret
+
+            return template.replace("{{HMAC_SIGNATURE}}", signature);
+
+        } catch (IOException | SignatureException e) {
+            throw new RuntimeException(
+                    "Failed to build Adyen test notification", e);
+        }
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Add Capture notification to connector task queue
- Ignore non Capture notifications and not add to task queue
- Handle error for when task queue submission fails and return 500 status code



