### PR TITLE
PP-15127: introduce AdyenCancelRequest

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/model/AdyenCancelRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/model/AdyenCancelRequest.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.connector.gateway.adyen.model;
+
+import jakarta.ws.rs.core.MediaType;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.adyen.model.json.PaymentCancelRequest;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import java.net.URI;
+import java.util.Map;
+
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+
+public record AdyenCancelRequest(URI url,
+                                 Map<String, String> headers,
+                                 PaymentCancelRequest paymentCancelRequest,
+                                 String gatewayAccountType,
+                                 JsonObjectMapper objectMapper) implements GatewayClientPostRequest {
+
+    @Override
+    public URI getUrl() {
+        return url;
+    }
+
+    @Override
+    public GatewayOrder getGatewayOrder() {
+        var payload = objectMapper.objectToString(paymentCancelRequest);
+        return new GatewayOrder(OrderRequestType.CANCEL, payload, MediaType.APPLICATION_JSON_TYPE);
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public String getGatewayAccountType() {
+        return gatewayAccountType;
+    }
+
+    @Override
+    public PaymentGatewayName getPaymentProvider() {
+        return ADYEN;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/model/AdyenCancelRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/model/AdyenCancelRequestTest.java
@@ -1,0 +1,67 @@
+package uk.gov.pay.connector.gateway.adyen.model;
+
+import com.jayway.jsonassert.JsonAssert;
+import io.dropwizard.jackson.Jackson;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.gateway.adyen.model.json.PaymentCancelRequest;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+import static uk.gov.pay.connector.gateway.model.OrderRequestType.CANCEL;
+
+class AdyenCancelRequestTest {
+
+    public static final URI TEST_URI = URI.create("https://example.com");
+    public static final String GATEWAY_ACCOUNT_TYPE = "gateway-account-type";
+    private static final Map<String, String> HEADERS = Map.of(
+            "header1", "value1",
+            "header2", "value2");
+    public static final String REFERENCE = "a-reference";
+    public static final String MERCHANT_ACCOUNT = "a-merchant-account";
+
+    private AdyenCancelRequest request;
+
+    @BeforeEach
+    void createCancelRequest() {
+        var cancelPayload = new PaymentCancelRequest(REFERENCE, MERCHANT_ACCOUNT);
+        var jsonObjectMapper = new JsonObjectMapper(Jackson.newObjectMapper());
+        request = new AdyenCancelRequest(TEST_URI, HEADERS, cancelPayload, GATEWAY_ACCOUNT_TYPE, jsonObjectMapper);
+    }
+
+    @Test
+    void should_return_expected_properties() {
+        assertThat(request.getUrl(), is(TEST_URI));
+        assertThat(request.getHeaders(), is(HEADERS));
+        assertThat(request.getGatewayAccountType(), is(GATEWAY_ACCOUNT_TYPE));
+
+    }
+
+    @Test
+    void should_return_the_Adyen_payment_provider() {
+        assertThat(request.getPaymentProvider(), is(ADYEN));
+    }
+
+    @Test
+    void should_return_CANCEL_type_gateway_order() {
+        assertThat(request.getGatewayOrder().getOrderRequestType(), is(CANCEL));
+    }
+
+    @Test
+    void should_return_gateway_order_with_serialised_PaymentCancelRequest_payload() {
+        JsonAssert.with(request.getGatewayOrder().getPayload())
+                .assertEquals("reference", REFERENCE)
+                .assertEquals("merchantAccount", MERCHANT_ACCOUNT);
+    }
+
+    @Test
+    void should_return_gateway_order_with_JSON_media_type() {
+        assertThat(request.getGatewayOrder().getMediaType(), is(MediaType.APPLICATION_JSON_TYPE));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
Introduced `AdyenCancelRequest`

## Observations
It feels to me like it may be time to convert the Adyen `GatewayClientPostRequest`s to classes and extract an abstract `AdyenPostRequest`, to factor out the duplication.

Additionally, `AdyenRequestFactory` now has the following Creation Methods:
* `createPaymentRequest(...) : PaymentRequest`
* `createPaymentCancelRequest(...) : PaymentCancelRequest`
* `createCapturePayload(...) : Capture`

Perhaps the last method could become

`createPaymentCaptureRequest(...) : PaymentCaptureRequest`

This would be consistent with [Adyen's naming](https://javadoc.io/doc/com.adyen/adyen-java-api-library/latest/com/adyen/model/checkout/PaymentCaptureRequest.html)