### PR TITLE
 PP-14490 Store Authorisation rejected reasons

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
@@ -13,6 +13,8 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
     private final AuthoriseStatus authoriseStatus;
     private final String redirectUrl;
     private final String httpMethod3ds;
+    private final String refusalReason;
+    private final String refusalReasonCode;
 
     private final String paReq;
     private final String md;
@@ -36,7 +38,9 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
                 url,
                 method,
                 paReq,
-                md);
+                md,
+                authoriseResponseBody.refusalReason(), 
+                authoriseResponseBody.refusalReasonCode());
     }
 
     private AdyenAuthoriseResponse(String transactionId,
@@ -44,13 +48,17 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
                                    String redirectUrl,
                                    String httpMethod3ds,
                                    String paReq,
-                                   String md) {
+                                   String md,
+                                   String refusalReason,
+                                   String refusalReasonCode) {
         this.transactionId = transactionId;
         authoriseStatus = mapAuthorisationStatusFrom(resultCode);
         this.redirectUrl = redirectUrl;
         this.httpMethod3ds = httpMethod3ds;
         this.paReq = paReq;
         this.md = md;
+        this.refusalReason = refusalReason;
+        this.refusalReasonCode = refusalReasonCode;
     }
 
     private static AuthoriseStatus mapAuthorisationStatusFrom(String resultCode) {
@@ -61,6 +69,14 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
             case "Error" -> AuthoriseStatus.ERROR;
             default -> throw new IllegalStateException("Unexpected value: " + resultCode);
         };
+    }
+    
+    @Override
+    public Optional<String> getGatewayRejectionReason() {
+        if (refusalReason != null && refusalReasonCode != null ) {
+            return Optional.of(refusalReasonCode + " - " +  refusalReason  );
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -166,5 +167,21 @@ class AdyenAuthoriseResponseTest {
         assertThat(auth3dsRequiredDetails.get().getHttpMethod3ds(), is(httpMethod));
         assertThat(auth3dsRequiredDetails.get().getPaRequest(), is("testPaReq123"));
         assertThat(auth3dsRequiredDetails.get().getMd(), is("testMD123"));
+    }
+    
+    @Test
+    void should_return_gateway_rejection_reason_when_adyen_response_is_refused() {
+        var response = new AuthoriseResponseBody(
+                "851563882585825A",
+                "Refused",
+                "Expired Card",
+                "6",
+                null
+        );
+
+        var adyenAuthoriseResponse = AdyenAuthoriseResponse.of(response);
+
+        assertThat(adyenAuthoriseResponse.getGatewayRejectionReason(),
+                is(Optional.of("6 - Expired Card")));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseIT.java
@@ -202,6 +202,7 @@ class AdyenCardResourceAuthoriseIT {
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is("AUTHORISATION REJECTED"));
         assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+        assertThat(charge.get().getGatewayRejectionReason(), is("6 - Expired Card"));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID

- Store the Adyen gateway rejection reason on charge when an authorisation is refused for normal Adyen payment
- Second scenario in [PP-14490](https://payments-platform.atlassian.net/browse/PP-14490) , the 3DS authorisation flow will be in a separate PR



[PP-14490]: https://payments-platform.atlassian.net/browse/PP-14490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