### PR TITLE
PP-15521: Add MD and PaReq fields to the AdyenAuthoriseResponse to stored on charge

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/Adyen3dsRequiredParams.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/Adyen3dsRequiredParams.java
@@ -5,13 +5,17 @@ import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 
 public record Adyen3dsRequiredParams(
         String issuerUrl,
-        String httpMethod3ds) implements Gateway3dsRequiredParams {
+        String httpMethod3ds,
+        String paReq,
+        String md) implements Gateway3dsRequiredParams {
 
     @Override
     public Auth3dsRequiredEntity toAuth3dsRequiredEntity() {
         Auth3dsRequiredEntity auth3dsRequiredEntity = new Auth3dsRequiredEntity();
         auth3dsRequiredEntity.setIssuerUrl(issuerUrl);
         auth3dsRequiredEntity.setHttpMethod3ds(httpMethod3ds);
+        auth3dsRequiredEntity.setPaRequest(paReq);
+        auth3dsRequiredEntity.setMd(md);
         return auth3dsRequiredEntity;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
@@ -14,25 +14,43 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
     private final String redirectUrl;
     private final String httpMethod3ds;
 
+    private final String paReq;
+    private final String md;
+
     public static AdyenAuthoriseResponse of(AuthoriseResponseBody authoriseResponseBody) {
         Action action = authoriseResponseBody.action();
         String url = Optional.ofNullable(action).map(Action::url).orElse(null);
         String method = Optional.ofNullable(action).map(Action::method).orElse(null);
-        
+        String paReq = Optional.ofNullable(action)
+                .map(Action::data)
+                .map(items -> items.get("PaReq"))
+                .orElse(null);
+
+        String md = Optional.ofNullable(action)
+                .map(Action::data)
+                .map(items -> items.get("MD"))
+                .orElse(null);
+
         return new AdyenAuthoriseResponse(authoriseResponseBody.pspReference(),
                 authoriseResponseBody.resultCode(),
                 url,
-                method);
+                method,
+                paReq,
+                md);
     }
 
     private AdyenAuthoriseResponse(String transactionId,
                                    String resultCode,
                                    String redirectUrl,
-                                   String httpMethod3ds) {
+                                   String httpMethod3ds,
+                                   String paReq,
+                                   String md) {
         this.transactionId = transactionId;
         authoriseStatus = mapAuthorisationStatusFrom(resultCode);
         this.redirectUrl = redirectUrl;
         this.httpMethod3ds = httpMethod3ds;
+        this.paReq = paReq;
+        this.md = md;
     }
 
     private static AuthoriseStatus mapAuthorisationStatusFrom(String resultCode) {
@@ -58,15 +76,23 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
     public String getRedirectUrl() {
         return redirectUrl;
     }
-    
+
     public String getHttpMethod3ds() {
         return httpMethod3ds;
+    }
+
+    public String getPaReq() {
+        return paReq;
+    }
+
+    public String getMd() {
+        return md;
     }
 
     @Override
     public Optional<? extends Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
         if (AuthoriseStatus.REQUIRES_3DS == authoriseStatus) {
-            return Optional.of(new Adyen3dsRequiredParams(redirectUrl, httpMethod3ds));
+            return Optional.of(new Adyen3dsRequiredParams(redirectUrl, httpMethod3ds, paReq, md));
         }
         return Optional.empty();
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
+import java.util.Map;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -81,7 +83,7 @@ class AdyenAuthoriseResponseTest {
 
         assertThat(adyenAuthoriseResponse.getRedirectUrl(), is("/redirectUrl"));
     }
-    
+
     @Test
     void should_set_httpMethod3ds_null_if_action_is_null() {
         var adyenPaymentResponse = anAdyenPaymentResponse()
@@ -116,6 +118,32 @@ class AdyenAuthoriseResponseTest {
     }
 
     @Test
+    void should_set_data_to_action_data() {
+        var adyenPaymentResponse = anAdyenPaymentResponse()
+                .withAction(anAction().withData(Map.of("MD", "testMD123", "PaReq", "testPaReq")).build())
+                .build();
+
+        var adyenAuthoriseResponse = AdyenAuthoriseResponse.of(adyenPaymentResponse);
+
+        assertThat(adyenAuthoriseResponse.getMd(), is("testMD123"));
+        assertThat(adyenAuthoriseResponse.getPaReq(), is("testPaReq"));
+    }
+
+    @Test
+    void should_not_set_data_to_action_data_if_Adyen_does_not_return_it() {
+        var adyenPaymentResponse = anAdyenPaymentResponse()
+                .withAction(anAction().withMethod("GET").build())
+                .build();
+
+        var adyenAuthoriseResponse = AdyenAuthoriseResponse.of(adyenPaymentResponse);
+
+        assertThat(adyenAuthoriseResponse.getHttpMethod3ds(), is("GET"));
+
+        assertThat(adyenAuthoriseResponse.getPaReq(), nullValue());
+        assertThat(adyenAuthoriseResponse.getMd(), nullValue());
+    }
+
+    @Test
     void should_extract_3ds_required_details_for_redirect_shopper_response() {
         var redirectUrl = "https://checkoutshopper-test.adyen.com/checkoutshopper/threeDS/redirect";
         var httpMethod = "GET";
@@ -125,6 +153,7 @@ class AdyenAuthoriseResponseTest {
                 .withAction(anAction()
                         .withUrl(redirectUrl)
                         .withMethod(httpMethod)
+                        .withData(Map.of("MD", "testMD123", "PaReq", "testPaReq123"))
                         .build())
                 .build();
 
@@ -135,5 +164,7 @@ class AdyenAuthoriseResponseTest {
         assertThat(auth3dsRequiredDetails.isPresent(), is(true));
         assertThat(auth3dsRequiredDetails.get().getIssuerUrl(), is(redirectUrl));
         assertThat(auth3dsRequiredDetails.get().getHttpMethod3ds(), is(httpMethod));
+        assertThat(auth3dsRequiredDetails.get().getPaRequest(), is("testPaReq123"));
+        assertThat(auth3dsRequiredDetails.get().getMd(), is("testMD123"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -22,6 +22,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.it.base.AddChargeParameters.Builder.anAddChargeParameters;
@@ -97,6 +98,7 @@ class AdyenCardResourceAuthoriseIT {
         assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
         assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
     }
+
     @Test
     void should_send_browser_info_origin_email_and_ip_to_adyen_for_web_payment() {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
@@ -126,17 +128,18 @@ class AdyenCardResourceAuthoriseIT {
         app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
                 .withRequestBody(matchingJsonPath("$.browserInfo.acceptHeader", equalTo(acceptHeader)))
                 .withRequestBody(matchingJsonPath("$.browserInfo.colorDepth", equalTo(colorDepth)))
-                .withRequestBody(matchingJsonPath("$.browserInfo.javaEnabled",equalTo("false")))
-                .withRequestBody(matchingJsonPath("$.browserInfo.javaScriptEnabled",equalTo("true")))
-                .withRequestBody(matchingJsonPath("$.browserInfo.language",equalTo(language)))
+                .withRequestBody(matchingJsonPath("$.browserInfo.javaEnabled", equalTo("false")))
+                .withRequestBody(matchingJsonPath("$.browserInfo.javaScriptEnabled", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.browserInfo.language", equalTo(language)))
                 .withRequestBody(matchingJsonPath("$.browserInfo.screenHeight", equalTo(screenHeight)))
-                .withRequestBody(matchingJsonPath("$.browserInfo.screenWidth",equalTo(screenWidth)))
-                .withRequestBody(matchingJsonPath("$.browserInfo.timeZoneOffset",equalTo(timezoneOffset)))
-                .withRequestBody(matchingJsonPath("$.browserInfo.userAgent",equalTo(userAgent)))
+                .withRequestBody(matchingJsonPath("$.browserInfo.screenWidth", equalTo(screenWidth)))
+                .withRequestBody(matchingJsonPath("$.browserInfo.timeZoneOffset", equalTo(timezoneOffset)))
+                .withRequestBody(matchingJsonPath("$.browserInfo.userAgent", equalTo(userAgent)))
                 .withRequestBody(matchingJsonPath("$.shopperEmail", equalTo(shopperEmail)))
                 .withRequestBody(matchingJsonPath("$.shopperIP", equalTo(shopperIp)))
                 .withRequestBody(matchingJsonPath("$.origin", equalTo(origin))));
     }
+
     @Test
     void successful_authorisation_of_a_payment_without_a_billing_address() {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
@@ -286,7 +289,7 @@ class AdyenCardResourceAuthoriseIT {
         assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
         assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
     }
-    
+
     @Test
     void should_save_3ds_data_on_charge_when_adyen_returns_with_result_code_redirect_shopper() {
         var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
@@ -295,7 +298,7 @@ class AdyenCardResourceAuthoriseIT {
         var httpMethod3ds = "GET";
 
         app.getAdyenCheckoutMockClient()
-                .mockAuthorisationRedirectShopper(pspReferenceFromAdyen, redirectUrl, httpMethod3ds);
+                .mockAuthorisationRedirectShopper(pspReferenceFromAdyen, redirectUrl, httpMethod3ds, "");
 
         var authCardDetails = anAuthCardDetails().build();
 
@@ -313,6 +316,43 @@ class AdyenCardResourceAuthoriseIT {
         assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
         assertThat(charge.get().get3dsRequiredDetails().getIssuerUrl(), is(redirectUrl));
         assertThat(charge.get().get3dsRequiredDetails().getHttpMethod3ds(), is(httpMethod3ds));
-    
+        assertThat(charge.get().get3dsRequiredDetails().getMd(), nullValue());
+        assertThat(charge.get().get3dsRequiredDetails().getPaRequest(), nullValue());
+    }
+
+    @Test
+    void should_save_action_data_on_charge_when_adyen_returns_with_result_code_redirect_shopper() {
+        var chargeId = testBaseExtension.createNewCharge(ENTERING_CARD_DETAILS);
+        var pspReferenceFromAdyen = "993617895215577D";
+        var redirectUrl = "https://checkoutshopper-test.adyen.com/checkoutshopper/threeDS/redirect";
+        var httpMethod3ds = "GET";
+        var data = """
+                    ,"data":{
+                    "MD":"testMD123",
+                    "PaReq":"testPaReq123"
+                }
+                """;
+
+        app.getAdyenCheckoutMockClient()
+                .mockAuthorisationRedirectShopper(pspReferenceFromAdyen, redirectUrl, httpMethod3ds, data);
+
+        var authCardDetails = anAuthCardDetails().build();
+
+        app.givenSetup()
+                .body(authCardDetails)
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(200)
+                .body("status", is("AUTHORISATION 3DS REQUIRED"));
+
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION 3DS REQUIRED"));
+        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+        assertThat(charge.get().get3dsRequiredDetails().getIssuerUrl(), is(redirectUrl));
+        assertThat(charge.get().get3dsRequiredDetails().getHttpMethod3ds(), is(httpMethod3ds));
+        assertThat(charge.get().get3dsRequiredDetails().getMd(), is("testMD123"));
+        assertThat(charge.get().get3dsRequiredDetails().getPaRequest(), is("testPaReq123"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
@@ -2,8 +2,8 @@ package uk.gov.pay.connector.rules;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
-import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 
@@ -45,7 +45,7 @@ public class AdyenCheckoutMockClient extends AdyenMockClient {
                 }""".formatted(pspReferenceFromAdyen);
         setupPostResponse(responseBody, "/payments", SC_OK);
     }
-    
+
     public void mock3dsAuthorisationResponse(String pspReferenceFromAdyen, String resultCode) {
         var responseBody = """
                 {
@@ -57,7 +57,7 @@ public class AdyenCheckoutMockClient extends AdyenMockClient {
         );
         setupPostResponse(responseBody, "/payments/details", SC_OK);
     }
-    
+
     public void mock3dsAuthorisationClientError() {
         var responseBody = """
                 {
@@ -120,21 +120,23 @@ public class AdyenCheckoutMockClient extends AdyenMockClient {
         var path = "/payments/%s/refunds".formatted(paymentPspReference);
         setupPostResponse(responseBody, path, 403);
     }
-    
+
     public void mockAuthorisationRedirectShopper(String pspReferenceFromAdyen,
                                                  String redirectUrl,
-                                                 String httpMethod) {
+                                                 String httpMethod,
+                                                 String data) {
         var responseBody = """
-            {
-              "pspReference": "%s",
-              "resultCode": "RedirectShopper",
-              "action": {
-                "paymentMethodType": "scheme",
-                "url": "%s",
-                "method": "%s",
-                "type": "redirect"
-              }
-            }""".formatted(pspReferenceFromAdyen, redirectUrl, httpMethod);
+                {
+                  "pspReference": "%s",
+                  "resultCode": "RedirectShopper",
+                  "action": {
+                    "paymentMethodType": "scheme",
+                    "url": "%s",
+                    "method": "%s",
+                    "type": "redirect"
+                    %s
+                  }
+                }""".formatted(pspReferenceFromAdyen, redirectUrl, httpMethod, data);
 
         setupPostResponse(responseBody, "/payments", SC_OK);
     }


### PR DESCRIPTION
## WHAT YOU DID
-  Added `md` and `paRequest` fields to `Adyen£dsRequiredParams` to be saved on the charge's `md_3ds` and `pa_request_3ds` fields 
- Deserialised `PaReq` and `MD` fields from Adyen's `action.data` allowing them to be ignored if null/not sent by Adyen

## How to test
- Ensure all tests pass
- I've added an integration test to check `md` and `paRequest` fields are present on the charge

