### PR TITLE
PP-15121 Build multi-release JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -604,6 +604,9 @@
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>uk.gov.pay.connector.app.ConnectorApp</mainClass>
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
                                 </transformer>
                             </transformers>
                         </configuration>


### PR DESCRIPTION
Configure the Maven shade plugin to produce a multi-release JAR, so dependencies that use multi-release JARs to can enable certain features on newer Java versions (such as support for records in Freemarker).