### PR TITLE
PP-14494 Create a payment instrument when payment is successful

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -144,6 +144,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CAR
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.PAYMENT_NOTIFICATION_CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.fromString;
 import static uk.gov.pay.connector.charge.model.domain.Exemption3dsType.CORPORATE;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.paymentprocessor.model.Exemption3ds.EXEMPTION_NOT_REQUESTED;
@@ -877,7 +878,14 @@ public class ChargeService {
             charge.setCardDetails(detailsEntity);
 
             if (charge.isSavePaymentInstrumentToAgreement()) {
-                Optional.ofNullable(recurringAuthToken).ifPresent(token -> setPaymentInstrument(token, charge));
+                Optional.ofNullable(recurringAuthToken).ifPresentOrElse(
+                        token -> setPaymentInstrument(token, charge),
+                        () -> {
+                            if (charge.getPaymentProvider().equals(ADYEN.getName())) {
+                                setPaymentInstrument(Map.of(), charge);
+                            }
+                        }
+                );
             }
             
             if (newStatus == AUTHORISATION_SUCCESS || newStatus == AUTHORISATION_REJECTED) {

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
@@ -1,12 +1,14 @@
 package uk.gov.pay.connector.gateway.adyen.response;
 
 import uk.gov.pay.connector.gateway.adyen.response.json.Action;
+import uk.gov.pay.connector.gateway.adyen.response.json.AdditionalData;
 import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenAuthorisationRejectedCodeMapper;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
+import java.util.Map;
 import java.util.Optional;
 
 public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
@@ -20,6 +22,8 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
 
     private final String paReq;
     private final String md;
+    
+    private final String storedPaymentMethodId;
 
     public static AdyenAuthoriseResponse of(AuthoriseResponseBody authoriseResponseBody) {
         Action action = authoriseResponseBody.action();
@@ -34,6 +38,11 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
                 .map(Action::data)
                 .map(items -> items.get("MD"))
                 .orElse(null);
+        
+        var additionalData = authoriseResponseBody.additionalData();
+        String storedPaymentMethodId = Optional.ofNullable(additionalData)
+                .map(AdditionalData::storedPaymentMethodId)
+                .orElse(null);
 
         return new AdyenAuthoriseResponse(authoriseResponseBody.pspReference(),
                 authoriseResponseBody.resultCode(),
@@ -42,7 +51,8 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
                 paReq,
                 md,
                 authoriseResponseBody.refusalReason(), 
-                authoriseResponseBody.refusalReasonCode());
+                authoriseResponseBody.refusalReasonCode(),
+                storedPaymentMethodId);
     }
 
     private AdyenAuthoriseResponse(String transactionId,
@@ -52,7 +62,8 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
                                    String paReq,
                                    String md,
                                    String refusalReason,
-                                   String refusalReasonCode) {
+                                   String refusalReasonCode,
+                                   String storedPaymentMethodId) {
         this.transactionId = transactionId;
         authoriseStatus = mapAuthorisationStatusFrom(resultCode);
         this.redirectUrl = redirectUrl;
@@ -61,6 +72,7 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
         this.md = md;
         this.refusalReason = refusalReason;
         this.refusalReasonCode = refusalReasonCode;
+        this.storedPaymentMethodId = storedPaymentMethodId;
     }
 
     private static AuthoriseStatus mapAuthorisationStatusFrom(String resultCode) {
@@ -137,5 +149,11 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
     @Override
     public String getErrorMessage() {
         return null;
+    }
+
+    @Override
+    public Optional<Map<String, String>> getGatewayRecurringAuthToken() {
+        return Optional.ofNullable(storedPaymentMethodId)
+                .map(_ -> Map.of("storedPaymentMethodId", storedPaymentMethodId));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/AdditionalData.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/AdditionalData.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.connector.gateway.adyen.response.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AdditionalData(
+        @JsonProperty("tokenization.storedPaymentMethodId")
+        String storedPaymentMethodId
+) {
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/AuthoriseResponseBody.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/AuthoriseResponseBody.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record AuthoriseResponseBody(
@@ -16,6 +18,8 @@ public record AuthoriseResponseBody(
         @JsonProperty("refusalReasonCode")
         String refusalReasonCode,
         @JsonProperty("action")
-        Action action
+        Action action,
+        @JsonProperty("additionalData")
+        AdditionalData additionalData
 ) {
 }

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
@@ -1,14 +1,6 @@
 package uk.gov.pay.connector.paymentinstrument.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.charge.model.CardDetailsEntity;
-import uk.gov.pay.connector.common.model.api.ToLowerCaseStringSerializer;
-import uk.gov.pay.connector.gatewayaccount.util.JsonToStringStringMapConverter;
-import uk.gov.pay.connector.util.RandomIdGenerator;
-import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
-
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
@@ -22,6 +14,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.CardDetailsEntity;
+import uk.gov.pay.connector.common.model.api.ToLowerCaseStringSerializer;
+import uk.gov.pay.connector.gatewayaccount.util.JsonToStringStringMapConverter;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
+
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.adyen.response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import uk.gov.pay.connector.gateway.adyen.response.json.AdditionalData;
 import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
 import uk.gov.pay.connector.gateway.model.MappedAuthorisationRejectedReason;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
@@ -32,6 +33,7 @@ class AdyenAuthoriseResponseTest {
                 adyenResultCode,
                 "refusal-reason",
                 "0",
+                null,
                 null);
 
         var adyenAuthoriseResponse = AdyenAuthoriseResponse.of(response);
@@ -46,6 +48,7 @@ class AdyenAuthoriseResponseTest {
                 "UNRECOGNISED_RESULT_CODE",
                 "refusal-reason",
                 "0",
+                null,
                 null);
 
         IllegalStateException exception = assertThrows(IllegalStateException.class,
@@ -132,6 +135,31 @@ class AdyenAuthoriseResponseTest {
     }
 
     @Test
+    void should_set_get_gateway_recurring_auth_token_to_stored_payment_method_id() {
+        var testStoredPaymentMethodId = "testStoredPaymentMethodId";
+        var adyenPaymentResponse = anAdyenPaymentResponse()
+                .withAdditionalData(new AdditionalData(testStoredPaymentMethodId))
+                .build();
+
+        var adyenAuthoriseResponse = AdyenAuthoriseResponse.of(adyenPaymentResponse);
+
+        var gatewayRecurringAuthToken = adyenAuthoriseResponse.getGatewayRecurringAuthToken();
+        assertThat(gatewayRecurringAuthToken.isPresent(), is(true));
+        assertThat(gatewayRecurringAuthToken.get().get("storedPaymentMethodId"), is(testStoredPaymentMethodId));
+    }
+
+    @Test
+    void should_set_get_gateway_recurring_auth_token_to_stored_payment_method_id_null() {
+        var adyenPaymentResponse = anAdyenPaymentResponse()
+                .build();
+
+        var adyenAuthoriseResponse = AdyenAuthoriseResponse.of(adyenPaymentResponse);
+
+        var gatewayRecurringAuthToken = adyenAuthoriseResponse.getGatewayRecurringAuthToken();
+        assertThat(gatewayRecurringAuthToken.isPresent(), is(false));
+    }
+
+    @Test
     void should_not_set_data_to_action_data_if_Adyen_does_not_return_it() {
         var adyenPaymentResponse = anAdyenPaymentResponse()
                 .withAction(anAction().withMethod("GET").build())
@@ -177,6 +205,7 @@ class AdyenAuthoriseResponseTest {
                 "Refused",
                 "Expired Card",
                 "6",
+                null,
                 null
         );
 

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenPaymentResponseFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenPaymentResponseFixture.java
@@ -1,45 +1,52 @@
 package uk.gov.pay.connector.gateway.adyen.response;
 
 import uk.gov.pay.connector.gateway.adyen.response.json.Action;
+import uk.gov.pay.connector.gateway.adyen.response.json.AdditionalData;
 import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
 
 public class AdyenPaymentResponseFixture {
-        String pspReference;
-        String resultCode = "Authorised";
-        String refusalReason;
-        String refusalReasonCode;
-        Action action;
+    String pspReference;
+    String resultCode = "Authorised";
+    String refusalReason;
+    String refusalReasonCode;
+    Action action;
+    AdditionalData additionalData;
 
-        static AdyenPaymentResponseFixture anAdyenPaymentResponse() {
-            return new AdyenPaymentResponseFixture();
-        }
-
-        public AdyenPaymentResponseFixture withPspReference(String pspReference) {
-            this.pspReference = pspReference;
-            return this;
-        }
-
-        public AdyenPaymentResponseFixture withResultCode(String resultCode) {
-            this.resultCode = resultCode;
-            return this;
-        }
-
-        public AdyenPaymentResponseFixture withRefusalReason(String refusalReason) {
-            this.refusalReason = refusalReason;
-            return this;
-        }
-
-        public AdyenPaymentResponseFixture withRefusalReasonCode(String refusalReasonCode) {
-            this.refusalReasonCode = refusalReasonCode;
-            return this;
-        }
-
-        public AdyenPaymentResponseFixture withAction(Action action) {
-            this.action = action;
-            return this;
-        }
-
-        public AuthoriseResponseBody build() {
-            return new AuthoriseResponseBody(pspReference, resultCode, refusalReason, refusalReasonCode, action);
-        }
+    static AdyenPaymentResponseFixture anAdyenPaymentResponse() {
+        return new AdyenPaymentResponseFixture();
     }
+
+    public AdyenPaymentResponseFixture withPspReference(String pspReference) {
+        this.pspReference = pspReference;
+        return this;
+    }
+
+    public AdyenPaymentResponseFixture withResultCode(String resultCode) {
+        this.resultCode = resultCode;
+        return this;
+    }
+
+    public AdyenPaymentResponseFixture withRefusalReason(String refusalReason) {
+        this.refusalReason = refusalReason;
+        return this;
+    }
+
+    public AdyenPaymentResponseFixture withRefusalReasonCode(String refusalReasonCode) {
+        this.refusalReasonCode = refusalReasonCode;
+        return this;
+    }
+
+    public AdyenPaymentResponseFixture withAction(Action action) {
+        this.action = action;
+        return this;
+    }
+
+    public AdyenPaymentResponseFixture withAdditionalData(AdditionalData additionalData) {
+        this.additionalData = additionalData;
+        return this;
+    }
+
+    public AuthoriseResponseBody build() {
+        return new AuthoriseResponseBody(pspReference, resultCode, refusalReason, refusalReasonCode, action, additionalData);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.it.base.ITestBaseExtension;
 import uk.gov.pay.connector.util.AddAgreementParams;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
@@ -38,6 +39,10 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
     private ChargeDao chargeDao;
 
+    private final String externalAgreementId = "agreement-external-id-123";
+
+    private AuthCardDetails authCardDetails;
+
     @BeforeEach
     void setUp() {
         chargeDao = app.getInstanceFromGuiceContainer(ChargeDao.class);
@@ -45,8 +50,103 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
     @Test
     void successful_authorisation_of_a_recurring_payment() {
+        var chargeId = createChargeWithAgreement();
+
+        var pspReferenceFromAdyen = "993617895215577D";
+
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
+
+        app.givenSetup()
+                .body(authCardDetails)
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(200)
+                .body("status", is("AUTHORISATION SUCCESS"));
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
+                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
+                .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId)))
+                .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
+
+
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
+        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+    }
+
+    @Test
+    void successful_creation_of_payment_instrument_with_recurring_auth_token() {
+        var chargeId = createChargeWithAgreement();
+
+        var pspReferenceFromAdyen = "993617895215577D";
+        var expectedStoredPaymentMethodId = "M5N7TQ4TG5PFWR50";
+
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccessForRecurringPayment(pspReferenceFromAdyen,
+                expectedStoredPaymentMethodId);
+
+        app.givenSetup()
+                .body(authCardDetails)
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(200)
+                .body("status", is("AUTHORISATION SUCCESS"));
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
+                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
+                .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId)))
+                .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
+
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
+        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+
+        var storedPaymentMethodId = charge.get().getPaymentInstrument().orElseThrow()
+                .getRecurringAuthToken().orElseThrow().get("storedPaymentMethodId");
+
+        assertThat(storedPaymentMethodId, is(expectedStoredPaymentMethodId));
+    }
+
+    @Test
+    void successful_creation_of_payment_instrument_without_recurring_auth_token() {
+        var chargeId = createChargeWithAgreement();
+
+        var pspReferenceFromAdyen = "993617895215577D";
+
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
+
+        app.givenSetup()
+                .body(authCardDetails)
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then()
+                .statusCode(200)
+                .body("status", is("AUTHORISATION SUCCESS"));
+
+        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
+                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
+                .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId)))
+                .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
+
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
+        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+
+        var paymentInstrument = charge.get().getPaymentInstrument();
+
+        assertThat(paymentInstrument.isEmpty(), is(true));
+    }
+
+    private String createChargeWithAgreement() {
         app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testBaseExtension.getAccountId()));
