### PR TITLE
PP-15514: Set gateway_accounts_adyen_setup.gateway_account_credential_id not null

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2145,4 +2145,8 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="make gateway_accounts_adyen_setup.gateway_account_credential_id not nullable" author="">
+        <addNotNullConstraint tableName="gateway_accounts_adyen_setup" columnName="gateway_account_credential_id"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
We set this to nullable previously for the sake of the pre-migration PR. We want it to be NOT NULL.