### PR TITLE
PP-15121 Support getting Authorization header from WorldpayRequest

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayRequest.java
@@ -1,4 +1,8 @@
 package uk.gov.pay.connector.gateway.model.request.records;
 
 public interface WorldpayRequest {
+
+    String username();
+    String password();
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
@@ -14,8 +14,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 
-import static java.lang.String.format;
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static java.lang.String.format;
 
 public class AuthUtil {
     private static final String STRIPE_VERSION_HEADER = "Stripe-Version";
@@ -72,7 +72,7 @@ public class AuthUtil {
     }
 
     private static Map<String, String> getWorldpayAuthHeader(WorldpayMerchantCodeCredentials creds) {
-        return getAuthHeader(creds.getUsername(), creds.getPassword());
+        return getAuthorizationHeader(creds.getUsername(), creds.getPassword());
     }
 
     public static Map<String, String> getWorldpayAuthHeaderForManagingRecurringAuthTokens(GatewayCredentials credentials) {
@@ -90,10 +90,14 @@ public class AuthUtil {
     }
 
     public static Map<String, String> getWorldpayCredentialsCheckAuthHeader(WorldpayValidatableCredentials worldpayValidatableCredentials) {
-        return getAuthHeader(worldpayValidatableCredentials.getUsername(), worldpayValidatableCredentials.getPassword());
+        return getAuthorizationHeader(worldpayValidatableCredentials.getUsername(), worldpayValidatableCredentials.getPassword());
     }
 
-    private static Map<String, String> getAuthHeader(String username, String password) {
+    public static Map<String, String> getAuthHeader(String username, String password) {
+        return getAuthorizationHeader(username, password);
+    }
+
+    private static Map<String, String> getAuthorizationHeader(String username, String password) {
         String value = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
         return Map.of(AUTHORIZATION, value);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthUtilTest.java
@@ -135,6 +135,13 @@ class AuthUtilTest {
         assertThat(merchantId, is(oneOffMerchantCode));
     }
 
+    @Test
+    void shouldGetAuthHeaderFromUsernameAndPassword() {
+        String expectedHeader = "Basic " + Base64.getEncoder().encodeToString((oneOffUsername + ":" + oneOffPassword).getBytes(StandardCharsets.UTF_8));
+        Map<String, String> encodedHeader = AuthUtil.getAuthHeader(oneOffUsername, oneOffPassword);
+        assertThat(encodedHeader.get(AUTHORIZATION), is(expectedHeader));
+    }
+
     private WorldpayCredentials getWorldpayCredentialsWithAllPaymentChannels() {
         WorldpayCredentials worldpayCredentials = new WorldpayCredentials();
         worldpayCredentials.setOneOffCustomerInitiatedCredentials(new WorldpayMerchantCodeCredentials(oneOffMerchantCode, oneOffUsername, oneOffPassword));


### PR DESCRIPTION
Add `username()` and `password()` methods to `WorldpayRequest` (thus ensuring all records that implement this interface must have `username` and `password` components).

Add a method to `AuthUtil` to generate a `Bearer` `Authorization` header from a supplied username and password.