### PR TITLE
PP-15385 Add an endpoint to switch Stripe test accounts to Adyen

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/AdyenAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/AdyenAccountResource.java
@@ -10,11 +10,13 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
+import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenGatewayAccountRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.service.AdyenTestAccountService;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountSwitchPaymentProviderService;
 
 import java.util.Map;
 
@@ -28,12 +30,15 @@ public class AdyenAccountResource {
 
     private final AdyenTestAccountService adyenTestAccountService;
     private final GatewayAccountService gatewayAccountService;
+    private final GatewayAccountSwitchPaymentProviderService gatewayAccountSwitchPaymentProviderService;
 
     @Inject
     public AdyenAccountResource(AdyenTestAccountService adyenTestAccountService,
-                                GatewayAccountService gatewayAccountService) {
+                                GatewayAccountService gatewayAccountService,
+                                GatewayAccountSwitchPaymentProviderService gatewayAccountSwitchPaymentProviderService) {
         this.adyenTestAccountService = adyenTestAccountService;
         this.gatewayAccountService = gatewayAccountService;
+        this.gatewayAccountSwitchPaymentProviderService = gatewayAccountSwitchPaymentProviderService;
     }
 
     @POST
@@ -96,10 +101,19 @@ public class AdyenAccountResource {
             Map<String, String> payload) {
         
         gatewayAccountService.throwIfNoStripeTestAccount(serviceId);
+        var gatewayAccount = gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, TEST)
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId));
 
         var serviceName = payload.get("service_name");
-        adyenTestAccountService.createTestAccount(serviceName);
-
-        return Response.ok().build();
+        AdyenCredentials adyenCredentials = adyenTestAccountService.createTestAccount(serviceName);
+        gatewayAccountSwitchPaymentProviderService.switchStripeTestAccountToAdyen(gatewayAccount, adyenCredentials);
+        
+        Map<String, String> response = Map.of("gateway_account_id", serviceId,
+                "legal_entity_id", adyenCredentials.legalEntityId(),
+                "store_id", adyenCredentials.storeId(),
+                "account_holder_id", adyenCredentials.accountHolderId(),
+                "balance_account_id", adyenCredentials.balanceAccountId());
+        
+        return Response.ok(response).build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderService.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.GatewayAccountSwitchPaymentProviderRequest;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
@@ -151,6 +152,56 @@ public class GatewayAccountSwitchPaymentProviderService {
                 kv(PROVIDER, PaymentGatewayName.STRIPE.getName()),
                 kv("new_payment_provider", PaymentGatewayName.SANDBOX.getName()),
                 kv(USER_EXTERNAL_ID, request.getUserExternalId())
+        );
+    }
+
+    @Transactional
+    public void switchStripeTestAccountToAdyen(GatewayAccountEntity gatewayAccountEntity, AdyenCredentials adyenCredentials) {
+        List<GatewayAccountCredentialsEntity> gatewayAccountCredentials = gatewayAccountEntity.getGatewayAccountCredentials();
+
+        var activeStripeCredentialEntities = gatewayAccountCredentials.stream()
+                .filter(this::isActiveStripeCredential)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        if (activeStripeCredentialEntities.isEmpty()) {
+            throw new BadRequestException(format("Stripe credential with ACTIVE state not found for account [gateway account id: %s]",
+                    gatewayAccountEntity.getId()));
+        }
+        
+        var activeStripeCredential = findSingleCredentialEntityByState(activeStripeCredentialEntities, ACTIVE);
+
+        activeStripeCredential.setState(RETIRED);
+        activeStripeCredential.setActiveEndDate(Instant.now());
+
+        gatewayAccountEntity.setDescription(
+                replaceAllCaseInsensitive(
+                        gatewayAccountEntity.getDescription(),
+                        PaymentGatewayName.STRIPE.getName(),
+                        PaymentGatewayName.ADYEN.getName()
+                )
+        );
+        
+        var adyenCredentialEntity = new GatewayAccountCredentialsEntity(
+                gatewayAccountEntity,
+                PaymentGatewayName.ADYEN.getName(),
+                Map.of("legal_entity_id", adyenCredentials.legalEntityId(),
+                        "store_id", adyenCredentials.storeId(),
+                        "account_holder_id", adyenCredentials.accountHolderId(),
+                        "balance_account_id", adyenCredentials.balanceAccountId()),
+                ACTIVE
+        );
+
+        adyenCredentialEntity.setExternalId(randomUuid());
+        adyenCredentialEntity.setActiveStartDate(Instant.now());
+
+        gatewayAccountCredentialsDao.mergeInSequence(List.of(adyenCredentialEntity, activeStripeCredential));
+        gatewayAccountDao.merge(gatewayAccountEntity);
+
+        LOGGER.info("Gateway account [id={}] switched to Adyen", gatewayAccountEntity.getId(),
+                kv(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId()),
+                kv(GATEWAY_ACCOUNT_TYPE, gatewayAccountEntity.getType()),
+                kv(PROVIDER, PaymentGatewayName.STRIPE.getName()),
+                kv("new_payment_provider", PaymentGatewayName.ADYEN.getName())
         );
     }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountSwitchPaymentProviderServiceTest.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.gatewayaccount.service;
 
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,13 +15,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.GatewayAccountSwitchPaymentProviderRequest;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentialsFixture;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
-
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotFoundException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -324,6 +325,85 @@ class GatewayAccountSwitchPaymentProviderServiceTest {
             gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity1));
             var thrown = assertThrows(BadRequestException.class, () -> gatewayAccountSwitchPaymentProviderService.revertStripeTestAccountToSandbox(gatewayAccountEntity, request));
             assertThat(thrown.getMessage(), is(format("Stripe credential with ACTIVE state not found for account [gateway account id: %s]", gatewayAccountEntity.getId())));
