### PR TITLE
PP-14490 Store authorisation rejected reason for Adyen 3DS payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -911,7 +911,8 @@ public class ChargeService {
                                                          String transactionId,
                                                          Auth3dsRequiredEntity auth3dsRequiredDetails,
                                                          ProviderSessionIdentifier sessionIdentifier,
-                                                         Map<String, String> recurringAuthToken) {
+                                                         Map<String, String> recurringAuthToken,
+                                                         String gatewayRejectionReason) {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
             try {
                 setTransactionId(charge, transactionId);
@@ -921,6 +922,7 @@ public class ChargeService {
 
                 checkToSavePaymentInstrument(recurringAuthToken, charge, newStatus);
 
+                Optional.ofNullable(gatewayRejectionReason).ifPresent(charge::setGatewayRejectionReason);
             } catch (InvalidStateTransitionException e) {
                 if (chargeIsInLockedStatus(operationType, charge)) {
                     throw new OperationAlreadyInProgressRuntimeException(operationType.getValue(), charge.getExternalId());

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandler.java
@@ -78,7 +78,8 @@ public class AdyenAuthorise3dsHandler {
                     responseBody.toString(),
                     mappedStatus,
                     responseBody.pspReference(),
-                    recurringAuthToken
+                    recurringAuthToken,
+                    getGatewayRejectionReason(responseBody)
             );
         } catch (GatewayErrorException e) {
             return handleGatewayErrorException(request, e);
@@ -128,5 +129,20 @@ public class AdyenAuthorise3dsHandler {
             case "Cancelled" -> AuthoriseStatus.CANCELLED;
             default -> ERROR;
         };
+    }
+    
+    private String getGatewayRejectionReason(Authorise3dsResponseBody responseBody) {
+        if (!"Refused".equals(responseBody.resultCode())) {
+            return null;
+        }
+
+        if (isBlank(responseBody.refusalReasonCode())
+                || isBlank(responseBody.refusalReason())) {
+            return null;
+        }
+
+        return responseBody.refusalReasonCode()
+                + " - "
+                + responseBody.refusalReason();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBody.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBody.java
@@ -16,7 +16,12 @@ public record Authorise3dsResponseBody(
         @JsonProperty("resultCode")
         String resultCode,
         @JsonProperty("additionalData")
-        AdditionalData additionalData
+        AdditionalData additionalData,
+        @JsonProperty("refusalReason")
+        String refusalReason,
+
+        @JsonProperty("refusalReasonCode")
+        String refusalReasonCode
 ) {
     @Override
     public String toString() {

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
@@ -17,55 +17,57 @@ public class Gateway3DSAuthorisationResponse {
     private final Gateway3dsRequiredParams gateway3dsRequiredParams;
     private final ProviderSessionIdentifier providerSessionIdentifier;
     private Map<String, String> gatewayRecurringAuthToken;
+    private final String gatewayRejectionReason;
 
     private Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus,
                                             String transactionId,
                                             String stringifiedResponse,
                                             Gateway3dsRequiredParams gateway3dsRequiredParams,
                                             ProviderSessionIdentifier providerSessionIdentifier,
-                                            Map<String, String> gatewayRecurringAuthToken) {
+                                            Map<String, String> gatewayRecurringAuthToken,
+                                            String gatewayRejectionReason) {
         this.transactionId = transactionId;
         this.authorisationStatus = authorisationStatus;
         this.stringifiedResponse = stringifiedResponse;
         this.gateway3dsRequiredParams = gateway3dsRequiredParams;
         this.providerSessionIdentifier = providerSessionIdentifier;
         this.gatewayRecurringAuthToken = gatewayRecurringAuthToken;
+        this.gatewayRejectionReason = gatewayRejectionReason;
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, null, null, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, null, null, null, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId,
                                                      Gateway3dsRequiredParams gateway3dsRequiredParams, ProviderSessionIdentifier providerSessionIdentifier, Map<String, String> gatewayRecurringAuthToken) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, gateway3dsRequiredParams, providerSessionIdentifier, gatewayRecurringAuthToken);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, gateway3dsRequiredParams, providerSessionIdentifier, gatewayRecurringAuthToken, null);
     }
 
-    public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId, Map<String, String> gatewayRecurringAuthToken) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, null, null, gatewayRecurringAuthToken);
-    }
-
-    public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", null, null, null);
+    public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId, Map<String, String> gatewayRecurringAuthToken, String gatewayRejectionReason) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, null, null, gatewayRecurringAuthToken, gatewayRejectionReason);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId,
                                                      Gateway3dsRequiredParams gateway3dsRequiredParams, ProviderSessionIdentifier providerSessionIdentifier) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", gateway3dsRequiredParams, providerSessionIdentifier, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", gateway3dsRequiredParams, providerSessionIdentifier, null, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringifiedResponse, null, null, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringifiedResponse, null, null, null, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "", null, null, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "", null, null, null, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, Gateway3dsRequiredParams gateway3dsRequiredParams) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringifiedResponse, gateway3dsRequiredParams, null, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringifiedResponse, gateway3dsRequiredParams, null, null, null);
     }
 
