### PR TITLE
PP-15147 Add Adyen refund url

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
@@ -29,6 +29,8 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -46,6 +48,8 @@ public class AdyenPaymentProvider implements PaymentProvider {
     private final AdyenAuthoriseHandler adyenAuthoriseHandler;
     private final AdyenCaptureHandler adyenCaptureHandler;
     private final AdyenCancelHandler adyenCancelHandler;
+    private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
+    private final RefundEntityFactory refundEntityFactory;
 
     @Inject
     public AdyenPaymentProvider(
@@ -60,6 +64,8 @@ public class AdyenPaymentProvider implements PaymentProvider {
         adyenAuthoriseHandler = new AdyenAuthoriseHandler(client, connectorConfiguration, jsonObjectMapper);
         adyenCaptureHandler = new AdyenCaptureHandler(client, connectorConfiguration, jsonObjectMapper);
         adyenCancelHandler = new AdyenCancelHandler(client, adyenGatewayConfig, new AdyenRequestFactory(connectorConfiguration));
+        this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
+        this.refundEntityFactory = refundEntityFactory;
     }
 
     @Override
@@ -113,8 +119,8 @@ public class AdyenPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundEntityList) {
-        throw new UnsupportedOperationException("Operation for Adyen is not Implemented yet");
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundList);
     }
 
     @Override
