### PR TITLE
PP-15568: Add check for empty recurringAuthToken so PaymentInstrument cannot be set to Active unless token is present.

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.charge.service;
 
 import com.google.inject.persist.Transactional;
+import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
@@ -13,10 +14,11 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 
-import jakarta.inject.Inject;
 import java.time.InstantSource;
 import java.util.List;
+import java.util.Map;
 
+import static java.util.function.Predicate.not;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_INSTRUMENT_EXTERNAL_ID;
@@ -33,7 +35,7 @@ public class LinkPaymentInstrumentToAgreementService {
     @Inject
     public LinkPaymentInstrumentToAgreementService(PaymentInstrumentDao paymentInstrumentDao,
                                                    LedgerService ledgerService,
-                                                   TaskQueueService taskQueueService, 
+                                                   TaskQueueService taskQueueService,
                                                    InstantSource instantSource) {
         this.paymentInstrumentDao = paymentInstrumentDao;
         this.ledgerService = ledgerService;
@@ -45,21 +47,25 @@ public class LinkPaymentInstrumentToAgreementService {
     public void linkPaymentInstrumentFromChargeToAgreement(ChargeEntity chargeEntity) {
         chargeEntity.getPaymentInstrument().ifPresentOrElse(paymentInstrumentEntity -> {
             chargeEntity.getAgreement().ifPresentOrElse(agreementEntity -> {
-                cancelActivePaymentInstruments(agreementEntity);
-                agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
-                paymentInstrumentEntity.setAgreementExternalId(agreementEntity.getExternalId());
-                paymentInstrumentEntity.setStatus(PaymentInstrumentStatus.ACTIVE);
-                ledgerService.postEvent(List.of(
-                        AgreementSetUp.from(agreementEntity, instantSource.instant()),
-                        PaymentInstrumentConfirmed.from(agreementEntity, instantSource.instant())
-                ));
-                LOGGER.info("Agreement successfully set up with payment instrument",
+                paymentInstrumentEntity.getRecurringAuthToken().filter(not(Map::isEmpty)).ifPresentOrElse(_ -> {
+                    cancelActivePaymentInstruments(agreementEntity);
+                    agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
+                    paymentInstrumentEntity.setAgreementExternalId(agreementEntity.getExternalId());
+                    paymentInstrumentEntity.setStatus(PaymentInstrumentStatus.ACTIVE);
+                    ledgerService.postEvent(List.of(
+                            AgreementSetUp.from(agreementEntity, instantSource.instant()),
+                            PaymentInstrumentConfirmed.from(agreementEntity, instantSource.instant())
+                    ));
+                    LOGGER.info("Agreement successfully set up with payment instrument",
+                            kv(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId()),
+                            kv(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrumentEntity.getExternalId()));
+                }, () -> LOGGER.info("Payment instrument doesn't have a token associated. Not linked the payment instrument to the agreement",
                         kv(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId()),
-                        kv(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrumentEntity.getExternalId()));
+                        kv(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrumentEntity.getExternalId())));
             }, () -> LOGGER.error("Expected charge {} to have an agreement but it does not have one", chargeEntity.getExternalId()));
         }, () -> LOGGER.error("Expected charge {} to have a payment instrument but it does not have one", chargeEntity.getExternalId()));
     }
-    
+
     private void cancelActivePaymentInstruments(AgreementEntity agreement) {
         List<PaymentInstrumentEntity> paymentInstruments = paymentInstrumentDao.findPaymentInstrumentsByAgreementAndStatus(
                 agreement.getExternalId(), PaymentInstrumentStatus.ACTIVE);
@@ -67,7 +73,7 @@ public class LinkPaymentInstrumentToAgreementService {
             paymentInstrument.setStatus(PaymentInstrumentStatus.CANCELLED);
             taskQueueService.addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
         });
-        
+
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementServiceTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
@@ -14,20 +17,25 @@ import uk.gov.pay.connector.events.model.charge.PaymentInstrumentConfirmed;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paymentinstrument.dao.PaymentInstrumentDao;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
-import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 
 import java.time.Instant;
 import java.time.InstantSource;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.slf4j.event.Level.ERROR;
+import static org.slf4j.event.Level.INFO;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.ACTIVE;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CANCELLED;
 
 @ExtendWith(MockitoExtension.class)
 class LinkPaymentInstrumentToAgreementServiceTest {
@@ -36,6 +44,11 @@ class LinkPaymentInstrumentToAgreementServiceTest {
     LogCapturer errorLogs = LogCapturer.create()
             .captureForType(LinkPaymentInstrumentToAgreementService.class)
             .forLevel(ERROR);
+
+    @RegisterExtension
+    LogCapturer infoLogs = LogCapturer.create()
+            .captureForType(LinkPaymentInstrumentToAgreementService.class)
+            .forLevel(INFO);
 
     @Mock
     private PaymentInstrumentDao paymentInstrumentDao;
@@ -70,6 +83,7 @@ class LinkPaymentInstrumentToAgreementServiceTest {
         String agreementExternalId = "an-agreement-external-id";
         when(mockAgreementEntity.getGatewayAccount()).thenReturn(mockGatewayAccountEntity);
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
+        when(mockPaymentInstrumentEntity.getRecurringAuthToken()).thenReturn(Optional.of(Map.of("authToken", "authToken")));
         when(mockAgreementEntity.getExternalId()).thenReturn(agreementExternalId);
         when(mockPaymentInstrumentEntity.getExternalId()).thenReturn("payment instrument external ID");
 
@@ -80,7 +94,7 @@ class LinkPaymentInstrumentToAgreementServiceTest {
 
         verify(mockAgreementEntity).setPaymentInstrument(mockPaymentInstrumentEntity);
         verify(mockPaymentInstrumentEntity).setAgreementExternalId(agreementExternalId);
-        verify(mockPaymentInstrumentEntity).setStatus(PaymentInstrumentStatus.ACTIVE);
+        verify(mockPaymentInstrumentEntity).setStatus(ACTIVE);
         verify(ledgerService).postEvent(List.of(
                 AgreementSetUp.from(mockAgreementEntity, instantSource.instant()),
                 PaymentInstrumentConfirmed.from(mockAgreementEntity, instantSource.instant())
@@ -95,9 +109,10 @@ class LinkPaymentInstrumentToAgreementServiceTest {
         String agreementExternalId = "an-agreement-external-id";
         when(mockAgreementEntity.getGatewayAccount()).thenReturn(mockGatewayAccountEntity);
         when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
+        when(mockPaymentInstrumentEntity.getRecurringAuthToken()).thenReturn(Optional.of(Map.of("authToken", "authToken")));
         when(mockAgreementEntity.getExternalId()).thenReturn(agreementExternalId);
         when(mockPaymentInstrumentEntity.getExternalId()).thenReturn("payment instrument external ID");
-        when(paymentInstrumentDao.findPaymentInstrumentsByAgreementAndStatus(agreementExternalId, PaymentInstrumentStatus.ACTIVE))
+        when(paymentInstrumentDao.findPaymentInstrumentsByAgreementAndStatus(agreementExternalId, ACTIVE))
                 .thenReturn(List.of(oldPaymentInstrument1, oldPaymentInstrument2));
 
         var chargeEntity = aValidChargeEntity().withPaymentInstrument(mockPaymentInstrumentEntity)
@@ -105,10 +120,38 @@ class LinkPaymentInstrumentToAgreementServiceTest {
 
         linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreement(chargeEntity);
 
-        verify(oldPaymentInstrument1).setStatus(PaymentInstrumentStatus.CANCELLED);
-        verify(oldPaymentInstrument2).setStatus(PaymentInstrumentStatus.CANCELLED);
+        verify(oldPaymentInstrument1).setStatus(CANCELLED);
+        verify(oldPaymentInstrument2).setStatus(CANCELLED);
         verify(taskQueueService).addDeleteStoredPaymentDetailsTask(mockAgreementEntity, oldPaymentInstrument1);
         verify(taskQueueService).addDeleteStoredPaymentDetailsTask(mockAgreementEntity, oldPaymentInstrument2);
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyOrMissingRecurringAuthToken")
+    void shouldNotSetPaymentInstrumentToACTIVEIfRecurringAuthTokenIsNotPresent(Optional<Map<String, String>> recurringAuthToken) {
+        String agreementExternalId = "an-agreement-external-id";
+
+        when(mockAgreementEntity.getGatewayAccount()).thenReturn(mockGatewayAccountEntity);
+        when(mockAgreementEntity.getPaymentInstrument()).thenReturn(Optional.of(mockPaymentInstrumentEntity));
+        when(mockPaymentInstrumentEntity.getRecurringAuthToken()).thenReturn(recurringAuthToken);
+        when(mockAgreementEntity.getExternalId()).thenReturn(agreementExternalId);
+        when(mockPaymentInstrumentEntity.getExternalId()).thenReturn("payment instrument external ID");
+
+        var chargeEntity = aValidChargeEntity()
+                .withPaymentInstrument(mockPaymentInstrumentEntity)
+                .withAgreementEntity(mockAgreementEntity).build();
+
+        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentFromChargeToAgreement(chargeEntity);
+
+        infoLogs.assertContains("Payment instrument doesn't have a token associated. Not linked the payment instrument to the agreement");
+
+        verify(mockAgreementEntity, never()).setPaymentInstrument(mockPaymentInstrumentEntity);
+        verify(mockPaymentInstrumentEntity, never()).setAgreementExternalId(agreementExternalId);
+        verify(mockPaymentInstrumentEntity, never()).setStatus(ACTIVE);
+        verify(ledgerService, never()).postEvent(List.of(
+                AgreementSetUp.from(mockAgreementEntity, instantSource.instant()),
+                PaymentInstrumentConfirmed.from(mockAgreementEntity, instantSource.instant())
+        ));
     }
 
     @Test
@@ -135,5 +178,12 @@ class LinkPaymentInstrumentToAgreementServiceTest {
         verifyNoInteractions(mockAgreementEntity);
         verifyNoInteractions(mockPaymentInstrumentEntity);
         verifyNoInteractions(ledgerService);
+    }
+
+    private static Stream<Arguments> emptyOrMissingRecurringAuthToken() {
+        return Stream.of(
+                Arguments.of(Optional.empty()),
+                Arguments.of(Optional.of(Map.of()))
+        );
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ITestBaseExtension.java
@@ -518,6 +518,7 @@ public class ITestBaseExtension implements BeforeEachCallback, BeforeAllCallback
                 .withPaymentInstrumentId(paymentInstrumentId)
                 .withAgreementExternalId(agreementExternalId)
                 .withPaymentInstrumentStatus(status)
+                .withRecurringAuthToken(Map.of("authToken", "authToken"))
                 .build();
         databaseTestHelper.addPaymentInstrument(paymentInstrumentParams);
         return paymentInstrumentId;


### PR DESCRIPTION
## WHAT YOU DID
- Added conditional to check if `recurringAuthToken` is not empty before linking `paymentInstrument` to `agreement` and setting `paymentInstrument` as `ACTIVE`
- updated mocking for tests that assumed `recurringAuthToken` would be present but had not mocked it out. 

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
- I added logging at info level