+    public static Gateway3DSAuthorisationResponse of(String stringifiedResponse, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId, String gatewayRejectionReason) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringifiedResponse, null, null, null, gatewayRejectionReason);
+    }
     public boolean isSuccessful() {
         return authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED
                 || authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.AUTH_3DS_READY;
@@ -93,6 +95,10 @@ public class Gateway3DSAuthorisationResponse {
 
     public Optional<Map<String, String>> getGatewayRecurringAuthToken() {
         return Optional.ofNullable(gatewayRecurringAuthToken);
+    }
+
+    public Optional<String> getGatewayRejectionReason() {
+        return Optional.ofNullable(gatewayRejectionReason);
     }
 
     public String toString() {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -127,7 +127,8 @@ public class Card3dsResponseAuthService {
                 transactionId.orElse(null),
                 operationResponse.getGateway3dsRequiredParams().map(Gateway3dsRequiredParams::toAuth3dsRequiredEntity).orElse(null),
                 operationResponse.getProviderSessionIdentifier().orElse(null),
-                operationResponse.getGatewayRecurringAuthToken().orElse(null)
+                operationResponse.getGatewayRecurringAuthToken().orElse(null),
+                operationResponse.getGatewayRejectionReason().orElse(null)
         );
 
         var worldPay3dsOrFlexLogMessage = integration3dsType(auth3dsResult, updatedCharge);

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -492,7 +492,7 @@ class ChargeServiceTest {
         when(mockedChargeDao.findByExternalId(chargeEntityExternalId)).thenReturn(Optional.of(chargeSpy));
 
         chargeService.updateChargePost3dsAuthorisation(chargeSpy.getExternalId(), AUTHORISATION_REJECTED, AUTHORISATION_3DS, null,
-                null, null, null);
+                null, null, null, null);
 
         verify(chargeSpy, never()).setGatewayTransactionId(anyString());
         verify(chargeSpy).setStatus(AUTHORISATION_REJECTED);
@@ -509,7 +509,7 @@ class ChargeServiceTest {
         when(mockedChargeDao.findByExternalId(chargeEntityExternalId)).thenReturn(Optional.of(chargeSpy));
         
         chargeService.updateChargePost3dsAuthorisation(chargeSpy.getExternalId(), AUTHORISATION_SUCCESS, AUTHORISATION_3DS, "transaction-id",
-                null, null, null);
+                null, null, null,null);
 
         verify(chargeSpy).setGatewayTransactionId("transaction-id");
         verify(chargeSpy).setStatus(AUTHORISATION_SUCCESS);
@@ -531,7 +531,8 @@ class ChargeServiceTest {
         when(mockedAuth3dsRequiredEntity.getThreeDsVersion()).thenReturn("2.1.0");
         
         chargeService.updateChargePost3dsAuthorisation(chargeSpy.getExternalId(), AUTHORISATION_3DS_REQUIRED, AUTHORISATION_3DS, "transaction-id",
-                mockedAuth3dsRequiredEntity, ProviderSessionIdentifier.of("provider-session-identifier"), null);
+                mockedAuth3dsRequiredEntity, ProviderSessionIdentifier.of("provider-session-identifier"), 
+                null, null);
 
         verify(chargeSpy).setGatewayTransactionId("transaction-id");
         verify(chargeSpy).set3dsRequiredDetails(mockedAuth3dsRequiredEntity);
@@ -557,7 +558,7 @@ class ChargeServiceTest {
         when(mockPaymentInstrumentService.createPaymentInstrument(chargeSpy, recurringAuthToken)).thenReturn(paymentInstrument);
         
         chargeService.updateChargePost3dsAuthorisation(chargeSpy.getExternalId(), AUTHORISATION_SUCCESS, AUTHORISATION_3DS, "transaction-id",
-                null, null, recurringAuthToken);
+                null, null, recurringAuthToken, null);
 
         verify(chargeSpy).setGatewayTransactionId("transaction-id");
         verify(chargeSpy).setStatus(AUTHORISATION_SUCCESS);
@@ -816,6 +817,26 @@ class ChargeServiceTest {
 
             Integer result = chargeService.getLongestDurationOfChargesAwaitingCaptureInMinutes(60);
             assertThat(result, is(nullValue()));
+        }
+
+        @Test
+        void shouldUpdateChargePost3dsAuthorisationWithGatewayRejectionReason() {
+            ChargeEntity chargeSpy = spy(aValidChargeEntity()
+                    .withStatus(AUTHORISATION_3DS_READY)
+                    .build());
+
+            String chargeEntityExternalId = chargeSpy.getExternalId();
+
+            when(mockedChargeDao.findByExternalId(chargeEntityExternalId)).thenReturn(Optional.of(chargeSpy));
+
+            chargeService.updateChargePost3dsAuthorisation(chargeEntityExternalId, AUTHORISATION_REJECTED,
+                    AUTHORISATION_3DS, "transaction-id", null, null, 
+                    null, "6 - Expired Card");
+
+            verify(chargeSpy).setGatewayTransactionId("transaction-id");
+            verify(chargeSpy).setGatewayRejectionReason("6 - Expired Card");
+            verify(chargeSpy).setStatus(AUTHORISATION_REJECTED);
+            verify(mockedChargeEventDao).persistChargeEventOf(eq(chargeSpy), isNull());
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandlerTest.java
@@ -22,6 +22,8 @@ import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -110,6 +112,7 @@ class AdyenAuthorise3dsHandlerTest {
         assertThat(response.getMappedChargeStatus(), is(expectedStatus.getMappedChargeStatus()));
         assertThat(response.getTransactionId().isPresent(), is(true));
         assertThat(response.getTransactionId().get(), is("adyen-3ds-psp-reference"));
+        assertThat(response.getGatewayRejectionReason(), is(Optional.empty()));
     }
 
     @Test
@@ -185,7 +188,47 @@ class AdyenAuthorise3dsHandlerTest {
                 auth3dsResult
         );
     }
+    
+    @Test
+    void should_return_gateway_rejection_reason_when_3ds_authorisation_is_refused() throws Exception {
+        when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
+        when(mockGatewayClientResponse.getEntity()).thenReturn(
+                """
+                        {
+                          "pspReference": "adyen-3ds-psp-reference",
+                          "resultCode": "Refused",
+                          "refusalReason": "Expired Card",
+                          "refusalReasonCode": "6"
+                        }
+                        """
+        );
 
+        var response = adyenAuthorise3dsHandler.authorise3dsResponse(buildRequestWith("redirect-result"));
+
+        assertThat(response.getGatewayRejectionReason(), is(Optional.of("6 - Expired Card")));
+    }
+
+    @Test
+    void should_not_return_gateway_rejection_reason_when_3ds_authorisation_is_authorised() throws Exception {
+        when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
+        when(mockGatewayClientResponse.getEntity()).thenReturn(
+                """
+                        {
+                          "pspReference": "adyen-3ds-psp-reference",
+                          "resultCode": "Authorised",
+                          "refusalReasonCode": "0",
+                           "refusalReason": "Authorised"
+                        }
+                        """
+        );
+
+        var response = adyenAuthorise3dsHandler.authorise3dsResponse(
+                buildRequestWith("redirect-result")
+        );
+
+        assertThat(response.getGatewayRejectionReason(), is(Optional.empty()));
+    }
+    
     private String successResponse(String resultCode) {
         return """
                 {

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBodyTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/response/json/Authorise3dsResponseBodyTest.java
@@ -11,56 +11,63 @@ class Authorise3dsResponseBodyTest {
     
     @Test
     void should_format_toString_with_both_fields_present() {
-        var response = new Authorise3dsResponseBody("psp-ref-123", "Authorised", null);
-
+        var response = new Authorise3dsResponseBody("psp-ref-123", "Authorised",
+                null, null, null);
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (pspReference: psp-ref-123, resultCode: Authorised)"));
     }
 
     @Test
     void should_exclude_null_pspReference_from_toString() {
-        var response = new Authorise3dsResponseBody(null, "Authorised", null);
+        var response = new Authorise3dsResponseBody(null, "Authorised", 
+                null, null, null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (resultCode: Authorised)"));
     }
 
     @Test
     void should_exclude_null_resultCode_from_toString() {
-        var response = new Authorise3dsResponseBody("psp-ref-123", null, null);
+        var response = new Authorise3dsResponseBody("psp-ref-123", null, 
+                null, null, null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (pspReference: psp-ref-123)"));
     }
 
     @Test
     void should_exclude_blank_pspReference_from_toString() {
-        var response = new Authorise3dsResponseBody("", "Authorised", null);
+        var response = new Authorise3dsResponseBody("", "Authorised", 
+                null, null, null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (resultCode: Authorised)"));
     }
 
     @Test
     void should_exclude_blank_resultCode_from_toString() {
-        var response = new Authorise3dsResponseBody("psp-ref-123", "", null);
+        var response = new Authorise3dsResponseBody("psp-ref-123", "", 
+                null, null, null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (pspReference: psp-ref-123)"));
     }
 
     @Test
     void should_return_empty_response_when_both_fields_null() {
-        var response = new Authorise3dsResponseBody(null, null, null);
+        var response = new Authorise3dsResponseBody(null, null, 
+                null, null, null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response ()"));
     }
 
     @Test
     void should_return_empty_response_when_both_fields_blank() {
-        var response = new Authorise3dsResponseBody("", "", null);
+        var response = new Authorise3dsResponseBody("", "", 
+                null, null, null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response ()"));
     }
 
     @Test
     void should_exclude_whitespace_only_fields_from_toString() {
-        var response = new Authorise3dsResponseBody("   ", "Authorised", null);
+        var response = new Authorise3dsResponseBody("   ", "Authorised", 
+                null, null, null);
 
         assertThat(response.toString(), is("Adyen Authorise 3DS Response (resultCode: Authorised)"));
     }
@@ -70,7 +77,7 @@ class Authorise3dsResponseBodyTest {
         Authorise3dsResponseBody response = new Authorise3dsResponseBody(
                 "psp-ref-123",
                 "Authorised",
-                null
+                null, null, null
         );
 
         String result = response.getStoredPaymentMethodId();
@@ -87,7 +94,7 @@ class Authorise3dsResponseBodyTest {
         Authorise3dsResponseBody response = new Authorise3dsResponseBody(
                 "psp-ref-123",
                 "Authorised",
-                additionalData
+                additionalData, null, null
         );
 
         String result = response.getStoredPaymentMethodId();

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthorise3dsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthorise3dsIT.java
@@ -105,6 +105,31 @@ class AdyenCardResourceAuthorise3dsIT {
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is("AUTHORISATION ERROR"));
     }
+    
+    @Test
+    void should_store_gateway_rejection_reason_when_adyen_3ds_authorisation_is_refused() {
+        var chargeId = testBaseExtension.createNewCharge(AUTHORISATION_3DS_REQUIRED);
+
+        app.getAdyenCheckoutMockClient()
+                .mock3dsAuthorisationRejected(AUTH_RESULT_REFERENCE);
+
+        app.givenSetup()
+                .body(Map.of("redirect_result", REDIRECT_RESULT))
+                .post(authorise3dsChargeUrlFor(chargeId))
+                .then()
+                .statusCode(400)
+                .body("status", is("AUTHORISATION REJECTED"));
+
+        var charge = chargeDao.findByExternalId(chargeId);
+
+        assertThat(charge.isPresent(), is(true));
+        assertThat(charge.get().getStatus(), is("AUTHORISATION REJECTED"));
+        assertThat(charge.get().getGatewayTransactionId(), is(AUTH_RESULT_REFERENCE));
+        assertThat(
+                charge.get().getGatewayRejectionReason(),
+                is("6 - Expired Card")
+        );
+    }
 }
 
 

--- a/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AdyenCheckoutMockClient.java
@@ -170,4 +170,16 @@ public class AdyenCheckoutMockClient extends AdyenMockClient {
 
         setupPostResponse(responseBody, "/payments", SC_OK);
     }
+    
+    public void mock3dsAuthorisationRejected(String pspReferenceFromAdyen) {
+        var responseBody = """
+            {
+              "pspReference": "%s",
+              "refusalReason": "Expired Card",
+              "resultCode": "Refused",
+              "refusalReasonCode": "6"
+            }""".formatted(pspReferenceFromAdyen);
+
+        setupPostResponse(responseBody, "/payments/details", SC_OK);
+    }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Extend Adyen 3dsresponse model to include `refusalReason` and `refusalReason`
- Extended `Gateway3DSAuthorisationResponse` to carry the gateway rejection reason through the 3DS authorisation flow
- Updated ChargeService.updateChargePost3dsAuthorisation() to save the gateway rejection reason on the charge