-        String externalAgreementId = "agreement-external-id-123";
+
         AddAgreementParams agreementParams = anAddAgreementParams()
                 .withGatewayAccountId(String.valueOf(testBaseExtension.getAccountId()))
                 .withExternalAgreementId(externalAgreementId)
@@ -59,11 +159,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
                 null,
                 RECURRING).toString();
 
-        var pspReferenceFromAdyen = "993617895215577D";
-
-        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
-
-        var authCardDetails = anAuthCardDetails()
+        authCardDetails = anAuthCardDetails()
                 .withCardNo("4444333322221111")
                 .withCardBrand("Visa")
                 .withCardHolder("John Doe")
@@ -78,29 +174,6 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
                         "country"
                 )).build();
 
-        app.givenSetup()
-                .body(authCardDetails)
-                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
-                .then()
-                .statusCode(200)
-                .body("status", is("AUTHORISATION SUCCESS"));
-
-        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
-                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
-                .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
-                .withRequestBody(matchingJsonPath("$.billingAddress.houseNumberOrName", equalTo("line1")))
-                .withRequestBody(matchingJsonPath("$.billingAddress.street", equalTo("line2")))
-                .withRequestBody(matchingJsonPath("$.billingAddress.city", equalTo("city")))
-                .withRequestBody(matchingJsonPath("$.billingAddress.country", equalTo("country")))
-                .withRequestBody(matchingJsonPath("$.billingAddress.postalCode", equalTo("postcode")))
-                .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId)))
-                .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
-                .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
-
-
-        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
-        assertThat(charge.isPresent(), is(true));
-        assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
-        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+        return chargeId;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
@@ -34,8 +34,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
 
     @RegisterExtension
