### PR TITLE
PP-15385 Add resource to switch to Adyen test account

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/NonStripeAccountException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/NonStripeAccountException.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.gatewayaccount.exception;
+
+import jakarta.ws.rs.WebApplicationException;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
+
+public class NonStripeAccountException extends WebApplicationException {
+    public NonStripeAccountException(String serviceId) {
+        super(badRequestResponse(format("No Stripe test account exists for service '%s'", serviceId)));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/AdyenAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/AdyenAccountResource.java
@@ -40,7 +40,7 @@ public class AdyenAccountResource {
     @Path("/v1/api/service/{serviceId}/request-adyen-test-account")
     @Produces(APPLICATION_JSON)
     @Operation(
-            summary = "Creates a Adyen Test Account " +
+            summary = "Creates an Adyen Test Account " +
                     "and associated entities",
             responses = {
                     @ApiResponse(responseCode = "201", description = "OK"),
@@ -77,5 +77,31 @@ public class AdyenAccountResource {
                 "account_holder_id", adyenCredentials.accountHolderId(),
                 "balance_account_id", adyenCredentials.balanceAccountId());
         return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/v1/api/service/{serviceId}/switch-to-adyen-test-account")
+    @Produces(APPLICATION_JSON)
+    @Operation(
+            summary = "Disables Stripe test account, " +
+                    "creates an Adyen Test Account " +
+                    "and associated entities",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "OK"),
+                    @ApiResponse(responseCode = "409", description = "Adyen account already exists"),
+                    @ApiResponse(responseCode = "502", description = "Bad gateway"),
+            }
+    )
+    public Response switchToAdyenTestAccount(
+            @Parameter(example = "service-external-id-123", description = "Service ID")
+            @PathParam("serviceId") String serviceId,
+            Map<String, String> payload) {
+        
+        gatewayAccountService.throwIfNoStripeTestAccount(serviceId);
+
+        var serviceName = payload.get("service_name");
+        adyenTestAccountService.createTestAccount(serviceName);
+
+        return Response.ok().build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/AdyenAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/AdyenAccountResource.java
@@ -43,7 +43,7 @@ public class AdyenAccountResource {
             summary = "Creates an Adyen Test Account " +
                     "and associated entities",
             responses = {
-                    @ApiResponse(responseCode = "201", description = "OK"),
+                    @ApiResponse(responseCode = "200", description = "OK"),
                     @ApiResponse(responseCode = "409", description = "Adyen account already exists"),
                     @ApiResponse(responseCode = "502", description = "Bad gateway"),
             }
@@ -83,12 +83,10 @@ public class AdyenAccountResource {
     @Path("/v1/api/service/{serviceId}/switch-to-adyen-test-account")
     @Produces(APPLICATION_JSON)
     @Operation(
-            summary = "Disables Stripe test account, " +
-                    "creates an Adyen Test Account " +
-                    "and associated entities",
+            summary = "Disables Stripe test account, creates an Adyen Test Account and associated entities",
             responses = {
-                    @ApiResponse(responseCode = "201", description = "OK"),
-                    @ApiResponse(responseCode = "409", description = "Adyen account already exists"),
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "400", description = "Bad request - account ineligible for switch"),
                     @ApiResponse(responseCode = "502", description = "Bad gateway"),
             }
     )

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountWithoutAnActi
 import uk.gov.pay.connector.gatewayaccount.exception.MissingWorldpay3dsFlexCredentialsEntityException;
 import uk.gov.pay.connector.gatewayaccount.exception.MultipleLiveGatewayAccountsException;
 import uk.gov.pay.connector.gatewayaccount.exception.MultiplePspTestGatewayAccountsException;
+import uk.gov.pay.connector.gatewayaccount.exception.NonStripeAccountException;
 import uk.gov.pay.connector.gatewayaccount.exception.NotSupportedGatewayAccountException;
 import uk.gov.pay.connector.gatewayaccount.model.CreateGatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
@@ -25,6 +26,7 @@ import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsHistoryDao;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchRequest;
 
@@ -191,6 +193,21 @@ public class GatewayAccountService {
             GatewayAccountEntity pspGatewayAccount = maybeGatewayAccount.get();
             throw new MultiplePspTestGatewayAccountsException(serviceId, pspGatewayAccount.getExternalId(),
                     pspGatewayAccount.getCurrentOrActiveGatewayAccountCredential().get().getExternalId());
+        }
+    }
+
+    public void throwIfNoStripeTestAccount(String serviceId) {
+        var gatewayAccount = getGatewayAccountByServiceIdAndAccountType(serviceId, TEST)
+                .orElseThrow(() -> new NonStripeAccountException(serviceId));
+
+        boolean isStripe = gatewayAccount.getCurrentOrActiveGatewayAccountCredential()
+                .map(GatewayAccountCredentialsEntity::getPaymentProvider)
+                .map(String::toLowerCase)
+                .filter(paymentProvider -> STRIPE.getName().equals(paymentProvider))
+                .isPresent();
+
+        if (!isStripe) {
+            throw new NonStripeAccountException(serviceId);
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountResourceIT.java
@@ -16,6 +16,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static java.lang.String.format;
 import static org.apache.http.HttpStatus.SC_BAD_GATEWAY;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_CONFLICT;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.CoreMatchers.any;
@@ -23,6 +24,8 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_CREATE_INDIVIDUAL_REQUEST;
@@ -176,20 +179,88 @@ public class AdyenAccountResourceIT {
                 .post(format("/v1/api/service/%s/request-adyen-test-account", serviceId))
                 .then().statusCode(SC_CONFLICT);
 
+        verifyNoRequests();
+    }
+
+    private static void verifyNoRequests() {
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo("/legalEntities")));
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo("/businessLines")));
         app.getAdyenWireMockServer().verify(0, patchRequestedFor(urlEqualTo(format("/legalEntities/%s", any(String.class)))));
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo("/transferInstruments")));
-        
+
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo("/stores")));
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo((format("/merchants/%s/paymentMethodSettings", any(String.class))))));
-        
+
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo("/accountHolders")));
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo("/balanceAccounts")));
-        
+
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo(format("/legalEntities/%s/termsOfService", any(String.class)))));
         app.getAdyenWireMockServer().verify(0, patchRequestedFor(urlEqualTo(format("/legalEntities/%s/termsOfService/%s", any(String.class),  any(String.class)))));
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo(format("/legalEntities/%s/pciQuestionnaires/generatePciTemplates", any(String.class)))));
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo(format("/legalEntities/%s/pciQuestionnaires/signPciTemplates", any(String.class)))));
+    }
+
+    @Test
+    void switchTestAccountShouldReturnBadGatewayWhenAdyenRespondsWithError() {
+        var serviceId = RandomIdGenerator.randomUuid();
+
+        app.getDatabaseFixtures()
+                .aTestAccount()
+                .withServiceId(serviceId)
+                .withPaymentProvider(STRIPE.getName())
+                .insert();
+
+        app.getAdyenKycMockClient().mockError("/legalEntities");
+
+        app.givenSetup()
+                .body(Map.of("service_name", "Existing service"))
+                .post(format("/v1/api/service/%s/switch-to-adyen-test-account", serviceId))
+                .then().statusCode(SC_BAD_GATEWAY);
+
+        app.getAdyenWireMockServer().verify(1, postRequestedFor(urlEqualTo("/legalEntities")));
+        app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo("/businessLines")));
+        app.getAdyenWireMockServer().verify(0, patchRequestedFor(urlEqualTo(format("/legalEntities/%s", any(String.class)))));
+        app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo("/transferInstruments")));
+
+        app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo("/stores")));
+        app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo((format("/merchants/%s/paymentMethodSettings", any(String.class))))));
+
+        app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo("/accountHolders")));
+        app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo("/balanceAccounts")));
+
+        app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo(format("/legalEntities/%s/termsOfService", any(String.class)))));
+        app.getAdyenWireMockServer().verify(0, patchRequestedFor(urlEqualTo(format("/legalEntities/%s/termsOfService/%s", any(String.class),  any(String.class)))));
+        app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo(format("/legalEntities/%s/pciQuestionnaires/generatePciTemplates", any(String.class)))));
+        app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo(format("/legalEntities/%s/pciQuestionnaires/signPciTemplates", any(String.class)))));
+    }
+
+    @Test
+    void switchTestAccountShouldReturnBadRequestWhenProviderIsNotStripe() {
+        var serviceId = RandomIdGenerator.randomUuid();
+
+        app.getDatabaseFixtures()
+                .aTestAccount()
+                .withServiceId(serviceId)
+                .withPaymentProvider(WORLDPAY.getName())
+                .insert();
+
+        app.givenSetup()
+                .body(Map.of("service_name", "Existing service"))
+                .post(format("/v1/api/service/%s/switch-to-adyen-test-account", serviceId))
+                .then().statusCode(SC_BAD_REQUEST);
+
+        verifyNoRequests();
+    }
+
+    @Test
+    void switchTestAccountShouldReturnBadRequestWhenStripeTestAccountDoesNotExist() {
+        var serviceId = RandomIdGenerator.randomUuid();
+        
+        app.givenSetup()
+                .body(Map.of("service_name", "Existing service"))
+                .post(format("/v1/api/service/%s/switch-to-adyen-test-account", serviceId))
+                .then().statusCode(SC_BAD_REQUEST);
+
+        verifyNoRequests();
     }
 }


### PR DESCRIPTION
## WHAT YOU DID

Add resource to switch from Stripe to Adyen test account and handle the below "unhappy" scenarios:

- Adyen responds with an error response to any request
- the current active provider of the account the switch is being requested for, is not Stripe
- no test account exists for the service switch is being requested for
