### PR TITLE
PP-15146: return a parameterised type from withResponse()

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
@@ -74,7 +74,7 @@ public class GatewayResponse<T extends BaseResponse> {
             return new GatewayResponseBuilder<>();
         }
 
-        public GatewayResponseBuilder withResponse(T response) {
+        public GatewayResponseBuilder<T> withResponse(T response) {
             this.response = response;
             return this;
         }

--- a/src/test/java/uk/gov/pay/connector/charge/service/AuthorisationErrorGatewayCleanupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/AuthorisationErrorGatewayCleanupServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseInquiryResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayCancelResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paymentprocessor.service.QueryService;
@@ -46,7 +47,6 @@ import static uk.gov.pay.connector.charge.service.AuthorisationErrorGatewayClean
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
@@ -122,10 +122,11 @@ class AuthorisationErrorGatewayCleanupServiceTest {
         when(mockQueryService.getChargeGatewayStatus(eq(stripeCharge))).thenReturn(stripeChargeQueryResponse);
         when(worldpayCancelResponse.cancelStatus()).thenReturn(BaseCancelResponse.CancelStatus.CANCELLED);
 
-        GatewayResponse worldpayCancelResponse = responseBuilder().withResponse(this.worldpayCancelResponse).build();
+        GatewayResponseBuilder<BaseCancelResponse> responseBuilder = GatewayResponseBuilder.responseBuilder();
+        GatewayResponse<BaseCancelResponse> worldpayCancelResponse = responseBuilder.withResponse(this.worldpayCancelResponse).build();
         when(mockWorldpayPaymentProvider.cancel(any())).thenReturn(worldpayCancelResponse);
         BaseCancelResponse stripeCancelResponse = buildStripeCancelResponse(stripeCharge.getGatewayTransactionId());
-        when(mockStripePaymentProvider.cancel(any())).thenReturn(responseBuilder().withResponse(stripeCancelResponse).build());
+        when(mockStripePaymentProvider.cancel(any())).thenReturn(responseBuilder.withResponse(stripeCancelResponse).build());
 
         Map<String, Integer> result = cleanupService.sweepAndCleanupAuthorisationErrors(10);
 
@@ -151,7 +152,8 @@ class AuthorisationErrorGatewayCleanupServiceTest {
         when(mockQueryService.getChargeGatewayStatus(eq(stripeCharge))).thenReturn(stripeChargeQueryResponse);
 
         BaseCancelResponse stripeCancelResponse = buildStripeCancelResponse(stripeCharge.getGatewayTransactionId());
-        when(mockStripePaymentProvider.cancel(any())).thenReturn(responseBuilder().withResponse(stripeCancelResponse).build());
+        GatewayResponseBuilder<BaseCancelResponse> responseBuilder = GatewayResponseBuilder.responseBuilder();
+        when(mockStripePaymentProvider.cancel(any())).thenReturn(responseBuilder.withResponse(stripeCancelResponse).build());
 
         Map<String, Integer> result = cleanupService.sweepAndCleanupAuthorisationErrors(10);
 
@@ -234,7 +236,8 @@ class AuthorisationErrorGatewayCleanupServiceTest {
         when(mockQueryService.getChargeGatewayStatus(eq(worldpayCharge))).thenReturn(chargeQueryResponse);
 
         when(worldpayCancelResponse.cancelStatus()).thenReturn(BaseCancelResponse.CancelStatus.ERROR);
-        GatewayResponse cancelResponse = responseBuilder().withResponse(worldpayCancelResponse).build();
+        GatewayResponseBuilder<BaseCancelResponse> responseBuilder = GatewayResponseBuilder.responseBuilder();
+        GatewayResponse<BaseCancelResponse> cancelResponse = responseBuilder.withResponse(worldpayCancelResponse).build();
         when(mockWorldpayPaymentProvider.cancel(any())).thenReturn(cancelResponse);
 
         Map<String, Integer> result = cleanupService.sweepAndCleanupAuthorisationErrors(10);


### PR DESCRIPTION
## WHAT YOU DID
Similar to #6384, properly parameterises the response of `GatewayResponseBuilder#withResponse`, since this should return a `GatewayResponseBuilder` of the same type as the builder on which it is called. As before, I have limited the scope of the change to fix compilation errors and a small number of warnings.