-    public static ITestBaseExtension testBaseExtension = new ITestBaseExtension(
-            "adyen", app.getLocalPort(), app.getDatabaseTestHelper());
+    public static ITestBaseExtension testBaseExtension = new ITestBaseExtension("adyen", app.getLocalPort(), app.getDatabaseTestHelper());
 
     private ChargeDao chargeDao;
 
@@ -56,20 +55,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
 
-        app.givenSetup()
-                .body(authCardDetails)
-                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
-                .then()
-                .statusCode(200)
-                .body("status", is("AUTHORISATION SUCCESS"));
-
-        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
-                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
-                .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
-                .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId)))
-                .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
-                .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
-
+        verifyResponseForRecurringPayment(chargeId);
 
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
@@ -84,30 +70,16 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
         var pspReferenceFromAdyen = "993617895215577D";
         var expectedStoredPaymentMethodId = "M5N7TQ4TG5PFWR50";
 
-        app.getAdyenCheckoutMockClient().mockAuthorisationSuccessForRecurringPayment(pspReferenceFromAdyen,
-                expectedStoredPaymentMethodId);
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccessForRecurringPayment(pspReferenceFromAdyen, expectedStoredPaymentMethodId);
 
-        app.givenSetup()
-                .body(authCardDetails)
-                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
-                .then()
-                .statusCode(200)
-                .body("status", is("AUTHORISATION SUCCESS"));
-
-        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
-                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
-                .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
-                .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId)))
-                .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
-                .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
+        verifyResponseForRecurringPayment(chargeId);
 
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
         assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
 
