### PR TITLE
PP-15645 Make AdyenAuthoriseRequest handle AdyenAuthoriseRequest

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseRequestToGatewayOrderConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseRequestToGatewayOrderConverter.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.gateway.adyen;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.ApplePayAuthoriseRequest;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import static uk.gov.pay.connector.gateway.model.OrderRequestType.AUTHORISE;
+import static uk.gov.pay.connector.gateway.model.OrderRequestType.AUTHORISE_APPLE_PAY;
+
+public class AdyenAuthoriseRequestToGatewayOrderConverter {
+
+    private final JsonObjectMapper jsonObjectMapper;
+
+    @Inject
+    public AdyenAuthoriseRequestToGatewayOrderConverter(JsonObjectMapper jsonObjectMapper) {
+        this.jsonObjectMapper = jsonObjectMapper;
+    }
+
+    public GatewayOrder convert(AdyenAuthoriseRequest adyenAuthoriseRequest) {
+        String json = jsonObjectMapper.objectToString(adyenAuthoriseRequest);
+        OrderRequestType orderRequestType = adyenAuthoriseRequest instanceof ApplePayAuthoriseRequest
+                ? AUTHORISE_APPLE_PAY : AUTHORISE;
+        return new GatewayOrder(orderRequestType, json, MediaType.APPLICATION_JSON_TYPE);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
@@ -59,10 +59,11 @@ public class AdyenPaymentProvider implements PaymentProvider {
             Environment environment,
             GatewayClientFactory gatewayClientFactory,
             @Named("DefaultRefundEntityFactory") RefundEntityFactory refundEntityFactory,
+            AdyenAuthoriseRequestToGatewayOrderConverter adyenAuthoriseRequestToGatewayOrderConverter,
             JsonObjectMapper jsonObjectMapper) {
         AdyenGatewayConfig adyenGatewayConfig = connectorConfiguration.getAdyenGatewayConfig();
         GatewayClient client = gatewayClientFactory.createGatewayClient(ADYEN, environment.metrics());
-        adyenAuthoriseHandler = new AdyenAuthoriseHandler(client, connectorConfiguration, jsonObjectMapper);
+        adyenAuthoriseHandler = new AdyenAuthoriseHandler(client, connectorConfiguration, adyenAuthoriseRequestToGatewayOrderConverter, jsonObjectMapper);
         adyenAuthorise3dsHandler = new AdyenAuthorise3dsHandler(client, connectorConfiguration, jsonObjectMapper);
         adyenCaptureHandler = new AdyenCaptureHandler(client, connectorConfiguration, jsonObjectMapper);
         adyenCancelHandler = new AdyenCancelHandler(client, adyenGatewayConfig, new AdyenRequestFactory(connectorConfiguration), jsonObjectMapper);

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandler.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.adyen.AdyenAuthoriseRequestToGatewayOrderConverter;
 import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.AuthoriseRequestPayloadToGatewayOrderConverter;
 import uk.gov.pay.connector.gateway.adyen.request.AdyenAuthorisationRequest;
@@ -15,8 +16,11 @@ import uk.gov.pay.connector.gateway.adyen.response.AdyenAuthoriseResponse;
 import uk.gov.pay.connector.gateway.adyen.response.json.AuthoriseResponseBody;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil.getAuthUrl;
@@ -31,26 +35,25 @@ public class AdyenAuthoriseHandler {
     private final AdyenGatewayConfig adyenGatewayConfig;
     private final AdyenRequestFactory adyenRequestFactory;
     private final AuthoriseRequestPayloadToGatewayOrderConverter authoriseRequestPayloadToGatewayOrderConverter;
+    private final AdyenAuthoriseRequestToGatewayOrderConverter adyenAuthoriseRequestToGatewayOrderConverter;
     private final JsonObjectMapper jsonObjectMapper;
 
     public AdyenAuthoriseHandler(GatewayClient gatewayClient,
                                  ConnectorConfiguration connectorConfig,
+                                 AdyenAuthoriseRequestToGatewayOrderConverter adyenAuthoriseRequestToGatewayOrderConverter,
                                  JsonObjectMapper jsonObjectMapper) {
         this.gatewayClient = gatewayClient;
         this.adyenGatewayConfig = connectorConfig.getAdyenGatewayConfig();
         this.jsonObjectMapper = jsonObjectMapper;
         this.adyenRequestFactory = new AdyenRequestFactory(connectorConfig);
         this.authoriseRequestPayloadToGatewayOrderConverter = new AuthoriseRequestPayloadToGatewayOrderConverter(jsonObjectMapper);
+        this.adyenAuthoriseRequestToGatewayOrderConverter = adyenAuthoriseRequestToGatewayOrderConverter;
     }
-    
-    public GatewayResponse authorise(CardAuthorisationGatewayRequest request) throws
+
+    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) throws
             GatewayException.GatewayErrorException,
             GatewayException.GenericGatewayException,
             GatewayException.GatewayConnectionTimeoutException {
-
-        GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse
-                .GatewayResponseBuilder
-                .responseBuilder();
 
         AuthoriseRequestPayload authoriseRequestPayload = adyenRequestFactory.createPaymentRequest(request);
         GatewayOrder gatewayOrder = authoriseRequestPayloadToGatewayOrderConverter.convert(authoriseRequestPayload);
@@ -61,27 +64,31 @@ public class AdyenAuthoriseHandler {
                 request.getGatewayAccount().getType(),
                 gatewayOrder);
 
-        logger.info("Calling Adyen for authorisation of charge");
-        try {
-            var jsonResponse = gatewayClient.postRequestFor(authorisationRequest).getEntity();
-            var paymentResponse = jsonObjectMapper.getObject(
-                    jsonResponse,
-                    AuthoriseResponseBody.class);
+        return sendRequestToAdyen(authorisationRequest, false);
+    }
 
-            return responseBuilder
-                    .withResponse(AdyenAuthoriseResponse.of(paymentResponse))
-                    .build();
-        } catch (GatewayException e) {
-            logger.error("GatewayException occurred when authorising payment", e);
-            return responseBuilder.withGatewayError(e.toGatewayError()).build();
-        }
+    public GatewayResponse<BaseAuthoriseResponse> authorise(AdyenAuthoriseRequest request, GatewayAccountType gatewayAccountType) throws
+            GatewayException.GatewayErrorException,
+            GatewayException.GenericGatewayException,
+            GatewayException.GatewayConnectionTimeoutException {
+
+        GatewayOrder gatewayOrder = adyenAuthoriseRequestToGatewayOrderConverter.convert(request);
+
+        boolean isLive = switch (gatewayAccountType) {
+            case LIVE -> true;
+            case TEST -> false;
+        };
+
+        var authorisationRequest = new AdyenAuthorisationRequest(
+                getAuthUrl(adyenGatewayConfig, isLive),
+                getHeaders(adyenGatewayConfig, isLive, AUTHORISE, request.reference()),
+                gatewayAccountType.toString(),
+                gatewayOrder);
+
+        return sendRequestToAdyen(authorisationRequest, false);
     }
     
-    public GatewayResponse authoriseUserNotPresent(RecurringPaymentAuthorisationGatewayRequest request) {
-        GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse
-                .GatewayResponseBuilder
-                .responseBuilder();
-
+    public GatewayResponse<BaseAuthoriseResponse> authoriseUserNotPresent(RecurringPaymentAuthorisationGatewayRequest request) {
         AuthoriseRequestPayload authoriseRequestPayload = adyenRequestFactory.createRecurringPaymentRequest(request);
         GatewayOrder gatewayOrder = authoriseRequestPayloadToGatewayOrderConverter.convert(authoriseRequestPayload);
 
@@ -91,7 +98,17 @@ public class AdyenAuthoriseHandler {
                 request.getGatewayAccount().getType(),
                 gatewayOrder);
 
-        logger.info("Calling Adyen for user-not-present authorisation of charge");
+        return sendRequestToAdyen(authorisationRequest, true);
+    }
+
+    private GatewayResponse sendRequestToAdyen(AdyenAuthorisationRequest authorisationRequest, boolean userNotPresent) {
+        String extraLog =  userNotPresent ? "user-not-present " : "";
+
+        GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse
+                .GatewayResponseBuilder
+                .responseBuilder();
+
+        logger.info("Calling Adyen for " + extraLog + "authorisation of charge");
         try {
             var jsonResponse = gatewayClient.postRequestFor(authorisationRequest).getEntity();
             var paymentResponse = jsonObjectMapper.getObject(
@@ -102,7 +119,7 @@ public class AdyenAuthoriseHandler {
                     .withResponse(AdyenAuthoriseResponse.of(paymentResponse))
                     .build();
         } catch (GatewayException e) {
-            logger.error("GatewayException occurred when authorising user not present payment", e);
+            logger.error("GatewayException occurred when authorising " + extraLog + "payment", e);
             return responseBuilder.withGatewayError(e.toGatewayError()).build();
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenRequestUtil.java
@@ -21,34 +21,38 @@ public class AdyenRequestUtil {
     }
 
     public static URI getAuthUrl(AdyenGatewayConfig config, GatewayRequest request) {
-        return getUrl(config, request, "/payments");
+        return getUrl(config, request.getGatewayAccount().isLive(), "/payments");
+    }
+
+    public static URI getAuthUrl(AdyenGatewayConfig config, boolean isLive) {
+        return getUrl(config, isLive, "/payments");
     }
 
     public static URI get3dsAuthUrl(AdyenGatewayConfig config, Auth3dsResponseGatewayRequest request) {
-        return getUrl(config, request, "/payments/details");
+        return getUrl(config, request.getGatewayAccount().isLive(), "/payments/details");
     }
 
     public static URI getRefundUrl(AdyenGatewayConfig config, RefundGatewayRequest request) {
         var path = "/payments/%s/refunds".formatted(request.getTransactionId());
-        return getUrl(config, request, path);
+        return getUrl(config, request.getGatewayAccount().isLive(), path);
     }
 
     public static URI getCancelUrl(AdyenGatewayConfig config, CancelGatewayRequest request) {
         var path = "/payments/%s/cancels".formatted(request.getTransactionId());
-        return getUrl(config, request, path);
+        return getUrl(config, request.getGatewayAccount().isLive(), path);
     }
 
     public static URI getCaptureUrl(AdyenGatewayConfig config, CaptureGatewayRequest request) {
         var path = "/payments/%s/captures".formatted(request.getGatewayTransactionId());
-        return getUrl(config, request, path);
+        return getUrl(config, request.getGatewayAccount().isLive(), path);
     }
     
     public static URI getDeleteStoredPaymentMethodUrl(AdyenGatewayConfig config, boolean isLive, String storedPaymentMethodId) {
         return URI.create(getBaseCheckoutUrl(config, isLive) + "/storedPaymentMethods/" + storedPaymentMethodId);
     }
 
-    private static URI getUrl(AdyenGatewayConfig config, GatewayRequest request, String path) {
-        return URI.create(getBaseCheckoutUrl(config, request.getGatewayAccount().isLive()) + path);
+    private static URI getUrl(AdyenGatewayConfig config, boolean isLive, String path) {
+        return URI.create(getBaseCheckoutUrl(config, isLive) + path);
     }
 
     public static Map<String, String> getHeaders(AdyenGatewayConfig config, boolean isLive, OrderRequestType requestType, String idempotencyKey) {

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AdyenAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AdyenAuthoriseRequest.java
@@ -2,4 +2,7 @@ package uk.gov.pay.connector.gateway.model.request.records;
 
 public sealed interface AdyenAuthoriseRequest extends AdyenRequest, AuthoriseRequest
         permits AdyenApplePayAuthoriseRequest {
+
+    String reference();
+
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseRequestToGatewayOrderConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseRequestToGatewayOrderConverterTest.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.connector.gateway.adyen;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonassert.JsonAssert;
+import jakarta.ws.rs.core.MediaType;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.adyen.request.json.AdyenApplePayPaymentMethod;
+import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequest;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class AdyenAuthoriseRequestToGatewayOrderConverterTest {
+
+    private static final String MERCHANT_ACCOUNT = "merchant_account";
+    private static final String STORE = "store";
+    private static final String REFERENCE = "reference";
+    private static final String AMOUNT_CURRENCY = "GBP";
+    private static final long AMOUNT_VALUE = 232_87L;
+    private static final String APPLE_PAY_TOKEN = "apple_pay_token";
+    private static final String RETURN_URL = "https://return_url.test/";
+
+    private final AdyenAuthoriseRequestToGatewayOrderConverter adyenAuthoriseRequestToGatewayOrderConverter = 
+            new AdyenAuthoriseRequestToGatewayOrderConverter(new JsonObjectMapper(new ObjectMapper()));
+
+    @Test
+    void convertsAdyenApplePayAuthoriseRequest() {
+        var request = new AdyenApplePayAuthoriseRequest(
+                MERCHANT_ACCOUNT,
+                STORE,
+                REFERENCE,
+                new Amount(AMOUNT_CURRENCY, AMOUNT_VALUE),
+                new AdyenApplePayPaymentMethod(APPLE_PAY_TOKEN),
+                RETURN_URL);
+
+        GatewayOrder gatewayOrder = adyenAuthoriseRequestToGatewayOrderConverter.convert(request);
+
+        assertThat(gatewayOrder.getOrderRequestType(), is(OrderRequestType.AUTHORISE_APPLE_PAY));
+        assertThat(gatewayOrder.getMediaType(), is(MediaType.APPLICATION_JSON_TYPE));
+        JsonAssert.with(gatewayOrder.getPayload())
+                .assertThat("$.merchantAccount", Matchers.is(MERCHANT_ACCOUNT))
+                .assertThat("$.store", Matchers.is(STORE))
+                .assertThat("$.reference", Matchers.is(REFERENCE))
+                .assertThat("$.amount.currency", Matchers.is(AMOUNT_CURRENCY))
+                .assertThat("$.amount.value", Matchers.is((int) AMOUNT_VALUE))
+                .assertThat("$.paymentMethod.applePayToken", Matchers.is(APPLE_PAY_TOKEN))
+                .assertThat("$.paymentMethod.type", Matchers.is("applepay"))
+                .assertThat("$.returnUrl", Matchers.is(RETURN_URL));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProviderTest.java
@@ -46,6 +46,8 @@ class AdyenPaymentProviderTest {
     @Mock
     private MetricRegistry metricRegistry;
     @Mock
+    private AdyenAuthoriseRequestToGatewayOrderConverter adyenAuthoriseRequestToGatewayOrderConverter;
+    @Mock
     JsonObjectMapper jsonObjectMapper;
 
     @BeforeEach
@@ -54,7 +56,8 @@ class AdyenPaymentProviderTest {
         when(gatewayClientFactory.createGatewayClient(eq(ADYEN), any(MetricRegistry.class))).thenReturn(gatewayClient);
         when(environment.metrics()).thenReturn(metricRegistry);
 
-        this.provider = new AdyenPaymentProvider(configuration, environment, gatewayClientFactory, refundEntityFactory, jsonObjectMapper);
+        this.provider = new AdyenPaymentProvider(configuration, environment, gatewayClientFactory, refundEntityFactory,
+                adyenAuthoriseRequestToGatewayOrderConverter, jsonObjectMapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
@@ -23,11 +23,15 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.adyen.AdyenAuthoriseRequestToGatewayOrderConverter;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequestFixture;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
@@ -40,6 +44,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -71,8 +76,15 @@ class AdyenAuthoriseHandlerTest {
     private GatewayClient mockClient;
     @Mock
     private ConnectorConfiguration mockConfig;
+    @Mock
+    private AdyenGatewayConfig mockAdyenGatewayConfig;
+
     private final JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(new ObjectMapper());
+    private final AdyenAuthoriseRequestToGatewayOrderConverter adyenAuthoriseRequestToGatewayOrderConverter =
+            new AdyenAuthoriseRequestToGatewayOrderConverter(jsonObjectMapper);
+
     private AdyenAuthoriseHandler authoriseHandler;
+ 
     @Mock
     private GatewayClient.Response mockGatewayClientResponse;
 
@@ -83,12 +95,8 @@ class AdyenAuthoriseHandlerTest {
 
     @BeforeEach
     void setUp() {
-        when(mockConfig.getLinks()).thenReturn(new LinksConfig());
-
         BaseUrls mockBaseUrls = mock(BaseUrls.class);
         when(mockBaseUrls.checkout()).thenReturn(new BaseUrls.CheckoutUrls(TEST_ADYEN_CHECKOUT_BASE_URL, LIVE_ADYEN_CHECKOUT_BASE_URL));
-        AdyenGatewayConfig mockAdyenGatewayConfig = mock(AdyenGatewayConfig.class);
-        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
         when(mockAdyenGatewayConfig.getBaseUrls()).thenReturn(mockBaseUrls);
 
         ApiKeys mockApiKeys = mock(ApiKeys.class);
@@ -98,11 +106,14 @@ class AdyenAuthoriseHandlerTest {
         when(mockAdyenGatewayConfig.getApiKeys()).thenReturn(mockApiKeys);
         when(mockConfig.getAdyenGatewayConfig()).thenReturn(mockAdyenGatewayConfig);
 
-        authoriseHandler = new AdyenAuthoriseHandler(mockClient, mockConfig, jsonObjectMapper);
+        authoriseHandler = new AdyenAuthoriseHandler(mockClient, mockConfig,
+                adyenAuthoriseRequestToGatewayOrderConverter, jsonObjectMapper);
     }
 
     @Test
     void should_send_request_to_Adyen_with_api_key_and_idempotency_key_headers() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockConfig.getLinks()).thenReturn(new LinksConfig());
+        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
         givenAdyenReturnsASuccessResponse();
 
         var authoriseRequest = aCardAuthorisationGatewayRequest()
@@ -121,6 +132,8 @@ class AdyenAuthoriseHandlerTest {
 
     @Test
     void should_send_request_to_Adyen_with_full_billing_address() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockConfig.getLinks()).thenReturn(new LinksConfig());
+        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
         givenAdyenReturnsASuccessResponse();
 
         var authoriseRequest = aCardAuthorisationGatewayRequest()
@@ -142,6 +155,8 @@ class AdyenAuthoriseHandlerTest {
 
     @Test
     void should_send_request_to_Adyen_with_no_billing_address() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockConfig.getLinks()).thenReturn(new LinksConfig());
+        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
         givenAdyenReturnsASuccessResponse();
 
         var authoriseRequest = aCardAuthorisationGatewayRequest()
@@ -159,6 +174,8 @@ class AdyenAuthoriseHandlerTest {
 
     @Test
     void should_send_request_to_Adyen_with_partial_billing_address() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockConfig.getLinks()).thenReturn(new LinksConfig());
+        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
         givenAdyenReturnsASuccessResponse();
 
         var partialBillingAddress = new Address();
@@ -181,6 +198,8 @@ class AdyenAuthoriseHandlerTest {
 
     @Test
     void should_log_when_calling_Adyen_authorisation_of_charge() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockConfig.getLinks()).thenReturn(new LinksConfig());
+        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
         givenAdyenReturnsASuccessResponse();
         var request = aCardAuthorisationGatewayRequest()
                 .withCredentials(ADYEN_CREDENTIALS)
@@ -193,6 +212,8 @@ class AdyenAuthoriseHandlerTest {
 
     @Test
     void should_return_a_GatewayResponse_for_successful_Authorisation() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockConfig.getLinks()).thenReturn(new LinksConfig());
+        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
         givenAdyenReturnsASuccessResponse();
 
         var authoriseRequest = aCardAuthorisationGatewayRequest()
@@ -210,6 +231,8 @@ class AdyenAuthoriseHandlerTest {
 
     @Test
     void should_not_authorise_when_payment_provider_returns_unexpected_status_code() throws Exception {
+        when(mockConfig.getLinks()).thenReturn(new LinksConfig());
+        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
         givenAdyenReturnsAnUnexpectedResponse();
         var authoriseRequest = aCardAuthorisationGatewayRequest()
                 .withAuthCardDetails(anAuthCardDetails()
@@ -228,6 +251,8 @@ class AdyenAuthoriseHandlerTest {
 
     @Test
     void should_send_request_to_Adyen_for_user_not_present_recurring_payment() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        when(mockConfig.getLinks()).thenReturn(new LinksConfig());
+        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
         givenAdyenReturnsASuccessResponse();
 
         var agreementId = "some-agreement-id";
@@ -259,6 +284,8 @@ class AdyenAuthoriseHandlerTest {
 
     @Test
     void should_return_gateway_error_for_recurring_payment_when_adyen_returns_unexpected_status_code() throws Exception {
+        when(mockConfig.getLinks()).thenReturn(new LinksConfig());
+        when(mockAdyenGatewayConfig.getMerchantAccountIds()).thenReturn(new AdyenIds("test", "live"));
         givenAdyenReturnsAnUnexpectedResponse();
         var agreementId = "some-agreement-id";
         var agreement = anAgreementEntity()
@@ -280,7 +307,23 @@ class AdyenAuthoriseHandlerTest {
                 containsString("server error"));
         assertThat(response.getGatewayError().get().getErrorType(), Is.is(GATEWAY_ERROR));
 
-        logger.assertContains("GatewayException occurred when authorising user not present payment");
+        logger.assertContains("GatewayException occurred when authorising user-not-present payment");
+    }
+
+    @Test
+    void should_return_a_GatewayResponse_for_successful_AydenAuthoriseRequest_authorisation() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        givenAdyenReturnsASuccessResponse();
+ 
+        AdyenAuthoriseRequest adyenAuthoriseRequest = AdyenApplePayAuthoriseRequestFixture.anAdyenApplePayAuthoriseRequestFixture().build();
+
+        GatewayResponse<BaseAuthoriseResponse> response = authoriseHandler.authorise(adyenAuthoriseRequest, GatewayAccountType.TEST);
+
+        then(mockClient).should().postRequestFor(captor.capture());
+        String payload = captor.getValue().getGatewayOrder().getPayload();
+        JsonAssert.with(payload).assertThat("$.reference", notNullValue());
+        assertThat(response.getBaseResponse().isPresent(), is(true));
+        assertThat(response.getBaseResponse().get(), hasProperty("transactionId", equalTo("adyen-PSP-reference")));
+        assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
     }
 
     private static ChargeEntity setupChargeEntityForRecurringPayment(AgreementEntity agreement, PaymentInstrumentEntity paymentInstrument) {


### PR DESCRIPTION
Add a new `authorise(…)` method to `AdyenAuthoriseRequest` that takes an `AdyenAuthoriseRequest` record, such as
`AdyenApplePayAuthoriseRequest`.

Introduce `AdyenAuthoriseRequestToGatewayOrderConverter` to convert an `AdyenAuthoriseRequest` to a `GatewayOrder.`

Move repeated code in `AdyenAuthoriseHandler` to private method.