### PR TITLE
PP-15617 Worldpay web MOTO payments allow payment instrument setup

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequestFactory.java
@@ -16,7 +16,8 @@ public class WorldpayAuthoriseRequestFactory {
     }
 
     public Optional<WorldpayAuthoriseRequest> create(CardAuthorisationGatewayRequest request) {
-        if (request.getAuthorisationMode() == AuthorisationMode.WEB && request.isMoto()) {
+        if (request.isMoto() && !request.isSavePaymentInstrumentToAgreement()
+                && request.getAuthorisationMode() == AuthorisationMode.WEB) {
             return Optional.of(worldpayMotoAuthoriseRequestFactory.create(request));
         }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayAuthoriseRequestFactoryTest.java
@@ -33,10 +33,11 @@ class WorldpayAuthoriseRequestFactoryTest {
     }
 
     @Test
-    void shouldBuildWorldpayMotoAuthoriseRequestIfWebAndMoto() {
+    void shouldBuildWorldpayMotoAuthoriseRequestIfWebAndMotoAndNotSavePaymentInstrumentToAgreement() {
         CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = aCardAuthorisationGatewayRequest()
                 .withAuthorisationMode(AuthorisationMode.WEB)
                 .withMoto(true)
+                .withSavePaymentInstrumentToAgreement(false)
                 .build();
 
         WorldpayMotoAuthoriseRequest worldpayMotoAuthoriseRequest = aWorldpayMotoAuthoriseRequestFixture().build();
@@ -54,6 +55,20 @@ class WorldpayAuthoriseRequestFactoryTest {
         CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = aCardAuthorisationGatewayRequest()
                 .withAuthorisationMode(AuthorisationMode.WEB)
                 .withMoto(false)
+                .withSavePaymentInstrumentToAgreement(false)
+                .build();
+
+        Optional<WorldpayAuthoriseRequest> result = worldpayAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest);
+
+        assertThat(result.isPresent(), is(false));
+    }
+
+    @Test
+    void shouldBuildNothingIfSavePaymentInstrumentToAgreement() {
+        CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = aCardAuthorisationGatewayRequest()
+                .withAuthorisationMode(AuthorisationMode.WEB)
+                .withMoto(true)
+                .withSavePaymentInstrumentToAgreement(true)
                 .build();
 
         Optional<WorldpayAuthoriseRequest> result = worldpayAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest);
@@ -67,6 +82,7 @@ class WorldpayAuthoriseRequestFactoryTest {
         CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest = aCardAuthorisationGatewayRequest()
                 .withAuthorisationMode(authorisationMode)
                 .withMoto(true)
+                .withSavePaymentInstrumentToAgreement(false)
                 .build();
 
         Optional<WorldpayAuthoriseRequest> result = worldpayAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest);


### PR DESCRIPTION
Restore the ability to save a payment instrument to an agreement when authorising a Worldpay MOTO payment with authorisation mode `WEB`.

This fixes a regression introduced by PP-15121.

The fix involves not creating a `WorldpayMotoAuthoriseRequest` and instead going down the classic path if `save_payment_instrument_to_agreement` is `true`.

Also reorder the checks when deciding whether to create a `WorldpayMotoAuthoriseRequest` record so that it’s more likely to bail out early, which is the common case.

This does not affect MOTO authorisation API payments (authorisation mode of `MOTO_API`), which have never supported saving payment instruments to agreements.