@@ -126,6 +132,6 @@ public class AdyenPaymentProvider implements PaymentProvider {
 
     @Override
     public RefundEntityFactory getRefundEntityFactory() {
-        throw new UnsupportedOperationException("Operation for Adyen is not Implemented yet");
+        return refundEntityFactory;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.GatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 
 import java.net.URI;
 import java.util.Map;
@@ -19,6 +20,10 @@ public class AdyenRequestUtil {
 
     public static URI getAuthUrl(AdyenGatewayConfig config, CardAuthorisationGatewayRequest request) {
         return getUrl(config, request, "/payments");
+    }
+    
+    public static URI getRefundUrl(AdyenGatewayConfig adyenGatewayConfig, RefundGatewayRequest request) {
+        return URI.create(getBaseCheckoutUrl(adyenGatewayConfig, request.getGatewayAccount().isLive()) + "/payments/" + request.getTransactionId() + "/refunds");
     }
 
     public static URI getCancelUrl(AdyenGatewayConfig config, CancelGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
@@ -23,8 +23,8 @@ public class AdyenRequestUtil {
     }
     
     public static URI getRefundUrl(AdyenGatewayConfig config, RefundGatewayRequest request) {
-        var path =  "/payments/" + request.getTransactionId() + "/refunds";
-        return getUrl(config, request, path );
+        var path =  "/payments/%s/refunds".formatted(request.getTransactionId());
+        return getUrl(config, request, path);
     }
 
     public static URI getCancelUrl(AdyenGatewayConfig config, CancelGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
@@ -22,8 +22,9 @@ public class AdyenRequestUtil {
         return getUrl(config, request, "/payments");
     }
     
-    public static URI getRefundUrl(AdyenGatewayConfig adyenGatewayConfig, RefundGatewayRequest request) {
-        return URI.create(getBaseCheckoutUrl(adyenGatewayConfig, request.getGatewayAccount().isLive()) + "/payments/" + request.getTransactionId() + "/refunds");
+    public static URI getRefundUrl(AdyenGatewayConfig config, RefundGatewayRequest request) {
+        var path =  "/payments/" + request.getTransactionId() + "/refunds";
+        return getUrl(config, request, path );
     }
 
     public static URI getCancelUrl(AdyenGatewayConfig config, CancelGatewayRequest request) {

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProviderTest.java
@@ -9,16 +9,22 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.refund.service.RefundEntityFactory;
 import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,5 +70,19 @@ class AdyenPaymentProviderTest {
     @Test
     void shouldGenerateEmptyTransactionId() {
         assertThat(provider.generateTransactionId().isEmpty(), is(true));
+    }
+
+    @Test
+    void shouldCalculateRefundAvailabilityUsingDefaultCalculator() {
+        Charge charge = Charge.from(
+                aValidChargeEntity().withAmount(1000L)
+                        .withStatus(ChargeStatus.CAPTURED)
+                        .build());
+        assertThat(provider.getExternalChargeRefundAvailability(charge, List.of()), is(ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE));
+    }
+
+    @Test
+    void shouldReturnRefundEntityFactory() {
+        assertThat(provider.getRefundEntityFactory(), is(refundEntityFactory));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
@@ -1,9 +1,10 @@
 package uk.gov.pay.connector.gateway.adyen.utils;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
@@ -17,18 +18,16 @@ import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 
@@ -82,63 +81,44 @@ class AdyenRequestUtilTest {
         var captureUrl = AdyenRequestUtil.getCaptureUrl(mockAdyenGatewayConfig, mockCaptureRequest).toString();
 
         assertThat(captureUrl, is(String.format("https://example.com/test/v71/payments/%s/captures", GATEWAY_TRANSACTION_ID)));
-
-        BaseUrls mockBaseUrls = mock(BaseUrls.class);
-        lenient().when(mockBaseUrls.checkout()).thenReturn(new BaseUrls.CheckoutUrls("https://example.com/test/v71", "https://example.com/live/v71"));
-        lenient().when(mockAdyenGatewayConfig.getBaseUrls()).thenReturn(mockBaseUrls);
     }
 
     @Test
     void should_create_adyen_checkout_authorisation_url() {
+        stubCheckoutBaseUrls("https://example.com/test/v71", "https://example.com/live/v71");
         var testCheckoutUrl = AdyenRequestUtil.getAuthUrl(mockAdyenGatewayConfig, mockAuthoriseRequest).toString();
         assertThat(testCheckoutUrl, is("https://example.com/test/v71/payments"));
     }
 
     @Test
     void should_create_adyen_checkout_capture_url() {
+        stubCheckoutBaseUrls("https://example.com/test/v71", "https://example.com/live/v71");
         mockCaptureRequest = CaptureGatewayRequest.valueOf(chargeEntity);
         var testCheckoutUrl = AdyenRequestUtil.getCaptureUrl(mockAdyenGatewayConfig, mockCaptureRequest).toString();
         assertThat(testCheckoutUrl, is(String.format("https://example.com/test/v71/payments/%s/captures", GATEWAY_TRANSACTION_ID)));
     }
 
-    @Nested
-    class TestGetRefundUrl {
-        private RefundGatewayRequest mockRefundRequest;
-        RefundEntity refundEntity;
+    @ParameterizedTest
+    @CsvSource({
+            "TEST,https://example.com/test/v71",
+            "LIVE,https://example.com/live/v71"
+    })
+    void should_create_adyen_checkout_refund_url(GatewayAccountType gatewayAccountType, String expectedCheckoutBaseUrl) {
+        stubCheckoutBaseUrls("https://example.com/test/v71", "https://example.com/live/v71");
+        chargeEntity.getGatewayAccount().setType(gatewayAccountType);
 
-        @BeforeEach
-        void setUp() {
-            refundEntity = new RefundEntityFixture()
-                    .withGatewayTransactionId(GATEWAY_TRANSACTION_ID)
-                    .withExternalId("refund-external-id")
-                    .build();
-        }
+        var refundEntity = new RefundEntityFixture()
+                .withGatewayTransactionId(GATEWAY_TRANSACTION_ID)
+                .withExternalId("refund-external-id")
+                .build();
+        var mockRefundRequest = RefundGatewayRequest.valueOf(
+                Charge.from(chargeEntity),
+                refundEntity,
+                chargeEntity.getGatewayAccount(),
+                chargeEntity.getGatewayAccountCredentialsEntity());
 
-        @Test
-        void should_create_adyen_checkout_refund_url_for_test() {
-            chargeEntity.getGatewayAccount().setType(TEST);
-            mockRefundRequest = RefundGatewayRequest.valueOf(
-                    Charge.from(chargeEntity),
-                    refundEntity,
-                    chargeEntity.getGatewayAccount(),
-                    chargeEntity.getGatewayAccountCredentialsEntity());
-
-            var testCheckoutUrl = AdyenRequestUtil.getRefundUrl(mockAdyenGatewayConfig, mockRefundRequest).toString();
-            assertThat(testCheckoutUrl, is(String.format("https://example.com/test/v71/payments/%s/refunds", GATEWAY_TRANSACTION_ID)));
-        }
-
-        @Test
-        void should_create_adyen_checkout_refund_url_for_live() {
-            chargeEntity.getGatewayAccount().setType(LIVE);
-            mockRefundRequest = RefundGatewayRequest.valueOf(
-                    Charge.from(chargeEntity),
-                    refundEntity,
-                    chargeEntity.getGatewayAccount(),
-                    chargeEntity.getGatewayAccountCredentialsEntity());
-
-            var testCheckoutUrl = AdyenRequestUtil.getRefundUrl(mockAdyenGatewayConfig, mockRefundRequest).toString();
-            assertThat(testCheckoutUrl, is(String.format("https://example.com/live/v71/payments/%s/refunds", GATEWAY_TRANSACTION_ID)));
-        }
+        var checkoutUrl = AdyenRequestUtil.getRefundUrl(mockAdyenGatewayConfig, mockRefundRequest).toString();
+        assertThat(checkoutUrl, is(String.format("%s/payments/%s/refunds", expectedCheckoutBaseUrl, GATEWAY_TRANSACTION_ID)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
@@ -81,18 +82,20 @@ class AdyenRequestUtilTest {
         var captureUrl = AdyenRequestUtil.getCaptureUrl(mockAdyenGatewayConfig, mockCaptureRequest).toString();
 
         assertThat(captureUrl, is(String.format("https://example.com/test/v71/payments/%s/captures", GATEWAY_TRANSACTION_ID)));
+
+        BaseUrls mockBaseUrls = mock(BaseUrls.class);
+        lenient().when(mockBaseUrls.checkout()).thenReturn(new BaseUrls.CheckoutUrls("https://example.com/test/v71", "https://example.com/live/v71"));
+        lenient().when(mockAdyenGatewayConfig.getBaseUrls()).thenReturn(mockBaseUrls);
     }
 
     @Test
     void should_create_adyen_checkout_authorisation_url() {
-        stubCheckoutBaseUrls("https://example.com/test/v71", "https://example.com/live/v71");
         var testCheckoutUrl = AdyenRequestUtil.getAuthUrl(mockAdyenGatewayConfig, mockAuthoriseRequest).toString();
         assertThat(testCheckoutUrl, is("https://example.com/test/v71/payments"));
     }
 
     @Test
     void should_create_adyen_checkout_capture_url() {
-        stubCheckoutBaseUrls("https://example.com/test/v71", "https://example.com/live/v71");
         mockCaptureRequest = CaptureGatewayRequest.valueOf(chargeEntity);
         var testCheckoutUrl = AdyenRequestUtil.getCaptureUrl(mockAdyenGatewayConfig, mockCaptureRequest).toString();
         assertThat(testCheckoutUrl, is(String.format("https://example.com/test/v71/payments/%s/captures", GATEWAY_TRANSACTION_ID)));
@@ -105,7 +108,6 @@ class AdyenRequestUtilTest {
 
         @BeforeEach
         void setUp() {
-            stubCheckoutBaseUrls("https://example.com/test/v71", "https://example.com/live/v71");
             refundEntity = new RefundEntityFixture()
                     .withGatewayTransactionId(GATEWAY_TRANSACTION_ID)
                     .withExternalId("refund-external-id")

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
@@ -23,7 +23,6 @@ import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
@@ -82,20 +81,18 @@ class AdyenRequestUtilTest {
         var captureUrl = AdyenRequestUtil.getCaptureUrl(mockAdyenGatewayConfig, mockCaptureRequest).toString();
 
         assertThat(captureUrl, is(String.format("https://example.com/test/v71/payments/%s/captures", GATEWAY_TRANSACTION_ID)));
-
-        BaseUrls mockBaseUrls = mock(BaseUrls.class);
-        lenient().when(mockBaseUrls.checkout()).thenReturn(new BaseUrls.CheckoutUrls("https://example.com/test/v71", "https://example.com/live/v71"));
-        lenient().when(mockAdyenGatewayConfig.getBaseUrls()).thenReturn(mockBaseUrls);
     }
 
     @Test
     void should_create_adyen_checkout_authorisation_url() {
+        stubCheckoutBaseUrls("https://example.com/test/v71", "https://example.com/live/v71");
         var testCheckoutUrl = AdyenRequestUtil.getAuthUrl(mockAdyenGatewayConfig, mockAuthoriseRequest).toString();
         assertThat(testCheckoutUrl, is("https://example.com/test/v71/payments"));
     }
 
     @Test
     void should_create_adyen_checkout_capture_url() {
+        stubCheckoutBaseUrls("https://example.com/test/v71", "https://example.com/live/v71");
         mockCaptureRequest = CaptureGatewayRequest.valueOf(chargeEntity);
         var testCheckoutUrl = AdyenRequestUtil.getCaptureUrl(mockAdyenGatewayConfig, mockCaptureRequest).toString();
         assertThat(testCheckoutUrl, is(String.format("https://example.com/test/v71/payments/%s/captures", GATEWAY_TRANSACTION_ID)));
@@ -108,6 +105,7 @@ class AdyenRequestUtilTest {
 
         @BeforeEach
         void setUp() {
+            stubCheckoutBaseUrls("https://example.com/test/v71", "https://example.com/live/v71");
             refundEntity = new RefundEntityFixture()
                     .withGatewayTransactionId(GATEWAY_TRANSACTION_ID)
                     .withExternalId("refund-external-id")

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.adyen.utils;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -8,19 +9,26 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.app.adyen.ApiKeys;
 import uk.gov.pay.connector.app.adyen.BaseUrls;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
+import uk.gov.pay.connector.model.domain.RefundEntityFixture;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 
@@ -37,6 +45,7 @@ class AdyenRequestUtilTest {
     private CardAuthorisationGatewayRequest mockAuthoriseRequest;
     private CancelGatewayRequest mockCancelRequest;
     private CaptureGatewayRequest mockCaptureRequest;
+    ChargeEntity chargeEntity;
 
     public static final String GATEWAY_TRANSACTION_ID = "gateway-transaction-id";
 
@@ -48,13 +57,13 @@ class AdyenRequestUtilTest {
                 .withGatewayAccount(aGatewayAccountEntity().withType(TEST).build())
                 .build();
 
-        var charge = new ChargeEntityFixture()
+        chargeEntity = new ChargeEntityFixture()
                 .withGatewayAccountEntity(
                         aGatewayAccountEntity().withType(TEST).build())
                 .withGatewayTransactionId(GATEWAY_TRANSACTION_ID)
                 .build();
-        mockCaptureRequest = CaptureGatewayRequest.valueOf(charge);
-        mockCancelRequest = CancelGatewayRequest.valueOf(charge);
+        mockCaptureRequest = CaptureGatewayRequest.valueOf(chargeEntity);
+        mockCancelRequest = CancelGatewayRequest.valueOf(chargeEntity);
     }
 
     @Test
@@ -73,6 +82,63 @@ class AdyenRequestUtilTest {
         var captureUrl = AdyenRequestUtil.getCaptureUrl(mockAdyenGatewayConfig, mockCaptureRequest).toString();
 
         assertThat(captureUrl, is(String.format("https://example.com/test/v71/payments/%s/captures", GATEWAY_TRANSACTION_ID)));
+
+        BaseUrls mockBaseUrls = mock(BaseUrls.class);
+        lenient().when(mockBaseUrls.checkout()).thenReturn(new BaseUrls.CheckoutUrls("https://example.com/test/v71", "https://example.com/live/v71"));
+        lenient().when(mockAdyenGatewayConfig.getBaseUrls()).thenReturn(mockBaseUrls);
+    }
+
+    @Test
+    void should_create_adyen_checkout_authorisation_url() {
+        var testCheckoutUrl = AdyenRequestUtil.getAuthUrl(mockAdyenGatewayConfig, mockAuthoriseRequest).toString();
+        assertThat(testCheckoutUrl, is("https://example.com/test/v71/payments"));
+    }
+
+    @Test
+    void should_create_adyen_checkout_capture_url() {
+        mockCaptureRequest = CaptureGatewayRequest.valueOf(chargeEntity);
+        var testCheckoutUrl = AdyenRequestUtil.getCaptureUrl(mockAdyenGatewayConfig, mockCaptureRequest).toString();
+        assertThat(testCheckoutUrl, is(String.format("https://example.com/test/v71/payments/%s/captures", GATEWAY_TRANSACTION_ID)));
+    }
+
+    @Nested
+    class TestGetRefundUrl {
+        private RefundGatewayRequest mockRefundRequest;
+        RefundEntity refundEntity;
+
+        @BeforeEach
+        void setUp() {
+            refundEntity = new RefundEntityFixture()
+                    .withGatewayTransactionId(GATEWAY_TRANSACTION_ID)
+                    .withExternalId("refund-external-id")
+                    .build();
+        }
+
+        @Test
+        void should_create_adyen_checkout_refund_url_for_test() {
+            chargeEntity.getGatewayAccount().setType(TEST);
+            mockRefundRequest = RefundGatewayRequest.valueOf(
+                    Charge.from(chargeEntity),
+                    refundEntity,
+                    chargeEntity.getGatewayAccount(),
+                    chargeEntity.getGatewayAccountCredentialsEntity());
+
+            var testCheckoutUrl = AdyenRequestUtil.getRefundUrl(mockAdyenGatewayConfig, mockRefundRequest).toString();
+            assertThat(testCheckoutUrl, is(String.format("https://example.com/test/v71/payments/%s/refunds", GATEWAY_TRANSACTION_ID)));
+        }
+
+        @Test
+        void should_create_adyen_checkout_refund_url_for_live() {
+            chargeEntity.getGatewayAccount().setType(LIVE);
+            mockRefundRequest = RefundGatewayRequest.valueOf(
+                    Charge.from(chargeEntity),
+                    refundEntity,
+                    chargeEntity.getGatewayAccount(),
+                    chargeEntity.getGatewayAccountCredentialsEntity());
+
+            var testCheckoutUrl = AdyenRequestUtil.getRefundUrl(mockAdyenGatewayConfig, mockRefundRequest).toString();
+            assertThat(testCheckoutUrl, is(String.format("https://example.com/live/v71/payments/%s/refunds", GATEWAY_TRANSACTION_ID)));
+        }
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
@@ -83,20 +83,6 @@ class AdyenRequestUtilTest {
         assertThat(captureUrl, is(String.format("https://example.com/test/v71/payments/%s/captures", GATEWAY_TRANSACTION_ID)));
     }
 
-    @Test
-    void should_create_adyen_checkout_authorisation_url() {
-        stubCheckoutBaseUrls("https://example.com/test/v71", "https://example.com/live/v71");
-        var testCheckoutUrl = AdyenRequestUtil.getAuthUrl(mockAdyenGatewayConfig, mockAuthoriseRequest).toString();
-        assertThat(testCheckoutUrl, is("https://example.com/test/v71/payments"));
-    }
-
-    @Test
-    void should_create_adyen_checkout_capture_url() {
-        stubCheckoutBaseUrls("https://example.com/test/v71", "https://example.com/live/v71");
-        mockCaptureRequest = CaptureGatewayRequest.valueOf(chargeEntity);
-        var testCheckoutUrl = AdyenRequestUtil.getCaptureUrl(mockAdyenGatewayConfig, mockCaptureRequest).toString();
-        assertThat(testCheckoutUrl, is(String.format("https://example.com/test/v71/payments/%s/captures", GATEWAY_TRANSACTION_ID)));
-    }
 
     @ParameterizedTest
     @CsvSource({


### PR DESCRIPTION
## WHAT YOU DID
Adds a utility to build the Adyen refund endpoint URL from base checkout URL, transaction ID, and live/test mode.

## How to test

- How should it be reviewed? PR
- What feedback do you need? PR comments, DM

## Code review checklist
- Tests covering code change
- Good coding standard (code smells)
- clean code
### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

