### PR TITLE
PP-15148 send 3ds info to adyen and map to 3ds required

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -153,42 +153,42 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4001
+        "line_number": 4004
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4431
+        "line_number": 4434
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4467
+        "line_number": 4470
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 5399
+        "line_number": 5402
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 5899
+        "line_number": 5902
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 5910
+        "line_number": 5913
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1086,5 +1086,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-26T15:53:20Z"
+  "generated_at": "2026-06-09T17:50:11Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3590,6 +3590,9 @@ components:
         ip_address:
           type: string
           example: 127.0.0.1
+        js_enabled:
+          type: boolean
+          example: true
         js_navigator_language:
           type: string
           example: en-GB

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -8,6 +8,8 @@ import uk.gov.pay.connector.gateway.adyen.request.json.BillingAddress;
 import uk.gov.pay.connector.gateway.adyen.request.json.CancelRequestPayload;
 import uk.gov.pay.connector.gateway.adyen.request.json.CaptureRequestPayload;
 import uk.gov.pay.connector.gateway.adyen.request.json.PaymentMethod;
+import uk.gov.pay.connector.gateway.adyen.response.json.BrowserInfo;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.adyen.request.json.RefundRequestPayload;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -33,6 +35,7 @@ public class AdyenRequestFactory {
 
     public AuthoriseRequestPayload createPaymentRequest(CardAuthorisationGatewayRequest request) {
         var authCardDetails = request.getAuthCardDetails();
+        boolean isMoto = "Moto".equals(getShopperInteraction(request));
 
         var mappedAddress = authCardDetails.getAddress()
                 .map(AdyenRequestFactory::mapToBillingAddress)
@@ -57,7 +60,11 @@ public class AdyenRequestFactory {
                 getShopperInteraction(request),
                 adyenCredentials.storeId(),
                 "Web",
-                new HashMap<>(Map.of("manualCapture", "true"))
+                new HashMap<>(Map.of("manualCapture", "true")),
+                 isMoto ? null : mapToBrowserInfo(authCardDetails), 
+                 isMoto ? null : configuration.getLinks().getFrontendUrl(),
+                 isMoto ? null : request.getEmail(),
+                 isMoto ? null : authCardDetails.getIpAddress().orElse(null)
         );
     }
 
@@ -108,5 +115,18 @@ public class AdyenRequestFactory {
             throw new IllegalArgumentException("Expected provided GatewayCredentials to be of type AdyenCredentials");
         }
         return (AdyenCredentials) gatewayCredentials;
+    }
+
+    private BrowserInfo mapToBrowserInfo(AuthCardDetails authCardDetails) {
+        return new BrowserInfo(
+                authCardDetails.getAcceptHeader(),
+                authCardDetails.getJsScreenColorDepth().map(Integer::valueOf).orElse(null),
+                authCardDetails.getJsEnabled(),
+                authCardDetails.getJsNavigatorLanguage().map(String::valueOf).orElse(null),
+                authCardDetails.getJsScreenHeight().map(Integer::valueOf).orElse(null),
+                authCardDetails.getJsScreenWidth().map(Integer::valueOf).orElse(null),
+                authCardDetails.getJsTimezoneOffsetMins().map(Integer::valueOf).orElse(null),
+                authCardDetails.getUserAgentHeader()
+        );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/AuthoriseRequestPayload.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/AuthoriseRequestPayload.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.adyen.request.json;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.connector.gateway.adyen.response.json.BrowserInfo;
 
 import java.util.HashMap;
 
@@ -26,5 +27,14 @@ public record AuthoriseRequestPayload(
         @JsonProperty("channel")
         String channel,
         @JsonProperty("additionalData")
-        HashMap<String,String> additionalData) {
+        HashMap<String,String> additionalData,
+        @JsonProperty("browserInfo")
+        BrowserInfo browserInfo,
+        @JsonProperty("origin")
+        String origin,
+        @JsonProperty("shopperEmail")
+        String shopperEmail,
+        @JsonProperty("shopperIP")
+        String shopperIP
+) {
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/BrowserInfo.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/BrowserInfo.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.gateway.adyen.response.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record BrowserInfo(
+        @JsonProperty("acceptHeader") String acceptHeader,
+        @JsonProperty("colorDepth") Integer colorDepth,
+        @JsonProperty("javaEnabled") Boolean javaEnabled,
+        @JsonProperty("language") String language,
+        @JsonProperty("screenHeight") Integer screenHeight,
+        @JsonProperty("screenWidth") Integer screenWidth,
+        @JsonProperty("timeZoneOffset") Integer timeZoneOffset,
+        @JsonProperty("userAgent") String userAgent
+) {}

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -57,7 +57,9 @@ public class AuthCardDetails {
     private String jsTimezoneOffsetMins;
     @Schema(example = "fr;q=0.9, fr-CH;q=1.0, en;q=0.8, de;q=0.7, *;q=0.5")
     private String acceptLanguageHeader;
-
+    @Schema(example = "true")
+    private Boolean jsEnabled;
+    
     public static AuthCardDetails anAuthCardDetails() {
         return new AuthCardDetails();
     }
@@ -254,6 +256,15 @@ public class AuthCardDetails {
         return Optional.ofNullable(jsNavigatorLanguage);
     }
 
+    public Boolean getJsEnabled() {
+        return jsEnabled;
+    }
+
+    @JsonProperty("js_enabled")
+    public void setJsEnabled(Boolean jsEnabled) {
+        this.jsEnabled = jsEnabled;
+    }
+    
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
@@ -40,6 +40,16 @@ import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCar
 
 class AdyenRequestFactoryTest {
 
+    final String acceptHeader = "text/html";
+    final String userAgent = "Mozilla/5.0";
+    final String shopperIp = "127.0.0.1";
+    final String language = "en-GB";
+    final String colorDepth = "24";
+    final String screenHeight = "900";
+    final String screenWidth = "1440";
+    final String timezoneOffset = "-60";
+    final String shopperEmail = "test@example.com";
+   
     public static final BillingAddress FULL_BILLING_ADDRESS = new BillingAddress(
             "line1",
             "line2",
@@ -226,6 +236,54 @@ class AdyenRequestFactoryTest {
     }
 
 
+    @Test
+    void should_include_browser_info_origin_shopper_email_and_ip_for_web_payment() {
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withAcceptHeader(acceptHeader)
+                        .withUserAgentHeader(userAgent)
+                        .withIpAddress(shopperIp)
+                        .withJsNavigatorLanguage(language)
+                        .withJsScreenColorDepth(colorDepth)
+                        .withJsScreenHeight(screenHeight)
+                        .withJsScreenWidth(screenWidth)
+                        .withJsTimezoneOffsetMins(timezoneOffset)
+                        .withJsEnabled(true)
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .withEmail(shopperEmail)
+                .build();
+        var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
+
+        assertThat(request.browserInfo().acceptHeader(), is(acceptHeader));
+        assertThat(request.browserInfo().colorDepth(), is(Integer.valueOf(colorDepth)));
+        assertThat(request.browserInfo().language(), is(language));
+        assertThat(request.browserInfo().screenHeight(), is(Integer.valueOf(screenHeight)));
+        assertThat(request.browserInfo().screenWidth(), is(Integer.valueOf(screenWidth)));
+        assertThat(request.browserInfo().timeZoneOffset(), is(Integer.valueOf(timezoneOffset)));
+        assertThat(request.browserInfo().userAgent(), is(userAgent));
+        assertThat(request.shopperEmail(), is(shopperEmail));
+        assertThat(request.shopperIP(), is(shopperIp));
+    }
+
+    @Test
+    void should_not_include_browser_info_origin_shopper_email_and_ip_for_moto_payment() {
+        var authoriseRequest = aCardAuthorisationGatewayRequest().withMoto(true)
+                .withAuthCardDetails(anAuthCardDetails()
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .withEmail("test@example.com")
+                .build();
+
+        var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
+
+        assertThat(request.shopperInteraction(), is("Moto"));
+        assertThat(request.browserInfo(), nullValue());
+        assertThat(request.origin(), nullValue());
+        assertThat(request.shopperEmail(), nullValue());
+        assertThat(request.shopperIP(), nullValue());
+    }
+    
     private static CancelGatewayRequest makeCancelGatewayRequestWithExternalChargeId(String externalChargeId) {
         var chargeEntity = aValidChargeEntity()
                 .withExternalId(externalChargeId)

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenAuthorisationRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenAuthorisationRequestTest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 import uk.gov.pay.connector.gateway.adyen.request.json.AuthoriseRequestPayload;
 import uk.gov.pay.connector.gateway.adyen.request.json.BillingAddress;
 import uk.gov.pay.connector.gateway.adyen.request.json.PaymentMethod;
+import uk.gov.pay.connector.gateway.adyen.response.json.BrowserInfo;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import java.net.URI;
@@ -54,7 +55,18 @@ class AdyenAuthorisationRequestTest {
                 .assertThat("$.returnUrl", is("frontend-3ds-url"))
                 .assertThat("$.shopperInteraction", is("Ecommerce"))
                 .assertThat("$.store", is("store-id"))
-                .assertThat("$.channel", is("Web"));
+                .assertThat("$.channel", is("Web"))
+                .assertThat("$.browserInfo.acceptHeader", is("text/html"))
+                .assertThat("$.browserInfo.colorDepth", is(24))
+                .assertThat("$.browserInfo.javaEnabled", is(false))
+                .assertThat("$.browserInfo.language", is("en-GB"))
+                .assertThat("$.browserInfo.screenHeight", is(900))
+                .assertThat("$.browserInfo.screenWidth", is(1440))
+                .assertThat("$.browserInfo.timeZoneOffset", is(-60))
+                .assertThat("$.browserInfo.userAgent", is("Mozilla/5.0"))
+                .assertThat("$.origin", is("https://frontend.pay.service.gov.uk"))
+                .assertThat("$.shopperEmail", is("test@example.com"))
+                .assertThat("$.shopperIP", is("127.0.0.1"));
     }
 
     private AdyenAuthorisationRequest buildValidRequestWithBillingAddress() {
@@ -82,6 +94,15 @@ class AdyenAuthorisationRequestTest {
                 "John Doe",
                 "4444333322221111",
                 "scheme");
+        
+        var browserInfo = new BrowserInfo("text/html", 
+                24,
+                false,
+                "en-GB",
+                900, 
+                1440, 
+                -60,
+                "Mozilla/5.0");
 
         return new AuthoriseRequestPayload(
                 new Amount("GBP", 1000L),
@@ -93,7 +114,11 @@ class AdyenAuthorisationRequestTest {
                 "Ecommerce",
                 "store-id",
                 "Web",
-                new HashMap<>(Map.of("manualCapture", "true"))
+                new HashMap<>(Map.of("manualCapture", "true")),
+                browserInfo,
+                "https://frontend.pay.service.gov.uk",
+                "test@example.com",
+                "127.0.0.1"
         );
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -26,7 +26,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.it.base.AddChargeParameters.Builder.anAddChargeParameters;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS_AND_BROWSER_INFO;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
@@ -78,16 +78,50 @@ class AdyenCardResourceAuthoriseIT {
         app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
                 .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
                 .withHeader("Idempotency-Key", equalTo("auth-" + chargeId))
-                .withRequestBody(equalToJson(
-                        load(ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS)
-                                .formatted(chargeId, "Ecommerce"))));
+                .withRequestBody(matchingJsonPath("$.billingAddress.houseNumberOrName", equalTo("line1")))
+                .withRequestBody(matchingJsonPath("$.billingAddress.street", equalTo("line2")))
+                .withRequestBody(matchingJsonPath("$.billingAddress.city", equalTo("city")))
+                .withRequestBody(matchingJsonPath("$.billingAddress.country", equalTo("country")))
+                .withRequestBody(matchingJsonPath("$.billingAddress.postalCode", equalTo("postcode"))));
 
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
         assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
     }
+    @Test
+    void should_send_browser_info_origin_email_and_ip_to_adyen_for_web_payment() {
+        var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
+        var pspReferenceFromAdyen = "993617895215577D";
 
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
+
+        var authCardDetails = anAuthCardDetails()
+                .withAcceptHeader("text/html")
+                .withUserAgentHeader("Mozilla/5.0")
+                .withIpAddress("127.0.0.1")
+                .withJsNavigatorLanguage("en-GB")
+                .withJsScreenColorDepth("24")
+                .withJsScreenHeight("900")
+                .withJsScreenWidth("1440")
+                .withJsTimezoneOffsetMins("-60")
+                .withJsEnabled(true)
+                .build();
+
+        app.givenSetup()
+                .body(authCardDetails)
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(200)
+                .body("status", is("AUTHORISATION SUCCESS"));
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
+                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withHeader("Idempotency-Key", equalTo("auth-" + chargeId))
+                .withRequestBody(equalToJson(
+                        load(ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS_AND_BROWSER_INFO)
+                                .formatted(chargeId, "Ecommerce"))));
+    }
     @Test
     void successful_authorisation_of_a_payment_without_a_billing_address() {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -32,6 +32,7 @@ public final class AuthCardDetailsFixture {
     private String jsScreenHeight;
     private String jsScreenWidth;
     private String jsTimezoneOffsetMins;
+    private Boolean jsEnabled;
 
     private AuthCardDetailsFixture() {
     }
@@ -130,6 +131,11 @@ public final class AuthCardDetailsFixture {
         return this;
     }    
     
+    public  AuthCardDetailsFixture withJsEnabled(boolean jsEnabled) {
+        this.jsEnabled = jsEnabled;
+        return this;
+    }
+    
     public AuthCardDetailsFixture withAcceptLanguageHeader(String acceptLanguageHeader) {
         this.acceptLanguageHeader = acceptLanguageHeader;
         return this;
@@ -181,6 +187,7 @@ public final class AuthCardDetailsFixture {
         authCardDetails.setJsScreenHeight(jsScreenHeight);
         authCardDetails.setJsScreenWidth(jsScreenWidth);
         authCardDetails.setJsTimezoneOffsetMins(jsTimezoneOffsetMins);
+        authCardDetails.setJsEnabled(jsEnabled);
         return authCardDetails;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -133,6 +133,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_SEARCH_TRANSFERS_EMPTY_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/search_transfers_empty_response.json";
 
     public static final String ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS = TEMPLATE_BASE_NAME + "/adyen/authorisation_request_with_full_billing_address.json";
+    public static final String ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS_AND_BROWSER_INFO = TEMPLATE_BASE_NAME + "/adyen/authorisation_request_with_full_billing_address_and_browser_info.json";
     public static final String ADYEN_NOTIFICATION = TEMPLATE_BASE_NAME + "/adyen/notification.json";
     public static final String ADYEN_CAPTURE_SUCCESS_NOTIFICATION = TEMPLATE_BASE_NAME + "/adyen/capture-successful.json";
     public static final String ADYEN_CREATE_LEGAL_ENTITY_REQUEST = TEMPLATE_BASE_NAME + "/adyen/create_legal_entity_request.json";

--- a/src/test/resources/templates/adyen/authorisation_request_with_full_billing_address_and_browser_info.json
+++ b/src/test/resources/templates/adyen/authorisation_request_with_full_billing_address_and_browser_info.json
@@ -1,0 +1,42 @@
+{
+  "amount": {
+    "currency": "GBP",
+    "value": 6234
+  },
+  "billingAddress" : {
+    "houseNumberOrName" : "125 Kingsway",
+    "street" : "Aviation House",
+    "city" : "London",
+    "country" : "GB",
+    "postalCode" : "WC2B 6NH"
+  },
+  "merchantAccount": "adyen-test-merchant-account-id",
+  "paymentMethod": {
+    "cvc" : "123",
+    "expiryMonth" : "12",
+    "expiryYear" : "2099",
+    "holderName" : "Mr Test",
+    "number" : "4242424242424242",
+    "type": "scheme"
+  },
+  "reference": "%s",
+  "returnUrl": "http://CardFrontend/",
+  "shopperInteraction": "%s",
+  "channel": "Web",
+  "additionalData": {
+    "manualCapture": "true"
+  },
+  "browserInfo": {
+    "acceptHeader": "text/html",
+    "colorDepth": 24,
+    "javaEnabled": true,
+    "language": "en-GB",
+    "screenHeight": 900,
+    "screenWidth": 1440,
+    "timeZoneOffset": -60,
+    "userAgent": "Mozilla/5.0"
+  },
+  "origin": "http://CardFrontend/",
+  "shopperEmail": "email@fake.test",
+  "shopperIP": "127.0.0.1"
+}


### PR DESCRIPTION
## WHAT YOU DID
- Add browser information so connector sends in the Adyen authorisation request
- Include shopper IP, origin, and shopper email for web payments
- For MOTO payments exclude these fields

 - Next PR will handle the response part from Adyen
