### PR TITLE
PP-15146: parameterise response type of `GatewayResponseBuilder#withGatewayError`

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -530,28 +530,28 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 146
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "fd9f851472586dc75f7a60ee311842ec64ecf527",
         "is_verified": false,
-        "line_number": 148
+        "line_number": 149
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "9367c8305bd1afe815ffc0cc3ebf95af9cb6d157",
         "is_verified": false,
-        "line_number": 151
+        "line_number": 152
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 1151
+        "line_number": 1153
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-18T09:04:09Z"
+  "generated_at": "2026-05-26T15:53:20Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
@@ -84,7 +84,7 @@ public class GatewayResponse<T extends BaseResponse> {
             return this;
         }
 
-        public GatewayResponseBuilder withGatewayError(GatewayError gatewayError) {
+        public GatewayResponseBuilder<T> withGatewayError(GatewayError gatewayError) {
             this.gatewayError = gatewayError;
             return this;
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCancelHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCancelHandler.java
@@ -9,8 +9,8 @@ import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayException.GenericGatewayException;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.stripe.request.StripePaymentIntentCancelRequest;
 
 import static java.util.UUID.randomUUID;
@@ -28,7 +28,7 @@ public class StripeCancelHandler {
     }
 
     public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) {
-        GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
+        GatewayResponseBuilder<BaseCancelResponse> responseBuilder = GatewayResponseBuilder.responseBuilder();
 
         try {
             client.postRequestFor(StripePaymentIntentCancelRequest.of(request, stripeGatewayConfig));

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -10,7 +10,9 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.util.AcceptLanguageHeaderParser;
@@ -26,7 +28,6 @@ import static jakarta.ws.rs.core.Response.Status.Family.SERVER_ERROR;
 import static java.lang.String.format;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
-import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.gateway.util.AuthUtil.getWorldpayAuthHeader;
 
 public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerator {
@@ -50,6 +51,7 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
     public GatewayResponse<WorldpayOrderStatusResponse> authoriseUserNotPresent(RecurringPaymentAuthorisationGatewayRequest request) {
         LOGGER.info("Authorising user not present request: {}", request.getGatewayTransactionId().orElse("gatewayTransactionId is not present"));
 
+        GatewayResponseBuilder<WorldpayOrderStatusResponse> responseBuilder = GatewayResponseBuilder.responseBuilder();
         try {
             GatewayClient.Response response = authoriseClient.postRequestFor(
                     gatewayUrlMap.get(request.getGatewayAccount().getType()),
@@ -64,12 +66,12 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
 
             GatewayError gatewayError = gatewayConnectionError(format("Non-success HTTP status code %s from gateway", e.getStatus().get()));
 
-            return responseBuilder().withGatewayError(gatewayError).build();
+            return responseBuilder.withGatewayError(gatewayError).build();
         } catch (GatewayException.GatewayConnectionTimeoutException | GatewayException.GenericGatewayException e) {
 
             LOGGER.error("GatewayException occurred, error:\n {}", e);
 
-            return responseBuilder().withGatewayError(e.toGatewayError()).build();
+            return responseBuilder.withGatewayError(e.toGatewayError()).build();
         }
     }
 
@@ -81,6 +83,7 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
         var worldpayOrderBuilder  = WorldpayOrderBuilder.buildAuthoriseOrder(request, sendExemptionRequest, acceptLanguageHeaderParser);
         logAuthorisationRequestToBePosted(request, worldpayOrderBuilder);
 
+        GatewayResponseBuilder<WorldpayOrderStatusResponse> responseBuilder = GatewayResponseBuilder.responseBuilder();
         try {            
             GatewayClient.Response response = authoriseClient.postRequestFor(
                     gatewayUrlMap.get(request.getGatewayAccount().getType()),
@@ -102,18 +105,18 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
 
                 GatewayError gatewayError = gatewayConnectionError(format("Non-success HTTP status code %s from gateway", e.getStatus().get()));
 
-                return responseBuilder().withGatewayError(gatewayError).build();
+                return responseBuilder.withGatewayError(gatewayError).build();
             }
 
             LOGGER.info("Unrecognised response status when authorising - status={}, response={}",
                     e.getStatus(), e.getResponseFromGateway());
-            return responseBuilder().withGatewayError(e.toGatewayError()).build();
+            return responseBuilder.withGatewayError(e.toGatewayError()).build();
 
         } catch (GatewayException.GatewayConnectionTimeoutException | GatewayException.GenericGatewayException e) {
 
             LOGGER.error("GatewayException occurred, error:\n {}", e);
 
-            return responseBuilder().withGatewayError(e.toGatewayError()).build();
+            return responseBuilder.withGatewayError(e.toGatewayError()).build();
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -30,6 +30,7 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
@@ -137,7 +138,9 @@ public class CardAuthoriseService {
 
         } catch (GatewayException e) {
             newStatus = AuthorisationService.mapFromGatewayErrorException(e);
-            operationResponse = GatewayResponse.GatewayResponseBuilder.responseBuilder().withGatewayError(e.toGatewayError()).build();
+            operationResponse = GatewayResponseBuilder.<BaseAuthoriseResponse>responseBuilder()
+                    .withGatewayError(e.toGatewayError())
+                    .build();
         }
 
         return updateChargePostAuthorisation(authCardDetails, charge, operationResponse, newStatus);
@@ -200,7 +203,9 @@ public class CardAuthoriseService {
 
         } catch (GatewayException e) {
             newStatus = AuthorisationService.mapFromGatewayErrorException(e);
-            operationResponse = GatewayResponse.GatewayResponseBuilder.responseBuilder().withGatewayError(e.toGatewayError()).build();
+            operationResponse = GatewayResponseBuilder.<BaseAuthoriseResponse>responseBuilder()
+                    .withGatewayError(e.toGatewayError())
+                    .build();
         }
 
         return Pair.of(operationResponse, newStatus);

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
@@ -96,7 +97,9 @@ public class WalletAuthoriseService {
                 }
 
                 chargeStatus = AuthorisationService.mapFromGatewayErrorException(e);
-                operationResponse = GatewayResponse.GatewayResponseBuilder.responseBuilder().withGatewayError(e.toGatewayError()).build();
+                operationResponse = GatewayResponseBuilder.<BaseAuthoriseResponse>responseBuilder()
+                        .withGatewayError(e.toGatewayError())
+                        .build();
             }
 
             Optional<String> transactionId = authorisationService.extractTransactionId(charge.getExternalId(), operationResponse, charge.getGatewayTransactionId());

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -38,6 +38,7 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.DeleteStoredPaymentDetailsGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
 import uk.gov.pay.connector.gateway.worldpay.wallets.WorldpayWalletAuthorisationHandler;
@@ -227,8 +228,9 @@ class WorldpayPaymentProviderTest {
         ChargeEntity chargeEntity = chargeEntityFixture.build();
         var cardAuthRequest = CardAuthorisationGatewayRequest.valueOf(chargeEntity, anAuthCardDetails().build());
 
+        GatewayResponseBuilder<WorldpayOrderStatusResponse> responseBuilder = responseBuilder();
         when(worldpayAuthoriseHandler.authorise(cardAuthRequest, SEND_EXEMPTION_ENGINE_REQUEST))
-                .thenReturn(responseBuilder().withGatewayError(gatewayConnectionError("connetion problemo")).build());
+                .thenReturn(responseBuilder.withGatewayError(gatewayConnectionError("connetion problemo")).build());
 
         worldpayPaymentProvider.authorise(cardAuthRequest, chargeEntity);
 


### PR DESCRIPTION
## WHAT YOU DID
`GatewayResponseBuilder#withGatewayError` returns `GatewayResponseBuilder` as a raw type, bypassing compile-time type checking and causing the compiler to emit "unchecked conversion" warnings.

`GatewayResponseBuilder#withGatewayError` should return the same type of `GatewayResponseBuilder` as the builder on which it is called.

There are just a few places where we need to properly parameterise the `GatewayResponseBuilder`, either by declaring a parameterised variable or using a type witness in the call to the `responseBuilder()` static creation method.