### PR TITLE
PP-15121 Use PaymentGatewayName.WORLDPAY.getName() not .toString()

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AuthoriseRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AuthoriseRequestFactory.java
@@ -14,7 +14,7 @@ public class AuthoriseRequestFactory {
     }
 
     public Optional<? extends AuthoriseRequest> create(CardAuthorisationGatewayRequest request) {
-        if (PaymentGatewayName.WORLDPAY.toString().equals(request.getGatewayAccount().getGatewayName())) {
+        if (PaymentGatewayName.WORLDPAY.getName().equals(request.getGatewayAccount().getGatewayName())) {
             return worldpayAuthoriseRequestFactory.create(request);
         }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/AuthoriseRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/AuthoriseRequestFactoryTest.java
@@ -40,7 +40,7 @@ class AuthoriseRequestFactoryTest {
     @Test
     void shouldBuildWorldpayAuthoriseRequestIfWorldpay() {
         GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
-                .withPaymentProvider(PaymentGatewayName.WORLDPAY.toString())
+                .withPaymentProvider(PaymentGatewayName.WORLDPAY.getName())
                 .build();
 
         GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()


### PR DESCRIPTION
Use `PaymentGatewayName.WORLDPAY.getName()` (which returns a string like “worldpay” rather than `PaymentGatewayName.WORLDPAY.toString()` (which returns a string like “WORLDPAY”).