### PR TITLE
PP-14494 Authorise a recurring payment to set up an agreement

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -24,6 +24,7 @@ import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayCredentials;
 import uk.gov.pay.connector.northamericaregion.NorthAmericaRegion;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
+import uk.gov.service.payments.commons.model.AgreementPaymentType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +45,7 @@ public class AdyenRequestFactory {
         var authCardDetails = request.getAuthCardDetails();
         boolean isMoto = "Moto".equals(getShopperInteraction(request));
         String frontendUrl = configuration.getLinks().getFrontendUrl();
-        
+
         var mappedAddress = authCardDetails.getAddress()
                 .map(AdyenRequestFactory::mapToBillingAddress)
                 .orElse(null);
@@ -57,7 +58,18 @@ public class AdyenRequestFactory {
                 "scheme");
 
         var adyenCredentials = mapToAdyenCredentials(request.getGatewayCredentials());
-        
+
+        String shopperReference = null;
+        Boolean storePaymentMethod = null;
+        String recurringProcessingModel = null;
+        if (request.isSavePaymentInstrumentToAgreement()) {
+            shopperReference = request.getAgreement()
+                    .orElseThrow(() -> new IllegalArgumentException("Expected charge with savePaymentInstrumentToAgreement to have an agreement"))
+                    .getExternalId();
+            storePaymentMethod = true;
+            recurringProcessingModel = fromAgreementPaymentType(request.getAgreementPaymentType());
+        }
+
         return new AuthoriseRequestPayload(
                 new Amount("GBP", Long.valueOf(request.getAmount())),
                 mappedAddress,
@@ -72,7 +84,10 @@ public class AdyenRequestFactory {
                 isMoto ? null : mapToBrowserInfo(authCardDetails),
                 isMoto ? null : frontendUrl,
                 isMoto ? null : request.getEmail(),
-                isMoto ? null : authCardDetails.getIpAddress().orElse(null)
+                isMoto ? null : authCardDetails.getIpAddress().orElse(null),
+                shopperReference,
+                storePaymentMethod,
+                recurringProcessingModel
         );
     }
 
@@ -130,15 +145,15 @@ public class AdyenRequestFactory {
         }
         return (AdyenCredentials) gatewayCredentials;
     }