-        var storedPaymentMethodId = charge.get().getPaymentInstrument().orElseThrow()
-                .getRecurringAuthToken().orElseThrow().get("storedPaymentMethodId");
+        var storedPaymentMethodId = charge.get().getPaymentInstrument().orElseThrow().getRecurringAuthToken().orElseThrow().get("storedPaymentMethodId");
 
         assertThat(storedPaymentMethodId, is(expectedStoredPaymentMethodId));
     }
@@ -120,19 +92,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
 
-        app.givenSetup()
-                .body(authCardDetails)
-                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
-                .then()
-                .statusCode(200)
-                .body("status", is("AUTHORISATION SUCCESS"));
-
-        app.getAdyenWireMockServer().verify(postRequestedFor(urlEqualTo("/payments"))
-                .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
-                .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
-                .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId)))
-                .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
-                .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
+        verifyResponseForRecurringPayment(chargeId);
 
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
@@ -141,39 +101,46 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         var paymentInstrument = charge.get().getPaymentInstrument();
 
-        assertThat(paymentInstrument.isEmpty(), is(true));
+        assertThat(paymentInstrument.isEmpty(), is(false));
+        assertThat(paymentInstrument.get().getRecurringAuthToken().isEmpty(), is(true));
     }
 
     private String createChargeWithAgreement() {
         app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testBaseExtension.getAccountId()));
