### PR TITLE
PP-15525: set the correct frontend return url for adyen authorisation request

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -39,7 +39,8 @@ public class AdyenRequestFactory {
     public AuthoriseRequestPayload createPaymentRequest(CardAuthorisationGatewayRequest request) {
         var authCardDetails = request.getAuthCardDetails();
         boolean isMoto = "Moto".equals(getShopperInteraction(request));
-
+        String frontendUrl = configuration.getLinks().getFrontendUrl();
+        
         var mappedAddress = authCardDetails.getAddress()
                 .map(AdyenRequestFactory::mapToBillingAddress)
                 .orElse(null);
@@ -52,20 +53,20 @@ public class AdyenRequestFactory {
                 "scheme");
 
         var adyenCredentials = mapToAdyenCredentials(request.getGatewayCredentials());
-
+        
         return new AuthoriseRequestPayload(
                 new Amount("GBP", Long.valueOf(request.getAmount())),
                 mappedAddress,
                 getMerchantAccountId(configuration.getAdyenGatewayConfig(), request.getGatewayAccount().isLive()),
                 paymentMethod,
                 request.getGovUkPayPaymentId(),
-                configuration.getLinks().getFrontendUrl(),
+                String.format("%s/card_details/%s/3ds_required_in/adyen", frontendUrl, request.getGovUkPayPaymentId()),
                 getShopperInteraction(request),
                 adyenCredentials.storeId(),
                 "Web",
                 new HashMap<>(Map.of("manualCapture", "true")),
                 isMoto ? null : mapToBrowserInfo(authCardDetails),
-                isMoto ? null : configuration.getLinks().getFrontendUrl(),
+                isMoto ? null : frontendUrl,
                 isMoto ? null : request.getEmail(),
                 isMoto ? null : authCardDetails.getIpAddress().orElse(null)
         );

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
@@ -12,8 +12,8 @@ import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.adyen.request.json.BillingAddress;
 import uk.gov.pay.connector.gateway.adyen.request.json.RefundRequestPayload;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
-import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -107,7 +107,7 @@ class AdyenRequestFactoryTest {
         assertThat(request.amount().currency(), is("GBP"));
         assertThat(request.channel(), is("Web"));
         assertThat(request.shopperInteraction(), is("Ecommerce"));
-        assertThat(request.returnUrl(), is("https://www.example.com"));
+        assertThat(request.returnUrl(), is("https://www.example.com/card_details/gov_uk_payment_id/3ds_required_in/adyen"));
         assertThat(request.reference(), is("gov_uk_payment_id"));
         assertThat(request.merchantAccount(), is("test"));
         assertThat(request.store(), is("store_id"));
@@ -152,7 +152,7 @@ class AdyenRequestFactoryTest {
         assertThat(request.amount().currency(), is("GBP"));
         assertThat(request.channel(), is("Web"));
         assertThat(request.shopperInteraction(), is("Ecommerce"));
-        assertThat(request.returnUrl(), is("https://www.example.com"));
+        assertThat(request.returnUrl(), is("https://www.example.com/card_details/gov_uk_payment_id/3ds_required_in/adyen"));
         assertThat(request.reference(), is("gov_uk_payment_id"));
         assertThat(request.merchantAccount(), is("test"));
         assertThat(request.store(), is("store_id"));

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseMotoApiPaymentIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseMotoApiPaymentIT.java
@@ -125,7 +125,7 @@ public class AdyenCardResourceAuthoriseMotoApiPaymentIT {
                 .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
                 .withRequestBody(equalToJson(
                         load(ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS)
-                                .formatted(CHARGE_EXTERNAL_ID, "Moto"))));
+                                .formatted(CHARGE_EXTERNAL_ID, "http://CardFrontend//card_details/" + CHARGE_EXTERNAL_ID +"/3ds_required_in/adyen", "Moto"))));
 
     }
 

--- a/src/test/resources/templates/adyen/authorisation_request_with_full_billing_address.json
+++ b/src/test/resources/templates/adyen/authorisation_request_with_full_billing_address.json
@@ -20,7 +20,7 @@
     "type": "scheme"
   },
   "reference": "%s",
-  "returnUrl": "http://CardFrontend/",
+  "returnUrl": "%s",
   "shopperInteraction": "%s",
   "channel": "Web",
   "additionalData" : {


### PR DESCRIPTION
## WHAT YOU DID
- changed `returnUrl` in `createPaymentRequest` to be in the format of `[frontendUrl]/card_details/[charge_external_id]/3ds_required_in/adyen`
- updated `authorisation_request_with_full_billing_address.json` template to be formatted in the tests
- fixed failing tests as a result of this hange to assert on new `returnUrl`

## How to test
- ensure all tests still pass