-    
+
     private BrowserInfo mapToBrowserInfo(AuthCardDetails authCardDetails) {
         return new BrowserInfo(
                 authCardDetails.getAcceptHeader(),
-                authCardDetails.getJsScreenColorDepth().flatMap(value -> parseInteger("js_screen_color_depth",value) ).orElse(null),                false,
+                authCardDetails.getJsScreenColorDepth().flatMap(value -> parseInteger("js_screen_color_depth", value)).orElse(null), false,
                 authCardDetails.getJsEnabled(),
                 authCardDetails.getJsNavigatorLanguage().orElse(null),
                 authCardDetails.getJsScreenHeight().flatMap(value -> parseInteger("js_screen_height", value)).orElse(null),
-                authCardDetails.getJsScreenWidth().flatMap(value-> parseInteger("js_screen_width", value)).orElse(null),
+                authCardDetails.getJsScreenWidth().flatMap(value -> parseInteger("js_screen_width", value)).orElse(null),
                 authCardDetails.getJsTimezoneOffsetMins().flatMap(value -> parseInteger("js_timezone_offset_min", value)).orElse(null),
                 authCardDetails.getUserAgentHeader()
         );
@@ -156,5 +171,13 @@ public class AdyenRequestFactory {
                     .log();
             return Optional.empty();
         }
+    }
+
+    String fromAgreementPaymentType(AgreementPaymentType agreementPaymentType) {
+        return switch (agreementPaymentType) {
+            case null -> "UnscheduledCardOnFile";
+            case RECURRING, INSTALMENT -> "Subscription";
+            default -> "UnscheduledCardOnFile";
+        };
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/AuthoriseRequestPayload.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/AuthoriseRequestPayload.java
@@ -35,6 +35,12 @@ public record AuthoriseRequestPayload(
         @JsonProperty("shopperEmail")
         String shopperEmail,
         @JsonProperty("shopperIP")
-        String shopperIP
+        String shopperIP,
+        @JsonProperty("shopperReference")
+        String shopperReference,
+        @JsonProperty("storePaymentMethod")
+        Boolean storePaymentMethod,
+        @JsonProperty("recurringProcessingModel")
+        String recurringProcessingModel
 ) {
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
@@ -4,6 +4,8 @@ import io.github.netmikey.logunit.api.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.slf4j.event.KeyValuePair;
 import org.slf4j.event.Level;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
@@ -25,6 +27,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.service.payments.commons.model.AgreementPaymentType;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.util.Map;
@@ -39,6 +42,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
@@ -46,6 +50,8 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixt
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+import static uk.gov.service.payments.commons.model.AgreementPaymentType.RECURRING;
+import static uk.gov.service.payments.commons.model.AgreementPaymentType.UNSCHEDULED;
 
 class AdyenRequestFactoryTest {
 
@@ -58,7 +64,7 @@ class AdyenRequestFactoryTest {
     final String screenWidth = "1440";
     final String timezoneOffset = "-60";
     final String shopperEmail = "test@example.com";
-   
+
     public static final BillingAddress FULL_BILLING_ADDRESS = new BillingAddress(
             "line1",
             "line2",
@@ -168,6 +174,45 @@ class AdyenRequestFactoryTest {
         assertThat(request.additionalData().get("manualCapture"), is("true"));
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "RECURRING,Subscription",
+            "INSTALMENT,Subscription",
+            "UNSCHEDULED,UnscheduledCardOnFile"
+    })
+    void should_map_agreementPaymentType_to_recurringProcessingModel_for_recurring_payment(AgreementPaymentType agreementPaymentType, String recurringProcessingModel) {
+        var mappedAdyenRecurringProcessingModel = adyenRequestFactory.fromAgreementPaymentType(agreementPaymentType);
+        assertThat(mappedAdyenRecurringProcessingModel, is(recurringProcessingModel));
+    }
+
+    @Test
+    void should_create_PaymentRequest_for_recurring_payment() {
+        var agreementId = "some-agreement-id";
+        var agreement = anAgreementEntity()
+                .withExternalId(agreementId)
+                .build();
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withAddress(makeFullBillingAddress())
+                        .withCardNo("4444333322221111")
+                        .withCardHolder("John Doe")
+                        .withCvc("737")
+                        .withEndDate(CardExpiryDate.valueOf("10/99"))
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .withAmount("6234")
+                .withSavePaymentInstrumentToAgreement(true)
+                .withAgreement(agreement)
+                .withAgreementPaymentType(RECURRING)
+                .build();
+
+        var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
+
+        assertThat(request.shopperReference(), is(agreementId));
+        assertThat(request.storePaymentMethod(), is(true));
+        assertThat(request.recurringProcessingModel(), is("Subscription"));
+    }
+
     @Test
     void should_throw_IllegalArgumentException_if_credentials_are_not_Adyen_specific() {
         var authoriseRequest = aCardAuthorisationGatewayRequest()
@@ -179,6 +224,29 @@ class AdyenRequestFactoryTest {
                 () -> adyenRequestFactory.createPaymentRequest(authoriseRequest));
 
         assertThat(exception.getMessage(), is("Expected provided GatewayCredentials to be of type AdyenCredentials"));
+    }
+
+    @Test
+    void should_throw_IllegalArgumentException_if_agreement_does_not_exist() {
+        var authoriseRequest = aCardAuthorisationGatewayRequest()
+                .withAuthCardDetails(anAuthCardDetails()
+                        .withAddress(makeFullBillingAddress())
+                        .withCardNo("4444333322221111")
+                        .withCardHolder("John Doe")
+                        .withCvc("737")
+                        .withEndDate(CardExpiryDate.valueOf("10/99"))
+                        .build())
+                .withCredentials(ADYEN_CREDENTIALS)
+                .withAmount("6234")
+                .withSavePaymentInstrumentToAgreement(true)
+                .withAgreement(null)
+                .withAgreementPaymentType(UNSCHEDULED)
+                .build();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> adyenRequestFactory.createPaymentRequest(authoriseRequest));
+
+        assertThat(exception.getMessage(), is("Expected charge with savePaymentInstrumentToAgreement to have an agreement"));
     }
 
     @Test
@@ -225,7 +293,7 @@ class AdyenRequestFactoryTest {
 
         assertThat(request.shopperInteraction(), is("Moto"));
     }
-    
+
     @Test
     void should_create_a_PaymentDetailsRequest_with_redirect_result() {
         var auth3dsResult = new Auth3dsResult();
@@ -303,7 +371,7 @@ class AdyenRequestFactoryTest {
         assertThat(request.shopperInteraction(), is("Moto"));
         assertThat(request.browserInfo(), is(nullValue()));
         assertThat(request.origin(), is(nullValue()));
-        assertThat(request.shopperEmail(),is(nullValue()));
+        assertThat(request.shopperEmail(), is(nullValue()));
         assertThat(request.shopperIP(), is(nullValue()));
     }
 
@@ -326,7 +394,7 @@ class AdyenRequestFactoryTest {
 
         assertThat(loggingEvents, everyItem(hasProperty("level", is(Level.WARN))));
         assertThat(loggingEvents, everyItem(hasProperty("message", is("Unable to parse browser info integer"))));
-        
+
         var keyValuePairs = loggingEvents.stream()
                 .flatMap(event -> event.getKeyValuePairs().stream())
                 .toList();
@@ -340,6 +408,7 @@ class AdyenRequestFactoryTest {
                 new KeyValuePair("value", "bad-offset")
         ));
     }
+
     private static CancelGatewayRequest makeCancelGatewayRequestWithExternalChargeId(String externalChargeId) {
         var chargeEntity = aValidChargeEntity()
                 .withExternalId(externalChargeId)

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenAuthorisationRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenAuthorisationRequestTest.java
@@ -119,7 +119,10 @@ class AdyenAuthorisationRequestTest {
                 browserInfo,
                 "https://frontend.pay.service.gov.uk",
                 "test@example.com",
-                "127.0.0.1"
+                "127.0.0.1",
+                null,
+                null,
+                null
         );
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
@@ -477,6 +477,10 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
     }
 
     public ChargeUtils.ExternalChargeId addChargeForSetUpAgreement(ChargeStatus status, String agreementExternalId, Long paymentInstrumentId) {
+        return addChargeForSetUpAgreement(status, agreementExternalId, paymentInstrumentId, null);
+    }
+
+    public ChargeUtils.ExternalChargeId addChargeForSetUpAgreement(ChargeStatus status, String agreementExternalId, Long paymentInstrumentId, AgreementPaymentType agreementPaymentType) {
         long chargeId = secureRandomInt();
         ChargeUtils.ExternalChargeId externalChargeId = ChargeUtils.ExternalChargeId.fromChargeId(chargeId);
         databaseTestHelper.addCharge(anAddChargeParams()
@@ -491,6 +495,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
                 .withAgreementExternalId(agreementExternalId)
                 .withGatewayCredentialId((long) gatewayAccountCredentialsId)
                 .withPaymentInstrumentId(paymentInstrumentId)
+                .withAgreementPaymentType(agreementPaymentType)
                 .build());
         return externalChargeId;
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
@@ -1,0 +1,106 @@
+package uk.gov.pay.connector.it.resources.adyen;
+
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.it.base.ITestBaseExtension;
+import uk.gov.pay.connector.util.AddAgreementParams;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
+
+import java.util.Optional;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
+import static uk.gov.service.payments.commons.model.AgreementPaymentType.RECURRING;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class AdyenCardResourceAuthoriseRecurringPaymentsIT {
+
+    @RegisterExtension
+    public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
+
+    @RegisterExtension
+    public static ITestBaseExtension testBaseExtension = new ITestBaseExtension(
+            "adyen", app.getLocalPort(), app.getDatabaseTestHelper());
+
+    private ChargeDao chargeDao;
+
+    @BeforeEach
+    void setUp() {
+        chargeDao = app.getInstanceFromGuiceContainer(ChargeDao.class);
+    }
+
+    @Test
+    void successful_authorisation_of_a_recurring_payment() {
+        app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testBaseExtension.getAccountId()));
+        String externalAgreementId = "agreement-external-id-123";
+        AddAgreementParams agreementParams = anAddAgreementParams()
+                .withGatewayAccountId(String.valueOf(testBaseExtension.getAccountId()))
+                .withExternalAgreementId(externalAgreementId)
+                .withReference("test reference")
+                .build();
+        app.getDatabaseTestHelper().addAgreement(agreementParams);
+
+        var chargeId = testBaseExtension.addChargeForSetUpAgreement(ENTERING_CARD_DETAILS,
+                externalAgreementId,
+                null,
+                RECURRING).toString();
+
+        var pspReferenceFromAdyen = "993617895215577D";
+
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
+
+        var authCardDetails = anAuthCardDetails()
+                .withCardNo("4444333322221111")
+                .withCardBrand("Visa")
+                .withCardHolder("John Doe")
+                .withCvc("737")
+                .withEndDate(CardExpiryDate.valueOf("03/30"))
+                .withAddress(new Address(
+                        "line1",
+                        "line2",
+                        "postcode",
+                        "city",
+                        "county",
+                        "country"
+                )).build();
+
+        app.givenSetup()
+                .body(authCardDetails)
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(200)
+                .body("status", is("AUTHORISATION SUCCESS"));
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
+                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
+                .withRequestBody(matchingJsonPath("$.billingAddress.houseNumberOrName", equalTo("line1")))
+                .withRequestBody(matchingJsonPath("$.billingAddress.street", equalTo("line2")))
+                .withRequestBody(matchingJsonPath("$.billingAddress.city", equalTo("city")))
+                .withRequestBody(matchingJsonPath("$.billingAddress.country", equalTo("country")))
+                .withRequestBody(matchingJsonPath("$.billingAddress.postalCode", equalTo("postcode")))
+                .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId)))
+                .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
+
+
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
+        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- Added parameters to Adyen's `AuthoriseRequestPayload`
  - `shopperReference` mapped from agreement's `ExternalId`
  - `storePaymentMethod`
  - `recurringProcessingModel` mapped from `agreementPaymentType`