### PR TITLE
PP-15431 Added Idempotency Id mapping to Adyen requests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
@@ -10,7 +10,6 @@ import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.request.AdyenAuthorisationRequest;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenAuthoriseResponse;
 import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
-import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -49,7 +48,7 @@ public class AdyenAuthoriseHandler {
         logger.info("Calling Adyen for authorisation of charge");
         var authorisationRequest = new AdyenAuthorisationRequest(
                 getAuthUrl(adyenGatewayConfig, request),
-                getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive(), OrderRequestType.AUTHORISE, request.getGovUkPayPaymentId()),
+                getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive(), request.getRequestType(), request.getGovUkPayPaymentId()),
                 request.getGatewayAccount().getType(),
                 adyenRequestFactory.createPaymentRequest(request),
                 jsonObjectMapper);

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.request.AdyenAuthorisationRequest;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenAuthoriseResponse;
 import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -48,7 +49,7 @@ public class AdyenAuthoriseHandler {
         logger.info("Calling Adyen for authorisation of charge");
         var authorisationRequest = new AdyenAuthorisationRequest(
                 getAuthUrl(adyenGatewayConfig, request),
-                getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive()),
+                getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive(), OrderRequestType.AUTHORISE, request.getGovUkPayPaymentId()),
                 request.getGatewayAccount().getType(),
                 adyenRequestFactory.createPaymentRequest(request),
                 jsonObjectMapper);

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandler.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.request.AdyenCancelRequest;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -36,7 +37,7 @@ public class AdyenCancelHandler {
         GatewayResponseBuilder<BaseCancelResponse> responseBuilder = GatewayResponseBuilder.responseBuilder();
         var cancelRequest = new AdyenCancelRequest(
                 getCancelUrl(adyenGatewayConfig, request),
-                getHeaders(adyenGatewayConfig, request.isLiveAccount()),
+                getHeaders(adyenGatewayConfig, request.isLiveAccount(), OrderRequestType.CANCEL, request.getExternalChargeId()),
                 adyenRequestFactory.createPaymentCancelRequest(request),
                 request.getGatewayAccount().getType(),
                 jsonObjectMapper);

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandler.java
@@ -37,7 +37,7 @@ public class AdyenCancelHandler {
         GatewayResponseBuilder<BaseCancelResponse> responseBuilder = GatewayResponseBuilder.responseBuilder();
         var cancelRequest = new AdyenCancelRequest(
                 getCancelUrl(adyenGatewayConfig, request),
-                getHeaders(adyenGatewayConfig, request.isLiveAccount(), OrderRequestType.CANCEL, request.getExternalChargeId()),
+                getHeaders(adyenGatewayConfig, request.isLiveAccount(), request.getRequestType(), request.getExternalChargeId()),
                 adyenRequestFactory.createPaymentCancelRequest(request),
                 request.getGatewayAccount().getType(),
                 jsonObjectMapper);

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandler.java
@@ -15,7 +15,6 @@ import uk.gov.pay.connector.gateway.adyen.response.AdyenCaptureResponse;
 import uk.gov.pay.connector.gateway.adyen.response.json.AdyenError;
 import uk.gov.pay.connector.gateway.adyen.response.json.CaptureResponseBody;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil;
-import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
@@ -50,7 +49,7 @@ public class AdyenCaptureHandler implements CaptureHandler {
 
         var adyenCaptureRequest = new AdyenCaptureRequest(
                 AdyenRequestUtil.getCaptureUrl(adyenGatewayConfig, request),
-                AdyenRequestUtil.getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive(), OrderRequestType.CAPTURE, request.getExternalId()),
+                AdyenRequestUtil.getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive(), request.getRequestType(), request.getExternalId()),
                 adyenRequestFactory.createCapturePayload(request),
                 request.getGatewayAccount().getType(),
                 jsonObjectMapper);

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandler.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.gateway.adyen.response.AdyenCaptureResponse;
 import uk.gov.pay.connector.gateway.adyen.response.json.AdyenError;
 import uk.gov.pay.connector.gateway.adyen.response.json.CaptureResponseBody;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
@@ -49,7 +50,7 @@ public class AdyenCaptureHandler implements CaptureHandler {
 
         var adyenCaptureRequest = new AdyenCaptureRequest(
                 AdyenRequestUtil.getCaptureUrl(adyenGatewayConfig, request),
-                AdyenRequestUtil.getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive()),
+                AdyenRequestUtil.getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive(), OrderRequestType.CAPTURE, request.getExternalId()),
                 adyenRequestFactory.createCapturePayload(request),
                 request.getGatewayAccount().getType(),
                 jsonObjectMapper);

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenRefundHandler.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.gateway.adyen.response.AdyenRefundResponse;
 import uk.gov.pay.connector.gateway.adyen.response.json.AdyenError;
 import uk.gov.pay.connector.gateway.adyen.response.json.RefundResponseBody;
 import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -50,7 +51,7 @@ public class AdyenRefundHandler implements RefundHandler {
     public GatewayRefundResponse refund(RefundGatewayRequest request) {
         var adyenRefundRequest = new AdyenRefundRequest(
                 getRefundUrl(adyenGatewayConfig, request),
-                getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive()),
+                getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive(), OrderRequestType.REFUND, request.getRefundExternalId()),
                 adyenRequestFactory.createRefundRequestPayload(request),
                 request.getGatewayAccount().getType(),
                 jsonObjectMapper);

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenRefundHandler.java
@@ -14,7 +14,6 @@ import uk.gov.pay.connector.gateway.adyen.response.AdyenRefundResponse;
 import uk.gov.pay.connector.gateway.adyen.response.json.AdyenError;
 import uk.gov.pay.connector.gateway.adyen.response.json.RefundResponseBody;
 import uk.gov.pay.connector.gateway.model.GatewayError;
