### PR TITLE
PP-15119 convert Worldpay MOTO authorisation request record into XML

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthoriseRequest.java
@@ -15,7 +15,7 @@ public record WorldpayMotoAuthoriseRequest(
         String expiryDateYearFourDigits,
         String cardholderName,
         String cvc
-) {
+) implements WorldpayRequest {
     @Override
     public String toString(){
         return getClass().getSimpleName() + '[' 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayRequest.java
@@ -1,0 +1,4 @@
+package uk.gov.pay.connector.gateway.model.request.records;
+
+public interface WorldpayRequest {
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/templates/TemplateBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/templates/TemplateBuilder.java
@@ -5,6 +5,7 @@ import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
 import uk.gov.pay.connector.gateway.OrderRequestBuilder.TemplateData;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayRequest;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -24,6 +25,16 @@ public class TemplateBuilder implements PayloadBuilder {
         Writer responseWriter = new StringWriter();
         try {
             template.process(templateData, responseWriter);
+        } catch (TemplateException | IOException e) {
+            throw new RuntimeException("Could not render template " + template.getName(), e);
+        }
+        return responseWriter.toString();
+    }
+
+    public String buildWith(WorldpayRequest templateRecord) {
+        Writer responseWriter = new StringWriter();
+        try {
+            template.process(templateRecord, responseWriter);
         } catch (TemplateException | IOException e) {
             throw new RuntimeException("Could not render template " + template.getName(), e);
         }

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="${merchantCode}">
+    <submit>
+        <order orderCode="${orderCode}">
+            <description>${description}</description>
+            <amount currencyCode="GBP" exponent="2" value="${amountInPence}"/>
+            <paymentDetails>
+                <CARD-SSL>
+                    <cardNumber>${cardNumber}</cardNumber>
+                    <expiryDate>
+                        <date month="${expiryDateMonthTwoDigits}" year="${expiryDateYearFourDigits}"/>
+                    </expiryDate>
+                    <cardHolderName>${cardholderName}</cardHolderName>
+                    <cvc>${cvc}</cvc>
+                </CARD-SSL>
+            </paymentDetails>
+        </order>
+    </submit>
+</paymentService>

--- a/src/test/java/uk/gov/pay/connector/gateway/templates/TemplateBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/templates/TemplateBuilderTest.java
@@ -1,0 +1,98 @@
+package uk.gov.pay.connector.gateway.templates;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.xmlunit.assertj3.XmlAssert;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_MOTO_AUTHORISATION_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
+
+class TemplateBuilderTest {
+
+    private static final String CARD_NUMBER = "4242424242424242";
+    private static final String EXPIRY_DATE_MONTH = "11";
+    private static final String EXPIRY_DATE_YEAR = "2030";
+    private static final String CARDHOLDER_NAME = "Alec Barley";
+    private static final String CVC = "123";
+    private static final String ORDER_CODE = "MyUniqueTransactionId";
+    private static final String DESCRIPTION = "My description";
+    private static final String USERNAME = "username"; // pragma: allowlist secret
+    private static final String PASSWORD = "password"; // pragma: allowlist secret
+    private static final String MERCHANT_CODE = "MERCHANTCODE";
+    private static final long AMOUNT_IN_PENCE = 2000L;
+
+    @Nested
+    class MotoAuthorisationRequest {
+        @Test
+        void shouldGenerateValidAuthoriseOrderRequestForWorldpayMotoAuthorisationRequest() {
+            TemplateBuilder templateBuilder = new TemplateBuilder("/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx");
+            WorldpayMotoAuthoriseRequest motoOrder = createWorldpayMotoAuthoriseRequest();
+
+            XmlAssert.assertThat(templateBuilder.buildWith(motoOrder))
+                    .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_MOTO_AUTHORISATION_REQUEST))
+                    .areIdentical();
+        }
+    }
+    
+    @Nested
+    class TemplateBuilderAppliesAutoEscape {
+        @Test
+        void shouldGenerateValidAuthoriseOrderRequestWithAutoEscape() {
+            TemplateBuilder templateBuilder = new TemplateBuilder("/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx");
+            WorldpayMotoAuthoriseRequest motoOrder = new WorldpayMotoAuthoriseRequest(
+                    USERNAME,
+                    PASSWORD,
+                    "MERCHANT\"\"CODE",
+                    ORDER_CODE,
+                    DESCRIPTION,
+                    String.valueOf(AMOUNT_IN_PENCE),
+                    CARD_NUMBER,
+                    EXPIRY_DATE_MONTH,
+                    EXPIRY_DATE_YEAR,
+                    "Alec & Barley",
+                    CVC);
+            String renderedAuthoriseOrder = templateBuilder.buildWith(motoOrder);
+            assertThat(renderedAuthoriseOrder, containsString("MERCHANT&quot;&quot;CODE"));
+            assertThat(renderedAuthoriseOrder, containsString("Alec &amp; Barley"));
+        }
+    }
+    
+    @Nested
+    class InvalidActionsThrowingException {
+        @Test
+        void shouldThrowRuntimeExceptionWhenTemplateIsNotFound() {
+            var thrown = assertThrows(RuntimeException.class, () -> new TemplateBuilder("/worldpay/NonExistentOrderTemplate.xml"));
+            assertThat(thrown.getMessage(), is("Could not load template /worldpay/NonExistentOrderTemplate.xml in dir /templates"));
+        }
+        
+        @Test
+        void shouldThrowRuntimeExceptionWhenCannotRenderTemplate() {
+            TemplateBuilder templateBuilder = new TemplateBuilder("/worldpay/WorldpayCancelOrderTemplate.xml");
+            WorldpayMotoAuthoriseRequest motoOrder = createWorldpayMotoAuthoriseRequest();
+            
+            var thrown = assertThrows(RuntimeException.class, () -> {    templateBuilder.buildWith(motoOrder);
+            });
+            assertThat(thrown.getMessage(), is("Could not render template worldpay/WorldpayCancelOrderTemplate.xml"));
+        }
+    }
+
+    private WorldpayMotoAuthoriseRequest createWorldpayMotoAuthoriseRequest() {
+        return new WorldpayMotoAuthoriseRequest(
+                USERNAME,
+                PASSWORD,
+                MERCHANT_CODE,
+                ORDER_CODE,
+                DESCRIPTION,
+                String.valueOf(AMOUNT_IN_PENCE),
+                CARD_NUMBER,
+                EXPIRY_DATE_MONTH,
+                EXPIRY_DATE_YEAR,
+                CARDHOLDER_NAME,
+                CVC);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -61,6 +61,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_3DS_REQUEST_EXEMPTION_OPTIMISED = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-exemption-optimised.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_3DS_REQUEST_CORPORATE_EXEMPTION_AUTHORISATION = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-corporate-exemption-authorisation.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-with-reference-as-description.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_MOTO_AUTHORISATION_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-moto-request.xml";
 
     public static final String WORLDPAY_3DS_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-response.xml";
     public static final String WORLDPAY_3DS_FLEX_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-flex-response.xml";

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-moto-request.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-moto-request.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId">
+            <description>My description</description>
+            <amount currencyCode="GBP" exponent="2" value="2000"/>
+            <paymentDetails>
+                <CARD-SSL>
+                    <cardNumber>4242424242424242</cardNumber>
+                    <expiryDate>
+                        <date month="11" year="2030"/>
+                    </expiryDate>
+                    <cardHolderName>Alec Barley</cardHolderName>
+                    <cvc>123</cvc>
+                </CARD-SSL>
+            </paymentDetails>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
## WHAT YOU DID

Use Freemarker to convert the record WorldpayMotoAuthoriseRequest into an xml.

- Use TemplateBuilder as we eventually want to get rid of OrderRequestBuilder
- Use `ftlx` file extension for the template to ensure automatic escape (see https://freemarker.apache.org/docs/pgui_config_outputformatsautoesc.html)
- The code is adapted so that it can take a record as input (currently it can only take a TemplateData class)
- None of this new stuff is actually called from anywhere yet
