### PR TITLE
PP-15084 Refactor AdyenCardResourceAuthoriseIT

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
@@ -62,10 +62,8 @@ public class AdyenAuthoriseHandler {
             return responseBuilder
                     .withResponse(AdyenAuthoriseResponse.of(paymentResponse))
                     .build();
-        } catch (GatewayException.GatewayConnectionTimeoutException
-                 | GatewayException.GenericGatewayException
-                 | GatewayException.GatewayErrorException e) {
-            logger.error("GatewayException occurred, error:\n {0}", e);
+        } catch (GatewayException e) {
+            logger.error("GatewayException occurred when authorising payment", e);
             return responseBuilder.withGatewayError(e.toGatewayError()).build();
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/model/json/Amount.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/model/json/Amount.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.adyen.model.json;
 
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
+++ b/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.InjectorLookup;
 import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.rules.AdyenMockClient;
 import uk.gov.pay.connector.rules.CardidStub;
 import uk.gov.pay.connector.rules.LedgerStub;
 import uk.gov.pay.connector.rules.NotifyStub;
@@ -58,6 +59,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
     private final int worldpayWireMockPort;
     private final int ledgerWireMockPort;
     private final int stripeWireMockPort;
+    private final int adyenWireMockPort;
     private final int notifyWireMockPort;
 
     protected static DatabaseTestHelper databaseTestHelper;
@@ -65,9 +67,11 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
     private WireMockServer worldpayWireMockServer;
     private WireMockServer ledgerWireMockServer;
     private WireMockServer stripeWireMockServer;
+    private WireMockServer adyenWireMockServer;
     private WireMockServer notifyWireMockServer;
     private WorldpayMockClient worldpayMockClient;
     private StripeMockClient stripeMockClient;
+    private AdyenMockClient adyenMockClient;
     private LedgerStub ledgerStub;
     private CardidStub cardidStub;
     private NotifyStub notifyStub;
@@ -95,11 +99,13 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
         wireMockServer = new WireMockServer(wireMockConfig().dynamicPort().bindAddress("localhost"));
         worldpayWireMockServer = new WireMockServer(wireMockConfig().dynamicPort().bindAddress("localhost"));
         stripeWireMockServer = new WireMockServer(wireMockConfig().dynamicPort().bindAddress("localhost"));
+        adyenWireMockServer = new WireMockServer(wireMockConfig().dynamicPort().bindAddress("localhost"));
         ledgerWireMockServer = new WireMockServer(wireMockConfig().dynamicPort().bindAddress("localhost"));
         notifyWireMockServer = new WireMockServer(wireMockConfig().dynamicPort().bindAddress("localhost"));
 
         wireMockServer.start();
         worldpayWireMockServer.start();
+        adyenWireMockServer.start();
         stripeWireMockServer.start();
         ledgerWireMockServer.start();
         notifyWireMockServer.start();
@@ -107,6 +113,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
         wireMockPort = wireMockServer.port();
         worldpayWireMockPort = worldpayWireMockServer.port();
         stripeWireMockPort = stripeWireMockServer.port();
+        adyenWireMockPort = adyenWireMockServer.port();
         ledgerWireMockPort = ledgerWireMockServer.port();
         notifyWireMockPort = notifyWireMockServer.port();
 
@@ -135,6 +142,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
 
         worldpayMockClient = new WorldpayMockClient(worldpayWireMockServer);
         stripeMockClient = new StripeMockClient(stripeWireMockServer);
+        adyenMockClient = new AdyenMockClient(adyenWireMockServer);
 
         ledgerStub = new LedgerStub(ledgerWireMockServer);
         cardidStub = new CardidStub(wireMockServer);
@@ -145,18 +153,20 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
 
         injector = InjectorLookup.getInjector(dropwizardAppExtension.getApplication()).get();
     }
-    
+
     private void resetIfRunning(WireMockServer server) {
         if (server.isRunning()) {
             server.resetRequests();
         }
     }
+
     public void resetWireMockServer() {
         resetIfRunning(wireMockServer);
         resetIfRunning(worldpayWireMockServer);
         resetIfRunning(ledgerWireMockServer);
         resetIfRunning(stripeWireMockServer);
         resetIfRunning(notifyWireMockServer);
+        resetIfRunning(adyenWireMockServer);
         ledgerStub.acceptPostEvent();
     }
 
