### PR TITLE
PP-14487 - Control Adyen 3DS handler response and improve test coverage

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandler.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.request.Adyen3dsAuthorisationRequest;
 import uk.gov.pay.connector.gateway.adyen.response.json.AdyenError;
@@ -67,11 +68,11 @@ public class AdyenAuthorise3dsHandler {
             var mappedStatus = mapStatus(responseBody.resultCode());
 
             return Gateway3DSAuthorisationResponse.of(
-                    jsonResponse,
+                    responseBody.toString(),
                     mappedStatus,
                     responseBody.pspReference()
             );
-        } catch (GatewayException.GatewayErrorException e) {
+        } catch (GatewayErrorException e) {
             return handleGatewayErrorException(request, e);
         } catch (GatewayException.GatewayConnectionTimeoutException | GatewayException.GenericGatewayException e) {
             LOGGER.atWarn()
@@ -86,7 +87,7 @@ public class AdyenAuthorise3dsHandler {
 
     private Gateway3DSAuthorisationResponse handleGatewayErrorException(
             Auth3dsResponseGatewayRequest request,
-            GatewayException.GatewayErrorException exception) {
+            GatewayErrorException exception) {
         try {
             var adyenError = jsonObjectMapper.getObject(exception.getResponseFromGateway(), AdyenError.class);
             LOGGER.atWarn()

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBody.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBody.java
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.StringJoiner;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record Authorise3dsResponseBody(
@@ -12,4 +16,15 @@ public record Authorise3dsResponseBody(
         @JsonProperty("resultCode")
         String resultCode
 ) {
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "Adyen Authorise 3DS Response (", ")");
+        if (isNotBlank(pspReference)) {
+            joiner.add("pspReference: " + pspReference);
+        }
+        if (isNotBlank(resultCode)) {
+            joiner.add("resultCode: " + resultCode);
+        }
+        return joiner.toString();
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/request/Adyen3dsAuthorisationRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/request/Adyen3dsAuthorisationRequestTest.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.connector.gateway.adyen.request;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.adyen.request.json.Authorise3dsRequestPayload;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import java.net.URI;
+import java.util.Map;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+import static uk.gov.pay.connector.gateway.model.OrderRequestType.AUTHORISE_3DS;
+
+class Adyen3dsAuthorisationRequestTest {
+
+    @Test
+    void should_return_expected_values_from_accessors_and_gateway_order() throws Exception {
+        var url = new URI("http://localhost:8080/payments/details");
+        var headers = Map.of("X-Api-Key", "test-api-key");
+        var gatewayAccountType = "test-account-type";
+        var details = new Authorise3dsRequestPayload.Details("redirect-result-value");
+        var payload = new Authorise3dsRequestPayload(details);
+        var jsonObjectMapper = new JsonObjectMapper(new ObjectMapper());
+
+        var request = new Adyen3dsAuthorisationRequest(
+                url,
+                headers,
+                gatewayAccountType,
+                payload,
+                jsonObjectMapper
+        );
+
+        assertEquals(url, request.getUrl());
+        assertEquals(headers, request.getHeaders());
+        assertEquals(gatewayAccountType, request.getGatewayAccountType());
+        assertEquals(ADYEN, request.getPaymentProvider());
+
+        GatewayOrder gatewayOrder = request.getGatewayOrder();
+        assertEquals(AUTHORISE_3DS, gatewayOrder.getOrderRequestType());
+        assertEquals(APPLICATION_JSON_TYPE, gatewayOrder.getMediaType());
+
+        String expectedPayload = jsonObjectMapper.objectToString(payload);
+        assertEquals(expectedPayload, gatewayOrder.getPayload());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBodyTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBodyTest.java
@@ -1,0 +1,67 @@
+package uk.gov.pay.connector.gateway.adyen.response.json;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class Authorise3dsResponseBodyTest {
+
+    @Test
+    void should_format_toString_with_both_fields_present() {
+        var response = new Authorise3dsResponseBody("psp-ref-123", "Authorised");
+
+        assertThat(response.toString(), is("Adyen Authorise 3DS Response (pspReference: psp-ref-123, resultCode: Authorised)"));
+    }
+
+    @Test
+    void should_exclude_null_pspReference_from_toString() {
+        var response = new Authorise3dsResponseBody(null, "Authorised");
+
+        assertThat(response.toString(), is("Adyen Authorise 3DS Response (resultCode: Authorised)"));
+    }
+
+    @Test
+    void should_exclude_null_resultCode_from_toString() {
+        var response = new Authorise3dsResponseBody("psp-ref-123", null);
+
+        assertThat(response.toString(), is("Adyen Authorise 3DS Response (pspReference: psp-ref-123)"));
+    }
+
+    @Test
+    void should_exclude_blank_pspReference_from_toString() {
+        var response = new Authorise3dsResponseBody("", "Authorised");
+
+        assertThat(response.toString(), is("Adyen Authorise 3DS Response (resultCode: Authorised)"));
+    }
+
+    @Test
+    void should_exclude_blank_resultCode_from_toString() {
+        var response = new Authorise3dsResponseBody("psp-ref-123", "");
+
+        assertThat(response.toString(), is("Adyen Authorise 3DS Response (pspReference: psp-ref-123)"));
+    }
+
+    @Test
+    void should_return_empty_response_when_both_fields_null() {
+        var response = new Authorise3dsResponseBody(null, null);
+
+        assertThat(response.toString(), is("Adyen Authorise 3DS Response ()"));
+    }
+
+    @Test
+    void should_return_empty_response_when_both_fields_blank() {
+        var response = new Authorise3dsResponseBody("", "");
+
+        assertThat(response.toString(), is("Adyen Authorise 3DS Response ()"));
+    }
+
+    @Test
+    void should_exclude_whitespace_only_fields_from_toString() {
+        var response = new Authorise3dsResponseBody("   ", "Authorised");
+
+        assertThat(response.toString(), is("Adyen Authorise 3DS Response (resultCode: Authorised)"));
+    }
+}
+
+

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthorise3dsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthorise3dsIT.java
@@ -16,6 +16,10 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.params.provider.Arguments;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
@@ -70,6 +74,11 @@ class AdyenCardResourceAuthorise3dsIT {
                 .statusCode(expectedHttpStatus)
                 .body("status", is(expectedBodyAndChargeStatus));
 
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments/details"))
+                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withHeader("Idempotency-Key", equalTo("authorise3DS-" + chargeId))
+                .withRequestBody(matchingJsonPath("$.details.redirectResult", equalTo(REDIRECT_RESULT))));
+
         var charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is(expectedBodyAndChargeStatus));
@@ -86,6 +95,11 @@ class AdyenCardResourceAuthorise3dsIT {
                 .post(authorise3dsChargeUrlFor(chargeId))
                 .then()
                 .statusCode(402);
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments/details"))
+                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withHeader("Idempotency-Key", equalTo("authorise3DS-" + chargeId))
+                .withRequestBody(matchingJsonPath("$.details.redirectResult", equalTo(REDIRECT_RESULT))));
 
         var charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));


### PR DESCRIPTION

## WHAT YOU DID
- Use sterilised body to explicitly control what is returned
- Add WireMock verification to test if expected fields are sent
- Simplify exception handling with explicit imports
- Override toString method for Authorise3dsResponseBody with unit tests
- 
## How to test

- How should it be reviewed? PR 
- What feedback do you need?  PR comments/DM
- If manual testing is needed, give suggested testing steps. NA

## Code review checklist

### Logging

- [X] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

