### PR TITLE
PP-15514 Added gateway_account_credential_id to gateway_accounts_adyen_setup table

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/AdyenAccountSetupTaskEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/AdyenAccountSetupTaskEntity.java
@@ -11,6 +11,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 
 @Entity
 @Table(name = "gateway_accounts_adyen_setup")
@@ -26,6 +28,10 @@ public class AdyenAccountSetupTaskEntity {
     @JoinColumn(name = "gateway_account_id", updatable = false)
     private GatewayAccountEntity gatewayAccount;
 
+    @ManyToOne
+    @JoinColumn(name = "gateway_account_credential_id", updatable = false)
+    private GatewayAccountCredentialsEntity gatewayAccountCredential;
+
     @Column(name = "task")
     @Enumerated(EnumType.STRING)
     private AdyenAccountSetupTask task;
@@ -34,10 +40,12 @@ public class AdyenAccountSetupTaskEntity {
     @Enumerated(EnumType.STRING)
     private AdyenAccountSetupStatus status;
 
-    public AdyenAccountSetupTaskEntity(GatewayAccountEntity gatewayAccount, AdyenAccountSetupTask task, AdyenAccountSetupStatus status) {
+    public AdyenAccountSetupTaskEntity(GatewayAccountEntity gatewayAccount, AdyenAccountSetupTask task, 
+                                       GatewayAccountCredentialsEntity gatewayAccountCredentials, AdyenAccountSetupStatus status) {
         this.gatewayAccount = gatewayAccount;
         this.task = task;
         this.status = status;
+        this.gatewayAccountCredential = gatewayAccountCredentials;
     }
 
     public AdyenAccountSetupTaskEntity() {
@@ -54,6 +62,10 @@ public class AdyenAccountSetupTaskEntity {
 
     public AdyenAccountSetupStatus getStatus() {
         return status;
+    }
+
+    public GatewayAccountCredentialsEntity getGatewayAccountCredential() {
+        return gatewayAccountCredential;
     }
 
     public void setGatewayAccount(GatewayAccountEntity gatewayAccount) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/AdyenAccountSetupService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/AdyenAccountSetupService.java
@@ -10,6 +10,8 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.util.List;
 
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+
 public class AdyenAccountSetupService {
 
     private final AdyenAccountSetupDao aydenAccountSetupDao;
@@ -22,8 +24,9 @@ public class AdyenAccountSetupService {
     @Transactional
     public void completeTestAccountSetup(GatewayAccountEntity gatewayAccountEntity) {
         if (gatewayAccountEntity.isAdyenTestAccount()) {
+            var gatewayAccountCredentialsEntity = gatewayAccountEntity.getRecentNonRetiredGatewayAccountCredentialsEntity(ADYEN.getName());
             List.of(AdyenAccountSetupTask.values()).forEach(task -> {
-                aydenAccountSetupDao.persist(new AdyenAccountSetupTaskEntity(gatewayAccountEntity, task, AdyenAccountSetupStatus.COMPLETED));
+                aydenAccountSetupDao.persist(new AdyenAccountSetupTaskEntity(gatewayAccountEntity, task, gatewayAccountCredentialsEntity, AdyenAccountSetupStatus.COMPLETED));
             });
         } else {
             throw new IllegalArgumentException("Gateway account type must be TEST and gateway name must be ADYEN");

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/AdyenAccountSetupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/AdyenAccountSetupServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.gatewayaccount.dao.AdyenAccountSetupDao;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenAccountSetupStatus;
@@ -14,26 +13,26 @@ import uk.gov.pay.connector.gatewayaccount.model.AdyenAccountSetupTask;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenAccountSetupTaskEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 
 @ExtendWith(MockitoExtension.class)
 class AdyenAccountSetupServiceTest {
 
     @Mock
     private AdyenAccountSetupDao mockAdyenAccountSetupDao;
-
-    @Spy
-    private GatewayAccountEntity spyGatewayAccountEntity;
 
     private AdyenAccountSetupService adyenAccountSetupService;
 
@@ -48,16 +47,20 @@ class AdyenAccountSetupServiceTest {
     class completeTestAccountSetup {
         @Test
         void shouldCompleteAllTasks_WhenAccountIsAdyenAndTest() {
-            doReturn(TEST.toString()).when(spyGatewayAccountEntity).getType();
-            doReturn(ADYEN.getName()).when(spyGatewayAccountEntity).getGatewayName();
+            var gatewayAccountCredentials = aGatewayAccountCredentialsEntity().withPaymentProvider(ADYEN.getName()).build();
+            GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                    .withType(TEST)
+                    .withGatewayAccountCredentials(List.of(gatewayAccountCredentials))
+                    .build();
 
-            adyenAccountSetupService.completeTestAccountSetup(spyGatewayAccountEntity);
+            adyenAccountSetupService.completeTestAccountSetup(gatewayAccountEntity);
 
             ArgumentCaptor<AdyenAccountSetupTaskEntity> captor =
                     ArgumentCaptor.forClass(AdyenAccountSetupTaskEntity.class);
 
             verify(mockAdyenAccountSetupDao, times(AdyenAccountSetupTask.values().length)).persist(captor.capture());
 
+            assertEquals(gatewayAccountCredentials.getId(), captor.getValue().getGatewayAccountCredential().getId());
             assertThat(captor.getAllValues())
                     .extracting(AdyenAccountSetupTaskEntity::getStatus)
                     .containsOnly(AdyenAccountSetupStatus.COMPLETED);
@@ -65,17 +68,24 @@ class AdyenAccountSetupServiceTest {
 
         @Test
         void shouldThrowIllegalArgException_WhenAccountIsNotTest() {
-            doReturn(LIVE.toString()).when(spyGatewayAccountEntity).getType();
-            var ex = assertThrows(IllegalArgumentException.class, () -> adyenAccountSetupService.completeTestAccountSetup(spyGatewayAccountEntity));
+            var gatewayAccountCredentials = aGatewayAccountCredentialsEntity().withPaymentProvider(ADYEN.getName()).build();
+            GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                    .withType(LIVE)
+                    .withGatewayAccountCredentials(List.of(gatewayAccountCredentials))
+                    .build();
+            var ex = assertThrows(IllegalArgumentException.class, () -> adyenAccountSetupService.completeTestAccountSetup(gatewayAccountEntity));
             verify(mockAdyenAccountSetupDao, times(0)).persist(any(AdyenAccountSetupTaskEntity.class));
             assertEquals(EXPECTED_ERROR_MSG, ex.getMessage());
         }
 
         @Test
         void shouldThrowIllegalArgException_WhenAccountIsNotAdyen() {
-            doReturn(TEST.toString()).when(spyGatewayAccountEntity).getType();
-            doReturn(SANDBOX.getName()).when(spyGatewayAccountEntity).getGatewayName();
-            var ex = assertThrows(IllegalArgumentException.class, () -> adyenAccountSetupService.completeTestAccountSetup(spyGatewayAccountEntity));
+            var gatewayAccountCredentials = aGatewayAccountCredentialsEntity().withPaymentProvider(WORLDPAY.getName()).build();
+            GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                    .withType(TEST)
+                    .withGatewayAccountCredentials(List.of(gatewayAccountCredentials))
+                    .build();
+            var ex = assertThrows(IllegalArgumentException.class, () -> adyenAccountSetupService.completeTestAccountSetup(gatewayAccountEntity));
             verify(mockAdyenAccountSetupDao, times(0)).persist(any(AdyenAccountSetupTaskEntity.class));
             assertEquals(EXPECTED_ERROR_MSG, ex.getMessage());
         }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountResourceIT.java
@@ -6,8 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenAccountSetupTask;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
@@ -145,11 +148,16 @@ public class AdyenAccountResourceIT {
         int accountId = app.givenSetup().get(format("/v1/api/service/%s/account/test", serviceId)).jsonPath().get("gateway_account_id");
 
         var adyenAccountSetupTaskEntities = app.getDatabaseTestHelper().getAdyenAccountSetupTaskEntities(accountId);
+        var gatewayAccountCredentialId = app.getDatabaseTestHelper().getGatewayAccountCredentialByPaymentProvider(accountId, ADYEN.getName());
 
         assertFalse(adyenAccountSetupTaskEntities.isEmpty());
         assertTrue(adyenAccountSetupTaskEntities.stream()
-                .allMatch(entity -> entity.get("status").equals("COMPLETED")));
+                .allMatch(entity -> entity.get("status").equals("COMPLETED")), 
+                "Not all (or any) AdyenAccountSetupTasks have a COMPLETED status");
         assertEquals(AdyenAccountSetupTask.values().length, adyenAccountSetupTaskEntities.size());
+        assertTrue(adyenAccountSetupTaskEntities.stream()
+                .allMatch(entity -> (entity.get("gateway_account_credential_id")).equals(gatewayAccountCredentialId)), 
+                "Not all (or any) AdyenAccountSetupTasks have the expected Gateway Account Credential Id");
     }
 
     private void verifyPaymentMethodsRequest(List<PaymentMethodSetupInfo.TypeEnum> paymentTypes, String merchantId) {
@@ -357,11 +365,16 @@ public class AdyenAccountResourceIT {
         int accountId = app.givenSetup().get(format("/v1/api/service/%s/account/test", serviceId)).jsonPath().get("gateway_account_id");
 
         var adyenAccountSetupTaskEntities = app.getDatabaseTestHelper().getAdyenAccountSetupTaskEntities(accountId);
+        var gatewayAccountCredentialId = app.getDatabaseTestHelper().getGatewayAccountCredentialByPaymentProvider(accountId, ADYEN.getName());
 
         assertFalse(adyenAccountSetupTaskEntities.isEmpty());
         assertTrue(adyenAccountSetupTaskEntities.stream()
-                .allMatch(entity -> entity.get("status").equals("COMPLETED")));
+                        .allMatch(entity -> entity.get("status").equals("COMPLETED")),
+                "Not all (or any) AdyenAccountSetupTasks have a COMPLETED status");
         assertEquals(AdyenAccountSetupTask.values().length, adyenAccountSetupTaskEntities.size());
+        assertTrue(adyenAccountSetupTaskEntities.stream()
+                        .allMatch(entity -> (entity.get("gateway_account_credential_id")).equals(gatewayAccountCredentialId)),
+                "Not all (or any) AdyenAccountSetupTasks have the expected Gateway Account Credential Id");
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -1284,6 +1284,15 @@ public class DatabaseTestHelper {
                         .list());
     }
 
+    public Long getGatewayAccountCredentialByPaymentProvider(long gatewayAccountId, String paymentProvider) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT id FROM gateway_account_credentials WHERE gateway_account_id = :gateway_account_id AND payment_provider = :payment_provider")
+                        .bind("gateway_account_id", gatewayAccountId)
+                        .bind("payment_provider", paymentProvider)
+                        .mapTo(long.class)
+                        .first());
+    }
+
     private PGobject buildCredentialsJson(AddGatewayAccountCredentialsParams params) {
         try {
             PGobject credentialsJson = getJsonPGobject();


### PR DESCRIPTION

## WHAT YOU DID
- Added gateway_account_credential_id as a foreign key to gateway_accounts_adyen_setup table
- Added mappings to set the credentials Id when a test account is created 
- Added mappings to set the credentials Id when a stripe account is switched to an adyen account
