### PR TITLE
PP-14489: Handle successful refund notification

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
@@ -61,7 +61,7 @@ public class AdyenNotificationService {
 
         try {
             NotificationRequest notificationRequest = deserialisePayloadToNotificationRequest(payload);
-            List<NotificationRequestItem> items = extractNotificationItem(notificationRequest);
+            List<NotificationRequestItem> items = extractNotificationItems(notificationRequest);
 
             boolean live = "true".equalsIgnoreCase(notificationRequest.getLive());
 
@@ -117,7 +117,7 @@ public class AdyenNotificationService {
         }
     }
 
-    public List<NotificationRequestItem> extractNotificationItem(NotificationRequest notificationRequest) {
+    public List<NotificationRequestItem> extractNotificationItems(NotificationRequest notificationRequest) {
         if (notificationRequest == null ||
                 (notificationRequest.getNotificationItems() == null || notificationRequest.getNotificationItems().isEmpty())) {
             LOGGER.info("Adyen notification request is empty or missing items");

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -62,7 +62,7 @@ public class RefundNotificationProcessor {
                     () -> logger.warn("{} notification '{}' could not be used to update refund (associated refund entity not found) for charge [{}]",
                             gatewayName, gatewayTransactionId, charge.getExternalId(),
                             kv(PAYMENT_EXTERNAL_ID, charge.getExternalId()), kv(PROVIDER, gatewayName),
-                            kv("provider_refund_id", transactionId),
+                            kv("payment_gateway_transaction_id", transactionId),
                             kv("gateway_transaction_id", gatewayTransactionId))
             );
             return;
@@ -98,7 +98,7 @@ public class RefundNotificationProcessor {
                 kv(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId()),
                 kv(PROVIDER, charge.getPaymentGatewayName()),
                 kv(GATEWAY_ACCOUNT_TYPE, gatewayAccountEntity.getType()),
-                kv("provider_refund_id", transactionId),
+                kv("payment_gateway_transaction_id", transactionId),
                 kv("gateway_transaction_id", gatewayTransactionId),
                 kv("from_status", oldStatus),
                 kv("to_status", newStatus)

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -26,9 +26,9 @@ import static uk.gov.service.payments.logging.LoggingKeys.REFUND_EXTERNAL_ID;
 
 public class RefundNotificationProcessor {
 
-    private Logger logger = LoggerFactory.getLogger(getClass());
-    private RefundService refundService;
-    private UserNotificationService userNotificationService;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final RefundService refundService;
+    private final UserNotificationService userNotificationService;
 
     @Inject
     RefundNotificationProcessor(RefundService refundService,

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenWebhookTaskHandler.java
@@ -9,16 +9,21 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
 import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.adyen.model.notification.NotificationRequestItem.EVENT_CODE_CAPTURE;
+import static com.adyen.model.notification.NotificationRequestItem.EVENT_CODE_REFUND;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
@@ -29,16 +34,19 @@ public class AdyenWebhookTaskHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdyenWebhookTaskHandler.class);
     private final ChargeService chargeService;
     private final ChargeNotificationProcessor chargeNotificationProcessor;
+    private final RefundNotificationProcessor refundNotificationProcessor;
     private final GatewayAccountService gatewayAccountService;
     private final AdyenNotificationService adyenNotificationService;
 
     @Inject
     public AdyenWebhookTaskHandler(ChargeService chargeService,
                                    ChargeNotificationProcessor chargeNotificationProcessor,
+                                   RefundNotificationProcessor refundNotificationProcessor,
                                    GatewayAccountService gatewayAccountService,
                                    AdyenNotificationService adyenNotificationService) {
         this.chargeService = chargeService;
         this.chargeNotificationProcessor = chargeNotificationProcessor;
+        this.refundNotificationProcessor = refundNotificationProcessor;
         this.gatewayAccountService = gatewayAccountService;
         this.adyenNotificationService = adyenNotificationService;
     }
@@ -48,11 +56,29 @@ public class AdyenWebhookTaskHandler {
         NotificationRequest notificationRequest =
                 adyenNotificationService.deserialisePayloadToNotificationRequest(payload);
 
-        List<NotificationRequestItem> items = adyenNotificationService.extractNotificationItem(notificationRequest);
+        List<NotificationRequestItem> items = adyenNotificationService.extractNotificationItems(notificationRequest);
 
         for (NotificationRequestItem item : items) {
-            processCapturedNotification(item);
+            switch (item.getEventCode()) {
+                case EVENT_CODE_CAPTURE -> processCapturedNotification(item);
+                case EVENT_CODE_REFUND -> processRefundNotification(item);
+            }
         }
+    }
+
+    private void processRefundNotification(NotificationRequestItem item) {
+        var charge = chargeService.findByProviderAndTransactionIdFromDbOrLedger(
+                ADYEN.getName(),
+                item.getOriginalReference());
+        var gatewayAccount = gatewayAccountService.getGatewayAccount(
+                charge.get().getGatewayAccountId());
+        refundNotificationProcessor.invoke(
+                PaymentGatewayName.ADYEN,
+                RefundStatus.REFUNDED,
+                gatewayAccount.get(),
+                item.getPspReference(),
+                item.getOriginalReference(),
+                charge.get());
     }
 
     private void processCapturedNotification(NotificationRequestItem item) {

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
@@ -61,6 +61,26 @@ class RefundNotificationProcessorTest {
     }
 
     @Test
+    void shouldInvokeTransitionRefundStateForSuccessfulRefund() {
+        var targetRefundStatus = RefundStatus.REFUNDED;
+        when(refundService.findByChargeExternalIdAndGatewayTransactionId(
+                charge.getExternalId(),
+                REFUND_GATEWAY_TRANSACTION_ID))
+                .thenReturn(Optional.of(refundEntity));
+
+        refundNotificationProcessor.invoke(
+                paymentGatewayName,
+                targetRefundStatus,
+                gatewayAccountEntity,
+                REFUND_GATEWAY_TRANSACTION_ID,
+                TRANSACTION_ID,
+                charge);
+
+        verify(refundService)
+                .transitionRefundState(refundEntity, gatewayAccountEntity, targetRefundStatus, charge);
+    }
+
+    @Test
     void shouldInvokeSendEmailNotificationsForSuccessfulRefunds() {
         Optional<RefundEntity> optionalRefundEntity = Optional.of(refundEntity);
         when(refundService.findByChargeExternalIdAndGatewayTransactionId(charge.getExternalId(), REFUND_GATEWAY_TRANSACTION_ID)).thenReturn(optionalRefundEntity);

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/AdyenWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/AdyenWebhookTaskHandlerTest.java
@@ -44,7 +44,7 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 
 
 @ExtendWith(MockitoExtension.class)
-public class AdyenWebhookTaskHandlerTest {
+class AdyenWebhookTaskHandlerTest {
 
     @Mock
     private GatewayAccountService mockGatewayAccountService;
@@ -57,16 +57,16 @@ public class AdyenWebhookTaskHandlerTest {
 
     @Mock
     private AdyenNotificationService mockAdyenNotificationService;
-    
+
     @Mock
     private Charge mockCharge;
-    
+
     @Mock
     NotificationRequest mockNotificationRequest;
-    
+
     @Mock
     NotificationRequestItem mockNotificationItem;
-    
+
     @Mock
     GatewayAccountEntity gatewayAccount;
 
@@ -78,29 +78,28 @@ public class AdyenWebhookTaskHandlerTest {
 
     @InjectMocks
     private AdyenWebhookTaskHandler adyenWebhookTaskHandler;
-    
+
     private final String gatewayTransactionId = "adyen-payment-id-1";
-    
+
     private final String payload = "payload";
-    private final  Date eventDate = Date.from(Instant.parse("2026-05-19T10:15:30Z"));
+    private final Date eventDate = Date.from(Instant.parse("2026-05-19T10:15:30Z"));
     private final long gatewayAccountId = 123L;
 
 
     @BeforeEach
     void setUp() {
-        adyenWebhookTaskHandler = new AdyenWebhookTaskHandler(mockChargeService, mockChargeNotificationProcessor,
-                mockGatewayAccountService, mockAdyenNotificationService);
         Logger root = (Logger) LoggerFactory.getLogger(AdyenWebhookTaskHandler.class);
         root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
     }
+
     @Test
     void shouldProcessSuccessfulCaptureNotificationForConnectorCharge() {
         when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
                 .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItem(mockNotificationRequest))
+        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
                 .thenReturn(List.of(mockNotificationItem));
-
+        when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockNotificationItem.isSuccess()).thenReturn(true);
         when(mockNotificationItem.getEventDate()).thenReturn(eventDate);
@@ -113,7 +112,7 @@ public class AdyenWebhookTaskHandlerTest {
 
         adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
 
-        verify(mockChargeService).findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(), 
+        verify(mockChargeService).findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
                 gatewayTransactionId);
 
         verify(mockChargeNotificationProcessor).invoke(gatewayTransactionId, mockCharge,
@@ -124,14 +123,14 @@ public class AdyenWebhookTaskHandlerTest {
     void shouldProcessCaptureFailedMessageFromTaskQueueForConnectorCharge() {
         when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
                 .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItem(mockNotificationRequest))
+        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
                 .thenReturn(List.of(mockNotificationItem));
-
+        when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockNotificationItem.isSuccess()).thenReturn(false);
         when(mockNotificationItem.getEventDate()).thenReturn(eventDate);
 
-        when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(), 
+        when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
                 gatewayTransactionId)).thenReturn(Optional.of(mockCharge));
 
         when(mockCharge.isHistoric()).thenReturn(false);
@@ -143,46 +142,47 @@ public class AdyenWebhookTaskHandlerTest {
 
         verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-        
+
         assertThat(loggingEvents.stream().anyMatch(event -> event.getFormattedMessage()
                 .equals("Capture failed")), is(true));
 
     }
-    
+
     @Test
     void shouldProcessSuccessfulCaptureMessageFromTaskQueueForLedgerCharge() {
         when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
                 .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItem(mockNotificationRequest))
+        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
                 .thenReturn(List.of(mockNotificationItem));
+        when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockNotificationItem.isSuccess()).thenReturn(true);
 
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
                 gatewayTransactionId)).thenReturn(Optional.of(mockCharge));
-        
+
         when(mockCharge.getGatewayAccountId()).thenReturn(gatewayAccountId);
         when(mockGatewayAccountService.getGatewayAccount(gatewayAccountId))
                 .thenReturn(Optional.of(gatewayAccount));
         when(mockCharge.isHistoric()).thenReturn(true);
         when(mockGatewayAccountService.getGatewayAccount(gatewayAccountId))
                 .thenReturn(Optional.of(gatewayAccount));
-        
+
         adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
 
         verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(
                 gatewayAccount, gatewayTransactionId, mockCharge, CAPTURED);
         verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
     }
-    
+
     @Test
     void shouldProcessFailedCaptureMessageFromTaskQueueForLedgerCharge() {
         when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
                 .thenReturn(mockNotificationRequest);
 
-        when(mockAdyenNotificationService.extractNotificationItem(mockNotificationRequest))
+        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
                 .thenReturn(List.of(mockNotificationItem));
-
+        when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockNotificationItem.isSuccess()).thenReturn(false);
 
@@ -197,7 +197,7 @@ public class AdyenWebhookTaskHandlerTest {
 
         adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
 
-        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccount, 
+        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccount,
                 gatewayTransactionId,
                 mockCharge,
                 CAPTURE_ERROR
@@ -209,16 +209,17 @@ public class AdyenWebhookTaskHandlerTest {
     void shouldLogWarningWhenChargeDoesNotExistInConnectorOrLedger() {
         when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
                 .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItem(mockNotificationRequest))
+        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
                 .thenReturn(List.of(mockNotificationItem));
+        when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
                 gatewayTransactionId)).thenReturn(Optional.empty());
-        
+
         adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
-        
+
         verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
-        verify(mockChargeNotificationProcessor, never()).processCaptureNotificationForExpungedCharge(any(), any(), 
+        verify(mockChargeNotificationProcessor, never()).processCaptureNotificationForExpungedCharge(any(), any(),
                 any(), any());
         verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
 

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenWebhookTaskHandlerForPaymentWebhooksIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenWebhookTaskHandlerForPaymentWebhooksIT.java
@@ -1,52 +1,73 @@
 package uk.gov.pay.connector.queue.tasks.handlers;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.util.TestTemplateResourceLoader;
-
-import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_CAPTURE_SUCCESS_NOTIFICATION;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_REFUND_SUCCESS_NOTIFICATION;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 class AdyenWebhookTaskHandlerForPaymentWebhooksIT {
+
+    public static final String CHARGE_EXTERNAL_ID = "charge-external-id";
+
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
 
+    private AdyenWebhookTaskHandler adyenWebhookTaskHandler;
+
+    @BeforeEach
+    void setUp() {
+        adyenWebhookTaskHandler = app.getInstanceFromGuiceContainer(AdyenWebhookTaskHandler.class);
+    }
+
     @ParameterizedTest
-    @MethodSource("chargeStatusAndExpectedTargetStatus")
-    void shouldUpdateChargeInDifferentCaptureStateToCapture_ForSuccessfulCaptureNotification(
-            ChargeStatus currentStatus, ChargeStatus expectedTargetStatus) {
-        DatabaseFixtures.TestCharge testCharge = getTestChargeWithStatus(currentStatus);
-        AdyenWebhookTaskHandler adyenWebhookTaskHandler = app.getInstanceFromGuiceContainer(AdyenWebhookTaskHandler.class);
-        String captureNotification = TestTemplateResourceLoader.load(ADYEN_CAPTURE_SUCCESS_NOTIFICATION);
+    @CsvSource({"CAPTURE_SUBMITTED", "CAPTURE_APPROVED_RETRY", "CAPTURED"})
+    void should_update_charge_in_different_capture_state_to_CAPTURED_for_successful_capture_notification(ChargeStatus currentStatus) {
+        var testCharge = createTestChargeWithStatus(currentStatus);
 
-        adyenWebhookTaskHandler.processAdyenWebhookNotification(captureNotification);
+        adyenWebhookTaskHandler.processAdyenWebhookNotification(load(ADYEN_CAPTURE_SUCCESS_NOTIFICATION));
 
-        Map<String, Object> chargeFromDatabase = app.getDatabaseTestHelper().getChargeByExternalId(testCharge.getExternalChargeId());
-        assertThat(chargeFromDatabase.get("status"), is(expectedTargetStatus.name()));
+        var chargeFromDatabase = app.getDatabaseTestHelper()
+                .getChargeByExternalId(testCharge.getExternalChargeId());
+        assertThat(chargeFromDatabase.get("status"), is(CAPTURED.name()));
     }
 
-    static Stream<Arguments> chargeStatusAndExpectedTargetStatus() {
-        return Stream.of(
-                Arguments.of(CAPTURE_SUBMITTED, CAPTURED),
-                Arguments.of(CAPTURE_APPROVED_RETRY, CAPTURED),
-                Arguments.of(CAPTURED, CAPTURED)
-        );
+    @Test
+    void should_update_charge_to_REFUNDED_for_successful_refund_notification() {
+        var capturedCharge = createTestChargeWithStatus(CAPTURED);
+        var testRefund = app.getDatabaseFixtures()
+                .aTestRefund()
+                .withTestCharge(capturedCharge)
+                .withGatewayTransactionId("some-pspReference-returned-from-refund-request-to-Adyen")
+                .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                .withRefundStatus(REFUND_SUBMITTED)
+                .insert();
+        var payload = load(ADYEN_REFUND_SUCCESS_NOTIFICATION)
+                .replace("{{pspReference}}", testRefund.getGatewayTransactionId())
+                .replace("{{merchantReference}}", testRefund.getExternalRefundId());
+
+        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
+
+        var refundFromDatabase = app.getDatabaseTestHelper()
+                .getRefund(testRefund.getId())
+                .getFirst();
+        assertThat(refundFromDatabase.get("status"), is(REFUNDED.name()));
     }
 
-    private static DatabaseFixtures.TestCharge getTestChargeWithStatus(ChargeStatus chargeStatus) {
+    private static DatabaseFixtures.TestCharge createTestChargeWithStatus(ChargeStatus chargeStatus) {
         DatabaseFixtures.TestAccount testAccount = app.getDatabaseFixtures()
                 .aTestAccount()
                 .withPaymentProvider(ADYEN.getName())
@@ -54,11 +75,11 @@ class AdyenWebhookTaskHandlerForPaymentWebhooksIT {
 
         return app.getDatabaseFixtures()
                 .aTestCharge()
+                .withExternalChargeId(CHARGE_EXTERNAL_ID)
                 .withTransactionId("adyen-transaction-id-123")
                 .withChargeStatus(chargeStatus)
                 .withPaymentProvider(ADYEN.getName())
                 .withTestAccount(testAccount)
                 .insert();
     }
-
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -136,6 +136,7 @@ public class TestTemplateResourceLoader {
     public static final String ADYEN_AUTHORISATION_REQUEST_WITH_FULL_BILLING_ADDRESS = TEMPLATE_BASE_NAME + "/adyen/authorisation_request_with_full_billing_address.json";
     public static final String ADYEN_NOTIFICATION = TEMPLATE_BASE_NAME + "/adyen/notification.json";
     public static final String ADYEN_CAPTURE_SUCCESS_NOTIFICATION = TEMPLATE_BASE_NAME + "/adyen/capture-successful.json";
+    public static final String ADYEN_REFUND_SUCCESS_NOTIFICATION = TEMPLATE_BASE_NAME + "/adyen/refund-successful.json";
     public static final String ADYEN_CREATE_LEGAL_ENTITY_REQUEST = TEMPLATE_BASE_NAME + "/adyen/create_legal_entity_request.json";
     public static final String ADYEN_CREATE_LEGAL_ENTITY_RESPONSE = TEMPLATE_BASE_NAME + "/adyen/create_legal_entity_response.json";
     public static final String ADYEN_CREATE_INDIVIDUAL_REQUEST =  TEMPLATE_BASE_NAME + "/adyen/create_individual_request.json";

--- a/src/test/resources/templates/adyen/capture-successful.json
+++ b/src/test/resources/templates/adyen/capture-successful.json
@@ -8,7 +8,7 @@
         "merchantAccountCode": "TestMerchant",
         "merchantReference": "TestPayment-1407325143704",
         "eventDate":"2026-06-05T15:54:01+02:00",
-        "eventCode": "AUTHORISATION",
+        "eventCode": "CAPTURE",
         "success": "true",
         "amount": {
           "value": 1130,

--- a/src/test/resources/templates/adyen/refund-successful.json
+++ b/src/test/resources/templates/adyen/refund-successful.json
@@ -1,0 +1,22 @@
+{
+  "live":"false",
+  "notificationItems":[
+    {
+      "NotificationRequestItem":{
+        "amount":{
+          "currency":"EUR",
+          "value":2500
+        },
+        "eventCode":"REFUND",
+        "eventDate":"2021-11-01T00:19:34+01:00",
+        "merchantAccountCode":"TestMerchant",
+        "merchantReference": "{{merchantReference}}",
+        "originalReference":"adyen-transaction-id-123",
+        "paymentMethod":"visa",
+        "pspReference":"{{pspReference}}",
+        "reason":"",
+        "success":"true"
+      }
+    }
+  ]
+}

--- a/src/test/resources/templates/adyen/refund-successful.json
+++ b/src/test/resources/templates/adyen/refund-successful.json
@@ -4,7 +4,7 @@
     {
       "NotificationRequestItem":{
         "amount":{
-          "currency":"EUR",
+          "currency":"GBP",
           "value":2500
         },
         "eventCode":"REFUND",


### PR DESCRIPTION
* Added happy-path scenario for successful REFUND webhook message
* Made `AdyenWebhookTaskHandler::processAdyenWebhookNotification()` switch on the event code of the notification request item
* Renamed the logged PSP reference of the original payment in `RefundNotificationProcessor`
* Added a missing test for `RefundNotificationProcessor`
* Corrected event type of `capture-successful.json` test fixture and added a fixture for `REFUND`
* Pluralised method name of `AdyenNotificationService`, for clarity
* Made fields of `RefundNotificationProcessor` `final`