### PR TITLE
PP-15434 Implemented logic to mark all switched test account tasks as complete

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/AdyenAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/AdyenAccountResource.java
@@ -111,6 +111,11 @@ public class AdyenAccountResource {
         var serviceName = payload.get("service_name");
         AdyenCredentials adyenCredentials = adyenTestAccountService.createTestAccount(serviceName);
         gatewayAccountSwitchPaymentProviderService.switchStripeTestAccountToAdyen(gatewayAccount, adyenCredentials);
+
+        var updatedGatewayAccount = gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, TEST)
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId));
+        
+        adyenAccountSetupService.completeTestAccountSetup(updatedGatewayAccount);
         
         Map<String, String> response = Map.of("gateway_account_id", serviceId,
                 "legal_entity_id", adyenCredentials.legalEntityId(),

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountResourceIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.it.resources.adyen;
 
 import com.adyen.model.management.PaymentMethodSetupInfo;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -354,6 +353,15 @@ public class AdyenAccountResourceIT {
                 .body("gateway_account_credentials[1].credentials.account_holder_id", is("AH3227C223222H5J4DCLW9VBV"))
                 .body("gateway_account_credentials[1].credentials.balance_account_id", is("BA0000000000000000000001"))
                 .body("gateway_account_credentials[1].external_id", is(notNullValue(String.class)));
+        
+        int accountId = app.givenSetup().get(format("/v1/api/service/%s/account/test", serviceId)).jsonPath().get("gateway_account_id");
+
+        var adyenAccountSetupTaskEntities = app.getDatabaseTestHelper().getAdyenAccountSetupTaskEntities(accountId);
+
+        assertFalse(adyenAccountSetupTaskEntities.isEmpty());
+        assertTrue(adyenAccountSetupTaskEntities.stream()
+                .allMatch(entity -> entity.get("status").equals("COMPLETED")));
+        assertEquals(AdyenAccountSetupTask.values().length, adyenAccountSetupTaskEntities.size());
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- Implemented call in AdyenAccountResource's switchToAdyenTestAccount method to mark all stripe to adyen switched test account setup tasks as complete
- Extended AdyenAccountResourceIT tests to check tasks are marked as complete for the switched test accounts
