### PR TITLE
PP-15146: implement successful system cancel scenario

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.adyen.handler.AdyenAuthoriseHandler;
+import uk.gov.pay.connector.gateway.adyen.handler.AdyenCancelHandler;
 import uk.gov.pay.connector.gateway.adyen.handler.AdyenCaptureHandler;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
@@ -44,6 +45,7 @@ public class AdyenPaymentProvider implements PaymentProvider {
     private final ConnectorConfiguration connectorConfiguration;
     private final AdyenAuthoriseHandler adyenAuthoriseHandler;
     private final AdyenCaptureHandler adyenCaptureHandler;
+    private final AdyenCancelHandler adyenCancelHandler;
 
     @Inject
     public AdyenPaymentProvider(
@@ -57,8 +59,9 @@ public class AdyenPaymentProvider implements PaymentProvider {
         this.client = gatewayClientFactory.createGatewayClient(ADYEN, environment.metrics());
         adyenAuthoriseHandler = new AdyenAuthoriseHandler(client, connectorConfiguration, jsonObjectMapper);
         adyenCaptureHandler = new AdyenCaptureHandler(client, connectorConfiguration, jsonObjectMapper);
+        adyenCancelHandler = new AdyenCancelHandler(client, new AdyenRequestFactory(connectorConfiguration), adyenGatewayConfig);
     }
-    
+
     @Override
     public PaymentGatewayName getPaymentGatewayName() {
         return ADYEN;
@@ -91,7 +94,7 @@ public class AdyenPaymentProvider implements PaymentProvider {
 
     @Override
     public CaptureResponse capture(CaptureGatewayRequest request) {
-       return adyenCaptureHandler.capture(request);
+        return adyenCaptureHandler.capture(request);
     }
 
     @Override
@@ -106,7 +109,7 @@ public class AdyenPaymentProvider implements PaymentProvider {
 
     @Override
     public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) throws GatewayException {
-        throw new UnsupportedOperationException("Operation for Adyen is not Implemented yet");
+        return adyenCancelHandler.cancel(request);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandler.java
@@ -1,0 +1,69 @@
+package uk.gov.pay.connector.gateway.adyen.handler;
+
+import io.dropwizard.jackson.Jackson;
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
+import uk.gov.pay.connector.gateway.adyen.request.AdyenCancelRequest;
+import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import static uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil.getCancelUrl;
+import static uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil.getHeaders;
+import static uk.gov.pay.connector.gateway.model.response.BaseCancelResponse.CancelStatus.SUBMITTED;
+
+public class AdyenCancelHandler {
+
+    private final GatewayClient client;
+    private final AdyenRequestFactory requestFactory;
+    private final AdyenGatewayConfig config;
+
+    public AdyenCancelHandler(GatewayClient client, AdyenRequestFactory requestFactory, AdyenGatewayConfig config) {
+        this.client = client;
+        this.requestFactory = requestFactory;
+        this.config = config;
+    }
+
+    public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) {
+        var responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
+        var cancelRequest = new AdyenCancelRequest(
+                getCancelUrl(config, request),
+                getHeaders(config, request.isLiveAccount()),
+                requestFactory.createPaymentCancelRequest(request),
+                request.getGatewayAccount().getType(),
+                new JsonObjectMapper(Jackson.newObjectMapper()));
+        try {
+            client.postRequestFor(cancelRequest);
+        } catch (GatewayException.GenericGatewayException e) {
+            throw new RuntimeException(e);
+        } catch (GatewayException.GatewayErrorException e) {
+            throw new RuntimeException(e);
+        } catch (GatewayException.GatewayConnectionTimeoutException e) {
+            throw new RuntimeException(e);
+        }
+        return responseBuilder.withResponse(new BaseCancelResponse() {
+            @Override
+            public String getTransactionId() {
+                return "";
+            }
+
+            @Override
+            public CancelStatus cancelStatus() {
+                return SUBMITTED;
+            }
+
+            @Override
+            public String getErrorCode() {
+                return "";
+            }
+
+            @Override
+            public String getErrorMessage() {
+                return "";
+            }
+        }).build();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/app/adyen/ApiKeysFixture.java
+++ b/src/test/java/uk/gov/pay/connector/app/adyen/ApiKeysFixture.java
@@ -17,7 +17,7 @@ public class ApiKeysFixture {
             "test-legal-entity-management-API-key",
             "live-legal-entity-management-API-key");
 
-    public static ApiKeysFixture anApiKeys() {
+    public static ApiKeysFixture someApiKeys() {
         return new ApiKeysFixture();
     }
 

--- a/src/test/java/uk/gov/pay/connector/app/adyen/ApiKeysFixture.java
+++ b/src/test/java/uk/gov/pay/connector/app/adyen/ApiKeysFixture.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.connector.app.adyen;
+
+import uk.gov.pay.connector.app.adyen.ApiKeys.BalancePlatformApiKeys;
+import uk.gov.pay.connector.app.adyen.ApiKeys.CompanyAccountApiKeys;
+import uk.gov.pay.connector.app.adyen.ApiKeys.LegalEntityManagementApiKeys;
+
+public class ApiKeysFixture {
+
+    private CompanyAccountApiKeys companyAccount = new CompanyAccountApiKeys(
+            "test-company-account-API-key",
+            "live-company-account-API-key");
+    private BalancePlatformApiKeys balancePlatform = new BalancePlatformApiKeys(
+            "test-balance-platform-API-key",
+            "live-balance-platform-API-key");
+
+    private LegalEntityManagementApiKeys legalEntityManagement = new LegalEntityManagementApiKeys(
+            "test-legal-entity-management-API-key",
+            "live-legal-entity-management-API-key");
+
+    public static ApiKeysFixture anApiKeys() {
+        return new ApiKeysFixture();
+    }
+
+    public ApiKeysFixture withCompanyAccount(CompanyAccountApiKeys companyAccount) {
+        this.companyAccount = companyAccount;
+        return this;
+    }
+
+    public ApiKeysFixture withBalancePlatform(BalancePlatformApiKeys balancePlatform) {
+        this.balancePlatform = balancePlatform;
+        return this;
+    }
+
+    public ApiKeysFixture withLegalEntityManagement(LegalEntityManagementApiKeys legalEntityManagement) {
+        this.legalEntityManagement = legalEntityManagement;
+        return this;
+    }
+
+    public ApiKeys build() {
+        return new ApiKeys(companyAccount, balancePlatform, legalEntityManagement);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/app/adyen/BaseUrlsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/app/adyen/BaseUrlsFixture.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.connector.app.adyen;
+
+import uk.gov.pay.connector.app.adyen.BaseUrls.BalancePlatformUrls;
+import uk.gov.pay.connector.app.adyen.BaseUrls.CheckoutUrls;
+import uk.gov.pay.connector.app.adyen.BaseUrls.LegalEntityManagementUrls;
+import uk.gov.pay.connector.app.adyen.BaseUrls.ManagementUrls;
+
+public class BaseUrlsFixture {
+
+    private CheckoutUrls checkout = new CheckoutUrls(
+            "https://checkout-test.example.com", "https://checkout.example.com");
+    private BalancePlatformUrls balancePlatform = new BalancePlatformUrls(
+            "https://balance-test.example.com", "https://balance.example.com");
+    private LegalEntityManagementUrls legalEntityManagement = new LegalEntityManagementUrls(
+            "https://legal-test.example.com", "https://legal.example.com");
+    private ManagementUrls management = new ManagementUrls(
+            "https://management-test.example.com", "https://management.example.com");
+
+    public static BaseUrlsFixture aBaseUrls() {
+        return new BaseUrlsFixture();
+    }
+
+    public BaseUrlsFixture withCheckout(CheckoutUrls checkout) {
+        this.checkout = checkout;
+        return this;
+    }
+
+    public BaseUrlsFixture withBalancePlatform(BalancePlatformUrls balancePlatform) {
+        this.balancePlatform = balancePlatform;
+        return this;
+    }
+
+    public BaseUrlsFixture withLegalEntityManagement(LegalEntityManagementUrls legalEntityManagement) {
+        this.legalEntityManagement = legalEntityManagement;
+        return this;
+    }
+
+    public BaseUrlsFixture withManagement(ManagementUrls management) {
+        this.management = management;
+        return this;
+    }
+
+    public BaseUrls build() {
+        return new BaseUrls(checkout, balancePlatform, legalEntityManagement, management);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/app/adyen/BaseUrlsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/app/adyen/BaseUrlsFixture.java
@@ -16,7 +16,7 @@ public class BaseUrlsFixture {
     private ManagementUrls management = new ManagementUrls(
             "https://management-test.example.com", "https://management.example.com");
 
-    public static BaseUrlsFixture aBaseUrls() {
+    public static BaseUrlsFixture someBaseUrls() {
         return new BaseUrlsFixture();
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -114,11 +115,15 @@ class AdyenCancelHandlerTest {
                 .assertEquals("merchantAccount", A_MERCHANT_ACCOUNT_ID);
     }
 
-    @Test
-    void should_POST_with_company_API_key_as_X_API_Key_header() throws Exception {
+    @ParameterizedTest
+    @CsvSource({
+            "LIVE," + LIVE_COMPANY_ACCOUNT_API_KEY,
+            "TEST," + TEST_COMPANY_ACCOUNT_API_KEY
+    })
+    void should_POST_with_company_API_key_as_X_API_Key_header(GatewayAccountType gatewayAccountType, String expectedApiKey) throws Exception {
         var request = CancelGatewayRequest.valueOf(
                 aValidChargeEntity()
-                        .withGatewayAccountEntity(makeGatewayAccountEntityForAccountType(LIVE))
+                        .withGatewayAccountEntity(makeGatewayAccountEntityForAccountType(gatewayAccountType))
                         .build());
 
         cancelHandler.cancel(request);
@@ -126,7 +131,7 @@ class AdyenCancelHandlerTest {
         then(mockGatewayClient).should()
                 .postRequestFor(captor.capture());
         var headers = captor.getValue().getHeaders();
-        assertThat(headers, hasEntry("X-API-Key", LIVE_COMPANY_ACCOUNT_API_KEY));
+        assertThat(headers, hasEntry("X-API-Key", expectedApiKey));
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
@@ -1,0 +1,166 @@
+package uk.gov.pay.connector.gateway.adyen.handler;
+
+import com.jayway.jsonassert.JsonAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.app.adyen.AdyenIds;
+import uk.gov.pay.connector.app.adyen.ApiKeys.CompanyAccountApiKeys;
+import uk.gov.pay.connector.app.adyen.BaseUrls.CheckoutUrls;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
+import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.then;
+import static uk.gov.pay.connector.app.adyen.ApiKeysFixture.anApiKeys;
+import static uk.gov.pay.connector.app.adyen.BaseUrlsFixture.aBaseUrls;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gateway.model.response.BaseCancelResponse.CancelStatus.SUBMITTED;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
+
+@ExtendWith(MockitoExtension.class)
+class AdyenCancelHandlerTest {
+
+    public static final String A_MERCHANT_ACCOUNT_ID = "a-merchant-account-id";
+    public static final String AN_EXTERNAL_ID = "a-charge-external-id";
+    public static final String LIVE_CHECKOUT_BASE_URL = "https://checkout.example.com";
+    public static final String A_GATEWAY_TRANSACTION_ID = "a-gateway-transaction-id";
+    public static final String TEST_COMPANY_ACCOUNT_API_KEY = "test-company-account-API-key"; // pragma: allowlist secret
+    public static final String LIVE_COMPANY_ACCOUNT_API_KEY = "live-company-account-API-key"; // pragma: allowlist secret
+
+    @Mock
+    private GatewayClient mockGatewayClient;
+    @Captor
+    private ArgumentCaptor<GatewayClientPostRequest> captor;
+
+    private AdyenCancelHandler cancelHandler;
+
+    @BeforeEach
+    void setUp() {
+        var mockAdyenIds = new AdyenIds(A_MERCHANT_ACCOUNT_ID, A_MERCHANT_ACCOUNT_ID);
+        var mockAdyenGatewayConfig = mock(AdyenGatewayConfig.class);
+        given(mockAdyenGatewayConfig.getMerchantAccountIds())
+                .willReturn(mockAdyenIds);
+        var mockApiKeys = anApiKeys()
+                .withCompanyAccount(
+                        new CompanyAccountApiKeys(TEST_COMPANY_ACCOUNT_API_KEY, LIVE_COMPANY_ACCOUNT_API_KEY))
+                .build();
+        given(mockAdyenGatewayConfig.getApiKeys())
+                .willReturn(mockApiKeys);
+        var mockBaseUrls = aBaseUrls()
+                .withCheckout(new CheckoutUrls("https://example.com", LIVE_CHECKOUT_BASE_URL))
+                .build();
+        given(mockAdyenGatewayConfig.getBaseUrls())
+                .willReturn(mockBaseUrls);
+        var mockConfiguration = mock(ConnectorConfiguration.class);
+        given(mockConfiguration.getAdyenGatewayConfig())
+                .willReturn(mockAdyenGatewayConfig);
+        cancelHandler = new AdyenCancelHandler(
+                mockGatewayClient,
+                new AdyenRequestFactory(mockConfiguration),
+                mockAdyenGatewayConfig);
+    }
+
+    @Test
+    void should_POST_request_to_the_cancel_an_authorised_payment_URL_and_pass_the_gateway_transaction_ID_as_the_path_parameter() throws Exception {
+        var request = CancelGatewayRequest.valueOf(
+                aValidChargeEntity()
+                        .withGatewayTransactionId(A_GATEWAY_TRANSACTION_ID)
+                        .withGatewayAccountEntity(makeGatewayAccountEntityForAccountType(LIVE))
+                        .build());
+
+        cancelHandler.cancel(request);
+
+        then(mockGatewayClient).should()
+                .postRequestFor(captor.capture());
+        assertThat(captor.getValue().getUrl().toString(), is(
+                LIVE_CHECKOUT_BASE_URL + "/payments/" + A_GATEWAY_TRANSACTION_ID + "/cancels"));
+    }
+
+    @Test
+    void should_POST_a_GatewayOrder_with_reference_and_merchant_account_in_payload() throws Exception {
+        var request = CancelGatewayRequest.valueOf(
+                aValidChargeEntity()
+                        .withExternalId(AN_EXTERNAL_ID)
+                        .withGatewayAccountEntity(makeGatewayAccountEntityForAccountType(LIVE))
+                        .build());
+
+        cancelHandler.cancel(request);
+
+        then(mockGatewayClient).should()
+                .postRequestFor(captor.capture());
+        var gatewayOrderPayload = captor.getValue()
+                .getGatewayOrder()
+                .getPayload();
+        JsonAssert.with(gatewayOrderPayload)
+                .assertEquals("reference", AN_EXTERNAL_ID)
+                .assertEquals("merchantAccount", A_MERCHANT_ACCOUNT_ID);
+    }
+
+    @Test
+    void should_POST_with_company_API_key_as_X_API_Key_header() throws Exception {
+        var request = CancelGatewayRequest.valueOf(
+                aValidChargeEntity()
+                        .withGatewayAccountEntity(makeGatewayAccountEntityForAccountType(LIVE))
+                        .build());
+
+        cancelHandler.cancel(request);
+
+        then(mockGatewayClient).should()
+                .postRequestFor(captor.capture());
+        var headers = captor.getValue().getHeaders();
+        assertThat(headers, hasEntry("X-API-Key", LIVE_COMPANY_ACCOUNT_API_KEY));
+    }
+
+    @ParameterizedTest
+    @EnumSource(GatewayAccountType.class)
+    void should_POST_request_with_account_type(GatewayAccountType type) throws Exception {
+        var request = CancelGatewayRequest.valueOf(
+                aValidChargeEntity()
+                        .withGatewayAccountEntity(makeGatewayAccountEntityForAccountType(type))
+                        .build());
+
+        cancelHandler.cancel(request);
+
+        then(mockGatewayClient).should()
+                .postRequestFor(captor.capture());
+        var accountType = captor.getValue().getGatewayAccountType();
+        assertThat(accountType, is(type.toString()));
+    }
+
+    @Test
+    void should_return_SUBMITTED_cancel_status() {
+        var request = CancelGatewayRequest.valueOf(
+                aValidChargeEntity()
+                        .withGatewayAccountEntity(makeGatewayAccountEntityForAccountType(LIVE))
+                        .build());
+
+        var gatewayResponse = cancelHandler.cancel(request);
+
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().get().cancelStatus(), is(SUBMITTED));
+    }
+
+    private static GatewayAccountEntity makeGatewayAccountEntityForAccountType(GatewayAccountType type) {
+        return aGatewayAccountEntity()
+                .withType(type)
+                .build();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
@@ -58,17 +58,17 @@ class AdyenCancelHandlerTest {
         var mockAdyenGatewayConfig = mock(AdyenGatewayConfig.class);
         given(mockAdyenGatewayConfig.getMerchantAccountIds())
                 .willReturn(mockAdyenIds);
-        var mockApiKeys = anApiKeys()
+        var apiKeys = anApiKeys()
                 .withCompanyAccount(
                         new CompanyAccountApiKeys(TEST_COMPANY_ACCOUNT_API_KEY, LIVE_COMPANY_ACCOUNT_API_KEY))
                 .build();
         given(mockAdyenGatewayConfig.getApiKeys())
-                .willReturn(mockApiKeys);
-        var mockBaseUrls = aBaseUrls()
+                .willReturn(apiKeys);
+        var baseUrls = aBaseUrls()
                 .withCheckout(new CheckoutUrls("https://example.com", LIVE_CHECKOUT_BASE_URL))
                 .build();
         given(mockAdyenGatewayConfig.getBaseUrls())
-                .willReturn(mockBaseUrls);
+                .willReturn(baseUrls);
         var mockConfiguration = mock(ConnectorConfiguration.class);
         given(mockConfiguration.getAdyenGatewayConfig())
                 .willReturn(mockAdyenGatewayConfig);

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
@@ -29,8 +29,8 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.then;
-import static uk.gov.pay.connector.app.adyen.ApiKeysFixture.anApiKeys;
-import static uk.gov.pay.connector.app.adyen.BaseUrlsFixture.aBaseUrls;
+import static uk.gov.pay.connector.app.adyen.ApiKeysFixture.someApiKeys;
+import static uk.gov.pay.connector.app.adyen.BaseUrlsFixture.someBaseUrls;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.model.response.BaseCancelResponse.CancelStatus.SUBMITTED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
@@ -59,13 +59,13 @@ class AdyenCancelHandlerTest {
         var mockAdyenGatewayConfig = mock(AdyenGatewayConfig.class);
         given(mockAdyenGatewayConfig.getMerchantAccountIds())
                 .willReturn(mockAdyenIds);
-        var apiKeys = anApiKeys()
+        var apiKeys = someApiKeys()
                 .withCompanyAccount(
                         new CompanyAccountApiKeys(TEST_COMPANY_ACCOUNT_API_KEY, LIVE_COMPANY_ACCOUNT_API_KEY))
                 .build();
         given(mockAdyenGatewayConfig.getApiKeys())
                 .willReturn(apiKeys);
-        var baseUrls = aBaseUrls()
+        var baseUrls = someBaseUrls()
                 .withCheckout(new CheckoutUrls("https://example.com", LIVE_CHECKOUT_BASE_URL))
                 .build();
         given(mockAdyenGatewayConfig.getBaseUrls())

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
@@ -79,7 +79,7 @@ class AdyenCancelHandlerTest {
     }
 
     @Test
-    void should_POST_request_to_the_cancel_an_authorised_payment_URL_and_pass_the_gateway_transaction_ID_as_the_path_parameter() throws Exception {
+    void should_pass_the_gateway_transaction_ID_as_the_path_parameter_to_the_cancel_request() throws Exception {
         var request = CancelGatewayRequest.valueOf(
                 aValidChargeEntity()
                         .withGatewayTransactionId(A_GATEWAY_TRANSACTION_ID)

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceCancelIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceCancelIT.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.it.resources.adyen;
+
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.it.base.ITestBaseExtension;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathTemplate;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class AdyenCardResourceCancelIT {
+
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+
+    @RegisterExtension
+    public static ITestBaseExtension testBaseExtension = new ITestBaseExtension(
+            "adyen", app.getLocalPort(), app.getDatabaseTestHelper());
+
+    private ChargeDao chargeDao;
+
+    @BeforeEach
+    void setUp() {
+        chargeDao = app.getInstanceFromGuiceContainer(ChargeDao.class);
+    }
+
+    @Test
+    void successful_system_cancellation_of_payment() {
+        var gatewayTransactionId = "XB7XNCQ8HXSKGK82";
+        var chargeExternalId = testBaseExtension.createNewChargeWith(ChargeStatus.AUTHORISATION_SUCCESS, gatewayTransactionId);
+        app.getAdyenCheckoutMockClient()
+                .mockCancellationSuccess("an-adyen-reference", gatewayTransactionId);
+
+        app.givenSetup()
+                .post("/v1/api/accounts/{accountId}/charges/{chargeId}/cancel",
+                        testBaseExtension.getAccountId(),
+                        chargeExternalId);
+
+        app.getAdyenWireMockServer()
+                .verify(postRequestedFor(urlPathTemplate("/payments/{paymentPspReference}/cancels")));
+        var charge = chargeDao.findByExternalId(chargeExternalId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is(ChargeStatus.SYSTEM_CANCEL_SUBMITTED.toString()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.rules;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
+import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_OK;
 
 public class AdyenCheckoutMockClient extends AdyenMockClient {
@@ -11,7 +12,7 @@ public class AdyenCheckoutMockClient extends AdyenMockClient {
     }
 
     public void mockAuthorisationSuccess(String pspReferenceFromAdyen) {
-        String responseBody = """
+        var responseBody = """
                 {
                   "pspReference": "%s",
                   "resultCode": "Authorised",
@@ -22,7 +23,7 @@ public class AdyenCheckoutMockClient extends AdyenMockClient {
     }
 
     public void mockAuthorisationRejected(String pspReferenceFromAdyen) {
-        String responseBody = """
+        var responseBody = """
                 {
                   "pspReference": "%s",
                   "refusalReason": "Expired Card",
@@ -33,7 +34,7 @@ public class AdyenCheckoutMockClient extends AdyenMockClient {
     }
 
     public void mockAuthorisationError(String pspReferenceFromAdyen) {
-        String responseBody = """
+        var responseBody = """
                 {
                   "pspReference": "%s",
                   "refusalReason": "Acquirer Error",
@@ -41,5 +42,18 @@ public class AdyenCheckoutMockClient extends AdyenMockClient {
                   "refusalReasonCode": "4"
                 }""".formatted(pspReferenceFromAdyen);
         setupPostResponse(responseBody, "/payments", SC_OK);
+    }
+
+    public void mockCancellationSuccess(String pspReferenceFromAdyen, String paymentPspReference) {
+        var responseBody = """
+                {
+                  "pspReference": "%s",
+                  "merchantAccount": "adyen-test-merchant-account-id",
+                  "paymentPspReference": "%s",
+                  "reference": "864vqloqrm71jn89r4bjkhvkv2",
+                  "status": "received"
+                }""".formatted(pspReferenceFromAdyen, paymentPspReference);
+        var path = "/payments/%s/cancels".formatted(paymentPspReference);
+        setupPostResponse(responseBody, path, SC_CREATED);
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
Implemented Scenario 1 of PP-15401, a successful system cancel.

* Introduced `AdyenCancelHandler` and used it in `AdyenPaymentProvider`

I am passing an `AdyenRequestFactory` instance into the `AdyenCancelHandler` constructor, since this is clearer than the previous approach of 
* passing in the whole `ConnectorConfiguration`, 
* using it to construct an `AdyenRequestFactory` in the handler, and
* Using the `AdyenGatewayConfig` property to obtain the proper headers and URL

It would be better to have the Guice injector construct the request factory and handlers.

The singleton `JsonObjectMapper` will be injected in `AdyenCancelHandler` in a subsequent PR. Perhaps it would be best for `AdyenRequestFactory` to have a reference to the mapper and have the responsibility for the serialisation of the request payload.