### PR TITLE
PP-15615 Refactor Payment HMAC Validation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
@@ -3,23 +3,21 @@ package uk.gov.pay.connector.gateway.adyen.webhook;
 import com.adyen.model.notification.NotificationRequest;
 import com.adyen.model.notification.NotificationRequestItem;
 import com.adyen.notification.WebhookHandler;
-import com.adyen.util.HMACValidator;
 import com.google.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
-import uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil;
 import uk.gov.pay.connector.gateway.exception.AdyenNotificationException;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.queue.tasks.TaskType;
 import uk.gov.pay.connector.queue.tasks.model.Task;
 
-import java.security.SignatureException;
 import java.util.List;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getHmacKey;
 import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER;
 
 public class AdyenNotificationService {
@@ -27,7 +25,6 @@ public class AdyenNotificationService {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdyenNotificationService.class);
 
     private final AdyenGatewayConfig adyenGatewayConfig;
-    private final HMACValidator hmacValidator;
     private final TaskQueueService taskQueueService;
     private final AdyenNotificationValidator adyenNotificationValidator;
 
@@ -35,7 +32,6 @@ public class AdyenNotificationService {
     public AdyenNotificationService(AdyenGatewayConfig adyenGatewayConfig, TaskQueueService taskQueueService, AdyenNotificationValidator adyenNotificationValidator) {
         this.adyenGatewayConfig = adyenGatewayConfig;
         this.taskQueueService = taskQueueService;
-        this.hmacValidator = new HMACValidator();
         this.adyenNotificationValidator = adyenNotificationValidator;
     }
 
@@ -51,10 +47,8 @@ public class AdyenNotificationService {
 
             boolean live = "true".equalsIgnoreCase(notificationRequest.getLive());
 
-            String hmacKey = AdyenConfigUtil.getHmacKey(adyenGatewayConfig, live);
-
             for (NotificationRequestItem item : items) {
-                if (!isValidHmac(item, hmacKey)) {
+                if (!adyenNotificationValidator.isValidHmac(item, getHmacKey(adyenGatewayConfig, live))) {
                     return false;
                 }
 
@@ -110,23 +104,5 @@ public class AdyenNotificationService {
             throw new AdyenNotificationException("Notification request is empty");
         }
         return notificationRequest.getNotificationItems();
-    }
-
-    private boolean isValidHmac(NotificationRequestItem item, String hmacKey) {
-        try {
-            boolean validSignature = hmacValidator.validateHMAC(item, hmacKey);
-
-            if (!validSignature) {
-                LOGGER.error("Invalid HMAC signature in the payload for Adyen notification",
-                        kv("pspReference", item.getPspReference()),
-                        kv("eventCode", item.getEventCode()));
-            }
-            return validSignature;
-        } catch (IllegalArgumentException | SignatureException e) {
-            LOGGER.info("Failed to validate HMAC signature",
-                    kv("pspReference", item.getPspReference()),
-                    kv("eventCode", item.getEventCode()));
-            throw new AdyenNotificationException("Failed to validate HMAC signature", e);
-        }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidator.java
@@ -1,10 +1,15 @@
 package uk.gov.pay.connector.gateway.adyen.webhook;
 
+import com.adyen.model.notification.NotificationRequestItem;
+import com.adyen.util.HMACValidator;
 import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.gateway.exception.AdyenNotificationException;
 import uk.gov.pay.connector.util.IpDomainMatcher;
+
+import java.security.SignatureException;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
@@ -17,11 +22,13 @@ public class AdyenNotificationValidator {
 
     private final IpDomainMatcher ipDomainMatcher;
     private final String notificationDomain;
+    private final HMACValidator hmacValidator;
 
     @Inject
-    public AdyenNotificationValidator(AdyenGatewayConfig gatewayConfig, IpDomainMatcher ipDomainMatcher) {
+    public AdyenNotificationValidator(AdyenGatewayConfig gatewayConfig, IpDomainMatcher ipDomainMatcher, HMACValidator hmacValidator) {
         this.notificationDomain = gatewayConfig.getNotificationDomain();
         this.ipDomainMatcher = ipDomainMatcher;
+        this.hmacValidator = hmacValidator;
     }
 
     public boolean isValidIpAddress(String forwardedIpAddresses) {
@@ -43,5 +50,27 @@ public class AdyenNotificationValidator {
         }
 
         return true;
+    }
+
+    public boolean isValidHmac(NotificationRequestItem item, String hmacKey) {
+        try {
+            boolean validSignature = hmacValidator.validateHMAC(item, hmacKey);
+
+            if (!validSignature) {
+                LOGGER.atError()
+                        .setMessage("Invalid HMAC signature in the payload for Adyen notification")
+                        .addKeyValue("pspReference", item.getPspReference())
+                        .addKeyValue("eventCode", item.getEventCode())
+                        .log();
+            }
+            return validSignature;
+        } catch (IllegalArgumentException | SignatureException e) {
+            LOGGER.atInfo()
+                    .setMessage("Failed to validate HMAC signature")
+                    .addKeyValue("pspReference", item.getPspReference())
+                    .addKeyValue("eventCode", item.getEventCode())
+                    .log();
+            throw new AdyenNotificationException("Failed to validate HMAC signature", e);
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
@@ -11,7 +11,6 @@ import com.adyen.notification.WebhookHandler;
 import com.adyen.util.HMACValidator;
 import jakarta.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,11 +24,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.app.adyen.HmacKeys;
+import uk.gov.pay.connector.app.adyen.HmacKeys.WebhookHmacKeyPair;
 import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.queue.tasks.TaskType;
 import uk.gov.pay.connector.queue.tasks.model.Task;
-import uk.gov.pay.connector.util.IpDomainMatcher;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import java.io.IOException;
@@ -38,8 +37,8 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -47,7 +46,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_NOTIFICATION;
 
@@ -64,17 +62,12 @@ class AdyenNotificationServiceTest {
 
     @Mock
     private AdyenGatewayConfig mockAdyenGatewayConfig;
-    
+
     @Mock
     private TaskQueueService mockTaskQueueService;
-    
-    @Mock
-    private IpDomainMatcher ipDomainMatcher;
-    
+
     @Mock
     private AdyenNotificationValidator mockAdyenNotificationValidator;
-
-    private String validHmacSigniture = "coqCmt/IZ4E3CzPvMY8zTjQVL5hYJUiBRg8UU+iCWo0="; // pragma: allowlist secret
 
     @BeforeEach
     void setUp() {
@@ -90,20 +83,26 @@ class AdyenNotificationServiceTest {
     void shouldAcceptNotificationWhenForwardedIpMatchesConfiguredDomain() {
         when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
         when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-        
+        when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
+
         String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
 
         boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
 
         assertTrue(result);
     }
-
+    
     @Test
-    void shouldRejectNotificationWhenForwardedIpHeaderIsMissing() {
-        boolean result = adyenNotificationService.handleNotificationFor("{\"notificationItems\":[]}", null);
+    void shouldRejectNotificationWhenHmacSignatureIsInvalid() {
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+        when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(false);
+
+        String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
+
+        boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
 
         assertFalse(result);
-        verifyNoInteractions(ipDomainMatcher);
     }
 
     @Test
@@ -115,197 +114,142 @@ class AdyenNotificationServiceTest {
         assertFalse(result);
     }
 
-    @Nested
-    class TestValidateNotification {
-        @BeforeEach
-        void setUp() {
-            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-        }
+    @Test
+    void shouldNotAddToTaskQueWhenHmacSignatureIsInvalid() {
+        String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
+                .replace("{{HMAC_SIGNATURE}}", "WrongSignature");
 
-        @Test
-        void shouldReturnTrueForValidHmacKey() {
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-            
-            String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
+        boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
 
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
+        assertFalse(result);
+        verify(mockTaskQueueService, never()).add(any(Task.class));
+    }
 
-            assertTrue(result);
-        }
+    @Test
+    void shouldThrowWebApplicationExceptionWhenPayloadIsInvalidJson() {
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        assertThrows(WebApplicationException.class,
+                () -> adyenNotificationService.handleNotificationFor("not-json", "5.6.7.8"));
 
-        @Test
-        void shouldReturnFalseWhenHmacSignatureIsInvalid() {
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents
+                .stream()
+                .anyMatch(event -> event
+                        .getFormattedMessage()
+                        .equals("Error deserialising Adyen notification payload")), is(true));
+    }
 
-            String payload = TestTemplateResourceLoader
-                    .load(ADYEN_NOTIFICATION)
-                    .replace("{{HMAC_SIGNATURE}}", "WrongSignature");
+    @Test
+    void shouldReturnFalseWhenPayloadIsValidJsonAndNotificationIsNull() {
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        String validJsonButMissingExpectedFields = """ 
+                {
+                    "live": false
+                }
+                """;
+        boolean result = adyenNotificationService.handleNotificationFor(validJsonButMissingExpectedFields,
+                "5.6.7.8");
 
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
+        assertFalse(result);
 
-            assertFalse(result);
-            verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents
+                .getFirst()
+                .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
+        assertThat(loggingEvents
+                .get(1)
+                .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
+    }
 
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                    .stream()
-                    .anyMatch(event -> event
-                            .getFormattedMessage()
-                            .equals("Invalid HMAC signature in the payload for Adyen notification")), is(true));
-        }
+    @Test
+    void shouldReturnFalseWhenPayloadIsValidJsonAndNotificationRequestItemsIsEmpty() {
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        String validJsonButMissingExpectedFields = """ 
+                {
+                    "live": false,
+                    "notificationItems": [
+                    ]
+                }
+                """;
+        boolean result = adyenNotificationService.handleNotificationFor(validJsonButMissingExpectedFields,
+                "5.6.7.8");
 
-        @Test
-        void shouldReturnFalseWhenHmacKeyIsInvalid() {
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys("invalid-hmac-key"));
+        assertFalse(result);
+        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents
+                .getFirst()
+                .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
+        assertThat(loggingEvents
+                .get(1)
+                .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
+    }
 
-            String payload = TestTemplateResourceLoader
-                    .load(ADYEN_NOTIFICATION)
-                    .replace("{{HMAC_SIGNATURE}}", validHmacSigniture);
+    @ParameterizedTest
+    @EnumSource(AdyenPaymentEvent.class)
+    void shouldAddTaskToQueueWhenValidNotificationEventIsReceived(AdyenPaymentEvent eventCode) {
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+        when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
 
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
 
-            assertFalse(result);
+        String payload = getNotificationWithValidHmacSignature(eventCode.toString());
 
-            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                    .getFirst()
-                    .getFormattedMessage(), is("Failed to validate HMAC signature"));
-            assertThat(loggingEvents
-                    .get(1)
-                    .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
-        }
+        boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
 
-        @Test
-        void shouldThrowWebApplicationExceptionWhenPayloadIsInvalidJson() {
+        assertTrue(result);
 
-            assertThrows(WebApplicationException.class,
-                    () -> adyenNotificationService.handleNotificationFor("not-json", "5.6.7.8"));
+        ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(mockTaskQueueService).add(taskCaptor.capture());
 
-            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                    .stream()
-                    .anyMatch(event -> event
-                            .getFormattedMessage()
-                            .equals("Error deserialising Adyen notification payload")), is(true));
-        }
+        Task task = taskCaptor.getValue();
+        assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION));
+        assertThat(task.getData(), is(payload));
+    }
 
-        @Test
-        void shouldReturnFalseWhenPayloadIsValidJsonAndNotificationIsNull() {
-            String validJsonButMissingExpectedFields = """ 
-                    {
-                        "live": false
-                    }
-                    """;
-            boolean result = adyenNotificationService.handleNotificationFor(validJsonButMissingExpectedFields,
-                    "5.6.7.8");
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"SOME_INVALID_VALUE"})
+    void shouldIgnoreUnrecognisedPaymentEventWebhookNotificationsAndNotAddToTaskQue(String eventCode) {
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+        when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
+        String payload = getNotificationWithValidHmacSignature(eventCode);
 
-            assertFalse(result);
+        boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
 
-            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                    .getFirst()
-                    .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
-            assertThat(loggingEvents
-                    .get(1)
-                    .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
-        }
+        assertTrue(result);
 
-        @Test
-        void shouldReturnFalseWhenPayloadIsValidJsonAndNotificationRequestItemsIsEmpty() {
-            String validJsonButMissingExpectedFields = """ 
-                    {
-                        "live": false,
-                        "notificationItems": [
-                        ]
-                    }
-                    """;
-            boolean result = adyenNotificationService.handleNotificationFor(validJsonButMissingExpectedFields,
-                    "5.6.7.8");
+        verify(mockTaskQueueService, never()).add(any(Task.class));
+        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.getFirst()
+                .getFormattedMessage(), is("Ignored Adyen notification"));
+        assertThat(loggingEvents.get(1).getFormattedMessage(), is("Processed Adyen notification"));
+    }
 
-            assertFalse(result);
-            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                    .getFirst()
-                    .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
-            assertThat(loggingEvents
-                    .get(1)
-                    .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
-        }
+    @ParameterizedTest
+    @EnumSource(AdyenPaymentEvent.class)
+    void shouldThrowWebApplicationExceptionWhenSendingNotificationToTaskQueueFails(AdyenPaymentEvent eventCode) {
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+        when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
 
-        @ParameterizedTest
-        @EnumSource(AdyenPaymentEvent.class)
-        void shouldAddTaskToQueueWhenValidCaptureNotificationIsReceived(AdyenPaymentEvent eventCode) {
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+        String payload = getNotificationWithValidHmacSignature(eventCode.toString());
 
-            String payload = getNotificationWithValidHmacSignature(eventCode.toString());
+        doThrow(new RuntimeException("SQS unavailable")).when(mockTaskQueueService).add(any(Task.class));
 
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
+        WebApplicationException exception = assertThrows(WebApplicationException.class, () ->
+                adyenNotificationService.handleNotificationFor(payload, "5.6.7.8"));
 
-            assertTrue(result);
-
-            ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
-            verify(mockTaskQueueService).add(taskCaptor.capture());
-
-            Task task = taskCaptor.getValue();
-            assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION));
-            assertThat(task.getData(), is(payload));
-        }
-        
-        @ParameterizedTest
-        @NullAndEmptySource
-        @ValueSource(strings = {"SOME_INVALID_VALUE"})
-        void shouldIgnoreNonCaptureWebhookNotificationsAndNotAddToTaskQue(String eventCode) {
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-            String payload = getNotificationWithValidHmacSignature(eventCode);
-
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
-
-            assertTrue(result);
-
-            verify(mockTaskQueueService, never()).add(any(Task.class));
-            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents.getFirst()
-                    .getFormattedMessage(), is("Ignored Adyen notification"));
-            assertThat(loggingEvents.get(1).getFormattedMessage(), is("Processed Adyen notification"));
-        }
-        
-        @Test
-        void ShouldNotAddToTaskQueWhenHmacSignatureIsInvalid() {
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-
-            String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
-                    .replace("{{HMAC_SIGNATURE}}", "WrongSignature");
-
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8");
-
-            assertFalse(result);
-            verify(mockTaskQueueService, never()).add(any(Task.class));
-        }
-        
-        @Test
-        void shouldThrowWebApplicationExceptionWhenSendingCaptureNotificationToTaskQueueFails() {
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-
-            String payload = getNotificationWithValidHmacSignature("CAPTURE");
-
-            doThrow(new RuntimeException("SQS unavailable")).when(mockTaskQueueService).add(any(Task.class));
-
-            WebApplicationException exception = assertThrows(WebApplicationException.class, () ->
-                    adyenNotificationService.handleNotificationFor(payload, "5.6.7.8"));
-
-            verify(mockTaskQueueService).add(any(Task.class));
-            assertThat(exception.getResponse().getStatus(), is(500));
-            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents.getFirst()
-                    .getFormattedMessage(), is("Error sending Adyen webhook notification to task SQS queue"));
-        }
-        
+        verify(mockTaskQueueService).add(any(Task.class));
+        assertThat(exception.getResponse().getStatus(), is(500));
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.getFirst()
+                .getFormattedMessage(), is("Error sending Adyen webhook notification to task SQS queue"));
     }
 
     private HmacKeys getHmacKeys(String... testKey) {
@@ -315,7 +259,7 @@ class AdyenNotificationServiceTest {
         WebhookHmacKeys testKeys = testKey == null || testKey.length == 0 ? new WebhookHmacKeys(validTestKey,
                 null) : new WebhookHmacKeys(testKey[0], null);
 
-        HmacKeys.WebhookHmacKeyPair pair = new HmacKeys.WebhookHmacKeyPair(testKeys, liveKeys);
+        WebhookHmacKeyPair pair = new WebhookHmacKeyPair(testKeys, liveKeys);
 
         return new HmacKeys(pair);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidatorTest.java
@@ -5,8 +5,13 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
+import com.adyen.model.notification.NotificationRequest;
+import com.adyen.model.notification.NotificationRequestItem;
+import com.adyen.util.HMACValidator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -18,20 +23,32 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.gateway.exception.AdyenNotificationException;
 import uk.gov.pay.connector.util.IpDomainMatcher;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+
+import java.security.SignatureException;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_NOTIFICATION;
 
 @ExtendWith(MockitoExtension.class)
 class AdyenNotificationValidatorTest {
-    
+    public static final String INVALID_HMAC_SIGNATURE = "invalidHmacSignature";
     private AdyenNotificationValidator adyenNotificationValidator;
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
     @Mock
     private IpDomainMatcher ipDomainMatcher;
@@ -45,12 +62,15 @@ class AdyenNotificationValidatorTest {
     @Mock
     private AdyenGatewayConfig gatewayConfig;
 
+    @Mock
+    HMACValidator hmacValidator;
+
     public static final String NOTIFICATION_DOMAIN = "notification.adyen.com";
 
     @BeforeEach
     void setUp() {
         when(gatewayConfig.getNotificationDomain()).thenReturn(NOTIFICATION_DOMAIN);
-        adyenNotificationValidator = new AdyenNotificationValidator(gatewayConfig, ipDomainMatcher);
+        adyenNotificationValidator = new AdyenNotificationValidator(gatewayConfig, ipDomainMatcher, hmacValidator);
 
         Logger logger = (Logger) LoggerFactory.getLogger(AdyenNotificationValidator.class);
         logger.setLevel(Level.INFO);
@@ -59,55 +79,114 @@ class AdyenNotificationValidatorTest {
 
     private static final String FORWARDED_IP = "192.168.1.1";
 
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"  ", "\t", "\n"})
-    void shouldReturnFalseWhenForwardedIpAddressesIsBlankOrNull(String forwardedIpAddresses) {
-        assertFalse(adyenNotificationValidator.isValidIpAddress(forwardedIpAddresses));
+    @Nested
+    class TestIpValidation {
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"  ", "\t", "\n"})
+        void shouldReturnFalseWhenForwardedIpAddressesIsBlankOrNull(String forwardedIpAddresses) {
+            assertFalse(adyenNotificationValidator.isValidIpAddress(forwardedIpAddresses));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"  ", "\t", "\n"})
+        void shouldLogMissingXForwardedForHeaderWhenForwardedIpAddressesIsBlankOrNull(String forwardedIpAddresses) {
+            adyenNotificationValidator.isValidIpAddress(forwardedIpAddresses);
+
+            verify(mockAppender, times(1)).doAppend(loggingEventCaptor.capture());
+            LoggingEvent loggingEvent = loggingEventCaptor.getValue();
+            assertThat(loggingEvent.getLevel(), is(Level.INFO));
+            assertThat(loggingEvent.getMessage(),
+                    is("Adyen notification missing X-Forwarded-For header"));
+        }
+
+        @Test
+        void shouldReturnTrueWhenIpMatchesDomain() {
+            when(ipDomainMatcher.ipMatchesDomain(FORWARDED_IP, NOTIFICATION_DOMAIN)).thenReturn(true);
+
+            assertTrue(adyenNotificationValidator.isValidIpAddress(FORWARDED_IP));
+            verify(ipDomainMatcher).ipMatchesDomain(FORWARDED_IP, NOTIFICATION_DOMAIN);
+        }
+
+        @Test
+        void shouldReturnFalseAndLogMismatchErrorWhenIpDoesNotMatchDomain() {
+            when(ipDomainMatcher.ipMatchesDomain(FORWARDED_IP, NOTIFICATION_DOMAIN))
+                    .thenReturn(false);
+
+            boolean result = adyenNotificationValidator.isValidIpAddress(FORWARDED_IP);
+
+            assertFalse(result);
+            verify(mockAppender, times(1)).doAppend(loggingEventCaptor.capture());
+            LoggingEvent loggingEvent = loggingEventCaptor.getValue();
+            assertThat(loggingEvent.getLevel(), is(Level.INFO));
+            assertThat(loggingEvent.getMessage(),
+                    is("Adyen notification from ip '{}' not matching configured domain '{}'"));
+            assertThat(loggingEvent.getArgumentArray()[0], is(FORWARDED_IP));
+            assertThat(loggingEvent.getArgumentArray()[1], Is.is(NOTIFICATION_DOMAIN));
+        }
     }
 
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"  ", "\t", "\n"})
-    void shouldLogMissingXForwardedForHeaderWhenForwardedIpAddressesIsBlankOrNull(String forwardedIpAddresses) {
-        adyenNotificationValidator.isValidIpAddress(forwardedIpAddresses);
+    @Nested
+    class TestHmacValidation {
+        private final String validHmacSignature = "44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056"; // pragma: allowlist secret
+        private final JsonObjectMapper mapper = new JsonObjectMapper(new ObjectMapper());
 
-        verify(mockAppender, times(1)).doAppend(loggingEventCaptor.capture());
-        LoggingEvent loggingEvent = loggingEventCaptor.getValue();
-        assertThat(loggingEvent.getLevel(), is(Level.INFO));
-        assertThat(loggingEvent.getMessage(),
-                is("Adyen notification missing X-Forwarded-For header"));
-    }
+        @Test
+        void shouldReturnTrueForValidHmacSignature() throws SignatureException {
+            when(hmacValidator.validateHMAC(any(), any())).thenReturn(true);
 
-    @Test
-    void shouldReturnTrueWhenIpMatchesDomain() {
-        when(ipDomainMatcher.ipMatchesDomain(FORWARDED_IP,NOTIFICATION_DOMAIN)).thenReturn(true);
+            var item = loadNotificationItem(validHmacSignature);
 
-        assertTrue(adyenNotificationValidator.isValidIpAddress(FORWARDED_IP));
-        verify(ipDomainMatcher).ipMatchesDomain(FORWARDED_IP, NOTIFICATION_DOMAIN);
-    }
 
-    @Test
-    void shouldReturnFalseWhenIpDoesNotMatchDomain() {
-        when(ipDomainMatcher.ipMatchesDomain(FORWARDED_IP, NOTIFICATION_DOMAIN))
-                .thenReturn(false);
+            var result = adyenNotificationValidator.isValidHmac(item, validHmacSignature);
+            assertTrue(result);
+        }
 
-        assertFalse(adyenNotificationValidator.isValidIpAddress(FORWARDED_IP));
-    }
+        @Test
+        void shouldReturnFalseAndLogWhenHmacSignatureIsInvalid() throws SignatureException {
+            when(hmacValidator.validateHMAC(any(), any())).thenReturn(false);
 
-    @Test
-    void shouldLogMismatchErrorWhenIpDoesNotMatchDomain() {
-        when(ipDomainMatcher.ipMatchesDomain(FORWARDED_IP, NOTIFICATION_DOMAIN))
-                .thenReturn(false);
+            var item = loadNotificationItem(INVALID_HMAC_SIGNATURE);
 
-        adyenNotificationValidator.isValidIpAddress(FORWARDED_IP);
+            var result = adyenNotificationValidator.isValidHmac(item, INVALID_HMAC_SIGNATURE);
 
-        verify(mockAppender, times(1)).doAppend(loggingEventCaptor.capture());
-        LoggingEvent loggingEvent = loggingEventCaptor.getValue();
-        assertThat(loggingEvent.getLevel(), is(Level.INFO));
-        assertThat(loggingEvent.getMessage(),
-                is("Adyen notification from ip '{}' not matching configured domain '{}'"));
-        assertThat(loggingEvent.getArgumentArray()[0], is(FORWARDED_IP));
-        assertThat(loggingEvent.getArgumentArray()[1], Is.is(NOTIFICATION_DOMAIN));
+            assertFalse(result);
+            verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .stream()
+                    .anyMatch(event -> event
+                            .getFormattedMessage()
+                            .equals("Invalid HMAC signature in the payload for Adyen notification")), is(true));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenAdyenPaymentNotificationItemIsNotValid() throws SignatureException {
+            when(hmacValidator.validateHMAC(any(), any())).thenThrow(IllegalArgumentException.class);
+
+            assertThrows(AdyenNotificationException.class, () ->
+                    adyenNotificationValidator.isValidHmac(new NotificationRequestItem(), validHmacSignature)
+            );
+
+            verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .stream()
+                    .anyMatch(event -> event
+                            .getFormattedMessage()
+                            .equals("Failed to validate HMAC signature")), is(true));
+        }
+
+        private NotificationRequestItem loadNotificationItem(String hmacSignature) {
+            return mapper.getObject(TestTemplateResourceLoader
+                                    .load(ADYEN_NOTIFICATION)
+                                    .replace("{{HMAC_SIGNATURE}}", hmacSignature),
+                            NotificationRequest.class)
+                    .getNotificationItems()
+                    .getFirst();
+        }
     }
 }


### PR DESCRIPTION
## WHAT YOU DID

- Extracted HMAC validator method into `AdyenNotificationValidator` for common use.
- Refactored affected tests including the use of a new json test template for the `paymentNotificationItem`.


## How to test

- How should it be reviewed?  - PR
- What feedback do you need?  PR comments/call/DM

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