+        }
+    }
+    
+    @Nested
+    class convertStripeTestAccountToAdyen {
+        AdyenCredentials adyenCredentials = new AdyenCredentialsFixture().build();
+        
+        @Test
+        void shouldConvertStripeTestGatewayToAdyen() {
+            var stripeTestCredential = aGatewayAccountCredentialsEntity()
+                    .withState(ACTIVE)
+                    .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                    .build();
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(stripeTestCredential));
+            gatewayAccountEntity.setDescription("Stripe test account for a service");
+            
+            ArgumentCaptor<List<GatewayAccountCredentialsEntity>> credentialsArgumentCaptor = ArgumentCaptor.forClass(List.class);
+            ArgumentCaptor<GatewayAccountEntity> gatewayArgumentCaptor = ArgumentCaptor.forClass(GatewayAccountEntity.class);
+
+            gatewayAccountSwitchPaymentProviderService.switchStripeTestAccountToAdyen(gatewayAccountEntity, adyenCredentials);
+
+            verify(mockGatewayAccountCredentialsDao, times(1)).mergeInSequence(credentialsArgumentCaptor.capture());
+            verify(mockGatewayAccountDao, times(1)).merge(gatewayArgumentCaptor.capture());
+
+            List<GatewayAccountCredentialsEntity> allCredentials = new ArrayList<>(credentialsArgumentCaptor.getValue());
+
+            Optional<GatewayAccountCredentialsEntity> activeCredential = allCredentials.stream().filter(credential -> ACTIVE.equals(credential.getState())).findFirst();
+            assertThat(activeCredential.get().getPaymentProvider(), is(PaymentGatewayName.ADYEN.getName()));
+
+            Optional<GatewayAccountCredentialsEntity> retiredCredential = allCredentials.stream().filter(credential -> RETIRED.equals(credential.getState())).findFirst();
+            assertThat(retiredCredential.get().getExternalId(), is(stripeTestCredential.getExternalId()));
+
+            GatewayAccountEntity gatewayAccount = gatewayArgumentCaptor.getValue();
+            assertThat(gatewayAccount.getDescription(), is("Adyen test account for a service"));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenNoActiveStripeCredential() {
+            var worldpayGatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+                    .withPaymentProvider(PaymentGatewayName.WORLDPAY.getName())
+                    .withState(ACTIVE)
+                    .build();
+            
+            gatewayAccountEntity.setType(GatewayAccountType.TEST);
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(worldpayGatewayAccountCredentialsEntity));
+            
+            var thrown = assertThrows(BadRequestException.class, () -> gatewayAccountSwitchPaymentProviderService.switchStripeTestAccountToAdyen(gatewayAccountEntity, adyenCredentials));
+            assertThat(thrown.getMessage(), is(format("Stripe credential with ACTIVE state not found for account [gateway account id: %s]", gatewayAccountEntity.getId())));
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideParamsForGatewayDescription")
+        void shouldCorrectlyUpdateGatewayDescriptionWhenSwitchingStripeTestAccount(String gatewayDescription, String expectedDescription) {
+            gatewayAccountEntity.setGatewayAccountCredentials(List.of(
+                    aGatewayAccountCredentialsEntity()
+                            .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                            .withState(ACTIVE)
+                            .build()));
+            gatewayAccountEntity.setType(GatewayAccountType.TEST);
+            gatewayAccountEntity.setDescription(gatewayDescription);
+
+            ArgumentCaptor<GatewayAccountEntity> gatewayArgumentCaptor = ArgumentCaptor.forClass(GatewayAccountEntity.class);
+
+            gatewayAccountSwitchPaymentProviderService.switchStripeTestAccountToAdyen(gatewayAccountEntity, adyenCredentials);
+
+            verify(mockGatewayAccountDao, times(1)).merge(gatewayArgumentCaptor.capture());
+
+            GatewayAccountEntity gatewayAccount = gatewayArgumentCaptor.getValue();
+            assertThat(gatewayAccount.getDescription(), is(expectedDescription));
+        }
+
+        private static Stream<Arguments> provideParamsForGatewayDescription() {
+            return Stream.of(
+                    Arguments.of("Stripe test account", "Adyen test account"),
+                    Arguments.of("STRIPE test account", "Adyen test account"),
+                    Arguments.of("STriPe test account", "Adyen test account"),
+                    Arguments.of("", ""),
+                    Arguments.of(null, null)
+            );
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountResourceIT.java
@@ -1,12 +1,17 @@
 package uk.gov.pay.connector.it.resources.adyen;
 
 import com.adyen.model.management.PaymentMethodSetupInfo;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +33,8 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.RETIRED;
+import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_CREATE_INDIVIDUAL_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_CREATE_LEGAL_ENTITY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_PAYMENT_METHOD_REQUEST;
@@ -36,15 +43,19 @@ public class AdyenAccountResourceIT {
 
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
-    
-    @Test
-    void requestingTestAccountShouldCreateAdyenEntitiesAndGatewayAccount() {
-        var serviceId = RandomIdGenerator.randomUuid();
-        var serviceName = "A local council";
-        var legalEntityId = "LE00000000000000000000001";
-        var merchantId = "adyen-test-merchant-account-id";
-        var termsOfServiceDocumentId = "doc123";
-        var paymentTypes = List.of(
+    private String serviceName;
+    private String legalEntityId;
+    private String merchantId;
+    private String termsOfServiceDocumentId;
+    private List<PaymentMethodSetupInfo.TypeEnum> paymentTypes;
+
+    @BeforeEach
+    void setUp() {
+        serviceName = "A local council";
+        legalEntityId = "LE00000000000000000000001";
+        merchantId = "adyen-test-merchant-account-id";
+        termsOfServiceDocumentId = "doc123";
+        paymentTypes = List.of(
                 PaymentMethodSetupInfo.TypeEnum.VISA,
                 PaymentMethodSetupInfo.TypeEnum.MC,
                 PaymentMethodSetupInfo.TypeEnum.AMEX,
@@ -56,7 +67,12 @@ public class AdyenAccountResourceIT {
                 PaymentMethodSetupInfo.TypeEnum.PAYBYBANK,
                 PaymentMethodSetupInfo.TypeEnum.APPLEPAY,
                 PaymentMethodSetupInfo.TypeEnum.GOOGLEPAY);
-        
+    }
+
+    @Test
+    void requestingTestAccountShouldCreateAdyenEntitiesAndGatewayAccount() {
+        var serviceId = RandomIdGenerator.randomUuid();
+
         app.getAdyenKycMockClient().mockCreateLegalEntity();
         app.getAdyenKycMockClient().mockCreateBusinessLine();
         app.getAdyenKycMockClient().mockCreateIndividual();
@@ -232,6 +248,97 @@ public class AdyenAccountResourceIT {
         app.getAdyenWireMockServer().verify(0, patchRequestedFor(urlEqualTo(format("/legalEntities/%s/termsOfService/%s", any(String.class),  any(String.class)))));
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo(format("/legalEntities/%s/pciQuestionnaires/generatePciTemplates", any(String.class)))));
         app.getAdyenWireMockServer().verify(0, postRequestedFor(urlEqualTo(format("/legalEntities/%s/pciQuestionnaires/signPciTemplates", any(String.class)))));
+    }
+    
+    @Test
+    void switchTestAccountShouldCreateAdyenEntitiesAndNewActiveCredential() {
+        var serviceId = RandomIdGenerator.randomUuid();
+
+        app.getDatabaseFixtures()
+                .aTestAccount()
+                .withServiceId(serviceId)
+                .withServiceName(serviceName)
+                .withDescription("Stripe test account for " +  serviceName)
+                .withPaymentProvider(STRIPE.getName())
+                .withAccountId(1337L)
+                .withGatewayAccountCredentials(List.of(anAddGatewayAccountCredentialsParams()
+                        .withGatewayAccountId(1337L)
+                        .withState(GatewayAccountCredentialState.ACTIVE)
+                        .withCreatedDate(Instant.now().minus(7, ChronoUnit.DAYS))
+                        .withActiveStartDate(Instant.now().minus(7, ChronoUnit.DAYS))
+                        .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                        .build()))
+                .insert();
+        
+        app.getAdyenKycMockClient().mockCreateLegalEntity();
+        app.getAdyenKycMockClient().mockCreateBusinessLine();
+        app.getAdyenKycMockClient().mockCreateIndividual();
+        app.getAdyenKycMockClient().mockUpdateLegalEntity(legalEntityId);
+        app.getAdyenKycMockClient().mockCreateTransferInstrument();
+
+        app.getAdyenManagementMockClient().mockCreateStore();
+        app.getAdyenManagementMockClient().mockRequestPaymentMethod(merchantId);
+
+        app.getAdyenBalancePlatformMockClient().mockCreateAccountHolder();
+        app.getAdyenBalancePlatformMockClient().mockCreateBalanceAccount();
+
+        app.getAdyenKycMockClient().mockGetTermsOfServiceDocument(legalEntityId);
+        app.getAdyenKycMockClient().mockAcceptTermsOfService(legalEntityId, termsOfServiceDocumentId);
+        app.getAdyenKycMockClient().mockGeneratePciQuestionnaire(legalEntityId);
+        app.getAdyenKycMockClient().mockSignPciTemplates(legalEntityId);
+
+        app.givenSetup()
+                .body(Map.of("service_name", serviceName))
+                .post(format("/v1/api/service/%s/switch-to-adyen-test-account", serviceId))
+                .then()
+                .statusCode(SC_OK)
+                .body("gateway_account_id", is(notNullValue()))
+                .body("legal_entity_id", is(legalEntityId))
+                .body("store_id" , is("STORE_ID_123"))
+                .body("account_holder_id", is("AH3227C223222H5J4DCLW9VBV"))
+                .body("balance_account_id", is("BA0000000000000000000001"));
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/legalEntities"))
+                .withRequestBody(equalToJson(TestTemplateResourceLoader
+                        .load(ADYEN_CREATE_LEGAL_ENTITY_REQUEST)
+                        .replace("{{serviceName}}", serviceName))));
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/businessLines")));
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/legalEntities"))
+                .withRequestBody(equalToJson(TestTemplateResourceLoader
+                        .load(ADYEN_CREATE_INDIVIDUAL_REQUEST))));
+        app.getAdyenWireMockServer().verify(patchRequestedFor(urlEqualTo(format("/legalEntities/%s", legalEntityId))));
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/transferInstruments")));
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/stores")));
+        verifyPaymentMethodsRequest(paymentTypes, merchantId);
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/accountHolders")));
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/balanceAccounts")));
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo(format("/legalEntities/%s/termsOfService", legalEntityId))));
+        app.getAdyenWireMockServer().verify(patchRequestedFor(urlEqualTo(format("/legalEntities/%s/termsOfService/%s", legalEntityId, termsOfServiceDocumentId))));
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo(format("/legalEntities/%s/pciQuestionnaires/generatePciTemplates", legalEntityId))));
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo(format("/legalEntities/%s/pciQuestionnaires/signPciTemplates", legalEntityId))));
+        
+        app.givenSetup().get(format("/v1/api/service/%s/account/test", serviceId))
+                .then()
+                .statusCode(SC_OK)
+                .body("service_id", is(serviceId))
+                .body("payment_provider", is(ADYEN.getName()))
+                .body("type", is(TEST.toString()))
+                .body("service_name", is(serviceName))
+                .body("description", is("Adyen test account for " + serviceName))
+                .body("gateway_account_credentials", hasSize(2))
+                .body("gateway_account_credentials[0].payment_provider", is(STRIPE.getName()))
+                .body("gateway_account_credentials[0].state", is(RETIRED.toString()))
+                .body("gateway_account_credentials[0].active_end_date", is(notNullValue()))
+                .body("gateway_account_credentials[1].payment_provider", is(ADYEN.getName()))
+                .body("gateway_account_credentials[1].state", is(ACTIVE.toString()))
+                .body("gateway_account_credentials[1].credentials.legal_entity_id", is(legalEntityId))
+                .body("gateway_account_credentials[1].credentials.store_id", is("STORE_ID_123"))
+                .body("gateway_account_credentials[1].credentials.account_holder_id", is("AH3227C223222H5J4DCLW9VBV"))
+                .body("gateway_account_credentials[1].credentials.balance_account_id", is("BA0000000000000000000001"))
+                .body("gateway_account_credentials[1].external_id", is(notNullValue(String.class)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountResourceIT.java
@@ -334,6 +334,7 @@ public class AdyenAccountResourceIT {
                 .body("gateway_account_credentials[0].active_end_date", is(notNullValue()))
                 .body("gateway_account_credentials[1].payment_provider", is(ADYEN.getName()))
                 .body("gateway_account_credentials[1].state", is(ACTIVE.toString()))
+                .body("gateway_account_credentials[1].active_start_date", is(notNullValue()))
                 .body("gateway_account_credentials[1].credentials.legal_entity_id", is(legalEntityId))
                 .body("gateway_account_credentials[1].credentials.store_id", is("STORE_ID_123"))
                 .body("gateway_account_credentials[1].credentials.account_holder_id", is("AH3227C223222H5J4DCLW9VBV"))


### PR DESCRIPTION
## WHAT YOU DID

- Add method to switch from Stripe to Adyen test account
- Complete implementation of resource, partially done in https://github.com/alphagov/pay-connector/pull/6363
- Add tests to verify successful account switch


