### PR TITLE
PP-15561: create mapper to map adyen's refusalReasonCodes to connector's rejectedReasons

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
@@ -2,7 +2,9 @@ package uk.gov.pay.connector.gateway.adyen.response;
 
 import uk.gov.pay.connector.gateway.adyen.response.json.Action;
 import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
+import uk.gov.pay.connector.gateway.adyen.utils.AdyenAuthorisationRejectedCodeMapper;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
+import uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
 import java.util.Optional;
@@ -111,6 +113,20 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
             return Optional.of(new Adyen3dsRequiredParams(redirectUrl, httpMethod3ds, paReq, md));
         }
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<MappedAuthorisationRejectedReason> getMappedAuthorisationRejectedReason() {
+        if (authoriseStatus() != AuthoriseStatus.REJECTED) {
+            return Optional.empty();
+        }
+
+        var mappedAuthorisationRejectedReason = Optional.ofNullable(refusalReasonCode)
+                .filter(code -> !code.isBlank())
+                .map(AdyenAuthorisationRejectedCodeMapper::toMappedAuthorisationRejectionReason)
+                .orElse(MappedAuthorisationRejectedReason.UNCATEGORISED);
+
+        return Optional.of(mappedAuthorisationRejectedReason);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthorisationRejectedCodeMapper.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthorisationRejectedCodeMapper.java
@@ -1,0 +1,75 @@
+package uk.gov.pay.connector.gateway.adyen.utils;
+
+import uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason;
+
+import java.util.Map;
+
+import static java.util.Map.entry;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.AUTHENTICATION_REQUESTED;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.AUTHENTICATION_REQUIRED;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.CANCELLED;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.DO_NOT_RETRY;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.EXCEEDS_WITHDRAWAL_AMOUNT_LIMIT;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.EXCEEDS_WITHDRAWAL_COUNT_LIMIT;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.EXPIRED_CARD;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.GENERIC_DECLINE;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.INSUFFICIENT_FUNDS;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.INVALID_AMOUNT;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.INVALID_CARD_NUMBER;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.INVALID_CVV2;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.ISSUER_TEMPORARILY_UNAVAILABLE;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.REENTER_TRANSACTION;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.REFER_TO_CARD_ISSUER;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.RESTRICTED_CARD;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.REVOCATION_OF_AUTHORISATION;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.SUSPECTED_FRAUD;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.TRANSACTION_NOT_PERMITTED;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.TRY_AGAIN_LATER;
+import static uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason.UNCATEGORISED;
+
+public class AdyenAuthorisationRejectedCodeMapper {
+
+    private static final Map<String, MappedAuthorisationRejectedReason> ADYEN_REJECTION_CODE_MAP = Map.ofEntries(
+            entry("2", GENERIC_DECLINE),
+            entry("3", REFER_TO_CARD_ISSUER),
+            entry("4", ISSUER_TEMPORARILY_UNAVAILABLE),
+            entry("5", CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT),
+            entry("6", EXPIRED_CARD),
+            entry("7", INVALID_AMOUNT),
+            entry("8", INVALID_CARD_NUMBER),
+            entry("9", ISSUER_TEMPORARILY_UNAVAILABLE),
+            entry("10", TRANSACTION_NOT_PERMITTED),
+            entry("11", AUTHENTICATION_REQUIRED),
+            entry("12", INSUFFICIENT_FUNDS),
+            entry("14", SUSPECTED_FRAUD),
+            entry("15", CANCELLED),
+            entry("16", CANCELLED),
+            entry("20", SUSPECTED_FRAUD),
+            entry("21", REENTER_TRANSACTION),
+            entry("22", SUSPECTED_FRAUD),
+            entry("23", TRANSACTION_NOT_PERMITTED),
+            entry("24", INVALID_CVV2),
+            entry("25", RESTRICTED_CARD),
+            entry("26", REVOCATION_OF_AUTHORISATION),
+            entry("27", GENERIC_DECLINE),
+            entry("28", EXCEEDS_WITHDRAWAL_AMOUNT_LIMIT),
+            entry("29", EXCEEDS_WITHDRAWAL_COUNT_LIMIT),
+            entry("31", SUSPECTED_FRAUD),
+            entry("32", INVALID_CVV2),
+            entry("33", AUTHENTICATION_REQUESTED),
+            entry("34", CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT),
+            entry("35", CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT),
+            entry("38", AUTHENTICATION_REQUIRED),
+            entry("39", TRY_AGAIN_LATER),
+            entry("40", TRY_AGAIN_LATER),
+            entry("41", TRY_AGAIN_LATER),
+            entry("42", AUTHENTICATION_REQUIRED),
+            entry("46", DO_NOT_RETRY),
+            entry("50", TRANSACTION_NOT_PERMITTED)
+    );
+
+    public static MappedAuthorisationRejectedReason toMappedAuthorisationRejectionReason(String adyenRefusalReasonCode) {
+        return ADYEN_REJECTION_CODE_MAP.getOrDefault(adyenRefusalReasonCode, UNCATEGORISED);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/model/MappedAuthorisationRejectedReason.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/MappedAuthorisationRejectedReason.java
@@ -6,6 +6,7 @@ public enum MappedAuthorisationRejectedReason {
     CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT(true),
     DO_NOT_HONOUR(true),
     EXCEEDS_WITHDRAWAL_AMOUNT_LIMIT(true),
+    EXCEEDS_WITHDRAWAL_COUNT_LIMIT(true),
     GENERIC_DECLINE(true),
     INSUFFICIENT_FUNDS(true),
     INVALID_ACCOUNT_NUMBER(true),
@@ -21,6 +22,7 @@ public enum MappedAuthorisationRejectedReason {
     TRY_AGAIN_LATER(true),
     TRY_ANOTHER_CARD(true),
     UNCATEGORISED(true),
+    CANCELLED(true),
 
     AUTHENTICATION_REQUIRED(false),
     CAPTURE_CARD(false),

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
+import uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
 import java.util.Map;
@@ -168,7 +169,7 @@ class AdyenAuthoriseResponseTest {
         assertThat(auth3dsRequiredDetails.get().getPaRequest(), is("testPaReq123"));
         assertThat(auth3dsRequiredDetails.get().getMd(), is("testMD123"));
     }
-    
+
     @Test
     void should_return_gateway_rejection_reason_when_adyen_response_is_refused() {
         var response = new AuthoriseResponseBody(
@@ -183,5 +184,53 @@ class AdyenAuthoriseResponseTest {
 
         assertThat(adyenAuthoriseResponse.getGatewayRejectionReason(),
                 is(Optional.of("6 - Expired Card")));
+    }
+
+    @Test
+    void should_return_mappedAuthorisationRejectedReason_for_refused_payment() {
+        var adyenPaymentResponse = anAdyenPaymentResponse()
+                .withResultCode("Refused")
+                .withRefusalReasonCode("6")
+                .withRefusalReason("Expired Card")
+                .build();
+
+        var adyenAuthoriseResponse = AdyenAuthoriseResponse.of(adyenPaymentResponse);
+
+        var mappedReason = adyenAuthoriseResponse.getMappedAuthorisationRejectedReason();
+
+        assertThat(mappedReason.isPresent(), is(true));
+        assertThat(mappedReason.get(), is(MappedAuthorisationRejectedReason.EXPIRED_CARD));
+        assertThat(mappedReason.get().canRetry(), is(false));
+    }
+
+    @Test
+    void should_return_empty_mappedAuthorisationRejectedReason_for_successful_payment() {
+        var adyenPaymentResponse = anAdyenPaymentResponse()
+                .withResultCode("Authorised")
+                .withRefusalReasonCode("6")
+                .withRefusalReason("Expired Card")
+                .build();
+
+        var adyenAuthoriseResponse = AdyenAuthoriseResponse.of(adyenPaymentResponse);
+
+        var mappedReason = adyenAuthoriseResponse.getMappedAuthorisationRejectedReason();
+
+        assertThat(mappedReason.isPresent(), is(false));
+    }
+
+    @Test
+    void should_return_UNCATAGORISED_for_refused_payment_with_unknown_code() {
+        var adyenPaymentResponse = anAdyenPaymentResponse()
+                .withResultCode("Refused")
+                .withRefusalReasonCode("999")
+                .withRefusalReason("Unknown Reason")
+                .build();
+
+        var adyenAuthoriseResponse = AdyenAuthoriseResponse.of(adyenPaymentResponse);
+
+        var mappedReason = adyenAuthoriseResponse.getMappedAuthorisationRejectedReason();
+
+        assertThat(mappedReason.isPresent(), is(true));
+        assertThat(mappedReason.get(), is(MappedAuthorisationRejectedReason.UNCATEGORISED));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthorisationRejectedCodeMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthorisationRejectedCodeMapperTest.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.connector.gateway.adyen.utils;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class AdyenAuthorisationRejectedCodeMapperTest {
+
+
+    @ParameterizedTest
+    @CsvSource({
+            "999, UNCATEGORISED, true",
+            "2, GENERIC_DECLINE, true",
+            "3,REFER_TO_CARD_ISSUER, true",
+            "4,ISSUER_TEMPORARILY_UNAVAILABLE, true",
+            "5,CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT, true",
+            "6,EXPIRED_CARD, false",
+            "7,INVALID_AMOUNT, true",
+            "8,INVALID_CARD_NUMBER,false",
+            "9,ISSUER_TEMPORARILY_UNAVAILABLE, true",
+            "10,TRANSACTION_NOT_PERMITTED, false",
+            "11,AUTHENTICATION_REQUIRED, false",
+            "12,INSUFFICIENT_FUNDS, true",
+            "14,SUSPECTED_FRAUD, true",
+            "15,CANCELLED, true",
+            "16,CANCELLED, true",
+            "20,SUSPECTED_FRAUD, true",
+            "21, REENTER_TRANSACTION, true",
+            "22,SUSPECTED_FRAUD, true",
+            "23,TRANSACTION_NOT_PERMITTED, false",
+            "24,INVALID_CVV2, false",
+            "25,RESTRICTED_CARD, false",
+            "26,REVOCATION_OF_AUTHORISATION, false",
+            "27,GENERIC_DECLINE, true",
+            "28,EXCEEDS_WITHDRAWAL_AMOUNT_LIMIT, true",
+            "29,EXCEEDS_WITHDRAWAL_COUNT_LIMIT, true",
+            "31,SUSPECTED_FRAUD, true",
+            "32,INVALID_CVV2, false",
+            "33,AUTHENTICATION_REQUESTED, true",
+            "34,CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT, true",
+            "35,CARD_BLOCKED_OR_INVALID_OR_NONEXISTENT, true",
+            "38,AUTHENTICATION_REQUIRED, false",
+            "39,TRY_AGAIN_LATER, true",
+            "40,TRY_AGAIN_LATER, true",
+            "41,TRY_AGAIN_LATER, true",
+            "42,AUTHENTICATION_REQUIRED, false",
+            "46,DO_NOT_RETRY, false",
+            "50,TRANSACTION_NOT_PERMITTED, false"
+    })
+    void should_map_refusalReasonCode_to_MappedAuthorisationRejectedReason(String refusalReasonCode,
+                                                                           String mappedRefusalReason,
+                                                                           boolean canRetry) {
+        var mappedAuthorisationRejectedReason = AdyenAuthorisationRejectedCodeMapper
+                .toMappedAuthorisationRejectionReason(refusalReasonCode);
+
+        assertThat(mappedAuthorisationRejectedReason.name(), is(mappedRefusalReason));
+        assertThat(mappedAuthorisationRejectedReason.canRetry(), is(canRetry));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- Created a mapper to map Adyen's `refusalReasonCodes` to Connector's `authorisationRejectedReasons` when an `AuthoriseResponse` is received from Adyen
- Some refusal reasons from Adyen have been omitted as they are not relevant to our use cases
- https://docs.adyen.com/development-resources/refusal-reasons 

