### PR TITLE
PP-15645 Extract JSON object mapper from AdyenAuthorisationRequest

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AuthoriseRequestPayloadToGatewayOrderConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AuthoriseRequestPayloadToGatewayOrderConverter.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.connector.gateway.adyen;
+
+import jakarta.ws.rs.core.MediaType;
+import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.adyen.request.json.AuthoriseRequestPayload;
+import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import static uk.gov.pay.connector.gateway.model.OrderRequestType.AUTHORISE;
+
+public class AuthoriseRequestPayloadToGatewayOrderConverter {
+
+    private final JsonObjectMapper jsonObjectMapper;
+    
+    public AuthoriseRequestPayloadToGatewayOrderConverter(JsonObjectMapper jsonObjectMapper) {
+        this.jsonObjectMapper = jsonObjectMapper;
+    }
+
+    public GatewayOrder convert(AuthoriseRequestPayload authoriseRequestPayload) {
+        String json = jsonObjectMapper.objectToString(authoriseRequestPayload);
+        return new GatewayOrder(AUTHORISE, json, MediaType.APPLICATION_JSON_TYPE);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
@@ -6,8 +6,11 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
+import uk.gov.pay.connector.gateway.adyen.AuthoriseRequestPayloadToGatewayOrderConverter;
 import uk.gov.pay.connector.gateway.adyen.request.AdyenAuthorisationRequest;
+import uk.gov.pay.connector.gateway.adyen.request.json.AuthoriseRequestPayload;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenAuthoriseResponse;
 import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
@@ -27,6 +30,7 @@ public class AdyenAuthoriseHandler {
     private final GatewayClient gatewayClient;
     private final AdyenGatewayConfig adyenGatewayConfig;
     private final AdyenRequestFactory adyenRequestFactory;
+    private final AuthoriseRequestPayloadToGatewayOrderConverter authoriseRequestPayloadToGatewayOrderConverter;
     private final JsonObjectMapper jsonObjectMapper;
 
     public AdyenAuthoriseHandler(GatewayClient gatewayClient,
@@ -36,6 +40,7 @@ public class AdyenAuthoriseHandler {
         this.adyenGatewayConfig = connectorConfig.getAdyenGatewayConfig();
         this.jsonObjectMapper = jsonObjectMapper;
         this.adyenRequestFactory = new AdyenRequestFactory(connectorConfig);
+        this.authoriseRequestPayloadToGatewayOrderConverter = new AuthoriseRequestPayloadToGatewayOrderConverter(jsonObjectMapper);
     }
     
     public GatewayResponse authorise(CardAuthorisationGatewayRequest request) throws
@@ -47,14 +52,16 @@ public class AdyenAuthoriseHandler {
                 .GatewayResponseBuilder
                 .responseBuilder();
 
-        logger.info("Calling Adyen for authorisation of charge");
+        AuthoriseRequestPayload authoriseRequestPayload = adyenRequestFactory.createPaymentRequest(request);
+        GatewayOrder gatewayOrder = authoriseRequestPayloadToGatewayOrderConverter.convert(authoriseRequestPayload);
+
         var authorisationRequest = new AdyenAuthorisationRequest(
                 getAuthUrl(adyenGatewayConfig, request),
                 getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive(), AUTHORISE, request.getGovUkPayPaymentId()),
                 request.getGatewayAccount().getType(),
-                adyenRequestFactory.createPaymentRequest(request),
-                jsonObjectMapper);
+                gatewayOrder);
 
+        logger.info("Calling Adyen for authorisation of charge");
         try {
             var jsonResponse = gatewayClient.postRequestFor(authorisationRequest).getEntity();
             var paymentResponse = jsonObjectMapper.getObject(
@@ -75,14 +82,16 @@ public class AdyenAuthoriseHandler {
                 .GatewayResponseBuilder
                 .responseBuilder();
 
-        logger.info("Calling Adyen for user-not-present authorisation of charge");
+        AuthoriseRequestPayload authoriseRequestPayload = adyenRequestFactory.createRecurringPaymentRequest(request);
+        GatewayOrder gatewayOrder = authoriseRequestPayloadToGatewayOrderConverter.convert(authoriseRequestPayload);
+
         var authorisationRequest = new AdyenAuthorisationRequest(
                 getAuthUrl(adyenGatewayConfig, request),
                 getHeaders(adyenGatewayConfig, request.getGatewayAccount().isLive(), AUTHORISE, request.getGovUkPayPaymentId()),
                 request.getGatewayAccount().getType(),
-                adyenRequestFactory.createRecurringPaymentRequest(request),
-                jsonObjectMapper);
+                gatewayOrder);
 
+        logger.info("Calling Adyen for user-not-present authorisation of charge");
         try {
             var jsonResponse = gatewayClient.postRequestFor(authorisationRequest).getEntity();
             var paymentResponse = jsonObjectMapper.getObject(

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/request/AdyenAuthorisationRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/request/AdyenAuthorisationRequest.java
@@ -1,12 +1,8 @@
 package uk.gov.pay.connector.gateway.adyen.request;
 
-import jakarta.ws.rs.core.MediaType;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.adyen.request.json.AuthoriseRequestPayload;
-import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
-import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import java.net.URI;
 import java.util.Map;
@@ -16,8 +12,7 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 public record AdyenAuthorisationRequest(URI url,
                                         Map<String, String> headers,
                                         String gatewayAccountType,
-                                        AuthoriseRequestPayload requestPayload,
-                                        JsonObjectMapper jsonObjectMapper) implements GatewayClientPostRequest {
+                                        GatewayOrder gatewayOrder) implements GatewayClientPostRequest {
     @Override
     public URI getUrl() {
         return url;
@@ -25,8 +20,7 @@ public record AdyenAuthorisationRequest(URI url,
 
     @Override
     public GatewayOrder getGatewayOrder() {
-        var payload = jsonObjectMapper.objectToString(requestPayload);
-        return new GatewayOrder(OrderRequestType.AUTHORISE, payload, MediaType.APPLICATION_JSON_TYPE);
+        return gatewayOrder;
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AuthoriseRequestPayloadToGatewayOrderConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AuthoriseRequestPayloadToGatewayOrderConverterTest.java
@@ -1,9 +1,11 @@
-package uk.gov.pay.connector.gateway.adyen.request;
+package uk.gov.pay.connector.gateway.adyen;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonassert.JsonAssert;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 import uk.gov.pay.connector.gateway.adyen.request.json.AuthoriseRequestPayload;
 import uk.gov.pay.connector.gateway.adyen.request.json.BillingAddress;
@@ -11,7 +13,6 @@ import uk.gov.pay.connector.gateway.adyen.request.json.PaymentMethod;
 import uk.gov.pay.connector.gateway.adyen.response.json.BrowserInfo;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
-import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,23 +21,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gateway.model.OrderRequestType.AUTHORISE;
 
-class AdyenAuthorisationRequestTest {
-    public static final String TEST_URL = "/adyen_authorisation";
-    private JsonObjectMapper jsonObjectMapper;
+@ExtendWith(MockitoExtension.class)
+class AuthoriseRequestPayloadToGatewayOrderConverterTest {
 
-    @BeforeEach
-    void setUp() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        jsonObjectMapper = new JsonObjectMapper(objectMapper);
-    }
+    private AuthoriseRequestPayloadToGatewayOrderConverter factory = new AuthoriseRequestPayloadToGatewayOrderConverter(new JsonObjectMapper(new ObjectMapper()));
 
     @Test
     void shouldCreateGatewayOrder_withSerialisedPayload() {
-        var request = buildValidRequestWithBillingAddress();
+        GatewayOrder gatewayOrder = factory.convert(makePaymentRequestWithFullBillingAddress());
 
-        assertThat(request.getGatewayOrder().getOrderRequestType(), is(AUTHORISE));
-        assertThat(request.getGatewayOrder().getMediaType(), is(APPLICATION_JSON_TYPE));
-        JsonAssert.with(request.getGatewayOrder().getPayload())
+        assertThat(gatewayOrder.getOrderRequestType(), is(AUTHORISE));
+        assertThat(gatewayOrder.getMediaType(), is(APPLICATION_JSON_TYPE));
+        JsonAssert.with(gatewayOrder.getPayload())
                 .assertThat("$.amount.value", is(1000))
                 .assertThat("$.amount.currency", is("GBP"))
                 .assertThat("$.billingAddress.houseNumberOrName", is("houseNumberOrName"))
@@ -67,16 +63,6 @@ class AdyenAuthorisationRequestTest {
                 .assertThat("$.origin", is("https://frontend.pay.service.gov.uk"))
                 .assertThat("$.shopperEmail", is("test@example.com"))
                 .assertThat("$.shopperIP", is("127.0.0.1"));
-    }
-
-    private AdyenAuthorisationRequest buildValidRequestWithBillingAddress() {
-        var paymentRequest = makePaymentRequestWithFullBillingAddress();
-        return new AdyenAuthorisationRequest(
-                URI.create(TEST_URL),
-                Map.of("X-API-Key", "test-api-key"),
-                "test",
-                paymentRequest,
-                jsonObjectMapper);
     }
 
     private AuthoriseRequestPayload makePaymentRequestWithFullBillingAddress() {
@@ -126,4 +112,5 @@ class AdyenAuthorisationRequestTest {
                 null
         );
     }
+
 }


### PR DESCRIPTION
Extract JSON object mapper from `AdyenAuthorisationRequest` and make `AdyenAuthorisationRequest` hold a `GatewayOrder` rather than an `AuthoriseRequestPayload` (because we want to support types other than `AuthoriseRequestPayload` such as `AdyenApplePayAuthoriseRequest`).

Introduce `AuthoriseRequestPayloadToGatewayOrderConverter` to convert an `AuthoriseRequestPayload` to a `GatewayOrder` (including the JSON object mapping).

Since `AdyenAuthorisationRequest` is now a pure data class with no JSON object mapping functionality itself, its tests have been moved to `AuthoriseRequestPayloadToGatewayOrderConverter`.