### PR TITLE
PP-15420 upgrade Dropwizard to 5.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,23 +27,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-bom</artifactId>
-                <version>12.1.9</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>2.21.3</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <version>5.0.1</version>
+                <version>5.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## WHAT YOU DID

We have pinned fasterxml and jetty bom’s because DW 5.0.1 had undesired versions (ITHC scan).

The DW 5.0.2 upgrade includes fasterxml 2.21.4 and jetty 12.1.9. Upgrade to Dropwizard 5.0.2 and remove the pinned jetty and fasterxml dependencies.
