### PR TITLE
PP-15572 Reject Adyen webhook with invalid HMAC signature

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidator.java
@@ -52,7 +52,7 @@ public class AdyenNotificationValidator {
         return true;
     }
 
-    public boolean isValidHmac(NotificationRequestItem item, String hmacKey) {
+    public boolean isValidHmac(NotificationRequestItem item, String hmacKey) throws AdyenNotificationException {
         try {
             boolean validSignature = hmacValidator.validateHMAC(item, hmacKey);
 
@@ -74,11 +74,14 @@ public class AdyenNotificationValidator {
         }
     }
 
-    public boolean isValidHmac(String hmacSignature, String hmacKey, String payload) {
+    public boolean isValidHmac(String hmacSignature, String hmacKey, String payload) throws AdyenNotificationException {
         try {
             return hmacValidator.validateHMAC(hmacSignature, hmacKey, payload);
         } catch (IllegalArgumentException | SignatureException e) {
-            throw new AdyenNotificationException("Failed to validate HMAC signature", e);
+            LOGGER.atInfo()
+                    .setMessage("Failed to validate HMAC signature for token notification")
+                    .log();
+            throw new AdyenNotificationException("Failed to validate HMAC signature for token notification", e);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationService.java
@@ -4,6 +4,7 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
+import uk.gov.pay.connector.gateway.exception.AdyenNotificationException;
 
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getTokenHmacKey;
@@ -23,24 +24,40 @@ public class AdyenRecurringTokenNotificationService {
     }
 
     public boolean handleNotificationFor(String payload, String hmacSignature, String forwardedIpAddresses) {
+        try {
+            if (!adyenNotificationValidator.isValidIpAddress(forwardedIpAddresses)) {
+                return false;
+            }
 
-        if (!adyenNotificationValidator.isValidIpAddress(forwardedIpAddresses)) {
+            if (hmacSignature == null || hmacSignature.isBlank()) {
+                LOGGER.atInfo()
+                        .setMessage("Hmac signature is missing, rejecting Adyen token notification")
+                        .addKeyValue(PROVIDER, ADYEN.getName())
+                        .log();
+                return false;
+            }
+
+            // Todo: need to work out how to set this. Hardcoding for now 
+            boolean live = false;
+            String hmacKey = getTokenHmacKey(adyenGatewayConfig, live);
+            if (!adyenNotificationValidator.isValidHmac(hmacSignature, hmacKey, payload)) {
+                LOGGER.atInfo()
+                        .setMessage("Hmac signature is invalid, rejecting Adyen token notification")
+                        .addKeyValue(PROVIDER, ADYEN.getName())
+                        .log();
+                return false;
+            }
+
+            LOGGER.atInfo()
+                    .setMessage("Processed Adyen token notification")
+                    .addKeyValue(PROVIDER, ADYEN.getName())
+                    .addKeyValue(NOTIFICATION_SOURCE, forwardedIpAddresses)
+                    .log();
+            return true;
+        } catch (AdyenNotificationException e) {
+            LOGGER.error("Failed to validate Adyen token notification payload", e);
             return false;
         }
-
-        // Todo: need to work out how to set this. Hardcoding for now 
-        boolean live = false;
-        String hmacKey = getTokenHmacKey(adyenGatewayConfig, live);
-        if (!adyenNotificationValidator.isValidHmac(hmacSignature, hmacKey, payload)) {
-            return false;
-        }
-
-        LOGGER.atInfo()
-                .setMessage("Processed Adyen token notification")
-                .addKeyValue(PROVIDER, ADYEN.getName())
-                .addKeyValue(NOTIFICATION_SOURCE, forwardedIpAddresses)
-                .log();
-        return true;
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationValidatorTest.java
@@ -47,9 +47,6 @@ class AdyenNotificationValidatorTest {
     public static final String INVALID_HMAC_SIGNATURE = "invalidHmacSignature";
     private AdyenNotificationValidator adyenNotificationValidator;
 
-    @Captor
-    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
-
     @Mock
     private IpDomainMatcher ipDomainMatcher;
 
@@ -152,9 +149,9 @@ class AdyenNotificationValidatorTest {
             var result = adyenNotificationValidator.isValidHmac(item, INVALID_HMAC_SIGNATURE);
 
             assertFalse(result);
-            verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+            verify(mockAppender, times(1)).doAppend(loggingEventCaptor.capture());
 
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            List<LoggingEvent> loggingEvents = loggingEventCaptor.getAllValues();
             assertThat(loggingEvents
                     .stream()
                     .anyMatch(event -> event
@@ -170,9 +167,9 @@ class AdyenNotificationValidatorTest {
                     adyenNotificationValidator.isValidHmac(new NotificationRequestItem(), validHmacSignature)
             );
 
-            verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+            verify(mockAppender, times(1)).doAppend(loggingEventCaptor.capture());
 
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            List<LoggingEvent> loggingEvents = loggingEventCaptor.getAllValues();
             assertThat(loggingEvents
                     .stream()
                     .anyMatch(event -> event
@@ -198,7 +195,7 @@ class AdyenNotificationValidatorTest {
         private final String payload = "Validpayload";
 
         @Test
-        void shouldReturnTrueForTokenSignature() throws SignatureException {
+        void shouldReturnTrueForValidTokenSignature() throws SignatureException {
             when(hmacValidator.validateHMAC(validHmacSignature, hmacKey, payload)).thenReturn(true);
 
             var result = adyenNotificationValidator.isValidHmac(validHmacSignature, hmacKey, payload);
@@ -206,11 +203,30 @@ class AdyenNotificationValidatorTest {
         }
 
         @Test
-        void shouldReturnFalseForTokenSignature() throws SignatureException {
+        void shouldReturnFalseForInvalidTokenSignature() throws SignatureException {
             when(hmacValidator.validateHMAC(validHmacSignature, hmacKey, payload)).thenReturn(false);
 
             var result = adyenNotificationValidator.isValidHmac(validHmacSignature, hmacKey, payload);
             assertFalse(result);
+        }
+
+        @Test
+        void shouldThrowExceptionWhenAdyenPaymentTokenNotificationIsNotValid() throws SignatureException {
+            when(hmacValidator.validateHMAC(any(), any(), any())).thenThrow(IllegalArgumentException.class);
+
+            assertThrows(AdyenNotificationException.class, () ->
+                    adyenNotificationValidator.isValidHmac("some signature", "some hmac key", 
+                            "some payload")
+            );
+
+            verify(mockAppender, times(1)).doAppend(loggingEventCaptor.capture());
+
+            List<LoggingEvent> loggingEvents = loggingEventCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .stream()
+                    .anyMatch(event -> event
+                            .getFormattedMessage()
+                            .equals("Failed to validate HMAC signature for token notification")), is(true));
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationServiceTest.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.app.adyen.HmacKeys;
 import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
-import uk.gov.pay.connector.util.IpDomainMatcher;
+import uk.gov.pay.connector.gateway.exception.AdyenNotificationException;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import java.util.List;
@@ -25,10 +25,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,9 +39,6 @@ class AdyenRecurringTokenNotificationServiceTest {
 
     @Mock
     private AdyenGatewayConfig adyenGatewayConfig;
-
-    @Mock
-    private IpDomainMatcher ipDomainMatcher;
 
     @Mock
     private Appender<ILoggingEvent> mockAppender;
@@ -71,7 +67,6 @@ class AdyenRecurringTokenNotificationServiceTest {
         boolean result = adyenRecurringTokenNotificationService.handleNotificationFor("{}", HMAC_SIGNATURE, null);
 
         assertFalse(result);
-        verifyNoInteractions(ipDomainMatcher);
     }
 
     @Test
@@ -81,6 +76,36 @@ class AdyenRecurringTokenNotificationServiceTest {
         boolean result = adyenRecurringTokenNotificationService.handleNotificationFor("{}", HMAC_SIGNATURE, NON_ADYEN_IP);
 
         assertFalse(result);
+    }
+
+    @Test
+    void shouldRejectTokenNotificationWhenHmacSignatureIsNull() {
+        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
+        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
+
+        boolean result = adyenRecurringTokenNotificationService.handleNotificationFor(payload, null, FORWARDED_IP);
+
+        assertFalse(result);
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.stream()
+                        .anyMatch(event -> event.getFormattedMessage().equals("Hmac signature is missing, rejecting Adyen token notification")),
+                is(true));
+    }
+
+    @Test
+    void shouldRejectTokenNotificationWhenHmacSignatureIsMissing() {
+        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
+        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
+
+        boolean result = adyenRecurringTokenNotificationService.handleNotificationFor(payload, "", FORWARDED_IP);
+
+        assertFalse(result);
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.stream()
+                        .anyMatch(event -> event.getFormattedMessage().equals("Hmac signature is missing, rejecting Adyen token notification")),
+                is(true));
     }
 
     @Test
@@ -105,7 +130,7 @@ class AdyenRecurringTokenNotificationServiceTest {
     }
 
     @Test
-    void shouldRejectInvalidTokenNotification() {
+    void shouldRejectTokenNotificationWhenHmacSignatureIsInvalid() {
         var primaryTestKey = "primaryTest";
         String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
         var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
@@ -118,6 +143,30 @@ class AdyenRecurringTokenNotificationServiceTest {
         boolean result = adyenRecurringTokenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP);
 
         assertFalse(result);
-        verify(mockAppender, never()).doAppend(loggingEventArgumentCaptor.capture());
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.stream()
+                        .anyMatch(event -> event.getFormattedMessage().equals("Hmac signature is invalid, rejecting Adyen token notification")),
+                is(true));
+    }
+
+    @Test
+    void shouldRejectTokenNotificationWhenExceptionIsThrown() {
+        var primaryTestKey = "primaryTest";
+        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
+        var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
+                new WebhookHmacKeys("primaryLive", "secondaryLive"));
+        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
+        when(adyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
+        when(mockAdyenNotificationValidator.isValidHmac(any(), any(), any())).thenThrow(AdyenNotificationException.class);
+
+        boolean result = adyenRecurringTokenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP);
+
+        assertFalse(result);
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.stream()
+                        .anyMatch(event -> event.getFormattedMessage().equals("Failed to validate Adyen token notification payload")),
+                is(true));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenTokensNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenTokensNotificationResourceIT.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.it.resources.adyen;
 
+import io.github.netmikey.logunit.api.LogCapturer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenRecurringTokenNotificationService;
 import uk.gov.pay.connector.util.ConnectorAppWithCustomInjector;
 import uk.gov.pay.connector.util.DnsPointerResourceRecord;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
@@ -20,6 +22,9 @@ public class AdyenTokensNotificationResourceIT {
 
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension(ConnectorAppWithCustomInjector.class);
+
+    @RegisterExtension
+    LogCapturer logs = LogCapturer.create().captureForType(AdyenRecurringTokenNotificationService.class);
 
     private static final String NOTIFICATION_PATH = "/v1/api/notifications/adyen/tokens";
     private static final String ADYEN_IP_ADDRESS = "192.168.0.1";
@@ -58,6 +63,23 @@ public class AdyenTokensNotificationResourceIT {
                 .post(NOTIFICATION_PATH)
                 .then()
                 .statusCode(403);
+    }
+
+    @Test
+    void shouldRejectNotificationWithInvalidHmacSignatureForRecurringTokenNotification() {
+        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
+
+        given()
+                .port(app.getLocalPort())
+                .body(payload)
+                .header("X-Forwarded-For", ADYEN_IP_ADDRESS)
+                .header("hmacSignature", "some invalid Hmac Signature")
+                .contentType(APPLICATION_JSON)
+                .post(NOTIFICATION_PATH)
+                .then()
+                .statusCode(403);
+
+        logs.assertContains("Hmac signature is invalid, rejecting Adyen token notification");
     }
 
     @Test


### PR DESCRIPTION
- Added exception handling and logging for errors while validating
- Added tests to check that invalid Hmac scenarios are handled as expected

Co-authored by @AbdirizakIdris @joshuapook-MT 