### PR TITLE
PP-15146: factor out an AdyenCheckoutMockClient

### DIFF
--- a/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
+++ b/src/test/java/uk/gov/pay/connector/extension/AppWithPostgresAndSqsExtension.java
@@ -23,7 +23,7 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.InjectorLookup;
 import uk.gov.pay.connector.app.config.AuthorisationConfig;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.rules.AdyenMockClient;
+import uk.gov.pay.connector.rules.AdyenCheckoutMockClient;
 import uk.gov.pay.connector.rules.CardidStub;
 import uk.gov.pay.connector.rules.LedgerStub;
 import uk.gov.pay.connector.rules.NotifyStub;
@@ -50,11 +50,11 @@ import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRando
 public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, BeforeAllCallback, AfterEachCallback, AfterAllCallback {
     private static final Logger logger = LoggerFactory.getLogger(AppWithPostgresAndSqsExtension.class);
     private static final String JPA_UNIT = "ConnectorUnit";
-    private static String CONFIG_PATH = resourceFilePath("config/test-it-config.yaml");
+    private static final String CONFIG_PATH = resourceFilePath("config/test-it-config.yaml");
     private final Jdbi jdbi;
     private final SqsClient sqsClient;
     private final DropwizardAppExtension<ConnectorConfiguration> dropwizardAppExtension;
-    private Injector injector;
+    private final Injector injector;
     private final int wireMockPort;
     private final int worldpayWireMockPort;
     private final int ledgerWireMockPort;
@@ -63,18 +63,18 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
     private final int notifyWireMockPort;
 
     protected static DatabaseTestHelper databaseTestHelper;
-    private WireMockServer wireMockServer;
-    private WireMockServer worldpayWireMockServer;
-    private WireMockServer ledgerWireMockServer;
-    private WireMockServer stripeWireMockServer;
-    private WireMockServer adyenWireMockServer;
-    private WireMockServer notifyWireMockServer;
-    private WorldpayMockClient worldpayMockClient;
-    private StripeMockClient stripeMockClient;
-    private AdyenMockClient adyenMockClient;
-    private LedgerStub ledgerStub;
-    private CardidStub cardidStub;
-    private NotifyStub notifyStub;
+    private final WireMockServer wireMockServer;
+    private final WireMockServer worldpayWireMockServer;
+    private final WireMockServer ledgerWireMockServer;
+    private final WireMockServer stripeWireMockServer;
+    private final WireMockServer adyenWireMockServer;
+    private final WireMockServer notifyWireMockServer;
+    private final WorldpayMockClient worldpayMockClient;
+    private final StripeMockClient stripeMockClient;
+    private final AdyenCheckoutMockClient adyenCheckoutMockClient;
+    private final LedgerStub ledgerStub;
+    private final CardidStub cardidStub;
+    private final NotifyStub notifyStub;
 
     protected static String accountId = String.valueOf(secureRandomInt());
     protected static ObjectMapper mapper;
@@ -142,7 +142,7 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
 
         worldpayMockClient = new WorldpayMockClient(worldpayWireMockServer);
         stripeMockClient = new StripeMockClient(stripeWireMockServer);
-        adyenMockClient = new AdyenMockClient(adyenWireMockServer);
+        adyenCheckoutMockClient = new AdyenCheckoutMockClient(adyenWireMockServer);
 
         ledgerStub = new LedgerStub(ledgerWireMockServer);
         cardidStub = new CardidStub(wireMockServer);
@@ -314,8 +314,8 @@ public class AppWithPostgresAndSqsExtension implements BeforeEachCallback, Befor
         return stripeMockClient;
     }
 
