### PR TITLE
PP-15392-Refactor Adyen model naming

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -3,11 +3,11 @@ package uk.gov.pay.connector.gateway.adyen;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
+import uk.gov.pay.connector.gateway.adyen.request.json.AuthoriseRequestPayload;
 import uk.gov.pay.connector.gateway.adyen.request.json.BillingAddress;
-import uk.gov.pay.connector.gateway.adyen.request.json.Capture;
-import uk.gov.pay.connector.gateway.adyen.request.json.PaymentCancelRequest;
+import uk.gov.pay.connector.gateway.adyen.request.json.CancelRequestPayload;
+import uk.gov.pay.connector.gateway.adyen.request.json.CaptureRequestPayload;
 import uk.gov.pay.connector.gateway.adyen.request.json.PaymentMethod;
-import uk.gov.pay.connector.gateway.adyen.request.json.PaymentRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
@@ -29,7 +29,7 @@ public class AdyenRequestFactory {
         this.configuration = configuration;
     }
 
-    public PaymentRequest createPaymentRequest(CardAuthorisationGatewayRequest request) {
+    public AuthoriseRequestPayload createPaymentRequest(CardAuthorisationGatewayRequest request) {
         var authCardDetails = request.getAuthCardDetails();
         var mappedAddress = authCardDetails.getAddress()
                 .map(AdyenRequestFactory::mapToBillingAddress)
@@ -44,7 +44,7 @@ public class AdyenRequestFactory {
 
         var adyenCredentials = mapToAdyenCredentials(request.getGatewayCredentials());
 
-        return new PaymentRequest(
+        return new AuthoriseRequestPayload(
                 new Amount("GBP", Long.valueOf(request.getAmount())),
                 mappedAddress,
                 getMerchantAccountId(configuration.getAdyenGatewayConfig(), request.getGatewayAccount().isLive()),
@@ -58,15 +58,15 @@ public class AdyenRequestFactory {
         );
     }
 
-    public PaymentCancelRequest createPaymentCancelRequest(CancelGatewayRequest request) {
-        return new PaymentCancelRequest(
+    public CancelRequestPayload createPaymentCancelRequest(CancelGatewayRequest request) {
+        return new CancelRequestPayload(
                 request.getExternalChargeId(),
                 getMerchantAccountId(configuration.getAdyenGatewayConfig(), request.getGatewayAccount().isLive())
         );
     }
 
-    public Capture createCapturePayload(CaptureGatewayRequest request) {
-        return new Capture(
+    public CaptureRequestPayload createCapturePayload(CaptureGatewayRequest request) {
+        return new CaptureRequestPayload(
                 new Amount("GBP", request.getAmount()),
                 getMerchantAccountId(configuration.getAdyenGatewayConfig(), request.getGatewayAccount().isLive())
         );

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
@@ -9,7 +9,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.request.AdyenAuthorisationRequest;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenAuthoriseResponse;
-import uk.gov.pay.connector.gateway.adyen.response.json.AdyenPaymentResponse;
+import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -57,7 +57,7 @@ public class AdyenAuthoriseHandler {
             var jsonResponse = gatewayClient.postRequestFor(authorisationRequest).getEntity();
             var paymentResponse = jsonObjectMapper.getObject(
                     jsonResponse,
-                    AdyenPaymentResponse.class);
+                    AuthoriseResponseBody.class);
 
             return responseBuilder
                     .withResponse(AdyenAuthoriseResponse.of(paymentResponse))

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandler.java
@@ -12,8 +12,8 @@ import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.request.AdyenCaptureRequest;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenCaptureResponse;
-import uk.gov.pay.connector.gateway.adyen.response.json.AdyenCapture;
 import uk.gov.pay.connector.gateway.adyen.response.json.AdyenError;
+import uk.gov.pay.connector.gateway.adyen.response.json.CaptureResponseBody;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -54,7 +54,7 @@ public class AdyenCaptureHandler implements CaptureHandler {
 
         try {
             var jsonResponse = gatewayClient.postRequestFor(adyenCaptureRequest).getEntity();
-            var captureResponse = jsonObjectMapper.getObject(jsonResponse, AdyenCapture.class);
+            var captureResponse = jsonObjectMapper.getObject(jsonResponse, CaptureResponseBody.class);
 
             return fromBaseCaptureResponse(AdyenCaptureResponse.from(captureResponse), PENDING);
         } catch (GatewayErrorException e) {

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/request/AdyenAuthorisationRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/request/AdyenAuthorisationRequest.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.gateway.adyen.request;
 import jakarta.ws.rs.core.MediaType;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.adyen.request.json.PaymentRequest;
+import uk.gov.pay.connector.gateway.adyen.request.json.AuthoriseRequestPayload;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -16,7 +16,7 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 public record AdyenAuthorisationRequest(URI url,
                                         Map<String, String> headers,
                                         String gatewayAccountType,
-                                        PaymentRequest requestPayload,
+                                        AuthoriseRequestPayload requestPayload,
                                         JsonObjectMapper jsonObjectMapper) implements GatewayClientPostRequest {
     @Override
     public URI getUrl() {

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCancelRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCancelRequest.java
@@ -1,9 +1,9 @@
-package uk.gov.pay.connector.gateway.adyen.model;
+package uk.gov.pay.connector.gateway.adyen.request;
 
 import jakarta.ws.rs.core.MediaType;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.adyen.request.json.PaymentCancelRequest;
+import uk.gov.pay.connector.gateway.adyen.request.json.CancelRequestPayload;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -15,7 +15,7 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 
 public record AdyenCancelRequest(URI url,
                                  Map<String, String> headers,
-                                 PaymentCancelRequest paymentCancelRequest,
+                                 CancelRequestPayload paymentCancelRequest,
                                  String gatewayAccountType,
                                  JsonObjectMapper objectMapper) implements GatewayClientPostRequest {
 

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCaptureRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCaptureRequest.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.gateway.adyen.request;
 import jakarta.ws.rs.core.MediaType;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.adyen.request.json.Capture;
+import uk.gov.pay.connector.gateway.adyen.request.json.CaptureRequestPayload;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -15,7 +15,7 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 
 public record AdyenCaptureRequest(URI url,
                                   Map<String, String> headers,
-                                  Capture payload,
+                                  CaptureRequestPayload payload,
                                   String gatewayAccountType,
                                   JsonObjectMapper jsonObjectMapper) implements GatewayClientPostRequest {
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/AuthoriseRequestPayload.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/AuthoriseRequestPayload.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record PaymentRequest(
+public record AuthoriseRequestPayload(
         @JsonProperty("amount")
         Amount amount,
         @JsonProperty("billingAddress")

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/CancelRequestPayload.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/CancelRequestPayload.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.adyen.request.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record PaymentCancelRequest(
+public record CancelRequestPayload(
         @JsonProperty("reference")
         String reference,
         @JsonProperty("merchantAccount")

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/CaptureRequestPayload.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/CaptureRequestPayload.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.adyen.request.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record Capture(
+public record CaptureRequestPayload(
         @JsonProperty("amount")
         Amount amount,
         @JsonProperty("merchantAccount")

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.adyen.response;
 
 import uk.gov.pay.connector.gateway.adyen.response.json.Action;
-import uk.gov.pay.connector.gateway.adyen.response.json.AdyenPaymentResponse;
+import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
@@ -13,12 +13,12 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
     private final AuthoriseStatus authoriseStatus;
     private final String redirectUrl;
 
-    public static AdyenAuthoriseResponse of(AdyenPaymentResponse adyenPaymentResponse) {
-        Action action = adyenPaymentResponse.action();
+    public static AdyenAuthoriseResponse of(AuthoriseResponseBody authoriseResponseBody) {
+        Action action = authoriseResponseBody.action();
         String url = Optional.ofNullable(action).map(Action::url).orElse(null);
         
-        return new AdyenAuthoriseResponse(adyenPaymentResponse.pspReference(),
-                adyenPaymentResponse.resultCode(),
+        return new AdyenAuthoriseResponse(authoriseResponseBody.pspReference(),
+                authoriseResponseBody.resultCode(),
                 url);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenCaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenCaptureResponse.java
@@ -1,8 +1,8 @@
 package uk.gov.pay.connector.gateway.adyen.response;
 
 import org.apache.commons.lang3.StringUtils;
-import uk.gov.pay.connector.gateway.adyen.response.json.AdyenCapture;
 import uk.gov.pay.connector.gateway.adyen.response.json.AdyenError;
+import uk.gov.pay.connector.gateway.adyen.response.json.CaptureResponseBody;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 
 import java.util.StringJoiner;
@@ -14,11 +14,11 @@ public record AdyenCaptureResponse(
         String errorMessage
 ) implements BaseCaptureResponse {
 
-    public static AdyenCaptureResponse from(AdyenCapture adyenCapture) {
+    public static AdyenCaptureResponse from(CaptureResponseBody captureResponseBody) {
         return new AdyenCaptureResponse(
-                adyenCapture.paymentPspReference(),
-                adyenCapture.pspReference(),
-                adyenCapture.status(),
+                captureResponseBody.paymentPspReference(),
+                captureResponseBody.pspReference(),
+                captureResponseBody.status(),
                 null
         );
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/AuthoriseResponseBody.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/AuthoriseResponseBody.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record AdyenPaymentResponse(
+public record AuthoriseResponseBody(
         @JsonProperty("pspReference")
         String pspReference,
         @JsonProperty("resultCode")

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/CaptureResponseBody.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/CaptureResponseBody.java
@@ -7,7 +7,7 @@ import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record AdyenCapture(
+public record CaptureResponseBody(
         @JsonProperty("merchantAccount")
         String merchantAccount,
         @JsonProperty("paymentPspReference")

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenAuthorisationRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenAuthorisationRequestTest.java
@@ -5,9 +5,9 @@ import com.jayway.jsonassert.JsonAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
+import uk.gov.pay.connector.gateway.adyen.request.json.AuthoriseRequestPayload;
 import uk.gov.pay.connector.gateway.adyen.request.json.BillingAddress;
 import uk.gov.pay.connector.gateway.adyen.request.json.PaymentMethod;
-import uk.gov.pay.connector.gateway.adyen.request.json.PaymentRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import java.net.URI;
@@ -67,7 +67,7 @@ class AdyenAuthorisationRequestTest {
                 jsonObjectMapper);
     }
 
-    private PaymentRequest makePaymentRequestWithFullBillingAddress() {
+    private AuthoriseRequestPayload makePaymentRequestWithFullBillingAddress() {
         var billingAddress = new BillingAddress(
                 "houseNumberOrName",
                 "street",
@@ -83,7 +83,7 @@ class AdyenAuthorisationRequestTest {
                 "4444333322221111",
                 "scheme");
 
-        return new PaymentRequest(
+        return new AuthoriseRequestPayload(
                 new Amount("GBP", 1000L),
                 billingAddress,
                 "adyen-test-merchant-account-id",

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCancelRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCancelRequestTest.java
@@ -1,11 +1,11 @@
-package uk.gov.pay.connector.gateway.adyen.model;
+package uk.gov.pay.connector.gateway.adyen.request;
 
 import com.jayway.jsonassert.JsonAssert;
 import io.dropwizard.jackson.Jackson;
 import jakarta.ws.rs.core.MediaType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.pay.connector.gateway.adyen.request.json.PaymentCancelRequest;
+import uk.gov.pay.connector.gateway.adyen.request.json.CancelRequestPayload;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import java.net.URI;
@@ -30,7 +30,7 @@ class AdyenCancelRequestTest {
 
     @BeforeEach
     void createCancelRequest() {
-        var cancelPayload = new PaymentCancelRequest(REFERENCE, MERCHANT_ACCOUNT);
+        var cancelPayload = new CancelRequestPayload(REFERENCE, MERCHANT_ACCOUNT);
         var jsonObjectMapper = new JsonObjectMapper(Jackson.newObjectMapper());
         request = new AdyenCancelRequest(TEST_URI, HEADERS, cancelPayload, GATEWAY_ACCOUNT_TYPE, jsonObjectMapper);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCaptureRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCaptureRequestTest.java
@@ -5,7 +5,7 @@ import com.jayway.jsonassert.JsonAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
-import uk.gov.pay.connector.gateway.adyen.request.json.Capture;
+import uk.gov.pay.connector.gateway.adyen.request.json.CaptureRequestPayload;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import java.net.URI;
@@ -40,7 +40,7 @@ class AdyenCaptureRequestTest {
     }
 
     private AdyenCaptureRequest buildValidCaptureRequest() {
-        var capturePayload = new Capture(
+        var capturePayload = new CaptureRequestPayload(
                 new Amount("GBP", 500L),
                 MERCHANT_ID);
         return new AdyenCaptureRequest(

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.gateway.adyen.response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import uk.gov.pay.connector.gateway.adyen.response.json.AdyenPaymentResponse;
+import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -23,7 +23,7 @@ class AdyenAuthoriseResponseTest {
             "Error, ERROR"
     })
     void should_map_Adyen_result_codes_to_Pay_AuthoriseStatuses(String adyenResultCode, BaseAuthoriseResponse.AuthoriseStatus expectedStatus) {
-        var response = new AdyenPaymentResponse(
+        var response = new AuthoriseResponseBody(
                 "psp-reference",
                 adyenResultCode,
                 "refusal-reason",
@@ -37,7 +37,7 @@ class AdyenAuthoriseResponseTest {
 
     @Test
     void should_throw_IllegalStateException_on_an_unrecognised_Adyen_result_code() {
-        var response = new AdyenPaymentResponse(
+        var response = new AuthoriseResponseBody(
                 "psp-reference",
                 "UNRECOGNISED_RESULT_CODE",
                 "refusal-reason",

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenPaymentResponseFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenPaymentResponseFixture.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.adyen.response;
 
 import uk.gov.pay.connector.gateway.adyen.response.json.Action;
-import uk.gov.pay.connector.gateway.adyen.response.json.AdyenPaymentResponse;
+import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
 
 public class AdyenPaymentResponseFixture {
         String pspReference;
@@ -39,7 +39,7 @@ public class AdyenPaymentResponseFixture {
             return this;
         }
 
-        public AdyenPaymentResponse build() {
-            return new AdyenPaymentResponse(pspReference, resultCode, refusalReason, refusalReasonCode, action);
+        public AuthoriseResponseBody build() {
+            return new AuthoriseResponseBody(pspReference, resultCode, refusalReason, refusalReasonCode, action);
         }
     }


### PR DESCRIPTION
## WHAT YOU DID
- Renamed Adyen models to match the style: `OperationRequestPayload` and `OperationResponseBody`
- Deleted the models package and moved `AdyenCancelRequest` to requests package

## How to test
- ensure all tests still pass
