### PR TITLE
PP-15511 Added integration tests to verify not found scenarios on patch endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/AdyenAccountSetupResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/AdyenAccountSetupResource.java
@@ -137,7 +137,8 @@ public class AdyenAccountSetupResource {
             @Parameter(example = "46eb1b601348499196c99de90482ee68", description = "Credential External ID") @PathParam("credentialExternalId") String credentialExternalId, // pragma: allowlist secret
             List<AccountSetupPatchRequest> requests) {
 
-        var gatewayAccountEntity = gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType).get();
+        var gatewayAccountEntity = gatewayAccountService.getGatewayAccountByServiceIdAndAccountType(serviceId, accountType)
+                .orElseThrow(() -> new GatewayAccountNotFoundException(serviceId, accountType));
         var gatewayAccountCredentialsEntity = validateGatewayAccountCredentialsEntity(credentialExternalId, gatewayAccountEntity);
 
         requests.forEach(patchRequest ->  {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
@@ -236,8 +236,35 @@ public class AdyenAccountSetupResourceIT {
         
         @Test
         void shouldReturnNotFoundResponseWhenGatewayAccountDoesNotExist() {
+
             app.givenSetup()
+                    .body(toJson(List.of(Map.of("op", "replace",
+                            "path", VAT_NUMBER.getValue(),
+                            "value", COMPLETED))))
                     .patch(format("/v1/api/service/%s/account/%s/adyen-setup/%s", serviceId, TEST, "credential-123"))
+                    .then()
+                    .statusCode(SC_NOT_FOUND);
+        }
+
+        @Test
+        void shouldReturnNotFoundResponseWhenAccountTypeDoesNotExistForService() {
+            var liveAccount = app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .withAccountId(adyenGatewayAccountId)
+                    .withServiceId(serviceId)
+                    .withPaymentProvider(ADYEN.getName())
+                    .withType(LIVE)
+                    .withGatewayAccountCredentials(Collections.singletonList(adyenCredentialsParams))
+                    .insert();
+
+            var credentialExternalId = liveAccount.getCredentials().getFirst().getExternalId();
+            
+            
+            app.givenSetup()
+                    .body(toJson(List.of(Map.of("op", "replace",
+                            "path", VAT_NUMBER.getValue(),
+                            "value", COMPLETED))))
+                    .patch(format("/v1/api/service/%s/account/%s/adyen-setup/%s", serviceId, TEST, credentialExternalId))
                     .then()
                     .statusCode(SC_NOT_FOUND);
         }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
@@ -285,6 +285,34 @@ public class AdyenAccountSetupResourceIT {
                     .then()
                     .statusCode(SC_NOT_FOUND);
         }
+
+        @Test
+        void shouldReturnNotFoundResponseWhenCredentialsBelongToADifferentAccount() {
+            app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .withAccountId(adyenGatewayAccountId)
+                    .withServiceId(serviceId)
+                    .withPaymentProvider(ADYEN.getName())
+                    .withGatewayAccountCredentials(Collections.singletonList(adyenCredentialsParams))
+                    .insert();
+
+            var differentAccount = app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .withAccountId(999L)
+                    .withServiceId("my-adyen-service")
+                    .withPaymentProvider(ADYEN.getName())
+                    .insert();
+            
+            var differentAccountCredentials = differentAccount.getCredentials().getFirst().getExternalId();
+
+            app.givenSetup()
+                    .body(toJson(List.of(Map.of("op", "replace",
+                            "path", VAT_NUMBER.getValue(),
+                            "value", COMPLETED))))
+                    .patch(format("/v1/api/service/%s/account/%s/adyen-setup/%s", serviceId, TEST, differentAccountCredentials))
+                    .then()
+                    .statusCode(SC_NOT_FOUND);
+        }
     }
     
     private void markTasksAsCompleted(long gatewayAccountId, long credentialId, List<AdyenAccountSetupTask> tasks) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
@@ -268,6 +268,23 @@ public class AdyenAccountSetupResourceIT {
                     .then()
                     .statusCode(SC_NOT_FOUND);
         }
+
+        @Test
+        void shouldReturnNotFoundResponseWhenCredentialIdDoesNotExist() {
+            app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .withServiceId(serviceId)
+                    .withPaymentProvider(ADYEN.getName())
+                    .insert();
+
+            app.givenSetup()
+                    .body(toJson(List.of(Map.of("op", "replace",
+                            "path", VAT_NUMBER.getValue(),
+                            "value", COMPLETED))))
+                    .patch(format("/v1/api/service/%s/account/%s/adyen-setup/%s", serviceId, TEST, "credential_does_not_exist"))
+                    .then()
+                    .statusCode(SC_NOT_FOUND);
+        }
     }
     
     private void markTasksAsCompleted(long gatewayAccountId, long credentialId, List<AdyenAccountSetupTask> tasks) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
@@ -17,6 +17,7 @@ import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.AdyenAccountSetupStatus.COMPLETED;
 import static uk.gov.pay.connector.gatewayaccount.model.AdyenAccountSetupStatus.NOT_STARTED;
@@ -312,6 +313,27 @@ public class AdyenAccountSetupResourceIT {
                     .patch(format("/v1/api/service/%s/account/%s/adyen-setup/%s", serviceId, TEST, differentAccountCredentials))
                     .then()
                     .statusCode(SC_NOT_FOUND);
+        }
+
+        @Test
+        void shouldReturnNotFoundResponseWhenCredentialIdExistsButPaymentProviderIsNotAdyen() {
+            var stripeAccount = app.getDatabaseFixtures()
+                    .aTestAccount()
+                    .withServiceId(serviceId)
+                    .withType(LIVE)
+                    .withPaymentProvider(STRIPE.getName())
+                    .insert();
+
+            var credentialExternalId = stripeAccount.getCredentials().getFirst().getExternalId();
+
+            app.givenSetup()
+                    .body(toJson(List.of(Map.of("op", "replace",
+                            "path", VAT_NUMBER.getValue(),
+                            "value", COMPLETED))))
+                    .patch(format("/v1/api/service/%s/account/%s/adyen-setup/%s", serviceId, LIVE, credentialExternalId))
+                    .then()
+                    .statusCode(SC_NOT_FOUND)
+                    .body("message", is("Credential is not associated with payment provider Adyen"));
         }
     }
     

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
@@ -233,6 +233,14 @@ public class AdyenAccountSetupResourceIT {
                     .body("tasks.bank_account.status", is(COMPLETED.toString()))
                     .body("tasks.vat_number.status", is(COMPLETED.toString()));
         }