@@ -190,6 +200,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
     public void afterAll(ExtensionContext context) {
         if (context.getRequiredTestClass().getEnclosingClass() == null) {
             wireMockServer.stop();
+            adyenWireMockServer.stop();
             worldpayWireMockServer.stop();
             stripeWireMockServer.stop();
             ledgerWireMockServer.stop();
@@ -217,6 +228,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
         newConfigOverride.add(config("worldpay.threeDsFlexDdcUrls.test", "http://localhost:" + worldpayWireMockPort + "/shopper/3ds/ddc.html"));
         newConfigOverride.add(config("worldpay.threeDsFlexDdcUrls.live", "http://localhost:" + worldpayWireMockPort + "/shopper/3ds/ddc.html"));
         newConfigOverride.add(config("stripe.url", "http://localhost:" + stripeWireMockPort));
+        newConfigOverride.add(config("adyen.baseUrls.checkout.test", "http://localhost:" + adyenWireMockPort));
         newConfigOverride.add(config("ledgerBaseURL", "http://localhost:" + ledgerWireMockPort));
         newConfigOverride.add(config("cardidBaseURL", "http://localhost:" + wireMockPort));
         newConfigOverride.add(config("notifyConfig.notificationBaseURL", "http://localhost:" + notifyWireMockPort));
@@ -278,6 +290,10 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
         return stripeWireMockServer;
     }
 
+    public WireMockServer getAdyenWireMockServer() {
+        return adyenWireMockServer;
+    }
+
     public DatabaseTestHelper getDatabaseTestHelper() {
         return databaseTestHelper;
     }
@@ -296,6 +312,10 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
 
     public StripeMockClient getStripeMockClient() {
         return stripeMockClient;
+    }
+
+    public AdyenMockClient getAdyenMockClient() {
+        return adyenMockClient;
     }
 
     public LedgerStub getLedgerStub() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -1,9 +1,6 @@
 package uk.gov.pay.connector.it.resources.adyen;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,17 +15,12 @@ import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.util.Optional;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.absent;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
@@ -40,14 +32,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 class AdyenCardResourceAuthoriseIT {
 
     @RegisterExtension
-    static WireMockExtension wireMockExtension = WireMockExtension.newInstance()
-            .options(wireMockConfig().notifier(new ConsoleNotifier(true)).port(8081))
-            .configureStaticDsl(true)
-            .build();
-
-    @RegisterExtension
-    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(
-            ConfigOverride.config("adyen.baseUrls.checkout.test", "http://localhost:8081/v71"));
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
 
     @RegisterExtension
     public static ITestBaseExtension testBaseExtension = new ITestBaseExtension(
@@ -64,13 +49,8 @@ class AdyenCardResourceAuthoriseIT {
     void successful_authorisation_of_a_payment_with_a_billing_address() {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
         var pspReferenceFromAdyen = "993617895215577D";
-        stubFor(post("/v71/payments")
-                .willReturn(aResponse().withBody("""
-                        {
-                          "pspReference": "%s",
-                          "resultCode": "Authorised",
-                          "merchantReference": "string"
-                        }""".formatted(pspReferenceFromAdyen))));
+
+        app.getAdyenMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
 
         var authCardDetails = anAuthCardDetails()
                 .withCardNo("4444333322221111")
@@ -94,11 +74,12 @@ class AdyenCardResourceAuthoriseIT {
                 .statusCode(200)
                 .body("status", is("AUTHORISATION SUCCESS"));
 
-        verify(postRequestedFor(urlEqualTo("/v71/payments"))
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
                 .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
                 .withRequestBody(equalToJson(
                         load(ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS)
                                 .formatted(chargeId))));
+
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
@@ -109,13 +90,8 @@ class AdyenCardResourceAuthoriseIT {
     void successful_authorisation_of_a_payment_without_a_billing_address() {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
         var pspReferenceFromAdyen = "993617895215577D";
-        stubFor(post("/v71/payments")
-                .willReturn(aResponse().withBody("""
-                        {
-                          "pspReference": "%s",
-                          "resultCode": "Authorised",
-                          "merchantReference": "string"
-                        }""".formatted(pspReferenceFromAdyen))));
+
+        app.getAdyenMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
 
         var authCardDetails = anAuthCardDetails()
                 .withCardNo("4444333322221111")
@@ -133,7 +109,7 @@ class AdyenCardResourceAuthoriseIT {
                 .statusCode(200)
                 .body("status", is("AUTHORISATION SUCCESS"));
 
-        verify(postRequestedFor(urlEqualTo("/v71/payments"))
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
                 .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
                 .withRequestBody(WireMock.matchingJsonPath("$.billingAddress", absent()))
                 .withRequestBody(matchingJsonPath("$.paymentMethod",
@@ -157,58 +133,62 @@ class AdyenCardResourceAuthoriseIT {
     void declined_authorisation() {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
         var pspReferenceFromAdyen = "883617895215577D";
-        stubFor(post("/v71/payments")
-                .willReturn(aResponse().withBody("""
-                        {
-                          "pspReference": "%s",
-                          "refusalReason": "Expired Card",
-                          "resultCode": "Refused",
-                          "refusalReasonCode": "6"
-                        }""".formatted(pspReferenceFromAdyen))));
 
+        app.getAdyenMockClient().mockAuthorisationRejected(pspReferenceFromAdyen);
 
-        var response = app.givenSetup()
+        app.givenSetup()
                 .body(anAuthCardDetails().build())
-                .post("/v1/frontend/charges/{chargeId}/cards", chargeId);
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(400)
+                .body("error_identifier", is("GENERIC"))
+                .body("message[0]", is("This transaction was declined."));
 
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is("AUTHORISATION REJECTED"));
         assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
-
-        response.then()
-                .statusCode(400)
-                .body("error_identifier", is("GENERIC"))
-                .body("message[0]", is("This transaction was declined."));
     }
 
-
     @Test
-    void unknown_error_from_Adyen() {
+    void should_return_402_for_authorisation_error_from_Adyen() {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
-        var pspReferenceFromAdyen = "851563882585825A";
-        stubFor(post("/v71/payments")
-                .willReturn(aResponse().withBody("""
-                        {
-                          "pspReference": "%s",
-                          "refusalReason": "Acquirer Error",
-                          "resultCode": "Error",
-                          "refusalReasonCode": "4"
-                        }""".formatted(pspReferenceFromAdyen))));
+        var pspReferenceFromAdyen = "883617895215577D";
 
+        app.getAdyenMockClient().mockAuthorisationError(pspReferenceFromAdyen);
 
-        var response = app.givenSetup()
+        app.givenSetup()
                 .body(anAuthCardDetails().build())
-                .post("/v1/frontend/charges/{chargeId}/cards", chargeId);
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(402)
+                .body("error_identifier", is("GENERIC"))
+                .body("message[0]", is("There was an error authorising the transaction."));
+        app.getAdyenWireMockServer().checkForUnmatchedRequests();
 
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is("AUTHORISATION ERROR"));
         assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+    }
 
-        response.then()
+    @Test
+    void should_return_402_for_unexpected_server_error() {
+        var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
+
+        app.getAdyenMockClient().mockError("/payments");
+
+        app.givenSetup()
+                .body(anAuthCardDetails().build())
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
                 .statusCode(402)
                 .body("error_identifier", is("GENERIC"))
-                .body("message[0]", is("There was an error authorising the transaction."));
+                .body("message[0]", is("Non-success HTTP status code 500 from gateway"));
+        app.getAdyenWireMockServer().checkForUnmatchedRequests();
+
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION UNEXPECTED ERROR"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/AdyenMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AdyenMockClient.java
@@ -9,10 +9,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.apache.http.HttpStatus.SC_BAD_GATEWAY;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_ERROR_RESPONSE;
 
-public abstract class AdyenMockClient {
+public class AdyenMockClient {
     protected WireMockServer wireMockServer;
 
     public AdyenMockClient(WireMockServer wireMockServer) {
@@ -27,9 +28,42 @@ public abstract class AdyenMockClient {
                         .withStatus(status)
                         .withBody(responseBody)));
     }
-    
+
     public void mockError(String path) {
         String responseBody = TestTemplateResourceLoader.load(ADYEN_ERROR_RESPONSE);
-        setupPostResponse(responseBody, path, SC_BAD_GATEWAY);
+        setupPostResponse(responseBody, path, SC_INTERNAL_SERVER_ERROR);
+    }
+
+    public void mockAuthorisationSuccess(String pspReferenceFromAdyen) {
+        String responseBody = """
+                {
+                  "pspReference": "%s",
+                  "resultCode": "Authorised",
+                  "merchantReference": "string"
+                }""".formatted(pspReferenceFromAdyen);
+
+        setupPostResponse(responseBody, "/payments", SC_OK);
+    }
+
+    public void mockAuthorisationRejected(String pspReferenceFromAdyen) {
+        String responseBody = """
+                {
+                  "pspReference": "%s",
+                  "refusalReason": "Expired Card",
+                  "resultCode": "Refused",
+                  "refusalReasonCode": "6"
+                }""".formatted(pspReferenceFromAdyen);
+        setupPostResponse(responseBody, "/payments", SC_OK);
+    }
+
+    public void mockAuthorisationError(String pspReferenceFromAdyen) {
+        String responseBody = """
+                {
+                  "pspReference": "%s",
+                  "refusalReason": "Acquirer Error",
+                  "resultCode": "Error",
+                  "refusalReasonCode": "4"
+                }""".formatted(pspReferenceFromAdyen);
+        setupPostResponse(responseBody, "/payments", SC_OK);
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Refactored Adyen payment authorisation integration tests to use a WireMock server created in AppWithPostgresAndSqsExtension for stubs and to remove the use of a hardcoded port for stubs
- Adds integration test to test GatewayError

