### PR TITLE
PP-14485: authorise a moto payment with adyen

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
@@ -76,7 +76,7 @@ public class AdyenPaymentProvider implements PaymentProvider {
 
     @Override
     public GatewayResponse authoriseMotoApi(CardAuthorisationGatewayRequest request) throws GatewayException {
-        throw new UnsupportedOperationException("Operation for Adyen is not Implemented yet");
+        return adyenAuthoriseHandler.authorise(request);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getMerchantAccountId;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 
 public class AdyenRequestFactory {
 
@@ -31,7 +32,9 @@ public class AdyenRequestFactory {
 
     public AuthoriseRequestPayload createPaymentRequest(CardAuthorisationGatewayRequest request) {
         var authCardDetails = request.getAuthCardDetails();
-        var mappedAddress = authCardDetails.getAddress()
+        var mappedAddress = request.isMoto()
+                ? null
+                : authCardDetails.getAddress()
                 .map(AdyenRequestFactory::mapToBillingAddress)
                 .orElse(null);
 
@@ -44,6 +47,8 @@ public class AdyenRequestFactory {
 
         var adyenCredentials = mapToAdyenCredentials(request.getGatewayCredentials());
 
+        var shopperInteraction = request.isMoto() || request.getAuthorisationMode().equals(MOTO_API) ? "Moto" : "Ecommerce";
+
         return new AuthoriseRequestPayload(
                 new Amount("GBP", Long.valueOf(request.getAmount())),
                 mappedAddress,
@@ -51,7 +56,7 @@ public class AdyenRequestFactory {
                 paymentMethod,
                 request.getGovUkPayPaymentId(),
                 configuration.getLinks().getFrontendUrl(),
-                "Ecommerce",
+                shopperInteraction,
                 adyenCredentials.storeId(),
                 "Web",
                 new HashMap<>(Map.of("manualCapture", "true"))

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.adyen;
 
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 import uk.gov.pay.connector.gateway.adyen.request.json.AuthoriseRequestPayload;
 import uk.gov.pay.connector.gateway.adyen.request.json.BillingAddress;
@@ -17,10 +18,8 @@ import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getMerchantAccountId;
-import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 
 public class AdyenRequestFactory {
 
@@ -33,7 +32,9 @@ public class AdyenRequestFactory {
     public AuthoriseRequestPayload createPaymentRequest(CardAuthorisationGatewayRequest request) {
         var authCardDetails = request.getAuthCardDetails();
 
-        var mappedAddress = mapToBillingAddress(request);
+        var mappedAddress = authCardDetails.getAddress()
+                .map(AdyenRequestFactory::mapToBillingAddress)
+                .orElse(null);
 
         var paymentMethod = new PaymentMethod(authCardDetails.getCvc(),
                 authCardDetails.getEndDate().getTwoDigitMonth(),
@@ -59,7 +60,7 @@ public class AdyenRequestFactory {
     }
 
     private static String getShopperInteraction(CardAuthorisationGatewayRequest request) {
-        return request.isMoto() || request.getAuthorisationMode().equals(MOTO_API) ? "Moto" : "Ecommerce";
+        return request.isMoto() ? "Moto" : "Ecommerce";
     }
 
     public CancelRequestPayload createPaymentCancelRequest(CancelGatewayRequest request) {
@@ -76,27 +77,18 @@ public class AdyenRequestFactory {
         );
     }
 
-    private static BillingAddress mapToBillingAddress(CardAuthorisationGatewayRequest request) {
-        if (request.isMoto() && !request.getAuthorisationMode().equals(MOTO_API)) {
-            return null;
-        }
-
-        Optional<BillingAddress> result = request.getAuthCardDetails().getAddress().map(address -> {
-            var northAmericanRegionMapper = new NorthAmericanRegionMapper();
-            String stateOrProvince = northAmericanRegionMapper.getNorthAmericanRegionForCountry(address)
-                    .map(NorthAmericaRegion::getFullName)
-                    .orElse(null);
-            
-            return new BillingAddress(
-                    address.getLine1(),
-                    address.getLine2(),
-                    address.getCity(),
-                    address.getCountry(),
-                    address.getPostcode(),
-                    stateOrProvince);
-        });
-        
-        return result.orElse(null);
+    static BillingAddress mapToBillingAddress(Address address) {
+        var northAmericanRegionMapper = new NorthAmericanRegionMapper();
+        String stateOrProvince = northAmericanRegionMapper.getNorthAmericanRegionForCountry(address)
+                .map(NorthAmericaRegion::getFullName)
+                .orElse(null);
+        return new BillingAddress(
+                address.getLine1(),
+                address.getLine2(),
+                address.getCity(),
+                address.getCountry(),
+                address.getPostcode(),
+                stateOrProvince);
     }
 
     private static AdyenCredentials mapToAdyenCredentials(GatewayCredentials gatewayCredentials) {

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.gateway.adyen;
 
 import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 import uk.gov.pay.connector.gateway.adyen.request.json.AuthoriseRequestPayload;
 import uk.gov.pay.connector.gateway.adyen.request.json.BillingAddress;
@@ -18,6 +17,7 @@ import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getMerchantAccountId;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
@@ -32,11 +32,8 @@ public class AdyenRequestFactory {
 
     public AuthoriseRequestPayload createPaymentRequest(CardAuthorisationGatewayRequest request) {
         var authCardDetails = request.getAuthCardDetails();
-        var mappedAddress = request.isMoto() && !request.getAuthorisationMode().equals(MOTO_API)
-                ? null
-                : authCardDetails.getAddress()
-                .map(AdyenRequestFactory::mapToBillingAddress)
-                .orElse(null);
+
+        var mappedAddress = mapToBillingAddress(request);
 
         var paymentMethod = new PaymentMethod(authCardDetails.getCvc(),
                 authCardDetails.getEndDate().getTwoDigitMonth(),
@@ -47,8 +44,6 @@ public class AdyenRequestFactory {
 
         var adyenCredentials = mapToAdyenCredentials(request.getGatewayCredentials());
 
-        var shopperInteraction = request.isMoto() || request.getAuthorisationMode().equals(MOTO_API) ? "Moto" : "Ecommerce";
-
         return new AuthoriseRequestPayload(
                 new Amount("GBP", Long.valueOf(request.getAmount())),
                 mappedAddress,
@@ -56,11 +51,15 @@ public class AdyenRequestFactory {
                 paymentMethod,
                 request.getGovUkPayPaymentId(),
                 configuration.getLinks().getFrontendUrl(),
-                shopperInteraction,
+                getShopperInteraction(request),
                 adyenCredentials.storeId(),
                 "Web",
                 new HashMap<>(Map.of("manualCapture", "true"))
         );
+    }
+
+    private static String getShopperInteraction(CardAuthorisationGatewayRequest request) {
+        return request.isMoto() || request.getAuthorisationMode().equals(MOTO_API) ? "Moto" : "Ecommerce";
     }
 
     public CancelRequestPayload createPaymentCancelRequest(CancelGatewayRequest request) {
@@ -77,18 +76,27 @@ public class AdyenRequestFactory {
         );
     }
 
-    private static BillingAddress mapToBillingAddress(Address address) {
-        var northAmericanRegionMapper = new NorthAmericanRegionMapper();
-        String stateOrProvince = northAmericanRegionMapper.getNorthAmericanRegionForCountry(address)
-                .map(NorthAmericaRegion::getFullName)
-                .orElse(null);
-        return new BillingAddress(
-                address.getLine1(),
-                address.getLine2(),
-                address.getCity(),
-                address.getCountry(),
-                address.getPostcode(),
-                stateOrProvince);
+    private static BillingAddress mapToBillingAddress(CardAuthorisationGatewayRequest request) {
+        if (request.isMoto() && !request.getAuthorisationMode().equals(MOTO_API)) {
+            return null;
+        }
+
+        Optional<BillingAddress> result = request.getAuthCardDetails().getAddress().map(address -> {
+            var northAmericanRegionMapper = new NorthAmericanRegionMapper();
+            String stateOrProvince = northAmericanRegionMapper.getNorthAmericanRegionForCountry(address)
+                    .map(NorthAmericaRegion::getFullName)
+                    .orElse(null);
+            
+            return new BillingAddress(
+                    address.getLine1(),
+                    address.getLine2(),
+                    address.getCity(),
+                    address.getCountry(),
+                    address.getPostcode(),
+                    stateOrProvince);
+        });
+        
+        return result.orElse(null);
     }
 
     private static AdyenCredentials mapToAdyenCredentials(GatewayCredentials gatewayCredentials) {

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -32,7 +32,7 @@ public class AdyenRequestFactory {
 
     public AuthoriseRequestPayload createPaymentRequest(CardAuthorisationGatewayRequest request) {
         var authCardDetails = request.getAuthCardDetails();
-        var mappedAddress = request.isMoto()
+        var mappedAddress = request.isMoto() && !request.getAuthorisationMode().equals(MOTO_API)
                 ? null
                 : authCardDetails.getAddress()
                 .map(AdyenRequestFactory::mapToBillingAddress)

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
@@ -19,7 +19,6 @@ import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -165,7 +164,7 @@ class AdyenRequestFactoryTest {
     }
 
     @Test
-    void should_create_a_PaymentRequest_without_a_billingAddress_when_isMoto_is_true() {
+    void should_create_a_PaymentRequest_with_shopperInteraction_as_Moto_when_isMoto_is_true() {
         var authoriseRequest = aCardAuthorisationGatewayRequest()
                 .withAuthCardDetails(anAuthCardDetails()
                         .withCardNo("4444333322221111")
@@ -181,11 +180,29 @@ class AdyenRequestFactoryTest {
         var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
 
         assertThat(request.shopperInteraction(), is("Moto"));
+    }
+
+    @Test
+    void should_create_a_PaymentRequest_without_a_billingAddress_when_isMoto_is_true() {
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withCardNo("4444333322221111")
+                        .withCardHolder("John Doe")
+                        .withCvc("737")
+                        .withEndDate(CardExpiryDate.valueOf("10/99"))
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .withAmount("6234")
+                .withMoto(true)
+                .build();
+
+        var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
+
         assertNull(request.billingAddress());
     }
 
     @Test
-    void should_create_a_moto_PaymentRequest_when_authorisationMode_is_MOTO_API() {
+    void should_create_a_PaymentRequest_with_shopperInteraction_as_Moto_when_authorisationMode_is_MOTO_API() {
         var authoriseRequest = aCardAuthorisationGatewayRequest()
                 .withAuthCardDetails(anAuthCardDetails()
                         .withCardNo("4444333322221111")
@@ -201,7 +218,6 @@ class AdyenRequestFactoryTest {
         var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
 
         assertThat(request.shopperInteraction(), is("Moto"));
-        assertThat(request.billingAddress(), notNullValue());
     }
 
     private static CancelGatewayRequest makeCancelGatewayRequestWithExternalChargeId(String externalChargeId) {

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
@@ -14,12 +14,15 @@ import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -159,6 +162,46 @@ class AdyenRequestFactoryTest {
 
         assertThat(paymentCancelRequest.reference(), is(externalChargeId));
         assertThat(paymentCancelRequest.merchantAccount(), is(liveMerchantAccountId));
+    }
+
+    @Test
+    void should_create_a_PaymentRequest_without_a_billingAddress_when_isMoto_is_true() {
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withCardNo("4444333322221111")
+                        .withCardHolder("John Doe")
+                        .withCvc("737")
+                        .withEndDate(CardExpiryDate.valueOf("10/99"))
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .withAmount("6234")
+                .withMoto(true)
+                .build();
+
+        var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
+
+        assertThat(request.shopperInteraction(), is("Moto"));
+        assertNull(request.billingAddress());
+    }
+
+    @Test
+    void should_create_a_moto_PaymentRequest_when_authorisationMode_is_MOTO_API() {
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withCardNo("4444333322221111")
+                        .withCardHolder("John Doe")
+                        .withCvc("737")
+                        .withEndDate(CardExpiryDate.valueOf("10/99"))
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .withAmount("6234")
+                .withAuthorisationMode(AuthorisationMode.MOTO_API)
+                .build();
+
+        var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
+
+        assertThat(request.shopperInteraction(), is("Moto"));
+        assertThat(request.billingAddress(), notNullValue());
     }
 
     private static CancelGatewayRequest makeCancelGatewayRequestWithExternalChargeId(String externalChargeId) {

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
@@ -14,7 +14,6 @@ import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
-import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -173,26 +172,6 @@ class AdyenRequestFactoryTest {
                         .build())
                 .withCredentials(ADYEN_CREDENTIALS)
                 .withAmount("6234")
-                .withMoto(true)
-                .build();
-
-        var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
-
-        assertThat(request.shopperInteraction(), is("Moto"));
-    }
-
-    @Test
-    void should_create_a_PaymentRequest_with_shopperInteraction_as_Moto_when_authorisationMode_is_MOTO_API() {
-        var authoriseRequest = aCardAuthorisationGatewayRequest()
-                .withAuthCardDetails(anAuthCardDetails()
-                        .withCardNo("4444333322221111")
-                        .withCardHolder("John Doe")
-                        .withCvc("737")
-                        .withEndDate(CardExpiryDate.valueOf("10/99"))
-                        .build())
-                .withCredentials(ADYEN_CREDENTIALS)
-                .withAmount("6234")
-                .withAuthorisationMode(AuthorisationMode.MOTO_API)
                 .withMoto(true)
                 .build();
 

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -183,25 +182,6 @@ class AdyenRequestFactoryTest {
     }
 
     @Test
-    void should_create_a_PaymentRequest_without_a_billingAddress_when_isMoto_is_true() {
-        var authoriseRequest = aCardAuthorisationGatewayRequest()
-                .withAuthCardDetails(anAuthCardDetails()
-                        .withCardNo("4444333322221111")
-                        .withCardHolder("John Doe")
-                        .withCvc("737")
-                        .withEndDate(CardExpiryDate.valueOf("10/99"))
-                        .build())
-                .withCredentials(ADYEN_CREDENTIALS)
-                .withAmount("6234")
-                .withMoto(true)
-                .build();
-
-        var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
-
-        assertNull(request.billingAddress());
-    }
-
-    @Test
     void should_create_a_PaymentRequest_with_shopperInteraction_as_Moto_when_authorisationMode_is_MOTO_API() {
         var authoriseRequest = aCardAuthorisationGatewayRequest()
                 .withAuthCardDetails(anAuthCardDetails()
@@ -213,6 +193,7 @@ class AdyenRequestFactoryTest {
                 .withCredentials(ADYEN_CREDENTIALS)
                 .withAmount("6234")
                 .withAuthorisationMode(AuthorisationMode.MOTO_API)
+                .withMoto(true)
                 .build();
 
         var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);

--- a/src/test/java/uk/gov/pay/connector/it/base/AddChargeParameters.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/AddChargeParameters.java
@@ -12,7 +12,7 @@ import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
 
 public record AddChargeParameters(long chargeId, String externalChargeId, ChargeStatus chargeStatus,
                                   ServicePaymentReference reference, Instant createdDate, String transactionId,
-                                  String paymentProvider, AuthorisationMode authorisationMode) {
+                                  String paymentProvider, AuthorisationMode authorisationMode, Boolean isMoto) {
 
 
     public static final class Builder {
@@ -24,6 +24,7 @@ public record AddChargeParameters(long chargeId, String externalChargeId, Charge
         private String transactionId = RandomIdGenerator.newId();
         private String paymentProvider = "sandbox";
         private AuthorisationMode authorisationMode = WEB;
+        private Boolean isMoto = false;
 
         public static Builder anAddChargeParameters() {
             return new Builder();
@@ -69,8 +70,13 @@ public record AddChargeParameters(long chargeId, String externalChargeId, Charge
             return this;
         }
 
+        public Builder withIsMoto(Boolean isMoto) {
+            this.isMoto = isMoto;
+            return this;
+        }
+
         public AddChargeParameters build() {
-            return new AddChargeParameters(chargeId, externalChargeId, chargeStatus, reference, createdDate, transactionId, paymentProvider, authorisationMode);
+            return new AddChargeParameters(chargeId, externalChargeId, chargeStatus, reference, createdDate, transactionId, paymentProvider, authorisationMode, isMoto);
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.it.util.ChargeUtils;
@@ -164,7 +165,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     public void createCredentialParams() {
         if (paymentProvider.equals(STRIPE.getName())) {
             credentials = Map.of(CREDENTIALS_STRIPE_ACCOUNT_ID, "stripe-account-id");
-        } else if (paymentProvider.equals(ADYEN.getName())){
+        } else if (paymentProvider.equals(ADYEN.getName())) {
             credentials = Map.of(CREDENTIALS_ADYEN_LEGAL_ENTITY_ID, "legal_entity_id");
         } else if (paymentProvider.equals(WORLDPAY.getName())) {
             credentials = Map.of(
@@ -351,36 +352,36 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     }
 
     public static String authoriseChargeUrlForApplePay(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/wallets/apple".replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/wallets/apple" .replace("{chargeId}", chargeId);
     }
 
     public static String authoriseChargeUrlForGooglePayStripe(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/wallets/google/stripe".replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/wallets/google/stripe" .replace("{chargeId}", chargeId);
     }
 
     public static String authoriseChargeUrlForGooglePayWorldpay(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/wallets/google/worldpay".replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/wallets/google/worldpay" .replace("{chargeId}", chargeId);
     }
 
     public static String authoriseChargeUrlForGooglePay(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/wallets/google".replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/wallets/google" .replace("{chargeId}", chargeId);
     }
 
 
     public static String authoriseChargeUrlFor(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/cards" .replace("{chargeId}", chargeId);
     }
 
     public static String authorise3dsChargeUrlFor(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/3ds".replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/3ds" .replace("{chargeId}", chargeId);
     }
 
     public static String captureChargeUrlFor(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/capture".replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/capture" .replace("{chargeId}", chargeId);
     }
 
     public static String cancelChargeUrlFor(String accountId, String chargeId) {
-        return "/v1/api/accounts/{accountId}/charges/{chargeId}/cancel".replace("{accountId}", accountId).replace("{chargeId}", chargeId);
+        return "/v1/api/accounts/{accountId}/charges/{chargeId}/cancel" .replace("{accountId}", accountId).replace("{chargeId}", chargeId);
     }
 
     public Matcher<? super List<Map<String, Object>>> hasEvent(ChargeStatus chargeStatus) {
@@ -463,6 +464,24 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
                 .withGatewayCredentialId(credentialParams.getId())
                 .withAuthorisationMode(addChargeParameters.authorisationMode())
                 .build());
+    }
+
+    public String addChargeWithMoto(ChargeStatus chargeStatus, Boolean isMoto, long chargeId, String paymentProvider) {
+        ChargeUtils.ExternalChargeId externalChargeId = ChargeUtils.ExternalChargeId.fromChargeId(chargeId);
+        databaseTestHelper.addCharge(anAddChargeParams()
+                .withExternalChargeId(externalChargeId.toString())
+                .withChargeId(chargeId)
+                .withIsMoto(isMoto)
+                .withPaymentProvider(paymentProvider)
+                .withStatus(chargeStatus)
+                .withAmount(AMOUNT)
+                .withReturnUrl(RETURN_URL)
+                .withGatewayAccountId(accountId)
+                .withDescription("testing moto flag")
+                .withReference(ServicePaymentReference.of("reference"))
+                .withGatewayCredentialId(credentialParams.getId())
+                .build());
+        return externalChargeId.toString();
     }
 
     public ChargeUtils.ExternalChargeId addChargeForSetUpAgreement(ChargeStatus status) {

--- a/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
-import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.it.util.ChargeUtils;
@@ -461,27 +460,10 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
                 .withLanguage(SupportedLanguage.ENGLISH)
                 .withDelayedCapture(false)
                 .withEmail(EMAIL)
+                .withIsMoto(addChargeParameters.isMoto())
                 .withGatewayCredentialId(credentialParams.getId())
                 .withAuthorisationMode(addChargeParameters.authorisationMode())
                 .build());
-    }
-
-    public String addChargeWithMoto(ChargeStatus chargeStatus, Boolean isMoto, long chargeId, String paymentProvider) {
-        ChargeUtils.ExternalChargeId externalChargeId = ChargeUtils.ExternalChargeId.fromChargeId(chargeId);
-        databaseTestHelper.addCharge(anAddChargeParams()
-                .withExternalChargeId(externalChargeId.toString())
-                .withChargeId(chargeId)
-                .withIsMoto(isMoto)
-                .withPaymentProvider(paymentProvider)
-                .withStatus(chargeStatus)
-                .withAmount(AMOUNT)
-                .withReturnUrl(RETURN_URL)
-                .withGatewayAccountId(accountId)
-                .withDescription("testing moto flag")
-                .withReference(ServicePaymentReference.of("reference"))
-                .withGatewayCredentialId(credentialParams.getId())
-                .build());
-        return externalChargeId.toString();
     }
 
     public ChargeUtils.ExternalChargeId addChargeForSetUpAgreement(ChargeStatus status) {

--- a/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
@@ -351,32 +351,32 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     }
 
     public static String authoriseChargeUrlForApplePay(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/wallets/apple" .replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/wallets/apple".replace("{chargeId}", chargeId);
     }
 
     public static String authoriseChargeUrlForGooglePayStripe(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/wallets/google/stripe" .replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/wallets/google/stripe".replace("{chargeId}", chargeId);
     }
 
     public static String authoriseChargeUrlForGooglePayWorldpay(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/wallets/google/worldpay" .replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/wallets/google/worldpay".replace("{chargeId}", chargeId);
     }
 
     public static String authoriseChargeUrlForGooglePay(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/wallets/google" .replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/wallets/google".replace("{chargeId}", chargeId);
     }
 
 
     public static String authoriseChargeUrlFor(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/cards" .replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeId);
     }
 
     public static String authorise3dsChargeUrlFor(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/3ds" .replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/3ds".replace("{chargeId}", chargeId);
     }
 
     public static String captureChargeUrlFor(String chargeId) {
-        return "/v1/frontend/charges/{chargeId}/capture" .replace("{chargeId}", chargeId);
+        return "/v1/frontend/charges/{chargeId}/capture".replace("{chargeId}", chargeId);
     }
 
     public static String cancelChargeUrlFor(String accountId, String chargeId) {

--- a/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
@@ -380,7 +380,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     }
 
     public static String cancelChargeUrlFor(String accountId, String chargeId) {
-        return "/v1/api/accounts/{accountId}/charges/{chargeId}/cancel" .replace("{accountId}", accountId).replace("{chargeId}", chargeId);
+        return "/v1/api/accounts/{accountId}/charges/{chargeId}/cancel".replace("{accountId}", accountId).replace("{chargeId}", chargeId);
     }
 
     public Matcher<? super List<Map<String, Object>>> hasEvent(ChargeStatus chargeStatus) {

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -42,8 +42,8 @@ import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.a
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
-import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRandomLong;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRandomLong;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
 
 public class DatabaseFixtures {
@@ -204,29 +204,36 @@ public class DatabaseFixtures {
     }
 
     public static class TestAddress {
+        
+        private String line1 = "line1";
+        private String line2 = "line2";
+        private String postcode = "postcode";
+        private String city = "city";
+        private String country = "country";
+        private String county = "county";
 
         public String getLine1() {
-            return "line1";
+            return line1;
         }
 
         public String getLine2() {
-            return "line2";
+            return line2;
         }
 
         public String getPostcode() {
-            return "postcode";
+            return postcode;
         }
 
         public String getCity() {
-            return "city";
+            return city;
         }
 
         public String getCounty() {
-            return "county";
+            return county;
         }
 
         public String getCountry() {
-            return "country";
+            return country;
         }
     }
 
@@ -838,7 +845,7 @@ public class DatabaseFixtures {
         }
 
         public TestCharge withCardDetails(TestCardDetails testCardDetails) {
-            cardDetails = testCardDetails;
+            this.cardDetails = testCardDetails;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -44,6 +44,7 @@ import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccoun
 import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRandomLong;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
 
 public class DatabaseFixtures {
@@ -918,6 +919,7 @@ public class DatabaseFixtures {
                     .withUpdatedDate(updatedDate)
                     .withServiceId(serviceId)
                     .withRequires3ds(requires3ds)
+                    .withIsMoto(authorisationMode.equals(MOTO_API))
                     .build());
 
             if (cardDetails != null) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.resources.adyen;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -113,7 +112,7 @@ class AdyenCardResourceAuthoriseIT {
 
         app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
                 .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
-                .withRequestBody(WireMock.matchingJsonPath("$.billingAddress", absent()))
+                .withRequestBody(matchingJsonPath("$.billingAddress", absent()))
                 .withRequestBody(matchingJsonPath("$.paymentMethod",
                         equalToJson(""" 
                                 {
@@ -195,7 +194,7 @@ class AdyenCardResourceAuthoriseIT {
     }
 
     @Test
-    void should_not_send_billingAddress_when_authorising_a_payment_with_moto_flag_set_to_true() {
+    void successful_authorisation_of_a_moto_payment() {
         var chargeParams = anAddChargeParameters().withChargeStatus(CREATED).withIsMoto(true).build();
         var chargeId = testBaseExtension.addCharge(chargeParams);
         var pspReferenceFromAdyen = "993617895215577D";
@@ -208,14 +207,8 @@ class AdyenCardResourceAuthoriseIT {
                 .withCardHolder("John Doe")
                 .withCvc("737")
                 .withEndDate(CardExpiryDate.valueOf("03/30"))
-                .withAddress(new Address(
-                        "line1",
-                        "line2",
-                        "postcode",
-                        "city",
-                        "county",
-                        "country"
-                )).build();
+                .withAddress(null)
+                .build();
 
         app.givenSetup()
                 .body(authCardDetails)
@@ -226,7 +219,7 @@ class AdyenCardResourceAuthoriseIT {
 
         app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
                 .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
-                .withRequestBody(WireMock.matchingJsonPath("$.billingAddress", absent()))
+                .withRequestBody(matchingJsonPath("$.billingAddress", absent()))
                 .withRequestBody(matchingJsonPath("$.paymentMethod",
                         equalToJson(""" 
                                 {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -203,7 +203,7 @@ class AdyenCardResourceAuthoriseIT {
                 "adyen");
         var pspReferenceFromAdyen = "993617895215577D";
 
-        app.getAdyenMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
 
         var authCardDetails = anAuthCardDetails()
                 .withCardNo("4444333322221111")

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -25,8 +25,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.it.base.AddChargeParameters.Builder.anAddChargeParameters;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
-import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRandomLong;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
@@ -196,11 +196,8 @@ class AdyenCardResourceAuthoriseIT {
 
     @Test
     void should_not_send_billingAddress_when_authorising_a_payment_with_moto_flag_set_to_true() {
-        var chargeId = testBaseExtension.addChargeWithMoto(
-                CREATED,
-                true,
-                secureRandomLong(),
-                "adyen");
+        var chargeParams = anAddChargeParameters().withChargeStatus(CREATED).withIsMoto(true).build();
+        var chargeId = testBaseExtension.addCharge(chargeParams);
         var pspReferenceFromAdyen = "993617895215577D";
 
         app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -23,8 +23,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRandomLong;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
@@ -78,7 +80,7 @@ class AdyenCardResourceAuthoriseIT {
                 .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
                 .withRequestBody(equalToJson(
                         load(ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS)
-                                .formatted(chargeId))));
+                                .formatted(chargeId, "Ecommerce"))));
 
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
@@ -190,5 +192,58 @@ class AdyenCardResourceAuthoriseIT {
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is("AUTHORISATION UNEXPECTED ERROR"));
+    }
+
+    @Test
+    void should_not_send_billingAddress_when_authorising_a_payment_with_moto_flag_set_to_true() {
+        var chargeId = testBaseExtension.addChargeWithMoto(
+                CREATED,
+                true,
+                secureRandomLong(),
+                "adyen");
+        var pspReferenceFromAdyen = "993617895215577D";
+
+        app.getAdyenMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
+
+        var authCardDetails = anAuthCardDetails()
+                .withCardNo("4444333322221111")
+                .withCardBrand("Visa")
+                .withCardHolder("John Doe")
+                .withCvc("737")
+                .withEndDate(CardExpiryDate.valueOf("03/30"))
+                .withAddress(new Address(
+                        "line1",
+                        "line2",
+                        "postcode",
+                        "city",
+                        "county",
+                        "country"
+                )).build();
+
+        app.givenSetup()
+                .body(authCardDetails)
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(200)
+                .body("status", is("AUTHORISATION SUCCESS"));
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
+                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withRequestBody(WireMock.matchingJsonPath("$.billingAddress", absent()))
+                .withRequestBody(matchingJsonPath("$.paymentMethod",
+                        equalToJson(""" 
+                                {
+                                  "type": "scheme",
+                                  "number": "4444333322221111",
+                                  "expiryMonth": "03",
+                                  "expiryYear": "2030",
+                                  "cvc": "737",
+                                  "holderName": "John Doe"
+                                }"""))));
+
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
+        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseMotoApiPaymentIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseMotoApiPaymentIT.java
@@ -1,0 +1,133 @@
+package uk.gov.pay.connector.it.resources.adyen;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.connector.client.cardid.model.CardidCardType;
+import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.it.base.ITestBaseExtension;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_QUEUED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.client.cardid.model.CardInformationFixture.aCardInformation;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_ADYEN_LEGAL_ENTITY_ID;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonForMotoApiPaymentAuthorisation;
+import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
+import static uk.gov.pay.connector.util.RandomIdGenerator.randomLong;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class AdyenCardResourceAuthoriseMotoApiPaymentIT {
+    
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+    @RegisterExtension
+    public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("adyen", app.getLocalPort(), app.getDatabaseTestHelper());
+
+    private static final String AUTHORISE_MOTO_API_URL = "/v1/api/charges/authorise";
+    private static final String VALID_CARD_NUMBER = "4444333322221111";
+    private static final String VISA = "visa";
+    private static final String CHARGE_EXTERNAL_ID = String.valueOf(randomLong());
+    private static final long CHARGE_ID = randomLong();
+
+    private DatabaseFixtures.TestToken token;
+    private DatabaseFixtures.TestCharge charge;
+
+    @BeforeEach
+    void setUp() {
+
+        var cardDetails = app.getDatabaseFixtures()
+                .aTestCardDetails()
+                .withChargeId(CHARGE_ID)
+                .withCardBrand(VISA)
+                .withBillingAddress(new DatabaseFixtures.TestAddress());
+
+        long testCredentialsId = randomLong();
+        long gatewayAccountId = randomLong();
+
+        var credentialParams = anAddGatewayAccountCredentialsParams()
+                .withId(testCredentialsId)
+                .withPaymentProvider(ADYEN.getName())
+                .withGatewayAccountId(gatewayAccountId)
+                .withState(ACTIVE)
+                .withCredentials(ImmutableMap.of(CREDENTIALS_ADYEN_LEGAL_ENTITY_ID, "legal_entity_id"))
+                .build();
+
+        var adyenAccount = DatabaseFixtures
+                .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                .aTestAccount()
+                .withCardTypeEntities(List.of(app.getDatabaseTestHelper().getVisaCreditCard()))
+                .withGatewayAccountCredentials(List.of(credentialParams))
+                .withAccountId(gatewayAccountId)
+                .withServiceId("service-id")
+                .insert();
+
+        charge = DatabaseFixtures
+                .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                .aTestCharge()
+                .withChargeId(CHARGE_ID)
+                .withExternalChargeId(CHARGE_EXTERNAL_ID)
+                .withCardDetails(cardDetails)
+                .withPaymentProvider("adyen")
+                .withChargeStatus(CREATED)
+                .withAuthorisationMode(MOTO_API)
+                .withAmount(6234L)
+                .withTestAccount(adyenAccount)
+                .withGatewayCredentialId(testCredentialsId)
+                .insert();
+
+        token = DatabaseFixtures
+                .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                .aTestToken()
+                .withCharge(charge)
+                .withUsed(false)
+                .insert();
+    }
+
+    @Test
+    void should_send_billingAddress_when_authorising_a_payment_with_authorisationMode_set_to_MOTO_API() throws JsonProcessingException {
+        String validPayload = buildJsonForMotoApiPaymentAuthorisation("John Doe", VALID_CARD_NUMBER, "03/30", "737",
+                token.getSecureRedirectToken());
+
+        var cardInformation = aCardInformation().withBrand(VISA).withType(CardidCardType.CREDIT).build();
+        app.getCardidStub().returnCardInformation(VALID_CARD_NUMBER, cardInformation);
+
+        var pspReferenceFromAdyen = "993617895215577D";
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
+
+        app.givenSetup()
+                .body(validPayload)
+                .post(AUTHORISE_MOTO_API_URL)
+                .then()
+                .statusCode(204);
+
+        assertThat(app.getDatabaseTestHelper().isChargeTokenUsed(token.getSecureRedirectToken()), is(true));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(charge.getChargeId()), is(CAPTURE_QUEUED.getValue()));
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
+                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withRequestBody(equalToJson(
+                        load(ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS)
+                                .formatted(CHARGE_EXTERNAL_ID, "Moto"))));
+
+    }
+
+
+}

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -52,7 +52,8 @@ public record AddChargeParams(
         Boolean requires3ds,
         Exemption3ds exemption3ds,
         Exemption3dsType exemption3dsType,
-        AgreementPaymentType agreementPaymentType) {
+        AgreementPaymentType agreementPaymentType,
+        boolean isMoto) {
 
     public static final class AddChargeParamsBuilder {
 
@@ -65,7 +66,7 @@ public record AddChargeParams(
                     delayedCapture, corporateSurcharge, externalMetadata, parityCheckStatus, cardType, parityCheckDate,
                     gatewayCredentialId, serviceId, issuerUrl, agreementExternalId, savePaymentInstrumentToAgreement,
                     authorisationMode, updatedDate, paymentInstrumentId, canRetry, requires3ds, exemption3ds, exemption3dsType,
-                    agreementPaymentType);
+                    agreementPaymentType, isMoto);
         }
 
         private String agreementExternalId;
@@ -102,6 +103,7 @@ public record AddChargeParams(
         private Instant updatedDate;
         private long version = 1;
         private AgreementPaymentType agreementPaymentType;
+        private boolean isMoto = false;
 
         private AddChargeParamsBuilder() {
         }
@@ -112,6 +114,11 @@ public record AddChargeParams(
 
         public AddChargeParamsBuilder withChargeId(Long chargeId) {
             this.chargeId = chargeId;
+            return this;
+        }
+
+        public AddChargeParamsBuilder withIsMoto(boolean isMoto) {
+            this.isMoto = isMoto;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -109,7 +109,7 @@ public class DatabaseTestHelper {
                                 "external_metadata, card_type, payment_provider, gateway_account_credential_id, service_id, " +
                                 "issuer_url_3ds, save_payment_instrument_to_agreement, authorisation_mode, updated_date, " +
                                 "payment_instrument_id, agreement_external_id, can_retry, requires_3ds, exemption_3ds, exemption_3ds_requested," +
-                                "agreement_payment_type) " +
+                                "agreement_payment_type, moto)" +
                                 "VALUES(:id, :external_id, :amount, " +
                                 ":status, :gateway_account_id, :return_url, :gateway_transaction_id, " +
                                 ":description, :created_date, :reference, :version, :email, :language, " +
@@ -117,7 +117,7 @@ public class DatabaseTestHelper {
                                 ":external_metadata, :card_type, :payment_provider, :gateway_account_credential_id, :service_id, " +
                                 ":issuer_url_3ds, :savePaymentInstrumentToAgreement, :authorisationMode, :updatedDate, " +
                                 ":paymentInstrumentId, :agreementExternalId, :canRetry, :requires3ds, :exemption_3ds, :exemption_3ds_requested, " +
-                                ":agreement_payment_type)")
+                                ":agreement_payment_type, :moto)")
                         .bind("id", addChargeParams.chargeId())
                         .bind("external_id", addChargeParams.externalChargeId())
                         .bind("amount", addChargeParams.amount())
@@ -151,6 +151,7 @@ public class DatabaseTestHelper {
                         .bind("exemption_3ds_requested", addChargeParams.exemption3dsType())
                         .bind("exemption_3ds", addChargeParams.exemption3ds())
                         .bind("agreement_payment_type", addChargeParams.agreementPaymentType())
+                        .bind("moto", addChargeParams.isMoto())
                         .execute());
     }
 

--- a/src/test/resources/templates/adyen/authorisation_request_with_full_billing_address.json
+++ b/src/test/resources/templates/adyen/authorisation_request_with_full_billing_address.json
@@ -21,7 +21,7 @@
   },
   "reference": "%s",
   "returnUrl": "http://CardFrontend/",
-  "shopperInteraction": "Ecommerce",
+  "shopperInteraction": "%s",
   "channel": "Web",
   "additionalData" : {
     "manualCapture" : "true"


### PR DESCRIPTION
## WHAT YOU DID
- added `AdyenAuthoriseHandler.authorise()` to `AdyenPaymentProvider` `authoriseMotoApi`
- added logic to `AdyenRequestFactory` to check for moto and if so remove billing address accordingly.
- added `addChargeWithMoto` method to `ITBaseExtension` to test when `isMoto` flag is true but `AuthorisationMode` is not `MOTO_API`. 
