### PR TITLE
PP-15121 refactor template builder

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -25,6 +25,7 @@ import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.stripe.StripeSdkClientFactory;
 import uk.gov.pay.connector.gateway.stripe.StripeSdkWrapper;
+import uk.gov.pay.connector.gateway.templates.WorldpayRequestTemplateBuilder;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
@@ -79,6 +80,7 @@ public class ConnectorModule extends AbstractModule {
         bind(RequestValidator.class);
         bind(GatewayAccountRequestValidator.class).in(Singleton.class);
         bind(InetAddressValidator.class).in(Singleton.class);
+        bind(WorldpayRequestTemplateBuilder.class).in(Singleton.class);
 
         install(jpaModule(configuration));
         install(new FactoryModuleBuilder().build(GatewayAccountServicesFactory.class));

--- a/src/main/java/uk/gov/pay/connector/gateway/templates/TemplateBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/templates/TemplateBuilder.java
@@ -5,7 +5,6 @@ import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
 import uk.gov.pay.connector.gateway.OrderRequestBuilder.TemplateData;
-import uk.gov.pay.connector.gateway.model.request.records.WorldpayRequest;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -25,16 +24,6 @@ public class TemplateBuilder implements PayloadBuilder {
         Writer responseWriter = new StringWriter();
         try {
             template.process(templateData, responseWriter);
-        } catch (TemplateException | IOException e) {
-            throw new RuntimeException("Could not render template " + template.getName(), e);
-        }
-        return responseWriter.toString();
-    }
-
-    public String buildWith(WorldpayRequest templateRecord) {
-        Writer responseWriter = new StringWriter();
-        try {
-            template.process(templateRecord, responseWriter);
         } catch (TemplateException | IOException e) {
             throw new RuntimeException("Could not render template " + template.getName(), e);
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/templates/WorldpayRequestTemplateBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/templates/WorldpayRequestTemplateBuilder.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.connector.gateway.templates;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateExceptionHandler;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayRequest;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Locale;
+
+import static freemarker.template.Configuration.VERSION_2_3_34;
+
+public class WorldpayRequestTemplateBuilder {
+    private final Configuration cfg;
+
+    public WorldpayRequestTemplateBuilder() {
+        cfg = new Configuration(VERSION_2_3_34);
+        cfg.setDefaultEncoding("UTF-8");
+        cfg.setLocale(Locale.ENGLISH);
+        cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+        cfg.setClassForTemplateLoading(WorldpayRequestTemplateBuilder.class, "/templates");
+    }
+
+    public String buildWith(String templatePath, WorldpayRequest templateRecord) {
+        Template template;
+        try {
+            template = cfg.getTemplate(templatePath);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not load template " + templatePath + " in dir /templates", e);
+        }
+        Writer responseWriter = new StringWriter();
+        try {
+            template.process(templateRecord, responseWriter);
+        } catch (TemplateException | IOException e) {
+            throw new RuntimeException("Could not render template " + template.getName(), e);
+        }
+        return responseWriter.toString();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/templates/WorldpayRequestTemplateBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/templates/WorldpayRequestTemplateBuilderTest.java
@@ -13,16 +13,16 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 import static uk.gov.pay.connector.util.XmlAssertions.assertThat;
 
-class TemplateBuilderTest {
+class WorldpayRequestTemplateBuilderTest {
+    private final WorldpayRequestTemplateBuilder worldpayRequestTemplateBuilder = new WorldpayRequestTemplateBuilder();
 
     @Nested
     class MotoAuthorisationRequest {
         @Test
         void shouldGenerateValidAuthoriseOrderRequestForWorldpayMotoAuthorisationRequest() {
-            TemplateBuilder templateBuilder = new TemplateBuilder("/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx");
             WorldpayMotoAuthoriseRequest motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
 
-            assertThat(templateBuilder.buildWith(motoOrder))
+            assertThat(worldpayRequestTemplateBuilder.buildWith("/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx", motoOrder))
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_MOTO_AUTHORISATION_REQUEST))
                     .areIdentical();
         }
@@ -32,12 +32,11 @@ class TemplateBuilderTest {
     class TemplateBuilderAppliesAutoEscape {
         @Test
         void shouldGenerateValidAuthoriseOrderRequestWithAutoEscape() {
-            TemplateBuilder templateBuilder = new TemplateBuilder("/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx");
-
             WorldpayMotoAuthoriseRequest motoOrder = aWorldpayMotoAuthoriseRequestFixture()
                     .withMerchantCode("MERCHANT\"\"CODE")
                     .withCardholderName("Alec & Barley").build();
-            String renderedAuthoriseOrder = templateBuilder.buildWith(motoOrder);
+            String renderedAuthoriseOrder = worldpayRequestTemplateBuilder.buildWith("/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx", motoOrder);
+            
             assertThat(renderedAuthoriseOrder, containsString("MERCHANT&quot;&quot;CODE"));
             assertThat(renderedAuthoriseOrder, containsString("Alec &amp; Barley"));
         }
@@ -47,20 +46,21 @@ class TemplateBuilderTest {
     class InvalidActionsThrowingException {
         @Test
         void shouldThrowRuntimeExceptionWhenTemplateIsNotFound() {
-            var thrown = assertThrows(RuntimeException.class, () -> new TemplateBuilder("/worldpay/NonExistentOrderTemplate.xml"));
+            WorldpayMotoAuthoriseRequest motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
+            var thrown = assertThrows(RuntimeException.class, () -> worldpayRequestTemplateBuilder.buildWith("/worldpay/NonExistentOrderTemplate.xml", motoOrder));
+            
             assertThat(thrown.getMessage(), is("Could not load template /worldpay/NonExistentOrderTemplate.xml in dir /templates"));
         }
 
         @Test
         void shouldThrowRuntimeExceptionWhenCannotRenderTemplate() {
-            TemplateBuilder templateBuilder = new TemplateBuilder("/worldpay/WorldpayCancelOrderTemplate.xml");
             WorldpayMotoAuthoriseRequest motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
 
             var thrown = assertThrows(RuntimeException.class, () -> {
-                templateBuilder.buildWith(motoOrder);
+                worldpayRequestTemplateBuilder.buildWith("/worldpay/WorldpayCancelOrderTemplate.xml", motoOrder);
             });
+            
             assertThat(thrown.getMessage(), is("Could not render template worldpay/WorldpayCancelOrderTemplate.xml"));
         }
     }
-
 }


### PR DESCRIPTION
## WHAT YOU DID

Split `TemplateBuilder` in two so we have a different singleton class that uses WordlpayRequest interface.
Return `TemplateBuilder` to its original state.
Make new template builder (`WorldpayRequestTemplateBuilder`) a singleton for injection.


