### PR TITLE
PP-15121 Introduce AuthoriseRequest sealed interface

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AuthoriseRequest.java
@@ -1,0 +1,4 @@
+package uk.gov.pay.connector.gateway.model.request.records;
+
+public sealed interface AuthoriseRequest permits WorldpayAuthoriseRequest {
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequest.java
@@ -1,4 +1,5 @@
 package uk.gov.pay.connector.gateway.model.request.records;
 
-public interface WorldpayAuthoriseRequest extends WorldpayRequest {
+public sealed interface WorldpayAuthoriseRequest extends WorldpayRequest, AuthoriseRequest
+        permits WorldpayMotoAuthoriseRequest {
 }

--- a/src/main/java/uk/gov/pay/connector/logging/AuthorisationLogger.java
+++ b/src/main/java/uk/gov/pay/connector/logging/AuthorisationLogger.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.gateway.model.request.records.AuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.request.records.WorldpayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
@@ -54,7 +55,7 @@ public class AuthorisationLogger {
     }
 
     public void logChargeAuthorisation(Logger logger,
-                                       WorldpayAuthoriseRequest worldpayAuthoriseRequest,
+                                       AuthoriseRequest authoriseRequest,
                                        AuthCardDetails authCardDetails,
                                        ChargeEntity charge,
                                        String transactionId,
@@ -62,17 +63,21 @@ public class AuthorisationLogger {
                                        ChargeStatus oldStatus,
                                        ChargeStatus newStatus) {
 
-        AuthorisationRequestLog authoriseRequestLog = worldpayAuthoriseRequestLogGenerator.generate(
-                worldpayAuthoriseRequest, authCardDetails);
+        switch (authoriseRequest) {
+            case WorldpayAuthoriseRequest worldpayAuthoriseRequest -> {
+                AuthorisationRequestLog authoriseRequestLog = worldpayAuthoriseRequestLogGenerator.generate(
+                        worldpayAuthoriseRequest, authCardDetails);
 
-        logChargeAuthorisation(logger,
-                authoriseRequestLog.authorisationRequest(),
-                authoriseRequestLog.structuredArguments().toArray(new StructuredArgument[0]),
-                charge,
-                transactionId,
-                gatewayResponse,
-                oldStatus,
-                newStatus);
+                logChargeAuthorisation(logger,
+                        authoriseRequestLog.authorisationRequest(),
+                        authoriseRequestLog.structuredArguments().toArray(new StructuredArgument[0]),
+                        charge,
+                        transactionId,
+                        gatewayResponse,
+                        oldStatus,
+                        newStatus);
+            }
+        }
     }
 
     public void logChargeAuthorisation(Logger logger,

--- a/src/test/java/uk/gov/pay/connector/logging/AuthorisationLoggerTest.java
+++ b/src/test/java/uk/gov/pay/connector/logging/AuthorisationLoggerTest.java
@@ -37,6 +37,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
 
 @ExtendWith(MockitoExtension.class)
 class AuthorisationLoggerTest {
@@ -49,9 +50,6 @@ class AuthorisationLoggerTest {
 
     @Mock
     private AuthorisationRequestSummaryStructuredLogging mockAuthorisationRequestSummaryStructuredLogging;
-
-    @Mock
-    private WorldpayAuthoriseRequest mockWorldpayAuthoriseRequest;
 
     @Mock
     private AuthCardDetails mockAuthCardDetails;
@@ -67,6 +65,8 @@ class AuthorisationLoggerTest {
 
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    private final WorldpayAuthoriseRequest worldpayAuthoriseRequest = aWorldpayMotoAuthoriseRequestFixture().build();
 
     private final GatewayAccountEntity gatewayAccountEntity = GatewayAccountEntityFixture.aGatewayAccountEntity()
             .withId(123L)
@@ -139,12 +139,12 @@ class AuthorisationLoggerTest {
     }
 
     @Test
-    void logsWithWorldayAuthorisationRequest() {
-        given(mockWorldpayAuthoriseRequestLogGenerator.generate(mockWorldpayAuthoriseRequest, mockAuthCardDetails))
+    void logsWithWorldpayAuthorisationRequest() {
+        given(mockWorldpayAuthoriseRequestLogGenerator.generate(worldpayAuthoriseRequest, mockAuthCardDetails))
                         .willReturn(new AuthorisationRequestLog(" with all the fancy details",
                                 List.of(kv("some", "fun"), kv("structured", "args"))));
 
-        authorisationLogger.logChargeAuthorisation(logger, mockWorldpayAuthoriseRequest, mockAuthCardDetails, chargeEntity,
+        authorisationLogger.logChargeAuthorisation(logger, worldpayAuthoriseRequest, mockAuthCardDetails, chargeEntity,
                 "payment-12345", mockGatewayResponse, ChargeStatus.ENTERING_CARD_DETAILS, ChargeStatus.AUTHORISATION_SUCCESS);
 
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());


### PR DESCRIPTION
Introduce `AuthoriseRequest` interface that is extended by the existing `WorldpayAuthoriseRequest` interface to avoid having PSP-specific types used in generic code.

Make `AuthoriseRequest` and `WorldpayAuthoriseRequest` sealed interfaces so we can take advantage of features like exhaustiveness checking in switch statements.