-    public AdyenMockClient getAdyenMockClient() {
-        return adyenMockClient;
+    public AdyenCheckoutMockClient getAdyenCheckoutMockClient() {
+        return adyenCheckoutMockClient;
     }
 
     public LedgerStub getLedgerStub() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -50,7 +50,7 @@ class AdyenCardResourceAuthoriseIT {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
         var pspReferenceFromAdyen = "993617895215577D";
 
-        app.getAdyenMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
 
         var authCardDetails = anAuthCardDetails()
                 .withCardNo("4444333322221111")
@@ -91,7 +91,7 @@ class AdyenCardResourceAuthoriseIT {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
         var pspReferenceFromAdyen = "993617895215577D";
 
-        app.getAdyenMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
 
         var authCardDetails = anAuthCardDetails()
                 .withCardNo("4444333322221111")
@@ -134,7 +134,7 @@ class AdyenCardResourceAuthoriseIT {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
         var pspReferenceFromAdyen = "883617895215577D";
 
-        app.getAdyenMockClient().mockAuthorisationRejected(pspReferenceFromAdyen);
+        app.getAdyenCheckoutMockClient().mockAuthorisationRejected(pspReferenceFromAdyen);
 
         app.givenSetup()
                 .body(anAuthCardDetails().build())
@@ -155,7 +155,7 @@ class AdyenCardResourceAuthoriseIT {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
         var pspReferenceFromAdyen = "883617895215577D";
 
-        app.getAdyenMockClient().mockAuthorisationError(pspReferenceFromAdyen);
+        app.getAdyenCheckoutMockClient().mockAuthorisationError(pspReferenceFromAdyen);
 
         app.givenSetup()
                 .body(anAuthCardDetails().build())
@@ -176,7 +176,7 @@ class AdyenCardResourceAuthoriseIT {
     void should_return_402_for_unexpected_server_error() {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
 
-        app.getAdyenMockClient().mockError("/payments");
+        app.getAdyenCheckoutMockClient().mockError("/payments");
 
         app.givenSetup()
                 .body(anAuthCardDetails().build())

--- a/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.rules;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import static org.apache.http.HttpStatus.SC_OK;
+
+public class AdyenCheckoutMockClient extends AdyenMockClient {
+
+    public AdyenCheckoutMockClient(WireMockServer wireMockServer) {
+        super(wireMockServer);
+    }
+
+    public void mockAuthorisationSuccess(String pspReferenceFromAdyen) {
+        String responseBody = """
+                {
+                  "pspReference": "%s",
+                  "resultCode": "Authorised",
+                  "merchantReference": "string"
+                }""".formatted(pspReferenceFromAdyen);
+
+        setupPostResponse(responseBody, "/payments", SC_OK);
+    }
+
+    public void mockAuthorisationRejected(String pspReferenceFromAdyen) {
+        String responseBody = """
+                {
+                  "pspReference": "%s",
+                  "refusalReason": "Expired Card",
+                  "resultCode": "Refused",
+                  "refusalReasonCode": "6"
+                }""".formatted(pspReferenceFromAdyen);
+        setupPostResponse(responseBody, "/payments", SC_OK);
+    }
+
+    public void mockAuthorisationError(String pspReferenceFromAdyen) {
+        String responseBody = """
+                {
+                  "pspReference": "%s",
+                  "refusalReason": "Acquirer Error",
+                  "resultCode": "Error",
+                  "refusalReasonCode": "4"
+                }""".formatted(pspReferenceFromAdyen);
+        setupPostResponse(responseBody, "/payments", SC_OK);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/rules/AdyenKycMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AdyenKycMockClient.java
@@ -3,12 +3,6 @@ package uk.gov.pay.connector.rules;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.matching;
-import static com.github.tomakehurst.wiremock.client.WireMock.patch;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static java.lang.String.format;
 import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_ACCEPT_TERMS_OF_SERVICE_RESPONSE;
@@ -22,11 +16,11 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_TRANSFE
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_UPDATE_LEGAL_ENTITY_RESPONSE;
 
 public class AdyenKycMockClient extends AdyenMockClient {
-    
+
     public AdyenKycMockClient(WireMockServer wireMockServer) {
         super(wireMockServer);
     }
-    
+
     public void mockCreateLegalEntity() {
         String responseBody = TestTemplateResourceLoader.load(ADYEN_CREATE_LEGAL_ENTITY_RESPONSE);
         var path = "/legalEntities";
@@ -35,17 +29,8 @@ public class AdyenKycMockClient extends AdyenMockClient {
 
     public void mockUpdateLegalEntity(String legalEntityId) {
         String responseBody = TestTemplateResourceLoader.load(ADYEN_UPDATE_LEGAL_ENTITY_RESPONSE);
-        var path = "/legalEntities/" + legalEntityId ;
-        setupPatchResponse(responseBody, path);
-    }
-
-    private void setupPatchResponse(String responseBody, String path) {
-        wireMockServer.stubFor(patch(urlPathEqualTo(path))
-                .withHeader(CONTENT_TYPE, matching(APPLICATION_JSON))
-                .willReturn(aResponse()
-                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
-                        .withStatus(org.apache.http.HttpStatus.SC_OK)
-                        .withBody(responseBody)));
+        var path = "/legalEntities/" + legalEntityId;
+        setupPatchResponse(responseBody, path, SC_OK);
     }
 
     public void mockCreateBusinessLine() {
@@ -69,7 +54,7 @@ public class AdyenKycMockClient extends AdyenMockClient {
     public void mockAcceptTermsOfService(String legalEntityId, String termsOfServiceDocumentId) {
         String responseBody = TestTemplateResourceLoader.load(ADYEN_ACCEPT_TERMS_OF_SERVICE_RESPONSE);
         var path = format("/legalEntities/%s/termsOfService/%s", legalEntityId, termsOfServiceDocumentId);
-        setupPatchResponse(responseBody, path);
+        setupPatchResponse(responseBody, path, SC_OK);
     }
 
     public void mockGeneratePciQuestionnaire(String legalEntityId) {

--- a/src/test/java/uk/gov/pay/connector/rules/AdyenMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AdyenMockClient.java
@@ -5,22 +5,32 @@ import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
-import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_ERROR_RESPONSE;
 
 public class AdyenMockClient {
+
     protected WireMockServer wireMockServer;
 
     public AdyenMockClient(WireMockServer wireMockServer) {
         this.wireMockServer = wireMockServer;
     }
 
-    protected void setupPostResponse(String responseBody, String path, int status) {
+    void setupPatchResponse(String responseBody, String path, int status) {
+        wireMockServer.stubFor(patch(urlPathEqualTo(path))
+                .withHeader(CONTENT_TYPE, matching(APPLICATION_JSON))
+                .willReturn(aResponse()
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withStatus(status)
+                        .withBody(responseBody)));
+    }
+
+    void setupPostResponse(String responseBody, String path, int status) {
         wireMockServer.stubFor(post(urlPathEqualTo(path))
                 .withHeader(CONTENT_TYPE, matching(APPLICATION_JSON))
                 .willReturn(aResponse()
@@ -32,38 +42,5 @@ public class AdyenMockClient {
     public void mockError(String path) {
         String responseBody = TestTemplateResourceLoader.load(ADYEN_ERROR_RESPONSE);
         setupPostResponse(responseBody, path, SC_INTERNAL_SERVER_ERROR);
-    }
-
-    public void mockAuthorisationSuccess(String pspReferenceFromAdyen) {
-        String responseBody = """
-                {
-                  "pspReference": "%s",
-                  "resultCode": "Authorised",
-                  "merchantReference": "string"
-                }""".formatted(pspReferenceFromAdyen);
-
-        setupPostResponse(responseBody, "/payments", SC_OK);
-    }
-
-    public void mockAuthorisationRejected(String pspReferenceFromAdyen) {
-        String responseBody = """
-                {
-                  "pspReference": "%s",
-                  "refusalReason": "Expired Card",
-                  "resultCode": "Refused",
-                  "refusalReasonCode": "6"
-                }""".formatted(pspReferenceFromAdyen);
-        setupPostResponse(responseBody, "/payments", SC_OK);
-    }
-
-    public void mockAuthorisationError(String pspReferenceFromAdyen) {
-        String responseBody = """
-                {
-                  "pspReference": "%s",
-                  "refusalReason": "Acquirer Error",
-                  "resultCode": "Error",
-                  "refusalReasonCode": "4"
-                }""".formatted(pspReferenceFromAdyen);
-        setupPostResponse(responseBody, "/payments", SC_OK);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/AdyenMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AdyenMockClient.java
@@ -13,11 +13,11 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_ERROR_RESPONSE;
 
-public class AdyenMockClient {
+public abstract class AdyenMockClient {
 
-    protected WireMockServer wireMockServer;
+    private final WireMockServer wireMockServer;
 
-    public AdyenMockClient(WireMockServer wireMockServer) {
+    AdyenMockClient(WireMockServer wireMockServer) {
         this.wireMockServer = wireMockServer;
     }
 


### PR DESCRIPTION
## WHAT YOU DID
* Factored out `AdyenCheckoutMockClient`, since we have added `AdyenMockClient` subclasses for each Adyen API. Cancellation-specific stubbings will be added to this client.
* Pulled PATCH stubbing method up to `AdyenMockClient`
* Made some non-mutated private fields in `AppWithPostgressAndSqsExtension` final

## Observation
This pattern will lead to a WireMock server per Adyen API. We could use composition, rather than inheritance, to use one `WireMockServer` instance for Adyen.