### PR TITLE
PP-14494 Create a payment instrument when payment is successful requiring 3DS

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -877,17 +877,8 @@ public class ChargeService {
             }
             charge.setCardDetails(detailsEntity);
 
-            if (charge.isSavePaymentInstrumentToAgreement()) {
-                Optional.ofNullable(recurringAuthToken).ifPresentOrElse(
-                        token -> setPaymentInstrument(token, charge),
-                        () -> {
-                            if (charge.getPaymentProvider().equals(ADYEN.getName())) {
-                                setPaymentInstrument(Map.of(), charge);
-                            }
-                        }
-                );
-            }
-            
+            checkToSavePaymentInstrument(recurringAuthToken, charge, newStatus);
+
             if (newStatus == AUTHORISATION_SUCCESS || newStatus == AUTHORISATION_REJECTED) {
                 if (!Boolean.TRUE.equals(charge.getRequires3ds())) {
                     charge.setRequires3ds(false);
@@ -915,7 +906,7 @@ public class ChargeService {
     }
 
     @Transactional
-    public ChargeEntity updateChargePost3dsAuthorisation(String chargeExternalId, ChargeStatus status,
+    public ChargeEntity updateChargePost3dsAuthorisation(String chargeExternalId, ChargeStatus newStatus,
                                                          OperationType operationType,
                                                          String transactionId,
                                                          Auth3dsRequiredEntity auth3dsRequiredDetails,
@@ -924,12 +915,12 @@ public class ChargeService {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
             try {
                 setTransactionId(charge, transactionId);
-                transitionChargeState(charge, status);
+                transitionChargeState(charge, newStatus);
                 Optional.ofNullable(auth3dsRequiredDetails).ifPresent(charge::set3dsRequiredDetails);
                 Optional.ofNullable(sessionIdentifier).map(ProviderSessionIdentifier::toString).ifPresent(charge::setProviderSessionId);
-                if (charge.isSavePaymentInstrumentToAgreement()) {
-                    Optional.ofNullable(recurringAuthToken).ifPresent(token -> setPaymentInstrument(token, charge));
-                }
+
+                checkToSavePaymentInstrument(recurringAuthToken, charge, newStatus);
+
             } catch (InvalidStateTransitionException e) {
                 if (chargeIsInLockedStatus(operationType, charge)) {
                     throw new OperationAlreadyInProgressRuntimeException(operationType.getValue(), charge.getExternalId());
@@ -1411,6 +1402,19 @@ public class ChargeService {
         return uriInfo.getBaseUriBuilder()
                 .path(path)
                 .build(chargeId);
+    }
+
+
+    private void checkToSavePaymentInstrument(Map<String, String> recurringAuthToken, ChargeEntity charge, ChargeStatus newStatus) {
+        if (charge.isSavePaymentInstrumentToAgreement() && AUTHORISATION_SUCCESS.equals(newStatus)) {
+            Optional.ofNullable(recurringAuthToken)
+                    .ifPresentOrElse(
+                            token -> setPaymentInstrument(token, charge),
+                            () -> Optional.ofNullable(charge.getPaymentProvider())
+                                    .filter(ADYEN.getName()::equals)
+                                    .ifPresent(provider -> setPaymentInstrument(Map.of(), charge))
+                    );
+        }
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandler.java
@@ -16,6 +16,8 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.Authori
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
+import java.util.Map;
+
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil.get3dsAuthUrl;
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil.getHeaders;
@@ -67,10 +69,16 @@ public class AdyenAuthorise3dsHandler {
             var responseBody = jsonObjectMapper.getObject(jsonResponse, Authorise3dsResponseBody.class);
             var mappedStatus = mapStatus(responseBody.resultCode());
 
+            var storedPaymentMethodId = responseBody.getStoredPaymentMethodId();
+
+            Map<String, String> recurringAuthToken = storedPaymentMethodId == null ? null
+                    : Map.of("storedPaymentMethodId", storedPaymentMethodId);
+
             return Gateway3DSAuthorisationResponse.of(
                     responseBody.toString(),
                     mappedStatus,
-                    responseBody.pspReference()
+                    responseBody.pspReference(),
+                    recurringAuthToken
             );
         } catch (GatewayErrorException e) {
             return handleGatewayErrorException(request, e);

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBody.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBody.java
@@ -14,7 +14,9 @@ public record Authorise3dsResponseBody(
         @JsonProperty("pspReference")
         String pspReference,
         @JsonProperty("resultCode")
-        String resultCode
+        String resultCode,
+        @JsonProperty("additionalData")
+        AdditionalData additionalData
 ) {
     @Override
     public String toString() {
@@ -26,5 +28,9 @@ public record Authorise3dsResponseBody(
             joiner.add("resultCode: " + resultCode);
         }
         return joiner.toString();
+    }
+
+    public String getStoredPaymentMethodId() {
+        return additionalData == null ? null : additionalData.storedPaymentMethodId();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
@@ -41,6 +41,10 @@ public class Gateway3DSAuthorisationResponse {
         return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, gateway3dsRequiredParams, providerSessionIdentifier, gatewayRecurringAuthToken);
     }
 
+    public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId, Map<String, String> gatewayRecurringAuthToken) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, null, null, gatewayRecurringAuthToken);
+    }
+
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
         return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", null, null, null);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBodyTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBodyTest.java
@@ -4,63 +4,95 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 class Authorise3dsResponseBodyTest {
-
+    
     @Test
     void should_format_toString_with_both_fields_present() {
-        var response = new Authorise3dsResponseBody("psp-ref-123", "Authorised");
+        var response = new Authorise3dsResponseBody("psp-ref-123", "Authorised", null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (pspReference: psp-ref-123, resultCode: Authorised)"));
     }
 
     @Test
     void should_exclude_null_pspReference_from_toString() {
-        var response = new Authorise3dsResponseBody(null, "Authorised");
+        var response = new Authorise3dsResponseBody(null, "Authorised", null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (resultCode: Authorised)"));
     }
 
     @Test
     void should_exclude_null_resultCode_from_toString() {
-        var response = new Authorise3dsResponseBody("psp-ref-123", null);
+        var response = new Authorise3dsResponseBody("psp-ref-123", null, null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (pspReference: psp-ref-123)"));
     }
 
     @Test
     void should_exclude_blank_pspReference_from_toString() {
-        var response = new Authorise3dsResponseBody("", "Authorised");
+        var response = new Authorise3dsResponseBody("", "Authorised", null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (resultCode: Authorised)"));
     }
 
     @Test
     void should_exclude_blank_resultCode_from_toString() {
-        var response = new Authorise3dsResponseBody("psp-ref-123", "");
+        var response = new Authorise3dsResponseBody("psp-ref-123", "", null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (pspReference: psp-ref-123)"));
     }
 
     @Test
     void should_return_empty_response_when_both_fields_null() {
-        var response = new Authorise3dsResponseBody(null, null);
+        var response = new Authorise3dsResponseBody(null, null, null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response ()"));
     }
 
     @Test
     void should_return_empty_response_when_both_fields_blank() {
-        var response = new Authorise3dsResponseBody("", "");
+        var response = new Authorise3dsResponseBody("", "", null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response ()"));
     }
 
     @Test
     void should_exclude_whitespace_only_fields_from_toString() {
-        var response = new Authorise3dsResponseBody("   ", "Authorised");
+        var response = new Authorise3dsResponseBody("   ", "Authorised", null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (resultCode: Authorised)"));
+    }
+
+    @Test
+    void getStoredPaymentMethodId_ShouldReturnNull_WhenAdditionalDataIsNull() {
+        Authorise3dsResponseBody response = new Authorise3dsResponseBody(
+                "psp-ref-123",
+                "Authorised",
+                null
+        );
+
+        String result = response.getStoredPaymentMethodId();
+
+        assertNull(result);
+    }
+
+    @Test
+    void getStoredPaymentMethodId_ShouldReturnId_WhenAdditionalDataIsPresent() {
+        String expectedId = "someStoredPaymentMethodId";
+
+        var additionalData = new AdditionalData(expectedId);
+
+        Authorise3dsResponseBody response = new Authorise3dsResponseBody(
+                "psp-ref-123",
+                "Authorised",
+                additionalData
+        );
+
+        String result = response.getStoredPaymentMethodId();
+
+        assertEquals(expectedId, result);
     }
 }
 

--- a/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
@@ -42,6 +42,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
@@ -496,6 +497,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
                 .withGatewayCredentialId((long) gatewayAccountCredentialsId)
                 .withPaymentInstrumentId(paymentInstrumentId)
                 .withAgreementPaymentType(agreementPaymentType)
+                .withRequires3ds(status == AUTHORISATION_3DS_REQUIRED)
                 .build());
         return externalChargeId;
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -14,6 +16,7 @@ import uk.gov.pay.connector.it.base.ITestBaseExtension;
 import uk.gov.pay.connector.util.AddAgreementParams;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -22,7 +25,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.it.base.ITestBaseExtension.authorise3dsChargeUrlFor;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
 import static uk.gov.service.payments.commons.model.AgreementPaymentType.RECURRING;
@@ -42,6 +47,13 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
     private AuthCardDetails authCardDetails;
 
+    private static final String REDIRECT_RESULT = "eyJ0cmFuc1N0YXR1cyI6IlkifQ==";
+    
+    private static final String AUTH_SUCCESS = "AUTHORISATION SUCCESS";
+    
+    private static final String PSP_REFERENCE_FROM_ADYEN = "993617895215577D";
+
+
     @BeforeEach
     void setUp() {
         chargeDao = app.getInstanceFromGuiceContainer(ChargeDao.class);
@@ -49,55 +61,39 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
     @Test
     void successful_authorisation_of_a_recurring_payment() {
-        var chargeId = createChargeWithAgreement();
+        var chargeId = createChargeWithAgreement(ENTERING_CARD_DETAILS);
 
-        var pspReferenceFromAdyen = "993617895215577D";
-
-        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(PSP_REFERENCE_FROM_ADYEN);
 
         verifyResponseForRecurringPayment(chargeId);
 
-        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
-        assertThat(charge.isPresent(), is(true));
-        assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
-        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+        getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
     }
 
     @Test
     void successful_creation_of_payment_instrument_with_recurring_auth_token() {
-        var chargeId = createChargeWithAgreement();
-
-        var pspReferenceFromAdyen = "993617895215577D";
+        var chargeId = createChargeWithAgreement(ENTERING_CARD_DETAILS);
         var expectedStoredPaymentMethodId = "M5N7TQ4TG5PFWR50";
 
-        app.getAdyenCheckoutMockClient().mockAuthorisationSuccessForRecurringPayment(pspReferenceFromAdyen, expectedStoredPaymentMethodId);
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccessForRecurringPayment(PSP_REFERENCE_FROM_ADYEN, expectedStoredPaymentMethodId);
 
         verifyResponseForRecurringPayment(chargeId);
 
-        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
-        assertThat(charge.isPresent(), is(true));
-        assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
-        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
 
-        var storedPaymentMethodId = charge.get().getPaymentInstrument().orElseThrow().getRecurringAuthToken().orElseThrow().get("storedPaymentMethodId");
+        var storedPaymentMethodId = getStoredPaymentMethodId(charge);
 
         assertThat(storedPaymentMethodId, is(expectedStoredPaymentMethodId));
     }
 
     @Test
     void successful_creation_of_payment_instrument_without_recurring_auth_token() {
-        var chargeId = createChargeWithAgreement();
-
-        var pspReferenceFromAdyen = "993617895215577D";
-
-        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(pspReferenceFromAdyen);
+        var chargeId = createChargeWithAgreement(ENTERING_CARD_DETAILS);
+        app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(PSP_REFERENCE_FROM_ADYEN);
 
         verifyResponseForRecurringPayment(chargeId);
 
-        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
-        assertThat(charge.isPresent(), is(true));
-        assertThat(charge.get().getStatus(), is("AUTHORISATION SUCCESS"));
-        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
 
         var paymentInstrument = charge.get().getPaymentInstrument();
 
@@ -105,18 +101,83 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
         assertThat(paymentInstrument.get().getRecurringAuthToken().isEmpty(), is(true));
     }
 
-    private String createChargeWithAgreement() {
+    @Test
+    void successful_creation_of_payment_instrument_for_3ds_with_recurring_auth_token() {
+        var chargeId = createChargeWithAgreement(AUTHORISATION_3DS_REQUIRED);
+        var expectedStoredPaymentMethodId = "M5N7TQ4TG5PFWR50";
+
+        app.getAdyenCheckoutMockClient().mock3dsAuthorisationResponseForRecurringPayment(PSP_REFERENCE_FROM_ADYEN, "Authorised", expectedStoredPaymentMethodId);
+
+        verifyResponseForRecurringPaymentWith3ds(chargeId, 200, AUTH_SUCCESS);
+
+        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+
+        var storedPaymentMethodId = getStoredPaymentMethodId(charge);
+
+        assertThat(storedPaymentMethodId, is(expectedStoredPaymentMethodId));
+    }
+
+    @Test
+    void successful_creation_of_payment_instrument_for_3ds_without_recurring_auth_token() {
+        var chargeId = createChargeWithAgreement(AUTHORISATION_3DS_REQUIRED);
+
+        app.getAdyenCheckoutMockClient().mock3dsAuthorisationResponse(PSP_REFERENCE_FROM_ADYEN, "Authorised");
+
+        verifyResponseForRecurringPaymentWith3ds(chargeId, 200, AUTH_SUCCESS);
+
+        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+
+        var paymentInstrument = charge.get().getPaymentInstrument();
+
+        assertThat(paymentInstrument.isEmpty(), is(false));
+        assertThat(paymentInstrument.get().getRecurringAuthToken().isEmpty(), is(true));
+    }
+
+    @Test
+    void errored_recurring_payment_should_not_create_a_paymentInstrument() {
+        var chargeId = createChargeWithAgreement(ENTERING_CARD_DETAILS);
+
+        app.getAdyenCheckoutMockClient().mockAuthorisationError(PSP_REFERENCE_FROM_ADYEN);
+
+        verifyDeclineErrorResponseForRecurringPayment(chargeId, 402, "There was an error authorising the transaction.");
+
+        getAndVerifyChargeEntityForFailedAuthorisation(chargeId, "AUTHORISATION ERROR", PSP_REFERENCE_FROM_ADYEN);
+    }
+
+    @Test
+    void rejected_recurring_payment_should_not_create_a_paymentInstrument() {
+        var chargeId = createChargeWithAgreement(ENTERING_CARD_DETAILS);
+
+        app.getAdyenCheckoutMockClient().mockAuthorisationRejected(PSP_REFERENCE_FROM_ADYEN);
+
+        verifyDeclineErrorResponseForRecurringPayment(chargeId, 400, "This transaction was declined.");
+
+        getAndVerifyChargeEntityForFailedAuthorisation(chargeId, "AUTHORISATION REJECTED", PSP_REFERENCE_FROM_ADYEN);
+    }
+
+    @Test
+    void errored_3ds_recurring_payment_should_not_create_a_paymentInstrument() {
+        var chargeId = createChargeWithAgreement(AUTHORISATION_3DS_REQUIRED);
+
+        app.getAdyenCheckoutMockClient().mock3dsAuthorisationClientError();
+
+        verifyResponseForRecurringPaymentWith3ds(chargeId, 402, null);
+
+        getAndVerifyChargeEntityForFailedAuthorisation(chargeId, "AUTHORISATION ERROR", null);
+    }
+    
+    private String createChargeWithAgreement(ChargeStatus chargeStatus) {
         app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testBaseExtension.getAccountId()));
-        
+
         AddAgreementParams agreementParams = anAddAgreementParams()
                 .withGatewayAccountId(String.valueOf(testBaseExtension.getAccountId()))
                 .withExternalAgreementId(externalAgreementId)
                 .withReference("test reference").build();
-        
+
         app.getDatabaseTestHelper().addAgreement(agreementParams);
-        
-        var chargeId = testBaseExtension.addChargeForSetUpAgreement(ENTERING_CARD_DETAILS, externalAgreementId, null, RECURRING).toString();
-        
+
+        var chargeId = testBaseExtension.addChargeForSetUpAgreement(chargeStatus, externalAgreementId, null, RECURRING).toString();
+
         authCardDetails = anAuthCardDetails()
                 .withCardNo("4444333322221111")
                 .withCardBrand("Visa")
@@ -124,7 +185,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
                 .withCvc("737")
                 .withEndDate(CardExpiryDate.valueOf("03/30"))
                 .withAddress(new Address("line1", "line2", "postcode", "city", "county", "country")).build();
-        
+
         return chargeId;
     }
 
@@ -133,8 +194,41 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
                 .body(authCardDetails)
                 .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
                 .then().statusCode(200)
-                .body("status", is("AUTHORISATION SUCCESS"));
+                .body("status", is(AUTH_SUCCESS));
+
+        verifyRequestToAdyenPaymentsEndpoint(chargeId);
+    }
+
+    private void verifyResponseForRecurringPaymentWith3ds(String chargeId, int statusCode, @Nullable String expectedStatus) {
+        var response = app.givenSetup()
+                .body(Map.of("redirect_result", REDIRECT_RESULT))
+                .post(authorise3dsChargeUrlFor(chargeId))
+                .then()
+                .statusCode(statusCode);
+
+        if (expectedStatus != null) {
+            response.body("status", is(expectedStatus));
+        }
         
+        app.getAdyenWireMockServer()
+                .verify(postRequestedFor(urlEqualTo("/payments/details"))
+                        .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
+                        .withHeader("Idempotency-Key", equalTo("authorise3DS-" + chargeId))
+                        .withRequestBody(matchingJsonPath("$.details.redirectResult", equalTo(REDIRECT_RESULT))));
+    }
+
+    private void verifyDeclineErrorResponseForRecurringPayment(String chargeId, int statusCode, String errorMessage) {
+        app.givenSetup()
+                .body(authCardDetails)
+                .post("/v1/frontend/charges/{chargeId}/cards", chargeId)
+                .then().statusCode(statusCode)
+                .body("error_identifier", is("GENERIC"))
+                .body("message[0]", is(errorMessage));
+
+        verifyRequestToAdyenPaymentsEndpoint(chargeId);
+    }
+
+    private void verifyRequestToAdyenPaymentsEndpoint(String chargeId) {
         app.getAdyenWireMockServer()
                 .verify(postRequestedFor(urlEqualTo("/payments"))
                         .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
@@ -142,5 +236,28 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
                         .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId)))
                         .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
                         .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
+    }
+    
+    private Optional<ChargeEntity> getAndVerifyChargeEntity(String chargeId, String pspReferenceFromAdyen) {
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is(AUTH_SUCCESS));
+        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+        return charge;
+    }
+
+    private void getAndVerifyChargeEntityForFailedAuthorisation(String chargeId, String status, @Nullable String pspReferenceFromAdyen) {
+        Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is(status));
+        assertThat(charge.get().getPaymentInstrument().isEmpty(), is(true));
+        
+        if (pspReferenceFromAdyen != null) {
+            assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
+        }
+    }
+
+    private static String getStoredPaymentMethodId(Optional<ChargeEntity> charge) {
+        return charge.get().getPaymentInstrument().orElseThrow().getRecurringAuthToken().orElseThrow().get("storedPaymentMethodId");
     }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
@@ -72,6 +72,22 @@ public class AdyenCheckoutMockClient extends AdyenMockClient {
         setupPostResponse(responseBody, "/payments/details", SC_OK);
     }
 
+    public void mock3dsAuthorisationResponseForRecurringPayment(
+            String pspReferenceFromAdyen,
+            String resultCode,
+            String storedPaymentMethodId
+    ) {
+        var responseBody = """
+                {
+                  "pspReference": "%s",
+                  "resultCode": "%s",
+                  "additionalData": {
+                    "tokenization.storedPaymentMethodId": "%s"
+                    }
+                }""".formatted(pspReferenceFromAdyen, resultCode, storedPaymentMethodId);
+        setupPostResponse(responseBody, "/payments/details", SC_OK);
+    }
+
     public void mock3dsAuthorisationClientError() {
         var responseBody = """
                 {


### PR DESCRIPTION
- Added additionalData mapping to Authorise3dsResponseBody
- Handled extracting the storedPaymentMethodId from Adyen response
- Added logic to create payment instruments when 3DS recurring payments are successful
- Added tests to check no payment instrument is created when authorisation errors and rejections are received back from Adyen