### PR TITLE
PP-15121 Add AuthoriseRequestFactory and friends

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AuthoriseRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AuthoriseRequestFactory.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.gateway.model.request.records;
+
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+
+import java.util.Optional;
+
+public class AuthoriseRequestFactory {
+
+    private final WorldpayAuthoriseRequestFactory worldpayAuthoriseRequestFactory;
+
+    public AuthoriseRequestFactory(WorldpayAuthoriseRequestFactory worldpayAuthoriseRequestFactory) {
+        this.worldpayAuthoriseRequestFactory = worldpayAuthoriseRequestFactory;
+    }
+
+    public Optional<? extends AuthoriseRequest> create(CardAuthorisationGatewayRequest request) {
+        if (PaymentGatewayName.WORLDPAY.toString().equals(request.getGatewayAccount().getGatewayName())) {
+            return worldpayAuthoriseRequestFactory.create(request);
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequestFactory.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.gateway.model.request.records;
+
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+
+import java.util.Optional;
+
+public class WorldpayAuthoriseRequestFactory {
+
+    private final WorldpayMotoAuthoriseRequestFactory worldpayMotoAuthoriseRequestFactory;
+
+    public WorldpayAuthoriseRequestFactory(WorldpayMotoAuthoriseRequestFactory worldpayMotoAuthoriseRequestFactory) {
+        this.worldpayMotoAuthoriseRequestFactory = worldpayMotoAuthoriseRequestFactory;
+    }
+
+    public Optional<WorldpayAuthoriseRequest> create(CardAuthorisationGatewayRequest request) {
+        if (request.getAuthorisationMode() == AuthorisationMode.WEB && request.isMoto()) {
+            return Optional.of(worldpayMotoAuthoriseRequestFactory.create(request));
+        }
+
+        return Optional.empty();
+    }
+    
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/AuthoriseRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/AuthoriseRequestFactoryTest.java
@@ -1,0 +1,85 @@
+package uk.gov.pay.connector.gateway.model.request.records;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
+import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
+
+@ExtendWith(MockitoExtension.class)
+class AuthoriseRequestFactoryTest {
+
+    @Mock
+    private WorldpayAuthoriseRequestFactory mockWorldpayAuthoriseRequestFactory;
+
+    private AuthoriseRequestFactory authoriseRequestFactory;
+
+    @BeforeEach
+    void setUp() {
+        authoriseRequestFactory = new AuthoriseRequestFactory(mockWorldpayAuthoriseRequestFactory);
+    }
+
+    @Test
+    void shouldBuildWorldpayAuthoriseRequestIfWorldpay() {
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(PaymentGatewayName.WORLDPAY.toString())
+                .build();
+
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                .withGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity))
+                .build();
+
+        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = aCardAuthorisationGatewayRequest()
+                .withGatewayAccount(gatewayAccountEntity)
+                .build();
+
+        WorldpayAuthoriseRequest worldpayAuthoriseRequest = aWorldpayMotoAuthoriseRequestFixture().build();
+
+        given(mockWorldpayAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest))
+                .willReturn(Optional.of(worldpayAuthoriseRequest));
+
+        Optional<? extends AuthoriseRequest> authoriseRequest = authoriseRequestFactory.create(cardAuthorisationGatewayRequest);
+
+        assertThat(authoriseRequest.isPresent(), is(true));
+        assertThat(authoriseRequest.get(), is(worldpayAuthoriseRequest));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = PaymentGatewayName.class,  mode = EXCLUDE, names = { "WORLDPAY" })
+    void shouldBuildNothingIfNotWorldpay(PaymentGatewayName paymentGatewayName) {
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+                .withPaymentProvider(paymentGatewayName.toString())
+                .build();
+
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                .withGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity))
+                .build();
+
+        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = aCardAuthorisationGatewayRequest()
+                .withGatewayAccount(gatewayAccountEntity)
+                .build();
+
+        Optional<? extends AuthoriseRequest> authoriseRequest = authoriseRequestFactory.create(cardAuthorisationGatewayRequest);
+
+        assertThat(authoriseRequest.isEmpty(), is(true));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequestFactoryTest.java
@@ -1,0 +1,77 @@
+package uk.gov.pay.connector.gateway.model.request.records;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
+import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
+
+@ExtendWith(MockitoExtension.class)
+class WorldpayAuthoriseRequestFactoryTest {
+
+    @Mock
+    private WorldpayMotoAuthoriseRequestFactory mockWorldpayMotoAuthoriseRequestFactory;
+    
+    private WorldpayAuthoriseRequestFactory worldpayAuthoriseRequestFactory;
+
+    @BeforeEach
+    void setUp() {
+        worldpayAuthoriseRequestFactory = new WorldpayAuthoriseRequestFactory(mockWorldpayMotoAuthoriseRequestFactory);
+    }
+
+    @Test
+    void shouldBuildWorldpayMotoAuthoriseRequestIfWebAndMoto() {
+        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = aCardAuthorisationGatewayRequest()
+                .withAuthorisationMode(AuthorisationMode.WEB)
+                .withMoto(true)
+                .build();
+
+        WorldpayMotoAuthoriseRequest worldpayMotoAuthoriseRequest = aWorldpayMotoAuthoriseRequestFixture().build();
+
+        given(mockWorldpayMotoAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest)).willReturn(worldpayMotoAuthoriseRequest);
+
+        Optional<WorldpayAuthoriseRequest> result = worldpayAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get(), is(worldpayMotoAuthoriseRequest));
+    }
+
+    @Test
+    void shouldBuildNothingIfNotMoto() {
+        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = aCardAuthorisationGatewayRequest()
+                .withAuthorisationMode(AuthorisationMode.WEB)
+                .withMoto(false)
+                .build();
+
+        Optional<WorldpayAuthoriseRequest> result = worldpayAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest);
+
+        assertThat(result.isPresent(), is(false));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AuthorisationMode.class, mode = EXCLUDE, names = { "WEB" })
+    void shouldBuildNothingIfNotWeb(AuthorisationMode authorisationMode) {
+        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = aCardAuthorisationGatewayRequest()
+                .withAuthorisationMode(authorisationMode)
+                .withMoto(true)
+                .build();
+
+        Optional<WorldpayAuthoriseRequest> result = worldpayAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest);
+
+        assertThat(result.isPresent(), is(false));
+    }
+
+}


### PR DESCRIPTION
Add `AuthoriseRequestFactory` and `WorldpayAuthoriseRequest` factory. The former figures out if it’s a Worldpay payment and calls the latter. The latter figures out if it’s a web MOTO payment and calls the `WorldpayMotoAuthoriseRequestFactory`. If not, an empty optional is returned. This will allow us to gradually increase the range of `AuthoriseRequest` implementations we support.