### PR TITLE
PP-15120 AuthorisationLogger logs WorldpayAuthoriseRequest

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -545,28 +545,28 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 146
+        "line_number": 147
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "fd9f851472586dc75f7a60ee311842ec64ecf527",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 150
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "9367c8305bd1afe815ffc0cc3ebf95af9cb6d157",
         "is_verified": false,
-        "line_number": 152
+        "line_number": 153
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 1153
+        "line_number": 1154
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-23T09:36:37Z"
+  "generated_at": "2026-06-25T09:05:23Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequest.java
@@ -1,0 +1,4 @@
+package uk.gov.pay.connector.gateway.model.request.records;
+
+public interface WorldpayAuthoriseRequest extends WorldpayRequest {
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthoriseRequest.java
@@ -15,7 +15,7 @@ public record WorldpayMotoAuthoriseRequest(
         String expiryDateYearFourDigits,
         String cardholderName,
         String cvc
-) implements WorldpayRequest {
+) implements WorldpayAuthoriseRequest {
     @Override
     public String toString(){
         return getClass().getSimpleName() + '[' 

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestLog.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestLog.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.connector.gateway.util;
+
+import net.logstash.logback.argument.StructuredArgument;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+@NullMarked
+public record AuthorisationRequestLog(
+        String authorisationRequest,
+        List<StructuredArgument> structuredArguments
+) {
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGenerator.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.gateway.util;
+
+
+import net.logstash.logback.argument.StructuredArgument;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.BILLING_ADDRESS;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.CORPORATE_CARD;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.DATA_FOR_3DS;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.EMAIL;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.MOTO;
+
+public class WorldpayAuthoriseRequestLogGenerator {
+
+    public AuthorisationRequestLog generate(WorldpayAuthoriseRequest worldpayAuthoriseRequest, AuthCardDetails authCardDetails) {
+        if (worldpayAuthoriseRequest instanceof WorldpayMotoAuthoriseRequest worldpayMotoAuthoriseRequest) {
+            return generate(worldpayMotoAuthoriseRequest, authCardDetails);
+        }
+        throw new IllegalArgumentException("WorldpayAuthoriseRequest type not supported: " + worldpayAuthoriseRequest.getClass().getSimpleName());
+    }
+
+    private AuthorisationRequestLog generate(WorldpayMotoAuthoriseRequest worldpayMotoAuthoriseRequest, AuthCardDetails authCardDetails) {
+        List<StructuredArgument> structuredArguments = new ArrayList<>();
+
+        var stringJoiner = new StringJoiner(" and ", " ", "");
+
+        stringJoiner.add("without billing address");
+        structuredArguments.add(kv(BILLING_ADDRESS, false));
+
+        if (authCardDetails.isCorporateCard()) {
+            stringJoiner.add("with corporate card");
+            structuredArguments.add(kv(CORPORATE_CARD, true));
+        } else {
+            structuredArguments.add(kv(CORPORATE_CARD, false));
+        }
+
+        authCardDetails.getIpAddress().ifPresent(ipAddress -> stringJoiner.add("with remote IP " + ipAddress));
+
+        structuredArguments.add(kv(EMAIL, false));
+        structuredArguments.add(kv(DATA_FOR_3DS, false));
+        structuredArguments.add(kv(MOTO, true));
+
+        return new AuthorisationRequestLog(stringJoiner.toString(), List.copyOf(structuredArguments));
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/logging/AuthorisationLogger.java
+++ b/src/main/java/uk/gov/pay/connector/logging/AuthorisationLogger.java
@@ -1,15 +1,20 @@
 package uk.gov.pay.connector.logging;
 
+import jakarta.inject.Inject;
+import net.logstash.logback.argument.StructuredArgument;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
+import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
 
-import jakarta.inject.Inject;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -17,48 +22,99 @@ public class AuthorisationLogger {
 
     private final AuthorisationRequestSummaryStringifier authorisationRequestSummaryStringifier;
     private final AuthorisationRequestSummaryStructuredLogging authorisationRequestSummaryStructuredLogging;
+    private final WorldpayAuthoriseRequestLogGenerator worldpayAuthoriseRequestLogGenerator;
 
     @Inject
     public AuthorisationLogger(AuthorisationRequestSummaryStringifier authorisationRequestSummaryStringifier, 
-                               AuthorisationRequestSummaryStructuredLogging authorisationRequestSummaryStructuredLogging) {
+                               AuthorisationRequestSummaryStructuredLogging authorisationRequestSummaryStructuredLogging,
+                               WorldpayAuthoriseRequestLogGenerator worldpayAuthoriseRequestLogGenerator) {
         this.authorisationRequestSummaryStringifier = authorisationRequestSummaryStringifier;
         this.authorisationRequestSummaryStructuredLogging = authorisationRequestSummaryStructuredLogging;
+        this.worldpayAuthoriseRequestLogGenerator = worldpayAuthoriseRequestLogGenerator;
     }
 
     public void logChargeAuthorisation(Logger logger,
                                        AuthorisationRequestSummary authorisationRequestSummary,
                                        ChargeEntity charge, 
                                        String transactionId,
-                                       GatewayResponse gatewayResponse,
+                                       GatewayResponse<?> gatewayResponse,
                                        ChargeStatus oldStatus,
                                        ChargeStatus newStatus) {
 
+        logChargeAuthorisation(logger,
+                Optional.ofNullable(authorisationRequestSummary)
+                        .map(authorisationRequestSummaryStringifier::stringify).orElse(null),
+                Optional.ofNullable(authorisationRequestSummary)
+                        .map(authorisationRequestSummaryStructuredLogging::createArgs).orElse(null),
+                charge,
+                transactionId,
+                gatewayResponse,
+                oldStatus,
+                newStatus);
+    }
+
+    public void logChargeAuthorisation(Logger logger,
+                                       WorldpayAuthoriseRequest worldpayAuthoriseRequest,
+                                       AuthCardDetails authCardDetails,
+                                       ChargeEntity charge,
+                                       String transactionId,
+                                       GatewayResponse<?> gatewayResponse,
+                                       ChargeStatus oldStatus,
+                                       ChargeStatus newStatus) {
+
+        AuthorisationRequestLog authoriseRequestLog = worldpayAuthoriseRequestLogGenerator.generate(
+                worldpayAuthoriseRequest, authCardDetails);
+
+        logChargeAuthorisation(logger,
+                authoriseRequestLog.authorisationRequest(),
+                authoriseRequestLog.structuredArguments().toArray(new StructuredArgument[0]),
+                charge,
+                transactionId,
+                gatewayResponse,
+                oldStatus,
+                newStatus);
+    }
+
+    public void logChargeAuthorisation(Logger logger,
+                                       ChargeEntity charge,
+                                       String transactionId,
+                                       GatewayResponse<?> gatewayResponse,
+                                       ChargeStatus oldStatus,
+                                       ChargeStatus newStatus) {
+        logChargeAuthorisation(logger,
+                (String) null,
+                (StructuredArgument[]) null,
+                charge,
+                transactionId,
+                gatewayResponse,
+                oldStatus,
+                newStatus);
+    }
+
+    private void logChargeAuthorisation(Logger logger,
+                                   String authorisationRequest,
+                                   StructuredArgument[] authorisationRequestStructuredArguments,
+                                   ChargeEntity charge,
+                                   String transactionId,
+                                   GatewayResponse<?> gatewayResponse,
+                                   ChargeStatus oldStatus,
+                                   ChargeStatus newStatus) {
         var logMessage = String.format(Locale.UK, "Authorisation%s for %s (%s %s) for %s (%s) - %s .'. %s -> %s",
-                Optional.ofNullable(authorisationRequestSummary).map(authorisationRequestSummaryStringifier::stringify).orElse(""),
+                Optional.ofNullable(authorisationRequest).orElse(""),
                 charge.getExternalId(),
                 charge.getPaymentGatewayName().getName(),
                 transactionId,
                 charge.getGatewayAccount().getAnalyticsId(),
                 charge.getGatewayAccount().getId(),
                 gatewayResponse,
-                oldStatus, 
+                oldStatus,
                 newStatus);
 
         var structuredLoggingArguments = ArrayUtils.addAll(
                 charge.getStructuredLoggingArgs(),
-                Optional.ofNullable(authorisationRequestSummary)
-                        .map(authorisationRequestSummaryStructuredLogging::createArgs)
-                        .orElse(null));
+                authorisationRequestStructuredArguments);
 
         logger.info(logMessage, structuredLoggingArguments);
     }
 
-    public void logChargeAuthorisation(Logger logger,
-                                       ChargeEntity charge,
-                                       String transactionId,
-                                       GatewayResponse gatewayResponse,
-                                       ChargeStatus oldStatus,
-                                       ChargeStatus newStatus) {
-        logChargeAuthorisation(logger, null, charge, transactionId, gatewayResponse, oldStatus, newStatus);
-    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGeneratorTest.java
@@ -1,0 +1,89 @@
+package uk.gov.pay.connector.gateway.util;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.BILLING_ADDRESS;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.CORPORATE_CARD;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.DATA_FOR_3DS;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.EMAIL;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.MOTO;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+
+class WorldpayAuthoriseRequestLogGeneratorTest {
+
+    private static final String IP_ADDRESS = "203.0.113.1";
+
+    private final WorldpayAuthoriseRequestLogGenerator  generator = new WorldpayAuthoriseRequestLogGenerator();
+
+    @Test
+    public void generatesWorldpayMotoAuthoriseRequestLogWithCorporateCard() {
+        WorldpayMotoAuthoriseRequest request = new WorldpayMotoAuthoriseRequest(
+                "username", "password", "merchant code", "order code",
+                "description", "1000", "4242424242424242",
+                "12", "2030", "Cardholder Name", "123");
+
+        AuthCardDetails authCardDetails = anAuthCardDetails().withCorporateCard(true).withIpAddress(IP_ADDRESS).build();
+
+        AuthorisationRequestLog result = generator.generate(request, authCardDetails);
+
+        assertThat(result.authorisationRequest(), is(
+                " without billing address and with corporate card and with remote IP " + IP_ADDRESS));
+
+        assertThat(result.structuredArguments(), containsInAnyOrder(
+                        kv(BILLING_ADDRESS, false),
+                        kv(CORPORATE_CARD, true),
+                        kv(EMAIL, false),
+                        kv(DATA_FOR_3DS, false),
+                        kv(MOTO, true)));
+    }
+
+    @Test
+    public void generatesWorldpayMotoAuthoriseRequestLogWithoutCorporateCard() {
+        WorldpayMotoAuthoriseRequest request = new WorldpayMotoAuthoriseRequest(
+                "username", "password", "merchant code", "order code",
+                "description", "1000", "4242424242424242",
+                "12", "2030", "Cardholder Name", "123");
+
+        AuthCardDetails authCardDetails = anAuthCardDetails().withCorporateCard(false).withIpAddress(IP_ADDRESS).build();
+
+        AuthorisationRequestLog result = generator.generate(request, authCardDetails);
+
+        assertThat(result.authorisationRequest(), is(
+                " without billing address and with remote IP " + IP_ADDRESS));
+
+        assertThat(result.structuredArguments(), containsInAnyOrder(
+                kv(BILLING_ADDRESS, false),
+                kv(CORPORATE_CARD, false),
+                kv(EMAIL, false),
+                kv(DATA_FOR_3DS, false),
+                kv(MOTO, true)));
+    }
+
+    @Test
+    public void generatesWorldpayMotoAuthoriseRequestLogWithoutIPAddress() {
+        WorldpayMotoAuthoriseRequest request = new WorldpayMotoAuthoriseRequest(
+                "username", "password", "merchant code", "order code",
+                "description", "1000", "4242424242424242",
+                "12", "2030", "Cardholder Name", "123");
+
+        AuthCardDetails authCardDetails = anAuthCardDetails().withCorporateCard(false).build();
+
+        AuthorisationRequestLog result = generator.generate(request, authCardDetails);
+
+        assertThat(result.authorisationRequest(), is(" without billing address"));
+
+        assertThat(result.structuredArguments(), containsInAnyOrder(
+                kv(BILLING_ADDRESS, false),
+                kv(CORPORATE_CARD, false),
+                kv(EMAIL, false),
+                kv(DATA_FOR_3DS, false),
+                kv(MOTO, true)));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -40,6 +40,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
+import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.worldpay.wallets.WorldpayWalletAuthorisationHandler;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.exception.MissingCredentialsForRecurringPaymentException;
@@ -199,7 +200,7 @@ class WorldpayPaymentProviderTest {
                 worldpayRefundHandler,
                 refundEntityFactory,
                 new AuthorisationService(mock(CardExecutorService.class), mock(Environment.class), mock(ConnectorConfiguration.class)),
-                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
+                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new WorldpayAuthoriseRequestLogGenerator()),
                 chargeDao,
                 eventService,
                 instantSource);

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
+import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthoriseHandler;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayCaptureHandler;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
@@ -659,7 +660,7 @@ class WorldpayPaymentProviderTest {
                 new WorldpayRefundHandler(gatewayClient, gatewayUrlMap()),
                 new WorldpayRefundEntityFactory(),
                 new AuthorisationService(mockCardExecutorService, mockEnvironment, mockConnectorConfiguration),
-                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
+                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new WorldpayAuthoriseRequestLogGenerator()),
                 mock(ChargeDao.class),
                 mock(EventService.class),
                 instantSource);

--- a/src/test/java/uk/gov/pay/connector/logging/AuthorisationLoggerTest.java
+++ b/src/test/java/uk/gov/pay/connector/logging/AuthorisationLoggerTest.java
@@ -1,0 +1,178 @@
+package uk.gov.pay.connector.logging;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import net.logstash.logback.argument.StructuredArgument;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
+import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
+import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
+import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
+
+import java.util.List;
+
+import static ch.qos.logback.classic.Level.INFO;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorisationLoggerTest {
+
+    @Mock
+    private AuthorisationRequestSummary mockAuthorisationRequestSummary;
+
+    @Mock
+    private AuthorisationRequestSummaryStringifier mockAuthorisationRequestSummaryStringifier;
+
+    @Mock
+    private AuthorisationRequestSummaryStructuredLogging mockAuthorisationRequestSummaryStructuredLogging;
+
+    @Mock
+    private WorldpayAuthoriseRequest mockWorldpayAuthoriseRequest;
+
+    @Mock
+    private AuthCardDetails mockAuthCardDetails;
+
+    @Mock
+    private WorldpayAuthoriseRequestLogGenerator mockWorldpayAuthoriseRequestLogGenerator;
+
+    @Mock
+    private GatewayResponse<?> mockGatewayResponse;
+
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    private final GatewayAccountEntity gatewayAccountEntity = GatewayAccountEntityFixture.aGatewayAccountEntity()
+            .withId(123L)
+            .withAnalyticsId("AnalyticsId")
+            .build();
+
+    private final ChargeEntity chargeEntity = aValidChargeEntity()
+            .withExternalId("abcdefghijklmnopqrstuvwxyz")
+            .withGatewayAccountEntity(gatewayAccountEntity)
+            .withPaymentProvider(PaymentGatewayName.WORLDPAY.getName())
+            .build();
+
+    private Logger logger;
+
+    private AuthorisationLogger authorisationLogger;
+
+    @BeforeEach
+    void setUp() {
+        logger = (Logger) LoggerFactory.getLogger("Test");
+        logger.addAppender(mockAppender);
+        logger.setLevel(INFO);
+
+        authorisationLogger = new AuthorisationLogger(mockAuthorisationRequestSummaryStringifier,
+                mockAuthorisationRequestSummaryStructuredLogging, mockWorldpayAuthoriseRequestLogGenerator);
+    }
+
+    @Test
+    void logsWithNullAuthorisationRequestSummary() {
+        given(mockAuthorisationRequestSummaryStringifier.stringify(mockAuthorisationRequestSummary))
+                .willReturn(null);
+
+        given(mockAuthorisationRequestSummaryStructuredLogging.createArgs(mockAuthorisationRequestSummary))
+                .willReturn(null);
+
+        authorisationLogger.logChargeAuthorisation(logger, mockAuthorisationRequestSummary, chargeEntity,
+                "payment-12345", mockGatewayResponse, ChargeStatus.ENTERING_CARD_DETAILS, ChargeStatus.AUTHORISATION_SUCCESS);
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+
+        var loggingEvent = loggingEventArgumentCaptor.getAllValues().getFirst();
+
+        assertThat(loggingEvent.getFormattedMessage(), is(
+                "Authorisation for abcdefghijklmnopqrstuvwxyz " +
+                        "(worldpay payment-12345) for AnalyticsId (123) - " +
+                        "mockGatewayResponse .'. ENTERING CARD DETAILS -> AUTHORISATION SUCCESS"));
+    }
+
+    @Test
+    void logsWithAuthorisationRequestSummary() {
+        given(mockAuthorisationRequestSummaryStringifier.stringify(mockAuthorisationRequestSummary))
+                .willReturn(" with all the fancy details");
+
+        given(mockAuthorisationRequestSummaryStructuredLogging.createArgs(mockAuthorisationRequestSummary))
+                .willReturn(new StructuredArgument[]{ kv("some", "fun"), kv("structured", "args") });
+
+        authorisationLogger.logChargeAuthorisation(logger, mockAuthorisationRequestSummary, chargeEntity,
+                "payment-12345", mockGatewayResponse, ChargeStatus.ENTERING_CARD_DETAILS, ChargeStatus.AUTHORISATION_SUCCESS);
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+
+        var loggingEvent = loggingEventArgumentCaptor.getAllValues().getFirst();
+
+        assertThat(loggingEvent.getFormattedMessage(), is(
+                "Authorisation with all the fancy details for abcdefghijklmnopqrstuvwxyz " +
+                        "(worldpay payment-12345) for AnalyticsId (123) - " +
+                        "mockGatewayResponse .'. ENTERING CARD DETAILS -> AUTHORISATION SUCCESS"));
+
+        assertThat(loggingEvent.getArgumentArray(), hasItemInArray(kv("some", "fun")));
+        assertThat(loggingEvent.getArgumentArray(), hasItemInArray(kv("structured", "args")));
+    }
+
+    @Test
+    void logsWithWorldayAuthorisationRequest() {
+        given(mockWorldpayAuthoriseRequestLogGenerator.generate(mockWorldpayAuthoriseRequest, mockAuthCardDetails))
+                        .willReturn(new AuthorisationRequestLog(" with all the fancy details",
+                                List.of(kv("some", "fun"), kv("structured", "args"))));
+
+        authorisationLogger.logChargeAuthorisation(logger, mockWorldpayAuthoriseRequest, mockAuthCardDetails, chargeEntity,
+                "payment-12345", mockGatewayResponse, ChargeStatus.ENTERING_CARD_DETAILS, ChargeStatus.AUTHORISATION_SUCCESS);
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+
+        var loggingEvent = loggingEventArgumentCaptor.getAllValues().getFirst();
+
+        assertThat(loggingEvent.getFormattedMessage(), is(
+                "Authorisation with all the fancy details for abcdefghijklmnopqrstuvwxyz " +
+                        "(worldpay payment-12345) for AnalyticsId (123) - " +
+                        "mockGatewayResponse .'. ENTERING CARD DETAILS -> AUTHORISATION SUCCESS"));
+
+        assertThat(loggingEvent.getArgumentArray(), hasItemInArray(kv("some", "fun")));
+        assertThat(loggingEvent.getArgumentArray(), hasItemInArray(kv("structured", "args")));
+    }
+
+    @Test
+    void logsWithNoAuthorisationRequest() {
+        authorisationLogger.logChargeAuthorisation(logger, chargeEntity,
+                "payment-12345", mockGatewayResponse, ChargeStatus.ENTERING_CARD_DETAILS, ChargeStatus.AUTHORISATION_SUCCESS);
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+
+        var loggingEvent = loggingEventArgumentCaptor.getAllValues().getFirst();
+
+        assertThat(loggingEvent.getFormattedMessage(), is(
+                "Authorisation for abcdefghijklmnopqrstuvwxyz " +
+                        "(worldpay payment-12345) for AnalyticsId (123) - " +
+                        "mockGatewayResponse .'. ENTERING CARD DETAILS -> AUTHORISATION SUCCESS"));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -56,6 +56,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
+import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
@@ -190,6 +191,9 @@ class CardAuthoriseServiceTest extends CardServiceTest {
     private AuthorisationRequestSummaryStructuredLogging mockAuthorisationRequestSummaryStructuredLogging;
 
     @Mock
+    private WorldpayAuthoriseRequestLogGenerator mockWorldpayAuthoriseRequestLogGenerator;
+
+    @Mock
     private TaskQueueService mockTaskQueueService;
 
     @Mock
@@ -251,7 +255,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
                 mockedProviders,
                 authorisationService,
                 chargeService,
-                new AuthorisationLogger(mockAuthorisationRequestSummaryStringifier, mockAuthorisationRequestSummaryStructuredLogging),
+                new AuthorisationLogger(mockAuthorisationRequestSummaryStringifier, mockAuthorisationRequestSummaryStructuredLogging, mockWorldpayAuthoriseRequestLogGenerator),
                 chargeEligibleForCaptureService,
                 mockPaymentInstrumentEntityToAuthCardDetailsConverter,
                 mockEnvironment);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
+import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthorisationRequestSummary;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -150,7 +151,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
                 mockedProviders,
                 new AuthorisationService(mockExecutorService, environment, mockConfiguration),
                 chargeService,
-                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
+                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new WorldpayAuthoriseRequestLogGenerator()),
                 mockChargeEligibleForCaptureService,
                 mock(PaymentInstrumentEntityToAuthCardDetailsConverter.class),
                 environment);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -40,6 +40,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.Authori
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
+import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
@@ -202,7 +203,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
                 chargeService,
                 authorisationService,
                 mockWalletPaymentInfoToAuthCardDetailsConverter,
-                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()),
+                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new WorldpayAuthoriseRequestLogGenerator()),
                 mockEnvironment);
     }
 


### PR DESCRIPTION
Introduce a new `WorldpayAuthoriseRequest` interface, which extends `WorldpayRequest` and is implemented by `WorldpayMotoAuthoriseRequest`.

Enhance `AuthorisationLogger` so that it can log `WorldpayAuthoriseRequest` records (just `WorldpayMotoAuthoriseRequest` for now but this will be expanded in the future) by using a new `WorldpayAuthoriseRequestLogGenerator` class, which takes a `WorldpayAuthoriseRequest` and produces both the request part of the log line string and also the structured logging arguments (this is in contrast to the existing `AuthorisationRequestSummaryStringifier` and `AuthorisationRequestSummaryStructuredLogging` classes, which generate the two parts separately).

This approach bypasses the need for an intermediary `AuthorisationRequestSummary` class, instead using the `WorldpayAuthoriseRequest` record directly.

Some data that’s logged, like whether or not a corporate card is being used, are not part of the request sent to Worldpay so have to be retrieved from the `AuthCardDetails` object.

The existing `AuthorisationLogger` functionality, such as logging an `AuthorisationRequestSummary`, remains unchanged.