### PR TITLE
PP-15147 Use DefaultRefundAvailabilityCalculator for Adyen payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
@@ -29,6 +29,8 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -46,6 +48,8 @@ public class AdyenPaymentProvider implements PaymentProvider {
     private final AdyenAuthoriseHandler adyenAuthoriseHandler;
     private final AdyenCaptureHandler adyenCaptureHandler;
     private final AdyenCancelHandler adyenCancelHandler;
+    private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
+    private final RefundEntityFactory refundEntityFactory;
 
     @Inject
     public AdyenPaymentProvider(
@@ -60,6 +64,8 @@ public class AdyenPaymentProvider implements PaymentProvider {
         adyenAuthoriseHandler = new AdyenAuthoriseHandler(client, connectorConfiguration, jsonObjectMapper);
         adyenCaptureHandler = new AdyenCaptureHandler(client, connectorConfiguration, jsonObjectMapper);
         adyenCancelHandler = new AdyenCancelHandler(client, adyenGatewayConfig, new AdyenRequestFactory(connectorConfiguration));
+        this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
+        this.refundEntityFactory = refundEntityFactory;
     }
 
     @Override
@@ -113,8 +119,8 @@ public class AdyenPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundEntityList) {
-        throw new UnsupportedOperationException("Operation for Adyen is not Implemented yet");
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundList);
     }
 
     @Override
@@ -126,6 +132,6 @@ public class AdyenPaymentProvider implements PaymentProvider {
 
     @Override
     public RefundEntityFactory getRefundEntityFactory() {
-        throw new UnsupportedOperationException("Operation for Adyen is not Implemented yet");
+        return refundEntityFactory;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProviderTest.java
@@ -9,16 +9,22 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,5 +70,19 @@ class AdyenPaymentProviderTest {
     @Test
     void shouldGenerateEmptyTransactionId() {
         assertThat(provider.generateTransactionId().isEmpty(), is(true));
+    }
+
+    @Test
+    void shouldCalculateRefundAvailabilityUsingDefaultCalculator() {
+        Charge charge = Charge.from(
+                aValidChargeEntity().withAmount(1000L)
+                        .withStatus(ChargeStatus.CAPTURED)
+                        .build());
+        assertThat(provider.getExternalChargeRefundAvailability(charge, List.of()), is(ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE));
+    }
+
+    @Test
+    void shouldReturnRefundEntityFactory() {
+        assertThat(provider.getRefundEntityFactory(), is(refundEntityFactory));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
Adyen to use DefaultRefundAvailabilityCalculator for refund-availability checks, with provider/unit test updates.

## How to test

- How should it be reviewed? PR
- What feedback do you need? PR comments, DMs

## Code review checklist

### Logging

- [ x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
