### PR TITLE
PP-15145: Implement captureHandler for Adyen

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
@@ -47,6 +47,13 @@ public class CaptureResponse {
             return new CaptureResponse(captureResponse.getTransactionId(), chargeState,null, captureResponse.stringify());
     }
 
+    public static CaptureResponse fromBaseCaptureResponse(BaseCaptureResponse captureResponse, ChargeState chargeState, String transactionId) {
+        if (isNotBlank(captureResponse.getErrorCode())) {
+            return new CaptureResponse(transactionId, chargeState, genericGatewayError(captureResponse.stringify()), captureResponse.stringify());
+        } else
+            return new CaptureResponse(transactionId, chargeState, null, captureResponse.stringify());
+    }
+
     public static CaptureResponse fromBaseCaptureResponse(BaseCaptureResponse captureResponse, ChargeState chargeState, List<Fee> feeList) {
         if (isNotBlank(captureResponse.getErrorCode())) {
             return new CaptureResponse(captureResponse.getTransactionId(), chargeState, genericGatewayError(captureResponse.stringify()), captureResponse.stringify());

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.adyen.handler.AdyenAuthoriseHandler;
+import uk.gov.pay.connector.gateway.adyen.handler.AdyenCaptureHandler;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
@@ -42,6 +43,7 @@ public class AdyenPaymentProvider implements PaymentProvider {
     private final AdyenGatewayConfig adyenGatewayConfig;
     private final ConnectorConfiguration connectorConfiguration;
     private final AdyenAuthoriseHandler adyenAuthoriseHandler;
+    private final AdyenCaptureHandler adyenCaptureHandler;
 
     @Inject
     public AdyenPaymentProvider(
@@ -54,6 +56,7 @@ public class AdyenPaymentProvider implements PaymentProvider {
         this.connectorConfiguration = connectorConfiguration;
         this.client = gatewayClientFactory.createGatewayClient(ADYEN, environment.metrics());
         adyenAuthoriseHandler = new AdyenAuthoriseHandler(client, connectorConfiguration, jsonObjectMapper);
+        adyenCaptureHandler = new AdyenCaptureHandler(client, connectorConfiguration, jsonObjectMapper);
     }
     
     @Override
@@ -88,7 +91,7 @@ public class AdyenPaymentProvider implements PaymentProvider {
 
     @Override
     public CaptureResponse capture(CaptureGatewayRequest request) {
-        throw new UnsupportedOperationException("Operation for Adyen is not Implemented yet");
+       return adyenCaptureHandler.capture(request);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandler.java
@@ -1,0 +1,98 @@
+package uk.gov.pay.connector.gateway.adyen.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.gateway.CaptureHandler;
+import uk.gov.pay.connector.gateway.CaptureResponse;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
+import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
+import uk.gov.pay.connector.gateway.adyen.model.AdyenCaptureRequest;
+import uk.gov.pay.connector.gateway.adyen.model.AdyenCaptureResponse;
+import uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import static jakarta.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
+import static jakarta.ws.rs.core.Response.Status.Family.SERVER_ERROR;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.gateway.CaptureResponse.ChargeState.PENDING;
+import static uk.gov.pay.connector.gateway.CaptureResponse.fromBaseCaptureResponse;
+import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ERROR;
+import static uk.gov.service.payments.logging.LoggingKeys.HTTP_STATUS;
+import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER_PAYMENT_ID;
+
+public class AdyenCaptureHandler implements CaptureHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdyenCaptureHandler.class);
+
+    private final GatewayClient gatewayClient;
+    private final AdyenGatewayConfig adyenGatewayConfig;
+    private final JsonObjectMapper jsonObjectMapper;
+    private final AdyenRequestFactory adyenRequestFactory;
+
+    public AdyenCaptureHandler(GatewayClient client, ConnectorConfiguration configuration, JsonObjectMapper jsonObjectMapper) {
+        this.gatewayClient = client;
+        this.adyenGatewayConfig = configuration.getAdyenGatewayConfig();
+        this.jsonObjectMapper = jsonObjectMapper;
+        this.adyenRequestFactory = new AdyenRequestFactory(configuration);
+    }
+
+    @Override
+    public CaptureResponse capture(CaptureGatewayRequest request) {
+        String transactionId = request.getGatewayTransactionId();
+
+        var adyenCaptureRequest = new AdyenCaptureRequest(
+                AdyenRequestUtil.getCaptureUrl(adyenGatewayConfig, request),
+                AdyenRequestUtil.getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive()),
+                adyenRequestFactory.createCapturePayload(request),
+                request.getGatewayAccount().getType(),
+                jsonObjectMapper);
+
+        try {
+            var jsonResponse = gatewayClient.postRequestFor(adyenCaptureRequest).getEntity();
+            var captureResponse = jsonObjectMapper.getObject(jsonResponse, AdyenCaptureResponse.class);
+
+            return fromBaseCaptureResponse(captureResponse, PENDING);
+        } catch (GatewayErrorException e) {
+            return handleGatewayErrorException(request, e, transactionId);
+        } catch (GatewayException e) {
+            return CaptureResponse.fromGatewayError(e.toGatewayError());
+        }
+    }
+
+    private CaptureResponse handleGatewayErrorException(CaptureGatewayRequest request, GatewayErrorException e, String transactionId) {
+        if (e.getFamily() == CLIENT_ERROR) {
+            var adyenErrorResponse = jsonObjectMapper.getObject(e.getResponseFromGateway(), AdyenCaptureResponse.class);
+            LOGGER.warn("Capture failed for transaction",
+                    kv(PROVIDER_PAYMENT_ID, transactionId),
+                    kv(PAYMENT_EXTERNAL_ID, request.getExternalId()),
+                    kv(HTTP_STATUS, e.getStatus()),
+                    kv(GATEWAY_ERROR, e.getMessage())
+            );
+            return fromBaseCaptureResponse(adyenErrorResponse, null, transactionId);
+        }
+        if (e.getFamily() == SERVER_ERROR) {
+            LOGGER.warn("Capture failed for transaction",
+                    kv(PROVIDER_PAYMENT_ID, transactionId),
+                    kv(PAYMENT_EXTERNAL_ID, request.getExternalId()),
+                    kv(HTTP_STATUS, e.getStatus()),
+                    kv(GATEWAY_ERROR, e.getMessage())
+            );
+            GatewayError gatewayError = gatewayConnectionError("An internal server error occurred when capturing charge_external_id: "
+                    + request.getExternalId());
+            return CaptureResponse.fromGatewayError(gatewayError);
+        }
+        LOGGER.error("Unrecognised response status during capture",
+                kv(PAYMENT_EXTERNAL_ID, request.getExternalId()),
+                kv(HTTP_STATUS, e.getStatus()),
+                kv(GATEWAY_ERROR, e.getResponseFromGateway())
+        );
+        throw new RuntimeException("Unrecognised response status during capture.");
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandlerTest.java
@@ -1,0 +1,184 @@
+package uk.gov.pay.connector.gateway.adyen.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonassert.JsonAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.app.adyen.AdyenIds;
+import uk.gov.pay.connector.app.adyen.ApiKeys;
+import uk.gov.pay.connector.app.adyen.BaseUrls;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.gateway.CaptureResponse;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdyenCaptureHandlerTest {
+    public static final String LIVE_ADYEN_CHECKOUT_BASE_URL = "https://example.com/live/v71";
+    public static final String TEST_ADYEN_CHECKOUT_BASE_URL = "https://example.com/test/v71";
+    @Mock
+    private GatewayClient mockClient;
+    @Mock
+    private ConnectorConfiguration mockConfig;
+    private final JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(new ObjectMapper());
+    private AdyenCaptureHandler captureHandler;
+    @Mock
+    private GatewayClient.Response mockGatewayClientResponse;
+    @Captor
+    private ArgumentCaptor<GatewayClientPostRequest> captor;
+
+    @BeforeEach
+    void setUp() {
+        BaseUrls mockBaseUrls = mock(BaseUrls.class);
+        when(mockBaseUrls.checkout()).thenReturn(new BaseUrls.CheckoutUrls(TEST_ADYEN_CHECKOUT_BASE_URL, LIVE_ADYEN_CHECKOUT_BASE_URL));
+        AdyenGatewayConfig mockAdyenGatewayConfig = mock(AdyenGatewayConfig.class);
+        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
+        when(mockAdyenGatewayConfig.getBaseUrls()).thenReturn(mockBaseUrls);
+
+        ApiKeys mockApiKeys = mock(ApiKeys.class);
+        ApiKeys.CompanyAccountApiKeys mockCompanyApiKeys = mock(ApiKeys.CompanyAccountApiKeys.class);
+        when(mockApiKeys.companyAccount()).thenReturn(mockCompanyApiKeys);
+        when(mockCompanyApiKeys.test()).thenReturn("test");
+        when(mockAdyenGatewayConfig.getApiKeys()).thenReturn(mockApiKeys);
+        when(mockConfig.getAdyenGatewayConfig()).thenReturn(mockAdyenGatewayConfig);
+
+        captureHandler = new AdyenCaptureHandler(mockClient, mockConfig, jsonObjectMapper);
+    }
+
+    @Test
+    void should_send_a_capture_request_for_an_authorised_payment() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
+        givenAdyenReturnsASuccessResponse();
+
+        CaptureGatewayRequest captureRequest = createCaptureRequest();
+        captureHandler.capture(captureRequest);
+
+        then(mockClient).should().postRequestFor(captor.capture());
+        String payload = captor.getValue().getGatewayOrder().getPayload();
+        JsonAssert.with(payload).assertThat("$.merchantAccount", is("test"));
+        JsonAssert.with(payload).assertThat("$.amount.value", is(500));
+        JsonAssert.with(payload).assertThat("$.amount.currency", is("GBP"));
+    }
+
+    @Test
+    void should_return_a_capture_response_with_a_charge_state_of_PENDING() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
+        givenAdyenReturnsASuccessResponse();
+
+        CaptureGatewayRequest captureRequest = createCaptureRequest();
+        var response = captureHandler.capture(captureRequest);
+
+        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getTransactionId().isPresent(), is(true));
+        assertThat(response.getTransactionId().get(), is("gateway-transaction-id"));
+        assertThat(response.state(), is(CaptureResponse.ChargeState.PENDING));
+    }
+
+    @Test
+    void should_return_GatewayError_when_Adyen_returns_SERVER_ERROR() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        var errorResponseBody = """
+                 {
+                 "status": 500,
+                 "errorCode": "905",
+                 "message": "Payment details are not supported",
+                 "errorType": "configuration",
+                 "pspReference": "capture-psp-reference"
+                }""";
+        when(mockClient.postRequestFor(any())).thenThrow(errorFromAdyen("server error", errorResponseBody, 500));
+
+        CaptureGatewayRequest captureRequest = createCaptureRequest();
+        var response = captureHandler.capture(captureRequest);
+
+        assertThat(response.isSuccessful(), is(false));
+        assertThat(response.getErrorMessage().isPresent(), is(true));
+        assertThat(response.getTransactionId().isPresent(), is(false));
+        assertNull(response.state());
+        assertThat(response.getErrorMessage().get(), equalTo("An internal server error occurred when capturing charge_external_id: " + captureRequest.getExternalId()));
+    }
+
+    @Test
+    void should_return_CaptureResponse_when_Adyen_returns_CLIENT_ERROR() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        var errorResponseBody = """
+                {
+                           "status": 403,
+                           "errorCode": "901",
+                           "message": "Invalid Merchant Account",
+                           "errorType": "security",
+                           "pspReference": "capture-psp-reference"
+                         }""";
+        when(mockClient.postRequestFor(any())).thenThrow(errorFromAdyen("client error", errorResponseBody, 403));
+
+        CaptureGatewayRequest captureRequest = createCaptureRequest();
+        var response = captureHandler.capture(captureRequest);
+
+        assertThat(response.isSuccessful(), is(false));
+        assertThat(response.getErrorMessage().isPresent(), is(true));
+        assertNull(response.state());
+        assertThat(response.getTransactionId().isPresent(), is(true));
+        assertThat(response.getTransactionId().get(), is("gateway-transaction-id"));
+        assertThat(response.getErrorMessage().get(), equalTo("Adyen capture response(pspReference: capture-psp-reference, status: 403, errorMessage: Invalid Merchant Account)"));
+    }
+
+    @Test
+    void should_throw_RuntimeException_when_Adyen_returns_unrecognised_response() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        var errorResponseBody = """
+                {"status": 700}
+                """;
+        when(mockClient.postRequestFor(any())).thenThrow(errorFromAdyen("other error", errorResponseBody, 700));
+
+        CaptureGatewayRequest captureRequest = createCaptureRequest();
+        var exception = assertThrows(RuntimeException.class, () -> captureHandler.capture(captureRequest));
+
+        assertThat(exception.getMessage(), equalTo("Unrecognised response status during capture."));
+    }
+
+    private CaptureGatewayRequest createCaptureRequest() {
+        var charge = ChargeEntityFixture.aValidChargeEntity()
+                .withGatewayTransactionId("gateway-transaction-id")
+                .withExternalId("gateway-external-id")
+                .withAmount(500L)
+                .build();
+
+        return CaptureGatewayRequest.valueOf(charge);
+    }
+
+    private void givenAdyenReturnsASuccessResponse() {
+        when(mockGatewayClientResponse.getEntity()).thenReturn("""
+                {
+                   "merchantAccount": "gov merchant account",
+                   "paymentPspReference": "gateway-transaction-id",
+                   "pspReference": "capture-psp-reference",
+                   "status": "received",
+                   "amount": {
+                     "value": 1000,
+                     "currency": "GBP"
+                   }
+                 }
+                """);
+    }
+
+    private GatewayException.GatewayErrorException errorFromAdyen(String errorMessage, String responseBody, int status) {
+        return new GatewayException.GatewayErrorException(errorMessage, responseBody, status);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/it/contract/AdyenPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/AdyenPaymentProviderTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.contract;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -8,8 +7,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.adyen.AdyenPaymentProvider;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -21,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.UUID.randomUUID;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
@@ -32,12 +35,12 @@ import static uk.gov.pay.connector.util.SystemUtils.envOrThrow;
 /**
  * This is an integration test with Adyen that can be run locally, but is ignored and so it won't be run by CI.
  * In order to make it work you need to set the following environment variables:
- * - GDS_CONNECTOR_ADYEN_MERCHANT_ACCOUNT_ID_TEST: set this to the Gov pay merchant account ID which can be found in Adyen test account dashboard 
+ * - GDS_CONNECTOR_ADYEN_MERCHANT_ACCOUNT_ID_TEST: set this to the Gov pay merchant account ID which can be found in Adyen test account dashboard
  * - GDS_CONNECTOR_ADYEN_COMPANY_ACCOUNT_API_KEY_TEST: set this to the "Payments API Key" for the Adyen test environment
  * To run tests using test runner, add env variables to the AppWithPostgresAndSqsExtension parameters as config overrides like so:
  * - ConfigOverride.config("adyen.merchantAccountIds.test", gdsConnectorAdyenMerchantAccountIdTest),
  * - ConfigOverride.config("adyen.apiKeys.companyAccount.test", gdsConnectorAdyenCompanyAccountApiKeyTest)
- * If you get an error referring to duplicated metrics, add app.getAppRule().getEnvironment().metrics().removeMatching(MetricFilter.ALL); to the setup method 
+ * If you get an error referring to duplicated metrics, add app.getAppRule().getEnvironment().metrics().removeMatching(MetricFilter.ALL); to the setup method
  */
 
 @Disabled
@@ -59,6 +62,7 @@ public class AdyenPaymentProviderTest {
         envOrThrow("GDS_CONNECTOR_ADYEN_COMPANY_ACCOUNT_API_KEY_TEST");
         
         adyenPaymentProvider = app.getInstanceFromGuiceContainer(AdyenPaymentProvider.class);
+
         gatewayAccountEntity = new GatewayAccountEntity();
         gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
                 .withCredentials(Map.of("legal_entity_id", "legal-entity-id"))
@@ -82,13 +86,13 @@ public class AdyenPaymentProviderTest {
                 "GB"
         );
         GatewayResponse gatewayResponse = authorisePayment(fullAddress);
-        Assertions.assertTrue(gatewayResponse.getBaseResponse().isPresent());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
     void authoriseAPaymentWithNoBillingAddress() throws GatewayException {
         GatewayResponse gatewayResponse = authorisePayment(null);
-        Assertions.assertTrue(gatewayResponse.getBaseResponse().isPresent());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     @Test
@@ -101,7 +105,7 @@ public class AdyenPaymentProviderTest {
                 null);
 
         GatewayResponse gatewayResponse = authorisePayment(partialAddress);
-        Assertions.assertTrue(gatewayResponse.getBaseResponse().isPresent());
+        assertTrue(gatewayResponse.getBaseResponse().isPresent());
     }
 
     private GatewayResponse<BaseAuthoriseResponse> authorisePayment(Address address) throws GatewayException {
@@ -116,6 +120,21 @@ public class AdyenPaymentProviderTest {
         return adyenPaymentProvider.authorise(request, charge);
     }
 
+    @Test
+    void captureCharge() throws GatewayException {
+        GatewayResponse<BaseAuthoriseResponse> gatewayResponse = authorisePayment(null);
+        var baseResponse = gatewayResponse.getBaseResponse().isPresent() ? gatewayResponse.getBaseResponse().get() : null;
+        assertNotNull(baseResponse);
+        
+        CaptureGatewayRequest request = CaptureGatewayRequest.valueOf(
+                getChargeWithTransactionId(baseResponse.getTransactionId()
+                ));
+
+        CaptureResponse captureGatewayResponse = adyenPaymentProvider.capture(request);
+
+        assertTrue(captureGatewayResponse.isSuccessful());
+    }
+
     private ChargeEntity getCharge() {
         return aValidChargeEntity()
                 .withGatewayAccountCredentialsEntity(gatewayAccountCredentialsEntity)
@@ -124,5 +143,11 @@ public class AdyenPaymentProviderTest {
                 .withTransactionId(randomUUID().toString())
                 .withDescription("Adyen payment provider test charge")
                 .build();
+    }
+
+    private ChargeEntity getChargeWithTransactionId(String transactionId) {
+        ChargeEntity chargeEntity = getCharge();
+        chargeEntity.setGatewayTransactionId(transactionId);
+        return chargeEntity;
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Implemented logic for a successful capture
- Handled gateway exceptions 
- Added logging for gateway exceptions
- Overloaded `fromBaseCaptureResponse` method to accept `transactionId` as a parameter as `paymentPspReference` (the charge's/requests `transactionId`) is not returned on an Adyen error
- Added a contract test for capture

## How to test

- Ensure all exisiting tests pass 
- Run `AdyenPaymentProviderTest` contract test

## Note

Capture retry functionality will be added in the next PR
