### PR TITLE
PP-15148-send-3ds-info-to-adyen-and-map-to-3ds-response-parse-ints

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.gateway.adyen;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
@@ -25,12 +27,14 @@ import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getMerchantAccountId;
 
 public class AdyenRequestFactory {
 
     private final ConnectorConfiguration configuration;
+    private final Logger LOGGER = LoggerFactory.getLogger(AdyenRequestFactory.class);
 
     public AdyenRequestFactory(ConnectorConfiguration configuration) {
         this.configuration = configuration;
@@ -125,18 +129,26 @@ public class AdyenRequestFactory {
         }
         return (AdyenCredentials) gatewayCredentials;
     }
-
+    
     private BrowserInfo mapToBrowserInfo(AuthCardDetails authCardDetails) {
         return new BrowserInfo(
                 authCardDetails.getAcceptHeader(),
-                authCardDetails.getJsScreenColorDepth().map(Integer::valueOf).orElse(null),
-                false,
+                authCardDetails.getJsScreenColorDepth().flatMap(this::parseInteger).orElse(null),                false,
                 authCardDetails.getJsEnabled(),
-                authCardDetails.getJsNavigatorLanguage().map(String::valueOf).orElse(null),
-                authCardDetails.getJsScreenHeight().map(Integer::valueOf).orElse(null),
-                authCardDetails.getJsScreenWidth().map(Integer::valueOf).orElse(null),
-                authCardDetails.getJsTimezoneOffsetMins().map(Integer::valueOf).orElse(null),
+                authCardDetails.getJsNavigatorLanguage().orElse(null),
+                authCardDetails.getJsScreenHeight().flatMap(this::parseInteger).orElse(null),
+                authCardDetails.getJsScreenWidth().flatMap(this::parseInteger).orElse(null),
+                authCardDetails.getJsTimezoneOffsetMins().flatMap(this::parseInteger).orElse(null),
                 authCardDetails.getUserAgentHeader()
         );
+    }
+
+    private Optional<Integer> parseInteger(String value) {
+        try {
+            return Optional.of(Integer.valueOf(value));
+        } catch (NumberFormatException e) {
+            LOGGER.warn("Unable to parse browser info integer '{}'", value, e);
+            return Optional.empty();
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
@@ -297,6 +297,38 @@ class AdyenRequestFactoryTest {
         assertThat(request.shopperEmail(),is(nullValue()));
         assertThat(request.shopperIP(), is(nullValue()));
     }
+
+    @Test
+    void should_handle_null_or_invalid_browser_info_values_for_web_payment() {
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withAcceptHeader("text/html")
+                        .withUserAgentHeader("Mozilla/5.0")
+                        .withIpAddress("127.0.0.1")
+                        .withJsNavigatorLanguage(null)
+                        .withJsScreenColorDepth("invalid")
+                        .withJsScreenHeight(null)
+                        .withJsScreenWidth("not-a-number")
+                        .withJsTimezoneOffsetMins("bad-offset")
+                        .withJsEnabled(null)
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .withEmail("test@example.com")
+                .build();
+
+        var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
+
+        assertThat(request.browserInfo().acceptHeader(), is("text/html"));
+        assertThat(request.browserInfo().colorDepth(), is(nullValue()));
+        assertThat(request.browserInfo().javaEnabled(), is(false));
+        assertThat(request.browserInfo().javaScriptEnabled(), is(nullValue()));
+        assertThat(request.browserInfo().language(), is(nullValue()));
+        assertThat(request.browserInfo().screenHeight(), is(nullValue()));
+        assertThat(request.browserInfo().screenWidth(), is(nullValue()));
+        assertThat(request.browserInfo().timeZoneOffset(), is(nullValue()));
+        assertThat(request.browserInfo().userAgent(), is("Mozilla/5.0"));
+        assertThat(request.shopperIP(), is("127.0.0.1"));
+    }
     
     private static CancelGatewayRequest makeCancelGatewayRequestWithExternalChargeId(String externalChargeId) {
         var chargeEntity = aValidChargeEntity()

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -131,7 +131,7 @@ public final class AuthCardDetailsFixture {
         return this;
     }    
     
-    public  AuthCardDetailsFixture withJsEnabled(boolean jsEnabled) {
+    public  AuthCardDetailsFixture withJsEnabled(Boolean jsEnabled) {
         this.jsEnabled = jsEnabled;
         return this;
     }


### PR DESCRIPTION
##   Context

 - From review it was found:
	- Some strings are converted to an integer when building the browserInfo object. There is a possibility that these will result in an exception when the frontend doesn’t send data (for null values- when JavaScript is disabled, and invalid integers for some reason )

##   What you did

- Add safe parsing for browser information fields that are expected to be integers (colourDepth, screenHeight, screenWidth and timeZoneOffset)