-import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -51,7 +50,7 @@ public class AdyenRefundHandler implements RefundHandler {
     public GatewayRefundResponse refund(RefundGatewayRequest request) {
         var adyenRefundRequest = new AdyenRefundRequest(
                 getRefundUrl(adyenGatewayConfig, request),
-                getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive(), OrderRequestType.REFUND, request.getRefundExternalId()),
+                getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive(), request.getRequestType(), request.getRefundExternalId()),
                 adyenRequestFactory.createRefundRequestPayload(request),
                 request.getGatewayAccount().getType(),
                 jsonObjectMapper);

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.adyen.utils;
 
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -43,8 +44,8 @@ public class AdyenRequestUtil {
         return URI.create(getBaseCheckoutUrl(config, request.getGatewayAccount().isLive()) + path);
     }
 
-    public static Map<String, String> getHeaders(AdyenGatewayConfig config, boolean isLive, OrderRequestType requestType, String idempotencyKey) {
-        return Map.of("X-API-Key", getCompanyApiKey(config, isLive), 
-                "Idempotency-Key", format("%s-%s", requestType.toString(), idempotencyKey));
+    public static Map<String, String> getHeaders(AdyenGatewayConfig config, boolean isLive, GatewayOperation requestType, String idempotencyKey) {
+        return Map.of("X-API-Key", getCompanyApiKey(config, isLive),
+                "Idempotency-Key", format("%s-%s", requestType.getConfigKey(), idempotencyKey));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.adyen.utils;
 
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
@@ -10,6 +11,7 @@ import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import java.net.URI;
 import java.util.Map;
 
+import static java.lang.String.format;
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getBaseCheckoutUrl;
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getCompanyApiKey;
 
@@ -41,7 +43,8 @@ public class AdyenRequestUtil {
         return URI.create(getBaseCheckoutUrl(config, request.getGatewayAccount().isLive()) + path);
     }
 
-    public static Map<String, String> getHeaders(AdyenGatewayConfig config, boolean isLive) {
-        return Map.of("X-API-Key", getCompanyApiKey(config, isLive));
+    public static Map<String, String> getHeaders(AdyenGatewayConfig config, boolean isLive, OrderRequestType requestType, String idempotencyKey) {
+        return Map.of("X-API-Key", getCompanyApiKey(config, isLive), 
+                "Idempotency-Key", format("%s-%s", requestType.toString(), idempotencyKey));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
@@ -30,9 +30,8 @@ import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -51,6 +50,8 @@ class AdyenAuthoriseHandlerTest {
             "balance_account_id");
     public static final String LIVE_ADYEN_CHECKOUT_BASE_URL = "https://example.com/live/v71";
     public static final String TEST_ADYEN_CHECKOUT_BASE_URL = "https://example.com/test/v71";
+    private static final String TEST_API_KEY = "test-api-key"; // pragma: allowlist secret
+    
     @Mock
     private GatewayClient mockClient;
     @Mock
@@ -78,7 +79,7 @@ class AdyenAuthoriseHandlerTest {
         ApiKeys mockApiKeys = mock(ApiKeys.class);
         ApiKeys.CompanyAccountApiKeys mockCompanyApiKeys = mock(ApiKeys.CompanyAccountApiKeys.class);
         when(mockApiKeys.companyAccount()).thenReturn(mockCompanyApiKeys);
-        when(mockCompanyApiKeys.test()).thenReturn("test");
+        when(mockCompanyApiKeys.test()).thenReturn(TEST_API_KEY);
         when(mockAdyenGatewayConfig.getApiKeys()).thenReturn(mockApiKeys);
         when(mockConfig.getAdyenGatewayConfig()).thenReturn(mockAdyenGatewayConfig);
 
@@ -121,6 +122,9 @@ class AdyenAuthoriseHandlerTest {
         then(mockClient).should().postRequestFor(captor.capture());
         String payload = captor.getValue().getGatewayOrder().getPayload();
         JsonAssert.with(payload).assertNotDefined("$.billingAddress");
+        var headers = captor.getValue().getHeaders();
+        assertThat(headers, hasEntry("X-API-Key", TEST_API_KEY));
+        assertThat(headers, hasEntry("Idempotency-Key", "authorise-" + authoriseRequest.getGovUkPayPaymentId()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
@@ -30,7 +30,9 @@ import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
@@ -89,6 +89,24 @@ class AdyenAuthoriseHandlerTest {
     }
 
     @Test
+    void should_send_request_to_Adyen_with_api_key_and_idempotency_key_headers() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        givenAdyenReturnsASuccessResponse();
+
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withAddress(null)
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .build();
+        authoriseHandler.authorise(authoriseRequest);
+
+        then(mockClient).should().postRequestFor(captor.capture());
+        var headers = captor.getValue().getHeaders();
+        assertThat(headers, hasEntry("X-API-Key", TEST_API_KEY));
+        assertThat(headers, hasEntry("Idempotency-Key", "auth-" + authoriseRequest.getGovUkPayPaymentId()));
+    }
+
+    @Test
     void should_send_request_to_Adyen_with_full_billing_address() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
         givenAdyenReturnsASuccessResponse();
 
@@ -124,9 +142,6 @@ class AdyenAuthoriseHandlerTest {
         then(mockClient).should().postRequestFor(captor.capture());
         String payload = captor.getValue().getGatewayOrder().getPayload();
         JsonAssert.with(payload).assertNotDefined("$.billingAddress");
-        var headers = captor.getValue().getHeaders();
-        assertThat(headers, hasEntry("X-API-Key", TEST_API_KEY));
-        assertThat(headers, hasEntry("Idempotency-Key", "authorise-" + authoriseRequest.getGovUkPayPaymentId()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
@@ -141,6 +141,7 @@ class AdyenCancelHandlerTest {
                 .postRequestFor(captor.capture());
         var headers = captor.getValue().getHeaders();
         assertThat(headers, hasEntry("X-API-Key", expectedApiKey));
+        assertThat(headers, hasEntry("Idempotency-Key", "cancel-" + request.getExternalChargeId()));
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
@@ -129,7 +129,7 @@ class AdyenCancelHandlerTest {
             "LIVE," + LIVE_COMPANY_ACCOUNT_API_KEY,
             "TEST," + TEST_COMPANY_ACCOUNT_API_KEY
     })
-    void should_POST_with_company_API_key_as_X_API_Key_header(GatewayAccountType gatewayAccountType, String expectedApiKey) throws Exception {
+    void should_POST_with_company_API_key_as_X_API_Key_header_And_Idempotency_Key_Header(GatewayAccountType gatewayAccountType, String expectedApiKey) throws Exception {
         var request = CancelGatewayRequest.valueOf(
                 aValidChargeEntity()
                         .withGatewayAccountEntity(makeGatewayAccountEntityForAccountType(gatewayAccountType))

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandlerTest.java
@@ -23,8 +23,8 @@ import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.when;
 class AdyenCaptureHandlerTest {
     public static final String LIVE_ADYEN_CHECKOUT_BASE_URL = "https://example.com/live/v71";
     public static final String TEST_ADYEN_CHECKOUT_BASE_URL = "https://example.com/test/v71";
+    private static final String TEST_API_KEY = "test-api-key"; // pragma: allowlist secret
     @Mock
     private GatewayClient mockClient;
     @Mock
@@ -57,7 +58,7 @@ class AdyenCaptureHandlerTest {
         ApiKeys mockApiKeys = mock(ApiKeys.class);
         ApiKeys.CompanyAccountApiKeys mockCompanyApiKeys = mock(ApiKeys.CompanyAccountApiKeys.class);
         when(mockApiKeys.companyAccount()).thenReturn(mockCompanyApiKeys);
-        when(mockCompanyApiKeys.test()).thenReturn("test");
+        when(mockCompanyApiKeys.test()).thenReturn(TEST_API_KEY);
         when(mockAdyenGatewayConfig.getApiKeys()).thenReturn(mockApiKeys);
         when(mockConfig.getAdyenGatewayConfig()).thenReturn(mockAdyenGatewayConfig);
 
@@ -77,6 +78,10 @@ class AdyenCaptureHandlerTest {
         JsonAssert.with(payload).assertThat("$.merchantAccount", is("test"));
         JsonAssert.with(payload).assertThat("$.amount.value", is(500));
         JsonAssert.with(payload).assertThat("$.amount.currency", is("GBP"));
+        var headers = captor.getValue().getHeaders();
+        assertThat(headers, hasEntry("X-API-Key", TEST_API_KEY));
+        assertThat(headers, hasEntry("Idempotency-Key", "capture-" + captureRequest.getExternalId()));
+
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandlerTest.java
@@ -23,7 +23,8 @@ import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandlerTest.java
@@ -79,10 +79,24 @@ class AdyenCaptureHandlerTest {
         JsonAssert.with(payload).assertThat("$.merchantAccount", is("test"));
         JsonAssert.with(payload).assertThat("$.amount.value", is(500));
         JsonAssert.with(payload).assertThat("$.amount.currency", is("GBP"));
+    }
+
+    @Test
+    void should_send_a_capture_request_with_api_key_and_idempotency_key_headers() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
+        givenAdyenReturnsASuccessResponse();
+
+        CaptureGatewayRequest captureRequest = createCaptureRequest();
+        captureHandler.capture(captureRequest);
+
+        then(mockClient).should().postRequestFor(captor.capture());
+        String payload = captor.getValue().getGatewayOrder().getPayload();
+        JsonAssert.with(payload).assertThat("$.merchantAccount", is("test"));
+        JsonAssert.with(payload).assertThat("$.amount.value", is(500));
+        JsonAssert.with(payload).assertThat("$.amount.currency", is("GBP"));
         var headers = captor.getValue().getHeaders();
         assertThat(headers, hasEntry("X-API-Key", TEST_API_KEY));
         assertThat(headers, hasEntry("Idempotency-Key", "capture-" + captureRequest.getExternalId()));
-
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenRefundHandlerTest.java
@@ -101,6 +101,22 @@ class AdyenRefundHandlerTest {
     }
 
     @Test
+    void shouldSendRefundRequestToCorrectAdyenEndpointWithAPIKeyAndIdempotencyHeaders() throws Exception {
+        when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
+        givenAdyenReturnsSuccessfulRefundResponse();
+        var request = buildRefundGatewayRequest(1000L);
+
+        refundHandler.refund(request);
+
+        then(mockClient).should().postRequestFor(captor.capture());
+        assertThat(captor.getValue().getUrl().toString(),
+                is(TEST_CHECKOUT_BASE_URL + "/payments/" + PAYMENT_PSP_REFERENCE + "/refunds"));
+        var headers = captor.getValue().getHeaders();
+        assertThat(headers, hasEntry("X-API-Key", TEST_API_KEY));
+        assertThat(headers, hasEntry("Idempotency-Key", "refund-" + request.getRefundExternalId()));
+    }
+
+    @Test
     void shouldSendCorrectPayloadToAdyenForFullRefund() throws Exception {
         when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
         givenAdyenReturnsSuccessfulRefundResponse();
@@ -135,9 +151,8 @@ class AdyenRefundHandlerTest {
     void shouldSendCorrectPayloadToAdyenForPartialRefund() throws Exception {
         when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
         givenAdyenReturnsSuccessfulRefundResponse();
-        var request = buildRefundGatewayRequest(100L);
 
-        refundHandler.refund(request);
+        refundHandler.refund(buildRefundGatewayRequest(100L));
 
         then(mockClient).should().postRequestFor(captor.capture());
         String payload = captor.getValue().getGatewayOrder().getPayload();
@@ -147,10 +162,6 @@ class AdyenRefundHandlerTest {
                 .assertThat("$.amount.currency", is("GBP"))
                 .assertThat("$.reference", is(REFUND_EXTERNAL_ID))
                 .assertThat("$.store", is(STORE_ID));
-        var headers = captor.getValue().getHeaders();
-        assertThat(headers, hasEntry("X-API-Key", TEST_API_KEY));
-        assertThat(headers, hasEntry("Idempotency-Key", "refund-" + request.getRefundExternalId()));
-
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenRefundHandlerTest.java
@@ -29,6 +29,7 @@ import uk.gov.pay.connector.util.JsonObjectMapper;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
@@ -134,8 +135,9 @@ class AdyenRefundHandlerTest {
     void shouldSendCorrectPayloadToAdyenForPartialRefund() throws Exception {
         when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
         givenAdyenReturnsSuccessfulRefundResponse();
+        var request = buildRefundGatewayRequest(100L);
 
-        refundHandler.refund(buildRefundGatewayRequest(100L));
+        refundHandler.refund(request);
 
         then(mockClient).should().postRequestFor(captor.capture());
         String payload = captor.getValue().getGatewayOrder().getPayload();
@@ -145,6 +147,10 @@ class AdyenRefundHandlerTest {
                 .assertThat("$.amount.currency", is("GBP"))
                 .assertThat("$.reference", is(REFUND_EXTERNAL_ID))
                 .assertThat("$.store", is(STORE_ID));
+        var headers = captor.getValue().getHeaders();
+        assertThat(headers, hasEntry("X-API-Key", TEST_API_KEY));
+        assertThat(headers, hasEntry("Idempotency-Key", "refund-" + request.getRefundExternalId()));
+
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.app.adyen.BaseUrls;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -125,10 +126,10 @@ class AdyenRequestUtilTest {
         when(mockCompanyApiKeys.test()).thenReturn("test");
         when(mockAdyenGatewayConfig.getApiKeys()).thenReturn(mockApiKeys);
 
-        var headers = AdyenRequestUtil.getHeaders(mockAdyenGatewayConfig, mockAuthoriseRequest.getGatewayAccount().isLive(), OrderRequestType.AUTHORISE, "some-unique-key");
+        var headers = AdyenRequestUtil.getHeaders(mockAdyenGatewayConfig, mockAuthoriseRequest.getGatewayAccount().isLive(), GatewayOperation.AUTHORISE, "some-unique-key");
 
         assertThat(headers, hasEntry("X-API-Key", "test"));
-        assertThat(headers, hasEntry("Idempotency-Key", "authorise-some-unique-key"));
+        assertThat(headers, hasEntry("Idempotency-Key", "auth-some-unique-key"));
     }
 
     private void stubCheckoutBaseUrls(String test, String live) {

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
@@ -118,7 +118,7 @@ class AdyenRequestUtilTest {
     }
 
     @Test
-    void should_create_api_key_headers_for_checkout_URL() {
+    void should_create_API_key_and_idempotency_key_headers_for_checkout_URL() {
         ApiKeys mockApiKeys = mock(ApiKeys.class);
         ApiKeys.CompanyAccountApiKeys mockCompanyApiKeys = mock(ApiKeys.CompanyAccountApiKeys.class);
         when(mockApiKeys.companyAccount()).thenReturn(mockCompanyApiKeys);

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtilTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.app.adyen.BaseUrls;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
@@ -124,9 +125,10 @@ class AdyenRequestUtilTest {
         when(mockCompanyApiKeys.test()).thenReturn("test");
         when(mockAdyenGatewayConfig.getApiKeys()).thenReturn(mockApiKeys);
 
-        var headers = AdyenRequestUtil.getHeaders(mockAdyenGatewayConfig, mockAuthoriseRequest.getGatewayAccount().isLive());
+        var headers = AdyenRequestUtil.getHeaders(mockAdyenGatewayConfig, mockAuthoriseRequest.getGatewayAccount().isLive(), OrderRequestType.AUTHORISE, "some-unique-key");
 
         assertThat(headers, hasEntry("X-API-Key", "test"));
+        assertThat(headers, hasEntry("Idempotency-Key", "authorise-some-unique-key"));
     }
 
     private void stubCheckoutBaseUrls(String test, String live) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -77,6 +77,7 @@ class AdyenCardResourceAuthoriseIT {
 
         app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
                 .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
                 .withRequestBody(equalToJson(
                         load(ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS)
                                 .formatted(chargeId, "Ecommerce"))));

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -77,7 +77,7 @@ class AdyenCardResourceAuthoriseIT {
 
         app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
                 .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
-                .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
+                .withHeader("Idempotency-Key", equalTo("auth-" + chargeId))
                 .withRequestBody(equalToJson(
                         load(ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS)
                                 .formatted(chargeId, "Ecommerce"))));

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenRefundSubmitResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenRefundSubmitResourceIT.java
@@ -152,6 +152,7 @@ class AdyenRefundSubmitResourceIT {
     private void verifyAdyenRefundRequest(long refundAmount, String refundId) {
         app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments/" + testCharge.getTransactionId() + "/refunds"))
                 .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withHeader("Idempotency-Key", equalTo("refund-" + refundId))
                 .withRequestBody(matchingJsonPath("$.amount.currency", equalTo("GBP")))
                 .withRequestBody(matchingJsonPath("$.amount.value", equalTo(String.valueOf(refundAmount))))
                 .withRequestBody(matchingJsonPath("$.merchantAccount", equalTo("adyen-test-merchant-account-id")))


### PR DESCRIPTION
## WHAT YOU DID
- Added Idempotency Id mapping to Adyen requests for authorise, capture, cancel and refund
- Idempotency key is made up of the operation name prepended to charge external id (for authorise, capture and cancel) and refund external id (for refund) to ensure it's always unique for each operation
