### PR TITLE
PP-15576 Include IP in WorldpayAuthoriseRequest structured logging

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGenerator.java
@@ -15,6 +15,7 @@ import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStruc
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.CORPORATE_CARD;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.DATA_FOR_3DS;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.EMAIL;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.IP_ADDRESS;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.MOTO;
 
 public class WorldpayAuthoriseRequestLogGenerator {
@@ -43,7 +44,10 @@ public class WorldpayAuthoriseRequestLogGenerator {
             structuredArguments.add(kv(CORPORATE_CARD, false));
         }
 
-        authCardDetails.getIpAddress().ifPresent(ipAddress -> stringJoiner.add("with remote IP " + ipAddress));
+        authCardDetails.getIpAddress().ifPresent(ipAddress -> {
+            stringJoiner.add("with remote IP " + ipAddress);
+            structuredArguments.add(kv(IP_ADDRESS, ipAddress));
+        });
 
         structuredArguments.add(kv(EMAIL, false));
         structuredArguments.add(kv(DATA_FOR_3DS, false));

--- a/src/test/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGeneratorTest.java
@@ -12,13 +12,14 @@ import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStruc
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.CORPORATE_CARD;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.DATA_FOR_3DS;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.EMAIL;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.IP_ADDRESS;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.MOTO;
 import static uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator.GATEWAY_REQUEST_RECORD;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 
 class WorldpayAuthoriseRequestLogGeneratorTest {
 
-    private static final String IP_ADDRESS = "203.0.113.1";
+    private static final String IP = "203.0.113.1";
 
     private final WorldpayAuthoriseRequestLogGenerator  generator = new WorldpayAuthoriseRequestLogGenerator();
 
@@ -29,12 +30,12 @@ class WorldpayAuthoriseRequestLogGeneratorTest {
                 "description", "1000", "4242424242424242",
                 "12", "2030", "Cardholder Name", "123");
 
-        AuthCardDetails authCardDetails = anAuthCardDetails().withCorporateCard(true).withIpAddress(IP_ADDRESS).build();
+        AuthCardDetails authCardDetails = anAuthCardDetails().withCorporateCard(true).withIpAddress(IP).build();
 
         AuthorisationRequestLog result = generator.generate(request, authCardDetails);
 
         assertThat(result.authorisationRequest(), is(
-                " without billing address and with corporate card and with remote IP " + IP_ADDRESS));
+                " without billing address and with corporate card and with remote IP " + IP));
 
         assertThat(result.structuredArguments(), containsInAnyOrder(
                         kv(GATEWAY_REQUEST_RECORD, true),
@@ -42,7 +43,8 @@ class WorldpayAuthoriseRequestLogGeneratorTest {
                         kv(CORPORATE_CARD, true),
                         kv(EMAIL, false),
                         kv(DATA_FOR_3DS, false),
-                        kv(MOTO, true)));
+                        kv(MOTO, true),
+                        kv(IP_ADDRESS, IP)));
     }
 
     @Test
@@ -52,12 +54,11 @@ class WorldpayAuthoriseRequestLogGeneratorTest {
                 "description", "1000", "4242424242424242",
                 "12", "2030", "Cardholder Name", "123");
 
-        AuthCardDetails authCardDetails = anAuthCardDetails().withCorporateCard(false).withIpAddress(IP_ADDRESS).build();
+        AuthCardDetails authCardDetails = anAuthCardDetails().withCorporateCard(false).withIpAddress(IP).build();
 
         AuthorisationRequestLog result = generator.generate(request, authCardDetails);
 
-        assertThat(result.authorisationRequest(), is(
-                " without billing address and with remote IP " + IP_ADDRESS));
+        assertThat(result.authorisationRequest(), is(" without billing address and with remote IP " + IP));
 
         assertThat(result.structuredArguments(), containsInAnyOrder(
                 kv(GATEWAY_REQUEST_RECORD, true),
@@ -65,7 +66,8 @@ class WorldpayAuthoriseRequestLogGeneratorTest {
                 kv(CORPORATE_CARD, false),
                 kv(EMAIL, false),
                 kv(DATA_FOR_3DS, false),
-                kv(MOTO, true)));
+                kv(MOTO, true),
+                kv(IP_ADDRESS, IP)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/gatewayrequestrecords/WorldpayMotoAuthoriseRequestIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/gatewayrequestrecords/WorldpayMotoAuthoriseRequestIT.java
@@ -47,6 +47,7 @@ public class WorldpayMotoAuthoriseRequestIT {
     private static final String CVC = "123";
     private static final CardExpiryDate EXPIRY_DATE = CardExpiryDate.valueOf("11/30");
     private static final String CARDHOLDER_NAME = "Alec Barley";
+    private static final String IP = "203.0.113.1";
 
     @Test
     void shouldSendCorrectRequestToWorldpayReturnCorrectResponseAndLog() throws JsonProcessingException {
@@ -68,6 +69,7 @@ public class WorldpayMotoAuthoriseRequestIT {
                 "cardholder_name", CARDHOLDER_NAME,
                 "accept_header", "text/html",
                 "user_agent_header", "Mozilla/5.0",
+                "ip_address", IP,
                 "prepaid", "NOT_PREPAID");
 
         String requestBody = objectMapper.writeValueAsString(requestParameters);
@@ -104,7 +106,7 @@ public class WorldpayMotoAuthoriseRequestIT {
                         .withRequestBody(hasNoSession())
                         .withRequestBody(hasNoShopper()));
 
-        logs.assertContains("Authorisation without billing address for " + externalChargeId);
+        logs.assertContains("Authorisation without billing address and with remote IP " + IP + " for " + externalChargeId);
         assertThat(logs.getEvents().stream().findFirst().isPresent(), is(true));
         List<String> structuredLogging = logs.getEvents().stream().findFirst().get()
                 .getArguments().stream().map(Object::toString).toList();
@@ -116,7 +118,8 @@ public class WorldpayMotoAuthoriseRequestIT {
                 "email_address=false",
                 "data_for_3ds=false",
                 "moto=true",
-                "corporate_card=false"
+                "corporate_card=false",
+                "remote_ip_address=" + IP
         ));
     }
 


### PR DESCRIPTION
Include a `remote_ip_address` key, with a value of the IP address provided by frontend for the person who entered the card details, in the structured logging when logging `WorldpayAuthoriseRequest` authorisations. This fixes a regression.