### PR TITLE
PP-15472 - added all payment events to join task queue logic

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
@@ -71,13 +71,15 @@ public class AdyenNotificationService {
                 if (!isValidHmac(item, hmacKey)) {
                     return false;
                 }
-                if (!"CAPTURE".equals(item.getEventCode())) {
-                    LOGGER.info("Ignored Adyen notification",
-                            kv("originalReference", item.getOriginalReference()),
-                            kv("eventCode", item.getEventCode()));
+                
+                if (AdyenPaymentEvent.contains(item.getEventCode())) {
+                    addNotificationToTaskQueue(payload, item);
                     continue;
                 }
-                addNotificationToTaskQueue(payload, item);
+                
+                LOGGER.info("Ignored Adyen notification",
+                        kv("originalReference", item.getOriginalReference()),
+                        kv("eventCode", item.getEventCode()));
             }
         } catch (AdyenNotificationException e) {
             LOGGER.error("Failed to validate Adyen notification payload", e);
@@ -93,7 +95,7 @@ public class AdyenNotificationService {
 
     private void addNotificationToTaskQueue(String payload, NotificationRequestItem item) {
         try {
-            taskQueueService.add(new Task(payload, TaskType.HANDLE_ADYEN_WEBHOOK_NOTIFICATION));
+            taskQueueService.add(new Task(payload, TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION));
         } catch (Exception e) {
             LOGGER.error("Error sending Adyen webhook notification to task SQS queue",
                     kv("pspReference", item.getPspReference()),

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenPaymentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenPaymentEvent.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.gateway.adyen.webhook;
+
+public enum AdyenPaymentEvent {
+    CAPTURE,
+    AUTHORISATION,
+    CANCELLATION,
+    CAPTURE_FAILED,
+    EXPIRE,
+    REFUND,
+    REFUND_FAILED,
+    REFUNDED_REVERSED;
+
+    public static boolean contains(String test) {
+        for (AdyenPaymentEvent e : AdyenPaymentEvent.values()) {
+            if (e.name().equals(test)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
@@ -97,7 +97,7 @@ public class TaskQueueMessageHandler {
                         LOGGER.info("Processing [{}] task.", taskType.getName());
                         stripeWebhookTaskHandler.process(stripeNotification);
                         break; 
-                    case HANDLE_ADYEN_WEBHOOK_NOTIFICATION:
+                    case HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION:
                         LOGGER.info("Processing [{}] task.", taskType.getName());
                         adyenWebhookTaskHandler.processAdyenWebhookNotification(taskMessage.getTask().getData());
                         break;

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum TaskType {
     COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT("collect_fee_for_stripe_failed_payment"),
     HANDLE_STRIPE_WEBHOOK_NOTIFICATION("handle_stripe_webhook_notification"),
-    HANDLE_ADYEN_WEBHOOK_NOTIFICATION("handle_adyen_webhook_notification"),
+    HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION("handle_adyen_payments_webhook_notification"),
     AUTHORISE_WITH_USER_NOT_PRESENT("authorise_with_user_not_present"),
     DELETE_STORED_PAYMENT_DETAILS("delete_stored_payment_details"),
     RETRY_FAILED_PAYMENT_OR_REFUND_EMAIL("retry_failed_payment_or_refund_email"), 

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
@@ -14,6 +14,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -229,12 +233,13 @@ class AdyenNotificationServiceTest {
                     .get(1)
                     .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
         }
-        
-        @Test
-        void shouldAddTaskToQueueWhenValidCaptureNotificationIsReceived() {
+
+        @ParameterizedTest
+        @EnumSource(AdyenPaymentEvent.class)
+        void shouldAddTaskToQueueWhenValidCaptureNotificationIsReceived(AdyenPaymentEvent eventCode) {
             when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
 
-            String payload = getNotificationWithValidHmacSignature("CAPTURE");
+            String payload = getNotificationWithValidHmacSignature(eventCode.toString());
 
             boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
 
@@ -244,17 +249,19 @@ class AdyenNotificationServiceTest {
             verify(mockTaskQueueService).add(taskCaptor.capture());
 
             Task task = taskCaptor.getValue();
-            assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_WEBHOOK_NOTIFICATION));
+            assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION));
             assertThat(task.getData(), is(payload));
         }
         
-        @Test
-        void shouldIgnoreNonCaptureWebhookNotificationsAndNotAddToTaskQue() {
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"SOME_INVALID_VALUE"})
+        void shouldIgnoreNonCaptureWebhookNotificationsAndNotAddToTaskQue(String eventCode) {
             when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-            String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
+            String payload = getNotificationWithValidHmacSignature(eventCode);
 
             boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
-            
+
             assertTrue(result);
 
             verify(mockTaskQueueService, never()).add(any(Task.class));


### PR DESCRIPTION
## WHAT YOU DID

- Added enum to hold all adyen payment events
- Integrated using enum in existing logic (for capture) to check if the event code exists if the enum - if it does, proceed with adding notification to task queue.
- Updated singular test (for capture) to run against all of the values in the enum. 
- Updated test that was previously checking "AUTHORISATION" event to NOT be added to the task queue to now check for null, empty and "SOME_INVALID_VALUE"
- Renamed `HANDLE_ADYEN_WEBHOOK_NOTIFICATION` to `HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION` and updated usages.