### PR TITLE
PP-15615: Extract Adyen Capture Notification Into Handler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <pay-java-commons.version>1.0.20260720083050</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20260723091458</pay-java-commons.version>
         <surefire.version>3.5.6</surefire.version>
         <jjwt.version>0.13.0</jjwt.version>
         <pact.version>4.7.3</pact.version>

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenCaptureNotificationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenCaptureNotificationHandler.java
@@ -1,0 +1,65 @@
+package uk.gov.pay.connector.queue.tasks.handlers.adyen;
+
+import com.adyen.model.notification.NotificationRequestItem;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
+import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_TRANSACTION_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
+
+public class AdyenCaptureNotificationHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdyenCaptureNotificationHandler.class);
+
+    private final ChargeNotificationProcessor chargeNotificationProcessor;
+    private final GatewayAccountService gatewayAccountService;
+
+
+    @Inject
+    public AdyenCaptureNotificationHandler(ChargeNotificationProcessor chargeNotificationProcessor,
+                                           GatewayAccountService gatewayAccountService) {
+        this.chargeNotificationProcessor = chargeNotificationProcessor;
+        this.gatewayAccountService = gatewayAccountService;
+    }
+
+    public void process(NotificationRequestItem item, Charge charge) {
+        String gatewayTransactionId = item.getOriginalReference();
+        ChargeStatus targetStatus = item.isSuccess() ? CAPTURED : CAPTURE_ERROR;
+
+        if (charge.isHistoric()) {
+            gatewayAccountService.getGatewayAccount(charge.getGatewayAccountId())
+                    .ifPresentOrElse(gatewayAccountEntity ->
+                                    chargeNotificationProcessor.processCaptureNotificationForExpungedCharge(
+                                            gatewayAccountEntity,
+                                            gatewayTransactionId,
+                                            charge,
+                                            targetStatus),
+                            () -> LOGGER.atError()
+                                    .setMessage("GatewayAccount not found for charge")
+                                    .addKeyValue(PAYMENT_EXTERNAL_ID, charge.getExternalId())
+                                    .log());
+        } else {
+            chargeNotificationProcessor.invoke(
+                    gatewayTransactionId,
+                    charge,
+                    targetStatus,
+                    toUTCZonedDateTime(item.getEventDate()));
+        }
+
+        if (!item.isSuccess()) {
+            LOGGER.atError()
+                    .setMessage("Capture failed")
+                    .addKeyValue(GATEWAY_TRANSACTION_ID, gatewayTransactionId)
+                    .addKeyValue("event_code", item.getEventCode())
+                    .log();
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenWebhookTaskHandler.java
@@ -7,51 +7,37 @@ import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
-import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static com.adyen.model.notification.NotificationRequestItem.EVENT_CODE_CANCELLATION;
 import static com.adyen.model.notification.NotificationRequestItem.EVENT_CODE_CAPTURE;
 import static com.adyen.model.notification.NotificationRequestItem.EVENT_CODE_REFUND;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
-import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 
 public class AdyenWebhookTaskHandler {
-    private static final ZoneId UTC = ZoneId.of("UTC");
     private static final String GATEWAY_TRANSACTION_ID = "gateway_transaction_id";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AdyenWebhookTaskHandler.class);
     private final ChargeService chargeService;
-    private final ChargeNotificationProcessor chargeNotificationProcessor;
-    private final GatewayAccountService gatewayAccountService;
+    private final AdyenCaptureNotificationHandler adyenCaptureNotificationHandler;
     private final AdyenNotificationService adyenNotificationService;
     private final AdyenCancellationNotificationHandler adyenCancellationNotificationHandler;
     private final AdyenRefundNotificationHandler adyenRefundNotificationHandler;
 
     @Inject
     public AdyenWebhookTaskHandler(ChargeService chargeService,
-                                   ChargeNotificationProcessor chargeNotificationProcessor,
-                                   GatewayAccountService gatewayAccountService,
                                    AdyenNotificationService adyenNotificationService,
                                    AdyenCancellationNotificationHandler adyenCancellationNotificationHandler,
-                                   AdyenRefundNotificationHandler adyenRefundNotificationHandler) {
+                                   AdyenRefundNotificationHandler adyenRefundNotificationHandler, 
+                                   AdyenCaptureNotificationHandler adyenCaptureNotificationHandler) {
         this.chargeService = chargeService;
-        this.chargeNotificationProcessor = chargeNotificationProcessor;
-        this.gatewayAccountService = gatewayAccountService;
         this.adyenNotificationService = adyenNotificationService;
         this.adyenCancellationNotificationHandler = adyenCancellationNotificationHandler;
         this.adyenRefundNotificationHandler = adyenRefundNotificationHandler;
+        this.adyenCaptureNotificationHandler = adyenCaptureNotificationHandler;
     }
 
     @Transactional
@@ -81,43 +67,13 @@ public class AdyenWebhookTaskHandler {
 
     private void processNotificationItem(NotificationRequestItem item, Charge foundCharge) {
         switch (item.getEventCode()) {
-            case EVENT_CODE_CAPTURE -> processCapturedNotification(item, foundCharge);
+            case EVENT_CODE_CAPTURE -> adyenCaptureNotificationHandler.process(item, foundCharge);
             case EVENT_CODE_REFUND -> adyenRefundNotificationHandler.process(item, foundCharge);
             case EVENT_CODE_CANCELLATION -> adyenCancellationNotificationHandler.process(item, foundCharge);
             default -> LOGGER.atWarn()
                     .setMessage("Ignoring unsupported Adyen webhook item")
                     .addKeyValue("event_code", item.getEventCode())
                     .addKeyValue(GATEWAY_TRANSACTION_ID, item.getOriginalReference())
-                    .log();
-        }
-    }
-
-    private void processCapturedNotification(NotificationRequestItem item, Charge charge) {
-        String gatewayTransactionId = item.getOriginalReference();
-
-        ChargeStatus targetStatus = item.isSuccess() ? CAPTURED : CAPTURE_ERROR;
-
-        if (charge.isHistoric()) {
-            Optional<GatewayAccountEntity> gatewayAccount = gatewayAccountService.getGatewayAccount(
-                    charge.getGatewayAccountId());
-
-            gatewayAccount.ifPresentOrElse(gatewayAccountEntity ->
-                            chargeNotificationProcessor.processCaptureNotificationForExpungedCharge(gatewayAccountEntity,
-                                    gatewayTransactionId, charge, targetStatus),
-                    () -> LOGGER.atError()
-                            .setMessage("GatewayAccount not found for charge")
-                            .addKeyValue(PAYMENT_EXTERNAL_ID, charge.getExternalId())
-                            .log());
-        } else {
-            chargeNotificationProcessor.invoke(gatewayTransactionId, charge, targetStatus,
-                    ZonedDateTime.ofInstant(item.getEventDate().toInstant(), UTC));
-        }
-
-        if (!item.isSuccess()) {
-            LOGGER.atError()
-                    .setMessage("Capture failed")
-                    .addKeyValue(GATEWAY_TRANSACTION_ID, gatewayTransactionId)
-                    .addKeyValue("event_code", item.getEventCode())
                     .log();
         }
     }

--- a/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
+++ b/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
@@ -6,6 +6,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Date;
 import java.util.Optional;
 
 import static java.time.Instant.ofEpochSecond;
@@ -42,6 +43,19 @@ public class DateTimeUtils {
         } catch (DateTimeParseException ex) {
             return Optional.empty();
         }
+    }
+
+    /**
+     * Converts a Date to a UTC ZonedDateTime
+     *
+     * @param date
+     * @return @ZonedDateTime instance represented by date in UTC ("Z") or null if `date` is null
+     */
+    public static ZonedDateTime toUTCZonedDateTime(Date date) {
+        if (isNull(date)) {
+            return null;
+        }
+        return ZonedDateTime.ofInstant(date.toInstant(), UTC);
     }
 
     /**

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/AdyenWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/AdyenWebhookTaskHandlerTest.java
@@ -20,18 +20,12 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
-import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.queue.tasks.handlers.adyen.AdyenCancellationNotificationHandler;
+import uk.gov.pay.connector.queue.tasks.handlers.adyen.AdyenCaptureNotificationHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.adyen.AdyenRefundNotificationHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.adyen.AdyenWebhookTaskHandler;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,8 +38,6 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_REFUND_FAILURE_NOTIFICATION;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_REFUND_SUCCESS_NOTIFICATION;
@@ -55,13 +47,10 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 class AdyenWebhookTaskHandlerTest {
 
     @Mock
-    private GatewayAccountService mockGatewayAccountService;
-
-    @Mock
     private ChargeService mockChargeService;
 
     @Mock
-    private ChargeNotificationProcessor mockChargeNotificationProcessor;
+    private AdyenCaptureNotificationHandler mockAdyenCaptureNotificationHandler;
 
     @Mock
     private AdyenRefundNotificationHandler mockAdyenRefundNotificationHandler;
@@ -81,9 +70,6 @@ class AdyenWebhookTaskHandlerTest {
     @Mock
     NotificationRequestItem mockNotificationItem;
 
-    @Mock
-    GatewayAccountEntity gatewayAccount;
-
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
@@ -96,8 +82,6 @@ class AdyenWebhookTaskHandlerTest {
     private final String gatewayTransactionId = "adyen-payment-id-1";
 
     private final String payload = "payload";
-    private final Date eventDate = Date.from(Instant.parse("2026-05-19T10:15:30Z"));
-    private final long gatewayAccountId = 123L;
 
 
     @BeforeEach
@@ -115,108 +99,14 @@ class AdyenWebhookTaskHandlerTest {
                 .thenReturn(List.of(mockNotificationItem));
         when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
-        when(mockNotificationItem.isSuccess()).thenReturn(true);
-        when(mockNotificationItem.getEventDate()).thenReturn(eventDate);
-
-
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
                 gatewayTransactionId)).thenReturn(Optional.of(mockCharge));
-
-        when(mockCharge.isHistoric()).thenReturn(false);
 
         adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
 
         verify(mockChargeService).findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
                 gatewayTransactionId);
-
-        verify(mockChargeNotificationProcessor).invoke(gatewayTransactionId, mockCharge,
-                CAPTURED, ZonedDateTime.ofInstant(eventDate.toInstant(), ZoneId.of("UTC")));
-    }
-
-    @Test
-    void shouldProcessCaptureFailedMessageFromTaskQueueForConnectorCharge() {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
-        when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
-        when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
-        when(mockNotificationItem.isSuccess()).thenReturn(false);
-        when(mockNotificationItem.getEventDate()).thenReturn(eventDate);
-
-        when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
-                gatewayTransactionId)).thenReturn(Optional.of(mockCharge));
-
-        when(mockCharge.isHistoric()).thenReturn(false);
-
-        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
-
-        verify(mockChargeNotificationProcessor).invoke(gatewayTransactionId, mockCharge,
-                CAPTURE_ERROR, ZonedDateTime.ofInstant(eventDate.toInstant(), ZoneId.of("UTC")));
-
-        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-
-        assertThat(loggingEvents.stream().anyMatch(event -> event.getFormattedMessage()
-                .equals("Capture failed")), is(true));
-
-    }
-
-    @Test
-    void shouldProcessSuccessfulCaptureMessageFromTaskQueueForLedgerCharge() {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
-        when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
-        when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
-        when(mockNotificationItem.isSuccess()).thenReturn(true);
-
-        when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
-                gatewayTransactionId)).thenReturn(Optional.of(mockCharge));
-
-        when(mockCharge.getGatewayAccountId()).thenReturn(gatewayAccountId);
-        when(mockGatewayAccountService.getGatewayAccount(gatewayAccountId))
-                .thenReturn(Optional.of(gatewayAccount));
-        when(mockCharge.isHistoric()).thenReturn(true);
-        when(mockGatewayAccountService.getGatewayAccount(gatewayAccountId))
-                .thenReturn(Optional.of(gatewayAccount));
-
-        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
-
-        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(
-                gatewayAccount, gatewayTransactionId, mockCharge, CAPTURED);
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
-    }
-
-    @Test
-    void shouldProcessFailedCaptureMessageFromTaskQueueForLedgerCharge() {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
-        when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
-        when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
-        when(mockNotificationItem.isSuccess()).thenReturn(false);
-
-        when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
-                gatewayTransactionId)).thenReturn(Optional.of(mockCharge));
-
-        when(mockCharge.isHistoric()).thenReturn(true);
-        when(mockCharge.getGatewayAccountId()).thenReturn(gatewayAccountId);
-
-        when(mockGatewayAccountService.getGatewayAccount(gatewayAccountId))
-                .thenReturn(Optional.of(gatewayAccount));
-
-        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
-
-        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccount,
-                gatewayTransactionId,
-                mockCharge,
-                CAPTURE_ERROR
-        );
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockAdyenCaptureNotificationHandler).process(mockNotificationItem, mockCharge);
     }
 
     @Test
@@ -232,9 +122,7 @@ class AdyenWebhookTaskHandlerTest {
 
         adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
 
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
-        verify(mockChargeNotificationProcessor, never()).processCaptureNotificationForExpungedCharge(any(), any(),
-                any(), any());
+        verify(mockAdyenCaptureNotificationHandler, never()).process(any(), any());
         verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
 
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
@@ -290,7 +178,7 @@ class AdyenWebhookTaskHandlerTest {
 
         verify(mockAdyenCancellationNotificationHandler).process(mockNotificationItem, mockCharge);
         verify(mockAdyenRefundNotificationHandler, never()).process(any(), any());
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockAdyenCaptureNotificationHandler, never()).process(any(), any());
     }
 
     @Test
@@ -308,35 +196,10 @@ class AdyenWebhookTaskHandlerTest {
 
         verify(mockAdyenRefundNotificationHandler, never()).process(any(), any());
         verify(mockAdyenCancellationNotificationHandler, never()).process(any(), any());
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
-        verify(mockChargeNotificationProcessor, never()).processCaptureNotificationForExpungedCharge(any(), any(), any(), any());
+        verify(mockAdyenCaptureNotificationHandler, never()).process(any(), any());
         verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
         assertThat(loggingEventArgumentCaptor.getAllValues().stream()
                 .anyMatch(event -> event.getFormattedMessage().equals("Ignoring unsupported Adyen webhook item")), is(true));
-    }
-
-    @Test
-    void shouldLogErrorWhenHistoricCaptureChargeHasNoGatewayAccount() {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
-        when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
-        when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
-        when(mockNotificationItem.isSuccess()).thenReturn(true);
-        when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(), gatewayTransactionId))
-                .thenReturn(Optional.of(mockCharge));
-        when(mockCharge.isHistoric()).thenReturn(true);
-        when(mockCharge.getGatewayAccountId()).thenReturn(gatewayAccountId);
-        when(mockGatewayAccountService.getGatewayAccount(gatewayAccountId)).thenReturn(Optional.empty());
-
-        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
-
-        verify(mockChargeNotificationProcessor, never()).processCaptureNotificationForExpungedCharge(any(), any(), any(), any());
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
-        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-        assertThat(loggingEventArgumentCaptor.getAllValues().stream()
-                .anyMatch(event -> event.getFormattedMessage().equals("GatewayAccount not found for charge")), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenCaptureNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenCaptureNotificationHandlerTest.java
@@ -1,0 +1,139 @@
+package uk.gov.pay.connector.queue.tasks.handlers;
+
+import com.adyen.model.notification.NotificationRequestItem;
+import io.github.netmikey.logunit.api.LogCapturer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.event.KeyValuePair;
+import org.slf4j.event.Level;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.queue.tasks.handlers.adyen.AdyenCaptureNotificationHandler;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Optional;
+
+import static java.time.ZoneOffset.UTC;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdyenCaptureNotificationHandlerTest {
+
+    @Mock
+    private ChargeNotificationProcessor mockChargeNotificationProcessor;
+    @Mock
+    private GatewayAccountService mockGatewayAccountService;
+    @Mock
+    private Charge mockCharge;
+    @Mock
+    private NotificationRequestItem mockNotificationItem;
+    @InjectMocks
+    private AdyenCaptureNotificationHandler adyenCaptureNotificationHandler;
+
+    @RegisterExtension
+    LogCapturer logs = LogCapturer.create().captureForType(AdyenCaptureNotificationHandler.class);
+
+    private final Date eventDate = Date.from(Instant.parse("2026-05-19T10:15:30Z"));
+
+    @ParameterizedTest
+    @CsvSource({
+            "true,CAPTURED",
+            "false,CAPTURE_ERROR"
+    })
+    void shouldProcessCaptureForConnectorCharge(boolean success, ChargeStatus expectedStatus) {
+        when(mockNotificationItem.isSuccess()).thenReturn(success);
+        when(mockNotificationItem.getOriginalReference()).thenReturn("gateway-transaction-id");
+        when(mockNotificationItem.getEventDate()).thenReturn(eventDate);
+        when(mockCharge.isHistoric()).thenReturn(false);
+
+        adyenCaptureNotificationHandler.process(mockNotificationItem, mockCharge);
+
+        verify(mockChargeNotificationProcessor).invoke(
+                "gateway-transaction-id",
+                mockCharge,
+                expectedStatus,
+                ZonedDateTime.ofInstant(eventDate.toInstant(), UTC));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "true,CAPTURED",
+            "false,CAPTURE_ERROR"
+    })
+    void shouldProcessCaptureForHistoricCharge(boolean success, ChargeStatus expectedStatus) {
+        GatewayAccountEntity gatewayAccount = GatewayAccountEntityFixture.aGatewayAccountEntity().build();
+
+        when(mockNotificationItem.isSuccess()).thenReturn(success);
+        when(mockNotificationItem.getOriginalReference()).thenReturn("gateway-transaction-id");
+        when(mockCharge.isHistoric()).thenReturn(true);
+        when(mockCharge.getGatewayAccountId()).thenReturn(123L);
+        when(mockGatewayAccountService.getGatewayAccount(anyLong())).thenReturn(Optional.of(gatewayAccount));
+
+        adyenCaptureNotificationHandler.process(mockNotificationItem, mockCharge);
+
+        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(
+                gatewayAccount,
+                "gateway-transaction-id",
+                mockCharge,
+                expectedStatus);
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldLogWhenGatewayAccountMissingForHistoricCharge() {
+        when(mockNotificationItem.isSuccess()).thenReturn(true);
+        when(mockNotificationItem.getOriginalReference()).thenReturn("gateway-transaction-id");
+        when(mockCharge.isHistoric()).thenReturn(true);
+        when(mockCharge.getGatewayAccountId()).thenReturn(123L);
+        when(mockCharge.getExternalId()).thenReturn("charge-external-id");
+        when(mockGatewayAccountService.getGatewayAccount(123L)).thenReturn(Optional.empty());
+
+        adyenCaptureNotificationHandler.process(mockNotificationItem, mockCharge);
+
+        verify(mockChargeNotificationProcessor, never()).processCaptureNotificationForExpungedCharge(any(), any(), any(), any());
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        assertThat(logs.getEvents(), everyItem(hasProperty("level", is(Level.ERROR))));
+        assertThat(logs.getEvents(), hasItems(hasProperty("message", is("GatewayAccount not found for charge"))));
+    }
+
+    @Test
+    void shouldLogCaptureFailedForUnsuccessfulNotification() {
+        when(mockNotificationItem.isSuccess()).thenReturn(false);
+        when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
+        when(mockNotificationItem.getOriginalReference()).thenReturn("gateway-transaction-id");
+        when(mockNotificationItem.getEventDate()).thenReturn(eventDate);
+        when(mockCharge.isHistoric()).thenReturn(false);
+
+        adyenCaptureNotificationHandler.process(mockNotificationItem, mockCharge);
+
+        var keyValuePairs = logs.getEvents().stream()
+                .flatMap(event -> event.getKeyValuePairs().stream())
+                .toList();
+
+        assertThat(logs.getEvents(), hasItems(hasProperty("message", is("Capture failed"))));
+        assertThat(keyValuePairs, hasItems(
+                new KeyValuePair("gateway_transaction_id", "gateway-transaction-id"),
+                new KeyValuePair("event_code", NotificationRequestItem.EVENT_CODE_CAPTURE)));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/DateTimeUtilsTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/DateTimeUtilsTest.java
@@ -8,6 +8,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -88,6 +89,24 @@ class DateTimeUtilsTest {
     void shouldReturnNullIfUnixEpochTimeIsNull() {
         Long epochTime = null;
         ZonedDateTime zonedDateTime = DateTimeUtils.toUTCZonedDateTime(epochTime);
+
+        assertThat(zonedDateTime, is(nullValue()));
+    }
+
+    @Test
+    void shouldConvertDateToUTCZonedDateTime() {
+        Date eventDate = Date.from(Instant.parse("2020-05-13T18:45:33Z"));
+
+        ZonedDateTime zonedDateTime = DateTimeUtils.toUTCZonedDateTime(eventDate);
+
+        assertThat(zonedDateTime.toString(), is("2020-05-13T18:45:33Z"));
+    }
+
+    @Test
+    void shouldReturnNullIfDateIsNull() {
+        Date eventDate = null;
+
+        ZonedDateTime zonedDateTime = DateTimeUtils.toUTCZonedDateTime(eventDate);
 
         assertThat(zonedDateTime, is(nullValue()));
     }


### PR DESCRIPTION
## WHAT YOU DID
Extracted Adyen notificaction code from `AdyenWebhookTaskHandler` into its own handler class.

- added new DateTime util method to be used by adyenCaptureNotificationHandler
- utilised GATEWAY_TRANSACTION_ID constant from pay-java-commons which required pom to be updated to use latest pay-java-commons.

## How to test

- How should it be reviewed? PR
- What feedback do you need? PR comments/calls/DMs

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

