### PR TITLE
PP-14489 - Scenario 5 - Refund not found + logs

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -14,7 +14,6 @@ import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import java.util.Optional;
 
-import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
@@ -33,18 +32,17 @@ public class RefundNotificationProcessor {
 
     @Inject
     public RefundNotificationProcessor(RefundService refundService,
-                                UserNotificationService userNotificationService) {
+                                       UserNotificationService userNotificationService) {
         this.refundService = refundService;
         this.userNotificationService = userNotificationService;
     }
 
-    public void invoke(PaymentGatewayName gatewayName, RefundStatus newStatus, GatewayAccountEntity gatewayAccountEntity,
-                       String gatewayTransactionId, String transactionId, Charge charge) {
+    // Currently used by WorldPay
+    public void invoke(PaymentGatewayName gatewayName, RefundStatus newStatus,
+                       GatewayAccountEntity gatewayAccountEntity, String gatewayTransactionId,
+                       String transactionId, Charge charge) {
         if (isBlank(gatewayTransactionId)) {
-            logger.warn("Refund notification could not be used to update charge (missing reference)",
-                    kv(PAYMENT_EXTERNAL_ID, charge.getExternalId()),
-                    kv(PROVIDER, gatewayName),
-                    kv(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId()));
+            logMissingRefundReference(gatewayName, gatewayAccountEntity, charge);
             return;
         }
 
@@ -52,24 +50,33 @@ public class RefundNotificationProcessor {
                 refundService.findByChargeExternalIdAndGatewayTransactionId(charge.getExternalId(), gatewayTransactionId);
 
         if (optionalRefundEntity.isEmpty()) {
-            Optional<Refund> mayBeHistoricRefund
-                    = refundService.findHistoricRefundByChargeExternalIdAndGatewayTransactionId(charge, gatewayTransactionId);
-
-            mayBeHistoricRefund.ifPresentOrElse(
-                    refund -> logger.warn("{} notification could not be processed as refund [{}] has been expunged from connector",
-                            gatewayName, refund.getExternalId(),
-                            kv(REFUND_EXTERNAL_ID, refund.getExternalId()), kv(PAYMENT_EXTERNAL_ID, charge.getExternalId()),
-                            kv(PROVIDER, gatewayName)),
-                    () -> logger.warn("{} notification '{}' could not be used to update refund (associated refund entity not found) for charge [{}]",
-                            gatewayName, gatewayTransactionId, charge.getExternalId(),
-                            kv(PAYMENT_EXTERNAL_ID, charge.getExternalId()), kv(PROVIDER, gatewayName),
-                            kv("payment_gateway_transaction_id", transactionId),
-                            kv("gateway_transaction_id", gatewayTransactionId))
-            );
+            handleMissingRefundByGatewayTransactionId(gatewayName, gatewayTransactionId, transactionId, charge);
             return;
         }
 
-        RefundEntity refundEntity = optionalRefundEntity.get();
+        processRefundNotification(gatewayName, newStatus, gatewayAccountEntity, gatewayTransactionId, transactionId, charge, optionalRefundEntity.get());
+    }
+
+    // Currently used by Adyen
+    public void processRefundByExternalId(PaymentGatewayName gatewayName, RefundStatus newStatus,
+                                          GatewayAccountEntity gatewayAccountEntity, String refundExternalId, Charge charge) {
+        if (isBlank(refundExternalId)) {
+            logMissingRefundReference(gatewayName, gatewayAccountEntity, charge);
+            return;
+        }
+
+        Optional<RefundEntity> optionalRefundEntity = refundService.findRefundByExternalId(refundExternalId);
+        if (optionalRefundEntity.isEmpty()) {
+            logMissingRefund(gatewayName, refundExternalId, null, null, charge);
+            return;
+        }
+
+        processRefundNotification(gatewayName, newStatus, gatewayAccountEntity, refundExternalId, null, charge, optionalRefundEntity.get());
+    }
+
+    private void processRefundNotification(PaymentGatewayName gatewayName, RefundStatus newStatus,
+                                           GatewayAccountEntity gatewayAccountEntity, String refundReference,
+                                           String transactionId, Charge charge, RefundEntity refundEntity) {
         RefundStatus currentStatus = refundEntity.getStatus();
 
         if (isRefundTransitionRedundant(currentStatus, newStatus)) {
@@ -77,12 +84,11 @@ public class RefundNotificationProcessor {
                     refundEntity.getExternalId(), currentStatus);
             return;
         }
-        
+
         if (isAdyenRefundTransitionIllegal(gatewayName, currentStatus, newStatus)) {
             logAdyenIllegalRefundTransition(refundEntity, newStatus, currentStatus);
             return;
-        }
-        else if (gatewayName != ADYEN && isRefundTransitionIllegal(currentStatus, newStatus)){
+        } else if (gatewayName != ADYEN && isRefundTransitionIllegal(currentStatus, newStatus)) {
             logIllegalRefundTransition(refundEntity, newStatus, currentStatus);
             return;
         }
@@ -95,24 +101,59 @@ public class RefundNotificationProcessor {
 
         String stateTransitionMessage = newStatus == REFUND_ERROR ? "Refund request record set as failed (REFUND_ERROR)" : "Refund request record set as successful (REFUNDED)";
 
-        logger.info("Notification received for refund. Updating refund: {}",
-                stateTransitionMessage,
-                kv(PAYMENT_EXTERNAL_ID, refundEntity.getChargeExternalId()),
-                kv(REFUND_EXTERNAL_ID, refundEntity.getExternalId()),
-                kv(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId()),
-                kv(PROVIDER, charge.getPaymentGatewayName()),
-                kv(GATEWAY_ACCOUNT_TYPE, gatewayAccountEntity.getType()),
-                kv("payment_gateway_transaction_id", transactionId),
-                kv("gateway_transaction_id", gatewayTransactionId),
-                kv("from_status", currentStatus),
-                kv("to_status", newStatus)
+        logger.atInfo()
+                .addKeyValue(PAYMENT_EXTERNAL_ID, refundEntity.getChargeExternalId())
+                .addKeyValue(REFUND_EXTERNAL_ID, refundEntity.getExternalId())
+                .addKeyValue(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId())
+                .addKeyValue(PROVIDER, charge.getPaymentGatewayName())
+                .addKeyValue(GATEWAY_ACCOUNT_TYPE, gatewayAccountEntity.getType())
+                .addKeyValue("payment_gateway_transaction_id", transactionId)
+                .addKeyValue("gateway_transaction_id", refundReference)
+                .addKeyValue("from_status", currentStatus)
+                .addKeyValue("to_status", newStatus)
+                .log("Notification received for refund. Updating refund: {}", stateTransitionMessage);
+
+    }
+
+    private void handleMissingRefundByGatewayTransactionId(PaymentGatewayName gatewayName, String gatewayTransactionId, String transactionId, Charge charge) {
+        Optional<Refund> mayBeHistoricRefund =
+                refundService.findHistoricRefundByChargeExternalIdAndGatewayTransactionId(charge, gatewayTransactionId);
+
+        mayBeHistoricRefund.ifPresentOrElse(
+                refund -> logger.atWarn()
+                        .addKeyValue(REFUND_EXTERNAL_ID, refund.getExternalId())
+                        .addKeyValue(PAYMENT_EXTERNAL_ID, charge.getExternalId())
+                        .addKeyValue(PROVIDER, gatewayName)
+                        .log("{} notification could not be processed as refund [{}] has been expunged from connector", gatewayName, refund.getExternalId()),
+                () -> logMissingRefund(gatewayName, gatewayTransactionId, transactionId, gatewayTransactionId, charge)
         );
     }
+
+    private void logMissingRefund(PaymentGatewayName gatewayName, String refundExternalId, String transactionId, String gatewayTransactionId, Charge charge) {
+        logger.atWarn()
+                .addKeyValue(PAYMENT_EXTERNAL_ID, charge.getExternalId())
+                .addKeyValue(PROVIDER, gatewayName)
+                .addKeyValue("payment_gateway_transaction_id", transactionId)
+                .addKeyValue(REFUND_EXTERNAL_ID, refundExternalId)
+                .addKeyValue("gateway_transaction_id", gatewayTransactionId)
+                .log("{} notification '{}' could not be used to update refund (associated refund entity not found) for charge [{}]",
+                        gatewayName, refundExternalId, charge.getExternalId());
+    }
+
+    private void logMissingRefundReference(PaymentGatewayName gatewayName, GatewayAccountEntity gatewayAccountEntity, Charge charge) {
+        logger.atWarn()
+                .setMessage("Refund notification could not be used to update charge (missing reference)")
+                .addKeyValue(PAYMENT_EXTERNAL_ID, charge.getExternalId())
+                .addKeyValue(PROVIDER, gatewayName)
+                .addKeyValue(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId())
+                .log();
+    }
+
 
     private boolean isRefundTransitionRedundant(RefundStatus currentStatus, RefundStatus newStatus) {
         return newStatus == currentStatus;
     }
-    
+
     private boolean isRefundTransitionIllegal(RefundStatus currentStatus, RefundStatus newStatus) {
         return (currentStatus == REFUNDED && newStatus == REFUND_ERROR) || (currentStatus == REFUND_ERROR && newStatus == REFUNDED);
     }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenRefundNotificationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenRefundNotificationHandler.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.*;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 
 public class AdyenRefundNotificationHandler {
@@ -39,12 +40,11 @@ public class AdyenRefundNotificationHandler {
                                     .addKeyValue("success", item.isSuccess())
                                     .log();
 
-                            refundNotificationProcessor.invoke(
-                                    PaymentGatewayName.ADYEN,
+                            refundNotificationProcessor.processRefundByExternalId(
+                                    ADYEN,
                                     targetStatus,
                                     gatewayAccount,
-                                    item.getPspReference(),
-                                    item.getOriginalReference(),
+                                    item.getMerchantReference(),
                                     charge);
                         },
                         () -> LOGGER.atWarn()

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -59,6 +60,7 @@ class RefundNotificationProcessorTest {
     private static PaymentGatewayName paymentGatewayName = PaymentGatewayName.WORLDPAY;
     private static final String PAYMENT_REFERENCE = "payment-reference";
     private static final String REFUND_GATEWAY_TRANSACTION_ID = "refund-gateway-tx-id";
+    private static final String ADYEN_REFUND_EXTERNAL_ID = "refund-123";
     private static final String TRANSACTION_ID = "transactionId";
     private final GatewayAccountEntity gatewayAccountEntity = defaultGatewayAccountEntity();
     private final ChargeEntity chargeEntity = aValidChargeEntity()
@@ -267,15 +269,14 @@ class RefundNotificationProcessorTest {
     void shouldTransitionRefund_WhenRefundStatusWasSetAsRefundError_ForAdyen() {
         refundEntity.setStatus(REFUND_ERROR);
 
-        when(refundService.findByChargeExternalIdAndGatewayTransactionId(charge.getExternalId(), REFUND_GATEWAY_TRANSACTION_ID))
+        when(refundService.findRefundByExternalId(ADYEN_REFUND_EXTERNAL_ID))
                 .thenReturn(Optional.of(refundEntity));
 
-        refundNotificationProcessor.invoke(
+        refundNotificationProcessor.processRefundByExternalId(
                 ADYEN,
                 RefundStatus.REFUNDED,
                 gatewayAccountEntity,
-                REFUND_GATEWAY_TRANSACTION_ID,
-                TRANSACTION_ID,
+                ADYEN_REFUND_EXTERNAL_ID,
                 charge);
 
         verify(refundService)
@@ -288,19 +289,43 @@ class RefundNotificationProcessorTest {
     @Test
     void shouldLogIllegalStateTransitionAtErrorLevel_IfRefundFailedWhenRefundStatusWasSetAsRefundedForAdyen() {
         refundEntity.setStatus(RefundStatus.REFUNDED);
-        when(refundService.findByChargeExternalIdAndGatewayTransactionId(charge.getExternalId(), REFUND_GATEWAY_TRANSACTION_ID))
+        when(refundService.findRefundByExternalId(ADYEN_REFUND_EXTERNAL_ID))
                 .thenReturn(Optional.of(refundEntity));
 
-        refundNotificationProcessor.invoke(
+        refundNotificationProcessor.processRefundByExternalId(
                 ADYEN,
                 RefundStatus.REFUND_ERROR,
                 gatewayAccountEntity,
-                REFUND_GATEWAY_TRANSACTION_ID,
-                TRANSACTION_ID,
+                ADYEN_REFUND_EXTERNAL_ID,
                 charge);
 
         assertThat(logs.getEvents(), everyItem(hasProperty("level", is(Level.ERROR))));
         logs.assertContains("Adyen Notification received for refund would cause an illegal state transition");
+        then(refundService)
+                .should(never())
+                .transitionRefundState(any(), any(), any(), any());
+        then(userNotificationService)
+                .should(never())
+                .sendRefundIssuedEmail(any(), any(), any());
+    }
+
+    @Test
+    void shouldLogWarningAndReturnWhenAdyenRefundCannotBeFoundByExternalId() {
+        when(refundService.findRefundByExternalId(ADYEN_REFUND_EXTERNAL_ID))
+                .thenReturn(Optional.empty());
+
+        refundNotificationProcessor.processRefundByExternalId(
+                ADYEN,
+                RefundStatus.REFUNDED,
+                gatewayAccountEntity,
+                ADYEN_REFUND_EXTERNAL_ID,
+                charge);
+
+        assertThat(logs.getEvents(), everyItem(hasProperty("level", is(Level.WARN))));
+        logs.assertContains("ADYEN notification 'refund-123' could not be used to update refund (associated refund entity not found) for charge [%s]".formatted(charge.getExternalId()));
+        then(refundService)
+                .should(never())
+                .findHistoricRefundByChargeExternalIdAndGatewayTransactionId(any(Charge.class), anyString());
         then(refundService)
                 .should(never())
                 .transitionRefundState(any(), any(), any(), any());

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenRefundNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenRefundNotificationHandlerTest.java
@@ -58,19 +58,18 @@ class AdyenRefundNotificationHandlerTest {
         GatewayAccountEntity gatewayAccount = GatewayAccountEntityFixture.aGatewayAccountEntity().build();
 
         when(mockNotificationItem.isSuccess()).thenReturn(success);
-        when(mockNotificationItem.getPspReference()).thenReturn("adyen-refund-id-1");
-        when(mockNotificationItem.getOriginalReference()).thenReturn("refund-123");
+        when(mockNotificationItem.getMerchantReference()).thenReturn("refund-123");
+        when(mockNotificationItem.getOriginalReference()).thenReturn("payment-123");
         when(mockCharge.getGatewayAccountId()).thenReturn(1L);
         when(mockCharge.getExternalId()).thenReturn("charge-123");
         when(mockGatewayAccountService.getGatewayAccount(anyLong())).thenReturn(Optional.of(gatewayAccount));
 
         adyenRefundNotificationHandler.process(mockNotificationItem, mockCharge);
 
-        verify(mockRefundNotificationProcessor).invoke(
+        verify(mockRefundNotificationProcessor).processRefundByExternalId(
                 PaymentGatewayName.ADYEN,
                 expectedStatus,
                 gatewayAccount,
-                "adyen-refund-id-1",
                 "refund-123",
                 mockCharge);
     }


### PR DESCRIPTION
## WHAT YOU DID
Adyen refund notifications include the merchantReference field, which is the refund_external_id set when sending a refund request. So, we can use merchantReference to process refunds for Adyen


## How to test

- How should it be reviewed? PR
- What feedback do you need? PR Comments, DM, Calls

## Code review checklist
[x] Clean Code
[x] tested Code

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