+        
+        @Test
+        void shouldReturnNotFoundResponseWhenGatewayAccountDoesNotExist() {
+            app.givenSetup()
+                    .patch(format("/v1/api/service/%s/account/%s/adyen-setup/%s", serviceId, TEST, "credential-123"))
+                    .then()
+                    .statusCode(SC_NOT_FOUND);
+        }
     }
     
     private void markTasksAsCompleted(long gatewayAccountId, long credentialId, List<AdyenAccountSetupTask> tasks) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenAccountSetupResourceIT.java
@@ -244,7 +244,8 @@ public class AdyenAccountSetupResourceIT {
                             "value", COMPLETED))))
                     .patch(format("/v1/api/service/%s/account/%s/adyen-setup/%s", serviceId, TEST, "credential-123"))
                     .then()
-                    .statusCode(SC_NOT_FOUND);
+                    .statusCode(SC_NOT_FOUND)
+                    .body("message[0]", is((format("Gateway account not found for service external id [%s] and account type [%s]", serviceId, TEST))));
         }
 
         @Test
@@ -267,7 +268,8 @@ public class AdyenAccountSetupResourceIT {
                             "value", COMPLETED))))
                     .patch(format("/v1/api/service/%s/account/%s/adyen-setup/%s", serviceId, TEST, credentialExternalId))
                     .then()
-                    .statusCode(SC_NOT_FOUND);
+                    .statusCode(SC_NOT_FOUND)
+                    .body("message[0]", is((format("Gateway account not found for service external id [%s] and account type [%s]", serviceId, TEST))));
         }
 
         @Test
@@ -284,7 +286,8 @@ public class AdyenAccountSetupResourceIT {
                             "value", COMPLETED))))
                     .patch(format("/v1/api/service/%s/account/%s/adyen-setup/%s", serviceId, TEST, "credential_does_not_exist"))
                     .then()
-                    .statusCode(SC_NOT_FOUND);
+                    .statusCode(SC_NOT_FOUND)
+                    .body("message", is(("HTTP 404 Not Found")));
         }
 
         @Test
@@ -312,7 +315,8 @@ public class AdyenAccountSetupResourceIT {
                             "value", COMPLETED))))
                     .patch(format("/v1/api/service/%s/account/%s/adyen-setup/%s", serviceId, TEST, differentAccountCredentials))
                     .then()
-                    .statusCode(SC_NOT_FOUND);
+                    .statusCode(SC_NOT_FOUND)
+                    .body("message", is(("HTTP 404 Not Found")));
         }
 
         @Test


### PR DESCRIPTION
## WHAT YOU DID
- Added integration tests to `patch` Adyen setup tasks endpoint.
- These cover various scenarios where gateway account and/or credentials are not found or invalid. 

**NB - Logic mostly untouched in resource as this behaviour was implemented for `get` endpoint.**