### PR TITLE
PP-15264 handle capture webhook messages from task queue

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
@@ -105,7 +105,7 @@ public class AdyenNotificationService {
         }
     }
 
-    private NotificationRequest deserialisePayloadToNotificationRequest(String rawAdyenJson) {
+    public NotificationRequest deserialisePayloadToNotificationRequest(String rawAdyenJson) {
         try {
             WebhookHandler webhookHandler = new WebhookHandler();
             return webhookHandler.handleNotificationJson(rawAdyenJson);
@@ -115,7 +115,7 @@ public class AdyenNotificationService {
         }
     }
 
-    private List<NotificationRequestItem> extractNotificationItem(NotificationRequest notificationRequest) {
+    public List<NotificationRequestItem> extractNotificationItem(NotificationRequest notificationRequest) {
         if (notificationRequest == null ||
                 (notificationRequest.getNotificationItems() == null || notificationRequest.getNotificationItems().isEmpty())) {
             LOGGER.info("Adyen notification request is empty or missing items");

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.common.exception.InvalidStateTransitionException;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmedByGatewayNotification;
+import uk.gov.pay.connector.events.model.charge.CaptureErrored;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import jakarta.inject.Inject;
@@ -103,8 +104,17 @@ public class ChargeNotificationProcessor {
                 kv(PROVIDER_PAYMENT_ID, gatewayTransactionId),
                 kv(GATEWAY_ACCOUNT_ID, gatewayAccount.getId()),
                 kv(PROVIDER, charge.getPaymentGatewayName()));
-        
-        Event event = new CaptureConfirmedByGatewayNotification(charge.getServiceId(), charge.isLive(), charge.getGatewayAccountId(), charge.getExternalId(), Instant.now());
+
+        Event event;
+        if (ChargeStatus.CAPTURED.equals(newStatus)) {
+            event = new CaptureConfirmedByGatewayNotification(charge.getServiceId(), charge.isLive(),
+                    charge.getGatewayAccountId(), charge.getExternalId(), Instant.now());
+
+        } else {
+            event = new CaptureErrored(charge.getServiceId(), charge.isLive(), charge.getGatewayAccountId(),
+                    charge.getExternalId(), Instant.now());
+        }
         eventService.emitEvent(event);
     }
+    
 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
@@ -1,11 +1,14 @@
 package uk.gov.pay.connector.queue.tasks;
 
+import com.adyen.model.notification.NotificationRequestItem;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sentry.Sentry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
 import uk.gov.pay.connector.gateway.stripe.response.StripeNotification;
+import uk.gov.pay.connector.queue.tasks.handlers.AdyenWebhookTaskHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.AuthoriseWithUserNotPresentHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.CollectFeesForFailedPaymentsTaskHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.DeleteStoredPaymentDetailsTaskHandler;
@@ -36,6 +39,7 @@ public class TaskQueueMessageHandler {
     private final TaskQueue taskQueue;
     private final CollectFeesForFailedPaymentsTaskHandler collectFeesForFailedPaymentsTaskHandler;
     private final StripeWebhookTaskHandler stripeWebhookTaskHandler;
+    private final AdyenWebhookTaskHandler adyenWebhookTaskHandler;
     private final AuthoriseWithUserNotPresentHandler authoriseWithUserNotPresentHandler;
     private final DeleteStoredPaymentDetailsTaskHandler deleteStoredPaymentDetailsHandler;
     private final RetryPaymentOrRefundEmailTaskHandler retryPaymentOrRefundEmailTaskHandler;
@@ -47,6 +51,7 @@ public class TaskQueueMessageHandler {
     public TaskQueueMessageHandler(TaskQueue taskQueue,
                                    CollectFeesForFailedPaymentsTaskHandler collectFeesForFailedPaymentsTaskHandler,
                                    StripeWebhookTaskHandler stripeWebhookTaskHandler,
+                                   AdyenWebhookTaskHandler adyenWebhookTaskHandler,
                                    AuthoriseWithUserNotPresentHandler authoriseWithUserNotPresentHandler,
                                    DeleteStoredPaymentDetailsTaskHandler deleteStoredPaymentDetailsHandler,
                                    RetryPaymentOrRefundEmailTaskHandler retryPaymentOrRefundEmailTaskHandler,
@@ -56,6 +61,7 @@ public class TaskQueueMessageHandler {
         this.taskQueue = taskQueue;
         this.collectFeesForFailedPaymentsTaskHandler = collectFeesForFailedPaymentsTaskHandler;
         this.stripeWebhookTaskHandler = stripeWebhookTaskHandler;
+        this.adyenWebhookTaskHandler = adyenWebhookTaskHandler;
         this.authoriseWithUserNotPresentHandler = authoriseWithUserNotPresentHandler;
         this.deleteStoredPaymentDetailsHandler = deleteStoredPaymentDetailsHandler;
         this.retryPaymentOrRefundEmailTaskHandler = retryPaymentOrRefundEmailTaskHandler;
@@ -92,6 +98,10 @@ public class TaskQueueMessageHandler {
                         MDC.put(STRIPE_EVENT_ID, stripeNotification.getId());
                         LOGGER.info("Processing [{}] task.", taskType.getName());
                         stripeWebhookTaskHandler.process(stripeNotification);
+                        break; 
+                    case HANDLE_ADYEN_WEBHOOK_NOTIFICATION:
+                        LOGGER.info("Processing [{}] task.", taskType.getName());
+                        adyenWebhookTaskHandler.processAdyenWebhookNotification(taskMessage.getTask().getData());
                         break;
                     case AUTHORISE_WITH_USER_NOT_PRESENT:
                         var taskData = objectMapper.readValue(taskMessage.getTask().getData(), PaymentTaskData.class);

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenWebhookTaskHandler.java
@@ -1,0 +1,94 @@
+package uk.gov.pay.connector.queue.tasks.handlers;
+
+import com.adyen.model.notification.NotificationRequest;
+import com.adyen.model.notification.NotificationRequestItem;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
+import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
+
+
+public class AdyenWebhookTaskHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdyenWebhookTaskHandler.class);
+    private final ChargeService chargeService;
+    private final ChargeNotificationProcessor chargeNotificationProcessor;
+    private final GatewayAccountService gatewayAccountService;
+    private final AdyenNotificationService adyenNotificationService;
+
+    @Inject
+    public AdyenWebhookTaskHandler(ChargeService chargeService, 
+                                   ChargeNotificationProcessor chargeNotificationProcessor,
+                                   GatewayAccountService gatewayAccountService,
+                                   AdyenNotificationService adyenNotificationService) {
+        this.chargeService = chargeService;
+        this.chargeNotificationProcessor = chargeNotificationProcessor;
+        this.gatewayAccountService = gatewayAccountService;
+        this.adyenNotificationService = adyenNotificationService;
+    }
+
+    public void processAdyenWebhookNotification(String payload) {
+        NotificationRequest notificationRequest =
+                adyenNotificationService.deserialisePayloadToNotificationRequest(payload);
+
+        List<NotificationRequestItem> items = adyenNotificationService.extractNotificationItem(notificationRequest);
+
+        for (NotificationRequestItem item : items) {
+            processCapturedNotification(item);
+        }
+    }
+
+    private void processCapturedNotification(NotificationRequestItem item) {
+        String gatewayTransactionId = item.getOriginalReference();
+
+        Optional<Charge> charge = chargeService.findByProviderAndTransactionIdFromDbOrLedger(
+                ADYEN.getName(), gatewayTransactionId);
+
+        if (charge.isPresent()) {
+            Charge foundCharge = charge.get();
+            ChargeStatus targetStatus = item.isSuccess() ? CAPTURED : CAPTURE_ERROR;
+
+            if (foundCharge.isHistoric()) {
+                Optional<GatewayAccountEntity> gatewayAccount = gatewayAccountService.getGatewayAccount(
+                        foundCharge.getGatewayAccountId());
+
+                gatewayAccount.ifPresentOrElse(gatewayAccountEntity ->
+                                chargeNotificationProcessor.processCaptureNotificationForExpungedCharge(gatewayAccountEntity,
+                                        gatewayTransactionId, foundCharge, targetStatus),
+                        () -> LOGGER.error("GatewayAccount not found for foundCharge",
+                                kv(PAYMENT_EXTERNAL_ID, foundCharge.getExternalId())));
+            } else {
+                chargeNotificationProcessor.invoke(gatewayTransactionId, foundCharge, targetStatus, ZonedDateTime.ofInstant(
+                        item.getEventDate().toInstant(), ZoneId.of("UTC")));
+            }
+
+            if (!item.isSuccess()) {
+                LOGGER.error("Capture failed",
+                        kv("gateway_transaction_id", gatewayTransactionId),
+                        kv("eventCode", item.getEventCode()));
+            }
+
+        } else {
+            LOGGER.error("Charge not found in Connector or Ledger for Adyen capture webhook",
+                    kv("gatewayTransactionId", gatewayTransactionId));
+        }
+
+    }
+    
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
@@ -82,9 +82,8 @@ class AdyenNotificationServiceTest {
         when(mockAdyenGatewayConfig.getNotificationDomain()).thenReturn("out.adyen.com.");
         when(ipDomainMatcher.ipMatchesDomain("5.6.7.8", "out.adyen.com.")).thenReturn(true);
         when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-
-        String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
-                .replace("{{HMAC_SIGNATURE}}", validHmacSigniture);
+        
+        String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
 
         boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
 
@@ -120,10 +119,8 @@ class AdyenNotificationServiceTest {
         @Test
         void shouldReturnTrueForValidHmacKey() {
             when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-
-            String payload = TestTemplateResourceLoader
-                    .load(ADYEN_NOTIFICATION)
-                    .replace("{{HMAC_SIGNATURE}}", validHmacSigniture);
+            
+            String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
 
             boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenNotificationResourceIT.java
@@ -34,7 +34,7 @@ public class AdyenNotificationResourceIT {
 
     @Test
     void shouldHandleAValidJsonNotification() {
-        String validHmacSignature = "coqCmt/IZ4E3CzPvMY8zTjQVL5hYJUiBRg8UU+iCWo0="; // pragma: allowlist secret
+        String validHmacSignature = "9C3600/ujEuztt/Be8+EX74c6ysk7GyiWwsVi2KW+s0="; // pragma: allowlist secret
         String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
                 .replace("{{HMAC_SIGNATURE}}", validHmacSignature);
         given()

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/AdyenWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/AdyenWebhookTaskHandlerTest.java
@@ -1,0 +1,230 @@
+package uk.gov.pay.connector.queue.tasks;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.adyen.model.notification.NotificationRequest;
+import com.adyen.model.notification.NotificationRequestItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
+import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.queue.tasks.handlers.AdyenWebhookTaskHandler;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+
+
+@ExtendWith(MockitoExtension.class)
+public class AdyenWebhookTaskHandlerTest {
+
+    @Mock
+    private GatewayAccountService mockGatewayAccountService;
+
+    @Mock
+    private ChargeService mockChargeService;
+
+    @Mock
+    private ChargeNotificationProcessor mockChargeNotificationProcessor;
+
+    @Mock
+    private AdyenNotificationService mockAdyenNotificationService;
+    
+    @Mock
+    private Charge mockCharge;
+    
+    @Mock
+    NotificationRequest mockNotificationRequest;
+    
+    @Mock
+    NotificationRequestItem mockNotificationItem;
+    
+    @Mock
+    GatewayAccountEntity gatewayAccount;
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+
+    @InjectMocks
+    private AdyenWebhookTaskHandler adyenWebhookTaskHandler;
+    
+    private final String gatewayTransactionId = "adyen-payment-id-1";
+    
+    private final String payload = "payload";
+    private final  Date eventDate = Date.from(Instant.parse("2026-05-19T10:15:30Z"));
+    private final long gatewayAccountId = 123L;
+
+
+    @BeforeEach
+    void setUp() {
+        adyenWebhookTaskHandler = new AdyenWebhookTaskHandler(mockChargeService, mockChargeNotificationProcessor,
+                mockGatewayAccountService, mockAdyenNotificationService);
+        Logger root = (Logger) LoggerFactory.getLogger(AdyenWebhookTaskHandler.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
+    }
+    @Test
+    void shouldProcessSuccessfulCaptureNotificationForConnectorCharge() {
+        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
+                .thenReturn(mockNotificationRequest);
+        when(mockAdyenNotificationService.extractNotificationItem(mockNotificationRequest))
+                .thenReturn(List.of(mockNotificationItem));
+
+        when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
+        when(mockNotificationItem.isSuccess()).thenReturn(true);
+        when(mockNotificationItem.getEventDate()).thenReturn(eventDate);
+
+
+        when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
+                gatewayTransactionId)).thenReturn(Optional.of(mockCharge));
+
+        when(mockCharge.isHistoric()).thenReturn(false);
+
+        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
+
+        verify(mockChargeService).findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(), 
+                gatewayTransactionId);
+
+        verify(mockChargeNotificationProcessor).invoke(gatewayTransactionId, mockCharge,
+                CAPTURED, ZonedDateTime.ofInstant(eventDate.toInstant(), ZoneId.of("UTC")));
+    }
+
+    @Test
+    void shouldProcessCaptureFailedMessageFromTaskQueueForConnectorCharge() {
+        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
+                .thenReturn(mockNotificationRequest);
+        when(mockAdyenNotificationService.extractNotificationItem(mockNotificationRequest))
+                .thenReturn(List.of(mockNotificationItem));
+
+        when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
+        when(mockNotificationItem.isSuccess()).thenReturn(false);
+        when(mockNotificationItem.getEventDate()).thenReturn(eventDate);
+
+        when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(), 
+                gatewayTransactionId)).thenReturn(Optional.of(mockCharge));
+
+        when(mockCharge.isHistoric()).thenReturn(false);
+
+        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
+
+        verify(mockChargeNotificationProcessor).invoke(gatewayTransactionId, mockCharge,
+                CAPTURE_ERROR, ZonedDateTime.ofInstant(eventDate.toInstant(), ZoneId.of("UTC")));
+
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        
+        assertThat(loggingEvents.stream().anyMatch(event -> event.getFormattedMessage()
+                .equals("Capture failed")), is(true));
+
+    }
+    
+    @Test
+    void shouldProcessSuccessfulCaptureMessageFromTaskQueueForLedgerCharge() {
+        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
+                .thenReturn(mockNotificationRequest);
+        when(mockAdyenNotificationService.extractNotificationItem(mockNotificationRequest))
+                .thenReturn(List.of(mockNotificationItem));
+        when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
+        when(mockNotificationItem.isSuccess()).thenReturn(true);
+
+        when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
+                gatewayTransactionId)).thenReturn(Optional.of(mockCharge));
+        
+        when(mockCharge.getGatewayAccountId()).thenReturn(gatewayAccountId);
+        when(mockGatewayAccountService.getGatewayAccount(gatewayAccountId))
+                .thenReturn(Optional.of(gatewayAccount));
+        when(mockCharge.isHistoric()).thenReturn(true);
+        when(mockGatewayAccountService.getGatewayAccount(gatewayAccountId))
+                .thenReturn(Optional.of(gatewayAccount));
+        
+        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
+
+        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(
+                gatewayAccount, gatewayTransactionId, mockCharge, CAPTURED);
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+    
+    @Test
+    void shouldProcessFailedCaptureMessageFromTaskQueueForLedgerCharge() {
+        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
+                .thenReturn(mockNotificationRequest);
+
+        when(mockAdyenNotificationService.extractNotificationItem(mockNotificationRequest))
+                .thenReturn(List.of(mockNotificationItem));
+
+        when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
+        when(mockNotificationItem.isSuccess()).thenReturn(false);
+
+        when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
+                gatewayTransactionId)).thenReturn(Optional.of(mockCharge));
+
+        when(mockCharge.isHistoric()).thenReturn(true);
+        when(mockCharge.getGatewayAccountId()).thenReturn(gatewayAccountId);
+
+        when(mockGatewayAccountService.getGatewayAccount(gatewayAccountId))
+                .thenReturn(Optional.of(gatewayAccount));
+
+        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
+
+        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccount, 
+                gatewayTransactionId,
+                mockCharge,
+                CAPTURE_ERROR
+        );
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldLogWarningWhenChargeDoesNotExistInConnectorOrLedger() {
+        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
+                .thenReturn(mockNotificationRequest);
+        when(mockAdyenNotificationService.extractNotificationItem(mockNotificationRequest))
+                .thenReturn(List.of(mockNotificationItem));
+        when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
+        when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
+                gatewayTransactionId)).thenReturn(Optional.empty());
+        
+        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
+        
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockChargeNotificationProcessor, never()).processCaptureNotificationForExpungedCharge(any(), any(), 
+                any(), any());
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(loggingEvents.stream().anyMatch(event -> event.getFormattedMessage()
+                .equals("Charge not found in Connector or Ledger for Adyen capture webhook")), is(true));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
@@ -12,6 +12,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.gateway.stripe.response.StripeNotification;
+import uk.gov.pay.connector.queue.tasks.handlers.AdyenWebhookTaskHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.AuthoriseWithUserNotPresentHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.CollectFeesForFailedPaymentsTaskHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.DeleteStoredPaymentDetailsTaskHandler;
@@ -52,6 +53,9 @@ class TaskQueueMessageHandlerTest {
     private StripeWebhookTaskHandler stripeWebhookTaskHandler;
 
     @Mock
+    AdyenWebhookTaskHandler mockAdyenWebhookTaskHandler;
+
+    @Mock
     private AuthoriseWithUserNotPresentHandler authoriseWithUserNotPresentHandler;
 
     @Mock
@@ -84,6 +88,7 @@ class TaskQueueMessageHandlerTest {
                 taskQueue,
                 collectFeesForFailedPaymentsTaskHandler,
                 stripeWebhookTaskHandler,
+                mockAdyenWebhookTaskHandler,
                 authoriseWithUserNotPresentHandler,
                 deleteStoredPaymentDetailsHandler,
                 mockRetryPaymentOrRefundEmailTaskHandler,

--- a/src/test/resources/templates/adyen/notification.json
+++ b/src/test/resources/templates/adyen/notification.json
@@ -4,6 +4,7 @@
     {
       "NotificationRequestItem": {
         "pspReference": "7914073381342284",
+        "originalReference": "79188877666242",
         "merchantAccountCode": "TestMerchant",
         "merchantReference": "TestPayment-1407325143704",
         "eventCode": "AUTHORISATION",


### PR DESCRIPTION
## WHAT YOU DID

- When charge is found in Connector
  - Successful capture notifications transition charge to `CAPTURED`
  - Fialed capture notifications transition to `CAPTURE_ERROR`

- When charge found in Ledger
   - Successful capture notifications are processed as historic capture eevnts
   - Failed capture notifications are processed as capture failure

- In the next PR  tests will be adde for TaskQueueMessageHandler.