-
+        
         AddAgreementParams agreementParams = anAddAgreementParams()
                 .withGatewayAccountId(String.valueOf(testBaseExtension.getAccountId()))
                 .withExternalAgreementId(externalAgreementId)
-                .withReference("test reference")
-                .build();
+                .withReference("test reference").build();
+        
         app.getDatabaseTestHelper().addAgreement(agreementParams);
-
-        var chargeId = testBaseExtension.addChargeForSetUpAgreement(ENTERING_CARD_DETAILS,
-                externalAgreementId,
-                null,
-                RECURRING).toString();
-
+        
+        var chargeId = testBaseExtension.addChargeForSetUpAgreement(ENTERING_CARD_DETAILS, externalAgreementId, null, RECURRING).toString();
+        
         authCardDetails = anAuthCardDetails()
                 .withCardNo("4444333322221111")
                 .withCardBrand("Visa")
                 .withCardHolder("John Doe")
                 .withCvc("737")
                 .withEndDate(CardExpiryDate.valueOf("03/30"))
-                .withAddress(new Address(
-                        "line1",
-                        "line2",
-                        "postcode",
-                        "city",
-                        "county",
-                        "country"
-                )).build();
-
+                .withAddress(new Address("line1", "line2", "postcode", "city", "county", "country")).build();
+        
         return chargeId;
+    }
+
+    private void verifyResponseForRecurringPayment(String chargeId) {
+        app.givenSetup()
+                .body(authCardDetails)
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then().statusCode(200)
+                .body("status", is("AUTHORISATION SUCCESS"));
+        
+        app.getAdyenWireMockServer()
+                .verify(postRequestedFor(urlEqualTo("/payments"))
+                        .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                        .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
+                        .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId)))
+                        .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
+                        .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
@@ -24,6 +24,20 @@ public class AdyenCheckoutMockClient extends AdyenMockClient {
         setupPostResponse(responseBody, "/payments", SC_OK);
     }
 
+    public void mockAuthorisationSuccessForRecurringPayment(String pspReferenceFromAdyen, String storedPaymentMethodId) {
+        var responseBody = """
+                {
+                  "pspReference": "%s",
+                  "resultCode": "Authorised",
+                  "merchantReference": "string",
+                  "additionalData": {
+                    "tokenization.storedPaymentMethodId": "%s"
+                    }
+                }""".formatted(pspReferenceFromAdyen, storedPaymentMethodId);
+
+        setupPostResponse(responseBody, "/payments", SC_OK);
+    }
+
     public void mockAuthorisationRejected(String pspReferenceFromAdyen) {
         var responseBody = """
                 {


### PR DESCRIPTION
## WHAT YOU DID
- Implemented getGatewayRecurringAuthToken in AdyenAuthoriseResponse
- Added mapping for additionalData on the AdyenAuthoriseResponse
- Added mocking for additionalData on the AdyenAuthoriseResponse
- Created JsonPaymentInstrumentConverter to allow for empty maps to be saved to the database for RecurringAuthToken