### PR TITLE
PP15417 Fix additional browser info API field name

### DIFF
--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3665,7 +3665,7 @@ components:
         js_screen_width:
           type: string
           example: "1440"
-        js_timezone_offset_min:
+        js_timezone_offset_mins:
           type: string
           example: "-60"
         prepaid:

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -88,7 +88,7 @@ public class AuthCardDetails {
         return Optional.ofNullable(jsTimezoneOffsetMins);
     }
 
-    @JsonProperty("js_timezone_offset_min")
+    @JsonProperty("js_timezone_offset_mins")
     public void setJsTimezoneOffsetMins(String jsTimezoneOffsetMins) {
         this.jsTimezoneOffsetMins = jsTimezoneOffsetMins;
     }


### PR DESCRIPTION
## WHAT YOU DID

- Updated field name `js_timezone_offset_min` to `js_timezone_offset_mins`, which is what the Frontend is sending to Connector https://github.com/alphagov/pay-frontend/blob/26243da0120be74d222b75d2f0404ee964ce0a68/app/services/normalise-charge.js#L187
