### PR TITLE
PP-15146 Overwrite to string in AdyenCancelResponse

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenCancelResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenCancelResponse.java
@@ -48,6 +48,7 @@ public record AdyenCancelResponse(
         return errorMessage();
     }
     
+    @Override
     public String toString() {
         StringJoiner joiner = new StringJoiner(", ", "Adyen cancel response (", ")");
         joiner.add("PSP reference: " + transactionId);

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenCancelResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenCancelResponse.java
@@ -1,8 +1,11 @@
 package uk.gov.pay.connector.gateway.adyen.response;
 
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.gateway.adyen.response.json.AdyenError;
 import uk.gov.pay.connector.gateway.adyen.response.json.CancelResponseBody;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+
+import java.util.StringJoiner;
 
 public record AdyenCancelResponse(
         String transactionId,
@@ -43,5 +46,21 @@ public record AdyenCancelResponse(
     @Override
     public String getErrorMessage() {
         return errorMessage();
+    }
+    
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "Adyen cancel response (", ")");
+        joiner.add("PSP reference: " + transactionId);
+        joiner.add("Cancel status: " + cancelStatus);
+        if (StringUtils.isNotBlank(errorCode)) {
+            joiner.add("error code: " + errorCode);
+        }
+        if (StringUtils.isNotBlank(errorType)) {
+            joiner.add("error type: " + errorType);
+        }
+        if (StringUtils.isNotBlank(errorMessage)) {
+            joiner.add("error: " + errorMessage);
+        }
+        return joiner.toString();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
@@ -266,12 +266,12 @@ class AdyenCancelHandlerTest {
                 "GatewayResponse should have a gateway error",
                 gatewayResponse.getGatewayError().isPresent(), is(true));
         var gatewayError = gatewayResponse.getGatewayError().get();
-        assertThat(gatewayError.getMessage(), is("AdyenCancelResponse[" +
-                "transactionId=a-PSP-reference, " +
-                "cancelStatus=ERROR, " +
-                "errorCode=000, " +
-                "errorType=security, " +
-                "errorMessage=HTTP Status Response - Unauthorized]"));
+        assertThat(gatewayError.getMessage(), is("Adyen cancel response (" +
+                "PSP reference: a-PSP-reference, " +
+                "Cancel status: ERROR, " +
+                "error code: 000, " +
+                "error type: security, " +
+                "error: HTTP Status Response - Unauthorized)"));
         assertThat(gatewayError.getErrorType(), is(ErrorType.GENERIC_GATEWAY_ERROR));
     }
 


### PR DESCRIPTION
## WHAT YOU DID

- Overwrite `toString()` method in Adyen Cancel Response
- This simplifies logging and makes consistent with [WorldpayCancelResponse.java](https://github.com/alphagov/pay-connector/blob/master/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCancelResponse.java#L31:L42)

