### PR TITLE
PP-15572 Validate Adyen webhook with valid HMAC signature

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -849,7 +849,7 @@
         "filename": "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 162
+        "line_number": 169
       }
     ],
     "src/test/resources/config/client-factory-test-config.yaml": [
@@ -879,7 +879,7 @@
         "filename": "src/test/resources/config/client-factory-test-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 152
+        "line_number": 159
       }
     ],
     "src/test/resources/config/test-config.yaml": [
@@ -909,7 +909,7 @@
         "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 161
+        "line_number": 168
       }
     ],
     "src/test/resources/config/test-it-config.yaml": [
@@ -939,7 +939,7 @@
         "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 157
+        "line_number": 164
       }
     ],
     "src/test/resources/googlepay/auth-request-with-empty-last-digits-card-number.json": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-16T09:58:38Z"
+  "generated_at": "2026-07-29T12:09:58Z"
 }

--- a/src/main/java/uk/gov/pay/connector/app/adyen/HmacKeys.java
+++ b/src/main/java/uk/gov/pay/connector/app/adyen/HmacKeys.java
@@ -6,7 +6,11 @@ import jakarta.validation.constraints.NotNull;
 public record HmacKeys(
         @Valid
         @NotNull
-        WebhookHmacKeyPair payments
+        WebhookHmacKeyPair payments,
+        @Valid
+        @NotNull
+        WebhookHmacKeyPair tokens
+        
 ) {
     public record WebhookHmacKeyPair(
             @Valid

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtil.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.adyen.utils;
 
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.app.adyen.HmacKeys;
 import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
 
 public class AdyenConfigUtil {
@@ -35,6 +36,17 @@ public class AdyenConfigUtil {
         } else {
             webhookHmacKeys = adyenGatewayConfig.getHmacKeys().payments().test();
         }
+
+        return webhookHmacKeys.getPrimary()
+                .orElseThrow(() -> new IllegalStateException("Missing primary Adyen HMAC key"));
+    }
+    
+    public static String getTokenHmacKey(AdyenGatewayConfig adyenGatewayConfig, boolean live) {
+        return getPrimaryHmacKey(adyenGatewayConfig.getHmacKeys().tokens(), live);
+    }
+    
+    private static String getPrimaryHmacKey(HmacKeys.WebhookHmacKeyPair keyPair, boolean live) {
+        WebhookHmacKeys webhookHmacKeys = live ? keyPair.live() : keyPair.test();
 
         return webhookHmacKeys.getPrimary()
                 .orElseThrow(() -> new IllegalStateException("Missing primary Adyen HMAC key"));

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidator.java
@@ -73,4 +73,12 @@ public class AdyenNotificationValidator {
             throw new AdyenNotificationException("Failed to validate HMAC signature", e);
         }
     }
+
+    public boolean isValidHmac(String hmacSignature, String hmacKey, String payload) {
+        try {
+            return hmacValidator.validateHMAC(hmacSignature, hmacKey, payload);
+        } catch (IllegalArgumentException | SignatureException e) {
+            throw new AdyenNotificationException("Failed to validate HMAC signature", e);
+        }
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationService.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
+import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getTokenHmacKey;
 import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER;
 
 public class AdyenRecurringTokenNotificationService {
@@ -13,15 +14,24 @@ public class AdyenRecurringTokenNotificationService {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdyenRecurringTokenNotificationService.class);
     private final AdyenNotificationValidator adyenNotificationValidator;
     private static final String NOTIFICATION_SOURCE = "notification_source";
+    private final AdyenGatewayConfig adyenGatewayConfig;
 
     @Inject
     public AdyenRecurringTokenNotificationService(AdyenGatewayConfig adyenGatewayConfig, AdyenNotificationValidator adyenNotificationValidator) {
         this.adyenNotificationValidator = adyenNotificationValidator;
+        this.adyenGatewayConfig = adyenGatewayConfig;
     }
 
     public boolean handleNotificationFor(String payload, String hmacSignature, String forwardedIpAddresses) {
 
         if (!adyenNotificationValidator.isValidIpAddress(forwardedIpAddresses)) {
+            return false;
+        }
+
+        // Todo: need to work out how to set this. Hardcoding for now 
+        boolean live = false;
+        String hmacKey = getTokenHmacKey(adyenGatewayConfig, live);
+        if (!adyenNotificationValidator.isValidHmac(hmacSignature, hmacKey, payload)) {
             return false;
         }
 
@@ -32,4 +42,5 @@ public class AdyenRecurringTokenNotificationService {
                 .log();
         return true;
     }
+
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -109,6 +109,13 @@ adyen:
       live:
         primary: ${GDS_CONNECTOR_ADYEN_HMAC_KEY_PAYMENTS_LIVE_PRIMARY:-}
         secondary: ${GDS_CONNECTOR_ADYEN_HMAC_KEY_PAYMENTS_LIVE_SECONDARY:-}
+    tokens:
+      test:
+        primary: ${GDS_CONNECTOR_ADYEN_HMAC_KEY_TOKENS_TEST_PRIMARY:-}
+        secondary: ${GDS_CONNECTOR_ADYEN_HMAC_KEY_TOKENS_TEST_SECONDARY:-}
+      live:
+        primary: ${GDS_CONNECTOR_ADYEN_HMAC_KEY_TOKENS_LIVE_PRIMARY:-}
+        secondary: ${GDS_CONNECTOR_ADYEN_HMAC_KEY_TOKENS_LIVE_SECONDARY:-}
 
 stripe:
   allowedCidrs: ${STRIPE_ALLOWED_CIDRS}

--- a/src/test/java/uk/gov/pay/connector/app/ConnectorConfigurationIT.java
+++ b/src/test/java/uk/gov/pay/connector/app/ConnectorConfigurationIT.java
@@ -56,9 +56,23 @@ public class ConnectorConfigurationIT {
         assertThat(adyenGatewayConfig.getApiKeys().legalEntityManagement().test(), is("adyen-test-legal-entity-management-api-key"));
 
         assertThat(adyenGatewayConfig.getNotificationDomain(), is(".adyen.com"));
-        
-        assertThat(adyenGatewayConfig.getHmacKeys().payments().test().getPrimary().get(), is("adyen-test-payments-hmac-primary"));
-        assertThat(adyenGatewayConfig.getHmacKeys().payments().live().getPrimary().get(), is("adyen-live-payments-hmac-primary"));
+
+        var paymentTestPrimary = adyenGatewayConfig.getHmacKeys().payments().test().getPrimary();
+        assertThat(paymentTestPrimary.isPresent(), is(true));
+        assertThat(paymentTestPrimary.get(), is("adyen-test-payments-hmac-primary"));
+
+        var paymentLivePrimary = adyenGatewayConfig.getHmacKeys().payments().live().getPrimary();
+        assertThat(paymentLivePrimary.isPresent(), is(true));
+        assertThat(paymentLivePrimary.get(), is("adyen-live-payments-hmac-primary"));
+
+        var tokenTestPrimary = adyenGatewayConfig.getHmacKeys().tokens().test().getPrimary();
+        assertThat(tokenTestPrimary.isPresent(), is(true));
+        assertThat(tokenTestPrimary.get(), is("adyen-test-tokens-hmac-primary"));
+
+        var tokenLivePrimary = adyenGatewayConfig.getHmacKeys().tokens().live().getPrimary();
+        assertThat(tokenLivePrimary.isPresent(), is(true));
+        assertThat(tokenLivePrimary.get(), is("adyen-live-tokens-hmac-primary"));
+
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtilTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
-import uk.gov.pay.connector.app.adyen.AdyenIds;
 import uk.gov.pay.connector.app.adyen.ApiKeys;
 import uk.gov.pay.connector.app.adyen.BaseUrls;
 import uk.gov.pay.connector.app.adyen.HmacKeys;
@@ -35,8 +34,6 @@ class AdyenConfigUtilTest {
     private BaseUrls mockBaseUrls;
     @Mock
     private BaseUrls.CheckoutUrls mockCheckoutUrl;
-    @Mock
-    private AdyenIds mockMerchantAccountIds;
 
     @Nested
     class TestGetCompanyApiKey {
@@ -146,5 +143,51 @@ class AdyenConfigUtilTest {
 
             assertThat(exception.getMessage(), is("Missing primary Adyen HMAC key"));
         }
+    }
+    
+    @Nested
+    class TestGetsTokenHmacKeys {
+
+        @Mock
+        private HmacKeys mockHmacKeys;
+        @Mock
+        private HmacKeys.WebhookHmacKeyPair mockKeyPair;
+        @Mock
+        private WebhookHmacKeys mockLiveKeys;
+        @Mock
+        private WebhookHmacKeys mockTestKeys;
+
+        @Test
+        void shouldReturnLiveHmacKeyWhenLiveIsTrue() {
+            var expectedValue = "live-hmac-key";
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(mockHmacKeys);
+            when(mockHmacKeys.tokens()).thenReturn(mockKeyPair);
+            when(mockKeyPair.live()).thenReturn(mockLiveKeys);
+            when(mockLiveKeys.getPrimary()).thenReturn(Optional.of(expectedValue));
+
+            String result = AdyenConfigUtil.getTokenHmacKey(mockAdyenGatewayConfig, true);
+
+            assertThat(result, is(expectedValue));
+
+            verify(mockKeyPair).live();
+            verify(mockKeyPair, never()).test();
+        }
+
+        @Test
+        void shouldReturnTestHmacKeyWhenLiveIsFalse() {
+            var expectedValue = "test-hmac-key";
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(mockHmacKeys);
+            when(mockHmacKeys.tokens()).thenReturn(mockKeyPair);
+            when(mockKeyPair.test()).thenReturn(mockTestKeys);
+            when(mockTestKeys.getPrimary()).thenReturn(Optional.of(expectedValue));
+
+            String result = AdyenConfigUtil.getTokenHmacKey(mockAdyenGatewayConfig, false);
+
+            assertThat(result, is(expectedValue));
+
+            verify(mockKeyPair).test();
+            verify(mockKeyPair, never()).live();
+        }
+        
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
@@ -260,8 +260,8 @@ class AdyenNotificationServiceTest {
                 null) : new WebhookHmacKeys(testKey[0], null);
 
         WebhookHmacKeyPair pair = new WebhookHmacKeyPair(testKeys, liveKeys);
-
-        return new HmacKeys(pair);
+        
+        return new HmacKeys(pair, null);
     }
 
     private String getNotificationWithValidHmacSignature(String eventCode) {

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidatorTest.java
@@ -188,5 +188,30 @@ class AdyenNotificationValidatorTest {
                     .getNotificationItems()
                     .getFirst();
         }
+
     }
+
+    @Nested
+    class TestHmacValidationWithSignatureForTokens {
+        private final String validHmacSignature = "44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056"; // pragma: allowlist secret
+        private final String hmacKey = "ValidHmacKey";
+        private final String payload = "Validpayload";
+
+        @Test
+        void shouldReturnTrueForTokenSignature() throws SignatureException {
+            when(hmacValidator.validateHMAC(validHmacSignature, hmacKey, payload)).thenReturn(true);
+
+            var result = adyenNotificationValidator.isValidHmac(validHmacSignature, hmacKey, payload);
+            assertTrue(result);
+        }
+
+        @Test
+        void shouldReturnFalseForTokenSignature() throws SignatureException {
+            when(hmacValidator.validateHMAC(validHmacSignature, hmacKey, payload)).thenReturn(false);
+
+            var result = adyenNotificationValidator.isValidHmac(validHmacSignature, hmacKey, payload);
+            assertFalse(result);
+        }
+    }
+
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationServiceTest.java
@@ -14,6 +14,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.app.adyen.HmacKeys;
+import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
 import uk.gov.pay.connector.util.IpDomainMatcher;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
@@ -24,6 +26,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -62,20 +65,6 @@ class AdyenRecurringTokenNotificationServiceTest {
         logger.addAppender(mockAppender);
     }
 
-    @Test
-    void shouldAcceptValidTokenNotification() {
-        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
-
-        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
-
-        boolean result = adyenRecurringTokenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP);
-
-        assertTrue(result);
-        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-        assertThat(loggingEvents.stream()
-                .anyMatch(event -> event.getFormattedMessage().equals("Processed Adyen token notification")), is(true));
-    }
 
     @Test
     void shouldRejectNotificationWhenForwardedIpHeaderIsMissing() {
@@ -92,5 +81,43 @@ class AdyenRecurringTokenNotificationServiceTest {
         boolean result = adyenRecurringTokenNotificationService.handleNotificationFor("{}", HMAC_SIGNATURE, NON_ADYEN_IP);
 
         assertFalse(result);
+    }
+
+    @Test
+    void shouldAcceptValidTokenNotification() {
+        var primaryTestKey = "primaryTest";
+        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
+        var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
+                new WebhookHmacKeys("primaryLive", "secondaryLive"));
+        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
+        when(adyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
+        when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey,
+                payload)).thenReturn(true);
+
+        boolean result = adyenRecurringTokenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP);
+
+        assertTrue(result);
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.stream()
+                        .anyMatch(event -> event.getFormattedMessage().equals("Processed Adyen token notification")),
+                is(true));
+    }
+
+    @Test
+    void shouldRejectInvalidTokenNotification() {
+        var primaryTestKey = "primaryTest";
+        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
+        var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
+                new WebhookHmacKeys("primaryLive", "secondaryLive"));
+        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
+        when(adyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
+        when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey,
+                payload)).thenReturn(false);
+
+        boolean result = adyenRecurringTokenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP);
+
+        assertFalse(result);
+        verify(mockAppender, never()).doAppend(loggingEventArgumentCaptor.capture());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenTokensNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenTokensNotificationResourceIT.java
@@ -24,7 +24,7 @@ public class AdyenTokensNotificationResourceIT {
     private static final String NOTIFICATION_PATH = "/v1/api/notifications/adyen/tokens";
     private static final String ADYEN_IP_ADDRESS = "192.168.0.1";
     private static final String UNEXPECTED_IP_ADDRESS = "8.8.8.8";
-    private static final String HMAC_SIGNATURE = "sha256=test-signature";
+    private static final String HMAC_SIGNATURE = "hLz2zuhuylC8q36sCWWH7PpvbVpyaWDpoBqoEeTjj7w="; // pragma: allowlist secret
 
     @BeforeAll
     static void before() {

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -77,6 +77,13 @@ adyen:
       live:
         primary: adyen-live-payments-hmac-primary
         secondary: ""
+    tokens:
+      test:
+        primary: adyen-test-tokens-hmac-primary
+        secondary: ""
+      live:
+        primary: adyen-live-tokens-hmac-primary
+        secondary: ""
 
 sandbox:
   allowedCidrs: ${SANDBOX_ALLOWED_CIDRS:-[]}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -67,6 +67,13 @@ adyen:
       live:
         primary: adyen-live-payments-hmac-primary
         secondary: ""
+    tokens:
+      test:
+        primary: adyen-test-tokens-hmac-primary
+        secondary: ""
+      live:
+        primary: adyen-live-tokens-hmac-primary
+        secondary: ""
 
 sandbox:
   allowedCidrs: ${SANDBOX_ALLOWED_CIDRS:-[]}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -73,6 +73,13 @@ adyen:
       live:
         primary: adyen-live-payments-hmac-primary
         secondary: ""
+    tokens:
+      test:
+        primary: adyen-test-tokens-hmac-primary
+        secondary: ""
+      live:
+        primary: adyen-live-tokens-hmac-primary
+        secondary: ""
 
 sandbox:
   allowedCidrs: ${SANDBOX_ALLOWED_CIDRS:-[]}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -9,7 +9,7 @@ server:
       port: 0
   registerDefaultExceptionMappers: false
   requestLog:
-    appenders: []
+    appenders: [ ]
 
 logging:
   level: INFO
@@ -68,13 +68,20 @@ adyen:
       live:
         primary: adyen-live-payments-hmac-primary
         secondary: ""
+    tokens:
+      test:
+        primary: 6D5BADA576A73109D879220DCB793FFD67DEF7AA18C74CCC0AB66FD87AC8AEEA # pragma: allowlist secret
+        secondary: ""
+      live:
+        primary: adyen-live-tokens-hmac-primary
+        secondary: ""
 
 sandbox:
-  allowedCidrs: ["3.3.3.0/22", "6.6.6.6/32"]
+  allowedCidrs: [ "3.3.3.0/22", "6.6.6.6/32" ]
   sandboxAuthToken: "let-me-in"
 
 stripe:
-  allowedCidrs: ["1.2.3.0/24", "9.9.9.9/32"]
+  allowedCidrs: [ "1.2.3.0/24", "9.9.9.9/32" ]
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}


### PR DESCRIPTION
- Added tokens HmacKeyPair to Adyen Hmac Keys
- Added method to validate Adyen Hmac keys using Hmac signature
- Added Hmac validation check to Adyen token notification handling

Co-authored @joshuapook-MT @AbdirizakIdris 
