### PR TITLE
PP-15645 Convert GatewayOrder to record

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -76,7 +76,7 @@ public class GatewayClient {
                                    Map<String, String> headers)
             throws GenericGatewayException, GatewayConnectionTimeoutException, GatewayErrorException {
 
-        String metricsPrefix = format("gateway-operations.%s.%s.%s", gatewayName.getName(), gatewayAccountType, request.getOrderRequestType());
+        String metricsPrefix = format("gateway-operations.%s.%s.%s", gatewayName.getName(), gatewayAccountType, request.orderRequestType());
 
         Supplier<jakarta.ws.rs.core.Response> requestCallable = () -> {
             LOGGER.info("POSTing request for account '{}' with type '{}'", gatewayName.getName(), gatewayAccountType);
@@ -84,9 +84,9 @@ public class GatewayClient {
             Builder requestBuilder = client.target(url).request();
             headers.keySet().forEach(headerKey -> requestBuilder.header(headerKey, headers.get(headerKey)));
             cookies.forEach(cookie -> requestBuilder.header("Cookie", cookie.getName() + "=" + cookie.getValue()));
-            return requestBuilder.post(Entity.entity(request.getPayload(), request.getMediaType()));
+            return requestBuilder.post(Entity.entity(request.payload(), request.mediaType()));
         };
-        return executeRequest(url, gatewayName, gatewayAccountType, request.getOrderRequestType(), metricsPrefix, requestCallable);
+        return executeRequest(url, gatewayName, gatewayAccountType, request.orderRequestType(), metricsPrefix, requestCallable);
     }
 
     public Response getRequestFor(GatewayClientGetRequest request)

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayOrder.java
@@ -3,46 +3,12 @@ package uk.gov.pay.connector.gateway;
 import jakarta.ws.rs.core.MediaType;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
-import java.util.Objects;
-
-public class GatewayOrder {
-
-    private OrderRequestType orderRequestType;
-    private String payload;
-    private MediaType mediaType;
-
-    public GatewayOrder(OrderRequestType orderRequestType, String payload, MediaType mediaType) {
-        this.orderRequestType = orderRequestType;
-        this.payload = payload;
-        this.mediaType = mediaType;
-    }
-
-    public OrderRequestType getOrderRequestType() {
-        return orderRequestType;
-    }
-
-    public String getPayload() {
-        return payload;
-    }
-
-    public MediaType getMediaType() {
-        return mediaType;
-    }
+public record GatewayOrder(OrderRequestType orderRequestType, String payload, MediaType mediaType) {
 
     @Override
-    public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        GatewayOrder that = (GatewayOrder) o;
-        return orderRequestType == that.orderRequestType
-                && Objects.equals(payload, that.payload)
-                && Objects.equals(mediaType, that.mediaType);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(orderRequestType, payload, mediaType);
+    public String toString() {
+        return getClass().getSimpleName() + "[orderRequestType=" + orderRequestType + ", payload=redacted"
+                + ", mediaType=" + mediaType + ']';
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseRequestToGatewayOrderConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenAuthoriseRequestToGatewayOrderConverterTest.java
@@ -40,9 +40,9 @@ class AdyenAuthoriseRequestToGatewayOrderConverterTest {
 
         GatewayOrder gatewayOrder = adyenAuthoriseRequestToGatewayOrderConverter.convert(request);
 
-        assertThat(gatewayOrder.getOrderRequestType(), is(OrderRequestType.AUTHORISE_APPLE_PAY));
-        assertThat(gatewayOrder.getMediaType(), is(MediaType.APPLICATION_JSON_TYPE));
-        JsonAssert.with(gatewayOrder.getPayload())
+        assertThat(gatewayOrder.orderRequestType(), is(OrderRequestType.AUTHORISE_APPLE_PAY));
+        assertThat(gatewayOrder.mediaType(), is(MediaType.APPLICATION_JSON_TYPE));
+        JsonAssert.with(gatewayOrder.payload())
                 .assertThat("$.merchantAccount", Matchers.is(MERCHANT_ACCOUNT))
                 .assertThat("$.store", Matchers.is(STORE))
                 .assertThat("$.reference", Matchers.is(REFERENCE))

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AuthoriseRequestPayloadToGatewayOrderConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AuthoriseRequestPayloadToGatewayOrderConverterTest.java
@@ -30,9 +30,9 @@ class AuthoriseRequestPayloadToGatewayOrderConverterTest {
     void shouldCreateGatewayOrder_withSerialisedPayload() {
         GatewayOrder gatewayOrder = factory.convert(makePaymentRequestWithFullBillingAddress());
 
-        assertThat(gatewayOrder.getOrderRequestType(), is(AUTHORISE));
-        assertThat(gatewayOrder.getMediaType(), is(APPLICATION_JSON_TYPE));
-        JsonAssert.with(gatewayOrder.getPayload())
+        assertThat(gatewayOrder.orderRequestType(), is(AUTHORISE));
+        assertThat(gatewayOrder.mediaType(), is(APPLICATION_JSON_TYPE));
+        JsonAssert.with(gatewayOrder.payload())
                 .assertThat("$.amount.value", is(1000))
                 .assertThat("$.amount.currency", is("GBP"))
                 .assertThat("$.billingAddress.houseNumberOrName", is("houseNumberOrName"))

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandlerTest.java
@@ -91,7 +91,7 @@ class AdyenAuthorise3dsHandlerTest {
 
         then(mockClient).should().postRequestFor(captor.capture());
         assertThat(captor.getValue().getUrl().toString(), is("https://example.com/test/someVersion/payments/details"));
-        JsonAssert.with(captor.getValue().getGatewayOrder().getPayload())
+        JsonAssert.with(captor.getValue().getGatewayOrder().payload())
                 .assertThat("$.details.redirectResult", equalTo("eyJ0cmFuc1N0YXR1cyI6IlkifQ=="));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
@@ -145,7 +145,7 @@ class AdyenAuthoriseHandlerTest {
         authoriseHandler.authorise(authoriseRequest);
 
         then(mockClient).should().postRequestFor(captor.capture());
-        String payload = captor.getValue().getGatewayOrder().getPayload();
+        String payload = captor.getValue().getGatewayOrder().payload();
         JsonAssert.with(payload).assertThat("$.billingAddress.houseNumberOrName", is("line1"));
         JsonAssert.with(payload).assertThat("$.billingAddress.street", is("line2"));
         JsonAssert.with(payload).assertThat("$.billingAddress.city", is("city"));
@@ -168,7 +168,7 @@ class AdyenAuthoriseHandlerTest {
         authoriseHandler.authorise(authoriseRequest);
 
         then(mockClient).should().postRequestFor(captor.capture());
-        String payload = captor.getValue().getGatewayOrder().getPayload();
+        String payload = captor.getValue().getGatewayOrder().payload();
         JsonAssert.with(payload).assertNotDefined("$.billingAddress");
     }
 
@@ -189,7 +189,7 @@ class AdyenAuthoriseHandlerTest {
         authoriseHandler.authorise(authoriseRequest);
 
         then(mockClient).should().postRequestFor(captor.capture());
-        String payload = captor.getValue().getGatewayOrder().getPayload();
+        String payload = captor.getValue().getGatewayOrder().payload();
         JsonAssert.with(payload).assertEquals("$.billingAddress.houseNumberOrName", partialBillingAddress.getLine1());
         JsonAssert.with(payload).assertNotDefined("$.billingAddress.city");
         JsonAssert.with(payload).assertNotDefined("$.billingAddress.country");
@@ -275,7 +275,7 @@ class AdyenAuthoriseHandlerTest {
         assertThat(headers, hasEntry("X-API-Key", TEST_API_KEY));
         assertThat(headers, hasEntry("Idempotency-Key", "authorise-" + authoriseRequest.getGovUkPayPaymentId()));
 
-        String payload = captor.getValue().getGatewayOrder().getPayload();
+        String payload = captor.getValue().getGatewayOrder().payload();
         assertThat(payload, hasNoJsonPath("$.billingAddress.houseNumberOrName"));
         JsonAssert.with(payload).assertThat("$.paymentMethod.storedPaymentMethodId", is(storedPaymentMethodId));
         JsonAssert.with(payload).assertThat("$.paymentMethod.type", is("scheme"));
@@ -319,7 +319,7 @@ class AdyenAuthoriseHandlerTest {
         GatewayResponse<BaseAuthoriseResponse> response = authoriseHandler.authorise(adyenAuthoriseRequest, GatewayAccountType.TEST);
 
         then(mockClient).should().postRequestFor(captor.capture());
-        String payload = captor.getValue().getGatewayOrder().getPayload();
+        String payload = captor.getValue().getGatewayOrder().payload();
         JsonAssert.with(payload).assertThat("$.reference", notNullValue());
         assertThat(response.getBaseResponse().isPresent(), is(true));
         assertThat(response.getBaseResponse().get(), hasProperty("transactionId", equalTo("adyen-PSP-reference")));

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCancelHandlerTest.java
@@ -159,7 +159,7 @@ class AdyenCancelHandlerTest {
                 .postRequestFor(captor.capture());
         var gatewayOrderPayload = captor.getValue()
                 .getGatewayOrder()
-                .getPayload();
+                .payload();
         JsonAssert.with(gatewayOrderPayload)
                 .assertEquals("reference", AN_EXTERNAL_ID)
                 .assertEquals("merchantAccount", A_MERCHANT_ACCOUNT_ID);

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenCaptureHandlerTest.java
@@ -24,8 +24,8 @@ import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
@@ -75,7 +75,7 @@ class AdyenCaptureHandlerTest {
         captureHandler.capture(captureRequest);
 
         then(mockClient).should().postRequestFor(captor.capture());
-        String payload = captor.getValue().getGatewayOrder().getPayload();
+        String payload = captor.getValue().getGatewayOrder().payload();
         JsonAssert.with(payload).assertThat("$.merchantAccount", is("test"));
         JsonAssert.with(payload).assertThat("$.amount.value", is(500));
         JsonAssert.with(payload).assertThat("$.amount.currency", is("GBP"));
@@ -90,7 +90,7 @@ class AdyenCaptureHandlerTest {
         captureHandler.capture(captureRequest);
 
         then(mockClient).should().postRequestFor(captor.capture());
-        String payload = captor.getValue().getGatewayOrder().getPayload();
+        String payload = captor.getValue().getGatewayOrder().payload();
         JsonAssert.with(payload).assertThat("$.merchantAccount", is("test"));
         JsonAssert.with(payload).assertThat("$.amount.value", is(500));
         JsonAssert.with(payload).assertThat("$.amount.currency", is("GBP"));

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenRefundHandlerTest.java
@@ -124,7 +124,7 @@ class AdyenRefundHandlerTest {
         refundHandler.refund(buildRefundGatewayRequest(1000L));
 
         then(mockClient).should().postRequestFor(captor.capture());
-        String payload = captor.getValue().getGatewayOrder().getPayload();
+        String payload = captor.getValue().getGatewayOrder().payload();
         JsonAssert.with(payload)
                 .assertThat("$.merchantAccount", is(TEST_MERCHANT_ACCOUNT))
                 .assertThat("$.amount.value", is(1000))
@@ -155,7 +155,7 @@ class AdyenRefundHandlerTest {
         refundHandler.refund(buildRefundGatewayRequest(100L));
 
         then(mockClient).should().postRequestFor(captor.capture());
-        String payload = captor.getValue().getGatewayOrder().getPayload();
+        String payload = captor.getValue().getGatewayOrder().payload();
         JsonAssert.with(payload)
                 .assertThat("$.merchantAccount", is(TEST_MERCHANT_ACCOUNT))
                 .assertThat("$.amount.value", is(100))

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/request/Adyen3dsAuthorisationRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/request/Adyen3dsAuthorisationRequestTest.java
@@ -39,10 +39,10 @@ class Adyen3dsAuthorisationRequestTest {
         assertEquals(ADYEN, request.getPaymentProvider());
 
         GatewayOrder gatewayOrder = request.getGatewayOrder();
-        assertEquals(AUTHORISE_3DS, gatewayOrder.getOrderRequestType());
-        assertEquals(APPLICATION_JSON_TYPE, gatewayOrder.getMediaType());
+        assertEquals(AUTHORISE_3DS, gatewayOrder.orderRequestType());
+        assertEquals(APPLICATION_JSON_TYPE, gatewayOrder.mediaType());
 
         String expectedPayload = jsonObjectMapper.objectToString(payload);
-        assertEquals(expectedPayload, gatewayOrder.getPayload());
+        assertEquals(expectedPayload, gatewayOrder.payload());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCancelRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCancelRequestTest.java
@@ -50,18 +50,18 @@ class AdyenCancelRequestTest {
 
     @Test
     void should_return_CANCEL_type_gateway_order() {
-        assertThat(request.getGatewayOrder().getOrderRequestType(), is(CANCEL));
+        assertThat(request.getGatewayOrder().orderRequestType(), is(CANCEL));
     }
 
     @Test
     void should_return_gateway_order_with_serialised_PaymentCancelRequest_payload() {
-        JsonAssert.with(request.getGatewayOrder().getPayload())
+        JsonAssert.with(request.getGatewayOrder().payload())
                 .assertEquals("reference", REFERENCE)
                 .assertEquals("merchantAccount", MERCHANT_ACCOUNT);
     }
 
     @Test
     void should_return_gateway_order_with_JSON_media_type() {
-        assertThat(request.getGatewayOrder().getMediaType(), is(MediaType.APPLICATION_JSON_TYPE));
+        assertThat(request.getGatewayOrder().mediaType(), is(MediaType.APPLICATION_JSON_TYPE));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCaptureRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenCaptureRequestTest.java
@@ -31,9 +31,9 @@ class AdyenCaptureRequestTest {
     void should_create_GatewayOrder_with_serialised_payload() {
         var request = buildValidCaptureRequest();
 
-        assertThat(request.getGatewayOrder().getOrderRequestType(), is(CAPTURE));
-        assertThat(request.getGatewayOrder().getMediaType(), is(APPLICATION_JSON_TYPE));
-        JsonAssert.with(request.getGatewayOrder().getPayload())
+        assertThat(request.getGatewayOrder().orderRequestType(), is(CAPTURE));
+        assertThat(request.getGatewayOrder().mediaType(), is(APPLICATION_JSON_TYPE));
+        JsonAssert.with(request.getGatewayOrder().payload())
                 .assertThat("$.amount.value", is(500))
                 .assertThat("$.amount.currency", is("GBP"))
                 .assertThat("$.merchantAccount", is(MERCHANT_ID));

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenRefundRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/request/AdyenRefundRequestTest.java
@@ -46,9 +46,9 @@ class AdyenRefundRequestTest {
     void should_return_gateway_order_with_serialised_payload() {
         var request = buildValidRefundRequest();
 
-        assertThat(request.getGatewayOrder().getOrderRequestType(), is(REFUND));
-        assertThat(request.getGatewayOrder().getMediaType(), is(APPLICATION_JSON_TYPE));
-        JsonAssert.with(request.getGatewayOrder().getPayload())
+        assertThat(request.getGatewayOrder().orderRequestType(), is(REFUND));
+        assertThat(request.getGatewayOrder().mediaType(), is(APPLICATION_JSON_TYPE));
+        JsonAssert.with(request.getGatewayOrder().payload())
                 .assertThat("$.merchantAccount", is(MERCHANT_ID))
                 .assertThat("$.reference", is(REFUND_EXTERNAL_ID))
                 .assertThat("$.amount.value", is(500))

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -127,7 +127,7 @@ class StripeCaptureHandlerTest {
         verify(gatewayClient).postRequestFor(transferRequestCaptor.capture());
         ArgumentCaptor<StripePaymentIntentCaptureRequest> captureRequestCaptor = ArgumentCaptor.forClass(StripePaymentIntentCaptureRequest.class);
         verify(gatewayClient).postRequestFor(captureRequestCaptor.capture());
-        assertThat(transferRequestCaptor.getValue().getGatewayOrder().getPayload(), containsString("amount=9937"));
+        assertThat(transferRequestCaptor.getValue().getGatewayOrder().payload(), containsString("amount=9937"));
 
         assertTrue(captureResponse.isSuccessful());
         assertThat(captureResponse.state(), is(CaptureResponse.ChargeState.COMPLETE));
@@ -364,7 +364,7 @@ class StripeCaptureHandlerTest {
         ArgumentCaptor<StripePaymentIntentCaptureRequest> captureRequestCaptor = ArgumentCaptor.forClass(StripePaymentIntentCaptureRequest.class);
         verify(gatewayClient).postRequestFor(captureRequestCaptor.capture());
 
-        assertThat(transferRequestCaptor.getValue().getGatewayOrder().getPayload(), containsString("amount=9885"));
+        assertThat(transferRequestCaptor.getValue().getGatewayOrder().payload(), containsString("amount=9885"));
 
         assertTrue(captureResponse.isSuccessful());
 
@@ -408,7 +408,7 @@ class StripeCaptureHandlerTest {
         ArgumentCaptor<StripePaymentIntentCaptureRequest> captureRequestCaptor = ArgumentCaptor.forClass(StripePaymentIntentCaptureRequest.class);
         verify(gatewayClient).postRequestFor(captureRequestCaptor.capture());
 
-        assertThat(transferRequestCaptor.getValue().getGatewayOrder().getPayload(), containsString("amount=9895"));
+        assertThat(transferRequestCaptor.getValue().getGatewayOrder().payload(), containsString("amount=9895"));
 
         assertTrue(captureResponse.isSuccessful());
 
@@ -504,7 +504,7 @@ class StripeCaptureHandlerTest {
         
         verify(gatewayClient).postRequestFor(stripeTransferOutRequestArgumentCaptor.capture());
         StripeTransferOutRequest transferOutRequest = stripeTransferOutRequestArgumentCaptor.getValue();
-        assertThat(transferOutRequest.getGatewayOrder().getPayload(), containsString("amount=9937"));
+        assertThat(transferOutRequest.getGatewayOrder().payload(), containsString("amount=9937"));
 
         verify(gatewayClient, never()).postRequestFor(any(StripeCaptureRequest.class));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -220,7 +220,7 @@ class StripePaymentProviderTest {
 
             verify(gatewayClient).postRequestFor(stripeTransferInRequestCaptor.capture());
 
-            String payload = stripeTransferInRequestCaptor.getValue().getGatewayOrder().getPayload();
+            String payload = stripeTransferInRequestCaptor.getValue().getGatewayOrder().payload();
 
             assertThat(payload, containsString("destination=" + stripePlatformAccountId));
             assertThat(payload, containsString("amount=8000"));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeDisputeHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeDisputeHandlerTest.java
@@ -11,8 +11,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
-import uk.gov.pay.connector.gateway.stripe.request.StripeSubmitTestDisputeEvidenceRequest;
 import uk.gov.pay.connector.gateway.stripe.json.StripeDisputeData;
+import uk.gov.pay.connector.gateway.stripe.request.StripeSubmitTestDisputeEvidenceRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -67,6 +67,6 @@ class StripeDisputeHandlerTest {
         verify(client).postRequestFor(captor.capture());
 
         assertThat(captor.getValue().getUrl().toString(), Matchers.is("https://example.org/v1/disputes/dispute-id"));
-        assertThat(captor.getValue().getGatewayOrder().getPayload(), containsString("winning_evidence"));
+        assertThat(captor.getValue().getGatewayOrder().payload(), containsString("winning_evidence"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandlerTest.java
@@ -189,7 +189,7 @@ class StripeFailedPaymentFeeCollectionHandlerTest {
 
     private void verifyTransferRequestPayload(int amount) throws Exception {
         verify(gatewayClient).postRequestFor(stripeTransferInRequestCaptor.capture());
-        String payload = stripeTransferInRequestCaptor.getValue().getGatewayOrder().getPayload();
+        String payload = stripeTransferInRequestCaptor.getValue().getGatewayOrder().payload();
 
         assertThat(payload, CoreMatchers.containsString("destination=" + stripePlatformAccountId));
         assertThat(payload, CoreMatchers.containsString("amount=" + amount));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequestTest.java
@@ -86,7 +86,7 @@ class StripeAuthoriseRequestTest {
 
     @Test
     void shouldCreateCorrectPayload() {
-        String payload = stripeAuthoriseRequest.getGatewayOrder().getPayload();
+        String payload = stripeAuthoriseRequest.getGatewayOrder().payload();
 
         assertThat(payload, CoreMatchers.containsString("amount=" + amount));
         assertThat(payload, CoreMatchers.containsString("transfer_group=" + chargeExternalId));
@@ -99,7 +99,7 @@ class StripeAuthoriseRequestTest {
 
     @Test
     void shouldSetCorrectOrderRequestTypeForAuthorisationWithout3DS() {
-        assertThat(stripeAuthoriseRequest.getGatewayOrder().getOrderRequestType(), is(OrderRequestType.AUTHORISE));
+        assertThat(stripeAuthoriseRequest.getGatewayOrder().orderRequestType(), is(OrderRequestType.AUTHORISE));
 
     }
 
@@ -109,7 +109,7 @@ class StripeAuthoriseRequestTest {
 
         assertThat(StripeAuthoriseRequest
                         .of(stripeSourceId, authorisationGatewayRequest, stripeGatewayConfig)
-                        .getGatewayOrder().getOrderRequestType(),
+                        .getGatewayOrder().orderRequestType(),
                 is(OrderRequestType.AUTHORISE_3DS));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
@@ -85,7 +85,7 @@ class StripeCaptureRequestTest {
     @Test
     void shouldCreateCorrectCapturePayload() {
         assertThat(
-                stripeCaptureRequest.getGatewayOrder().getPayload(),
+                stripeCaptureRequest.getGatewayOrder().payload(),
                 containsString("expand%5B%5D=charges.data.balance_transaction")
         );
     }
@@ -93,7 +93,7 @@ class StripeCaptureRequestTest {
     @Test
     void shouldSetGatewayOrderToBeOfTypeCapture() {
         assertThat(
-                stripeCaptureRequest.getGatewayOrder().getOrderRequestType(),
+                stripeCaptureRequest.getGatewayOrder().orderRequestType(),
                 is(OrderRequestType.CAPTURE)
         );
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCustomerRequestTest.java
@@ -30,7 +30,7 @@ class StripeCustomerRequestTest {
     void shouldHaveCorrectParameters() {
         StripeCustomerRequest stripeCustomerRequest = createStripeCustomerRequest();
 
-        String payload = stripeCustomerRequest.getGatewayOrder().getPayload();
+        String payload = stripeCustomerRequest.getGatewayOrder().payload();
         assertThat(payload, containsString("name=" + CARD_HOLDER));
         assertThat(payload, containsString("description=" + AGREEMENT_DESCRIPTION));
         assertThat(payload, containsString("metadata%5Bgovuk_pay_agreement_external_id%5D=" + AGREEMENT_EXTERNAL_ID));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
@@ -79,7 +79,7 @@ class StripePaymentIntentRequestTest {
     void shouldHaveCorrectParametersWithAddress() {
         StripePaymentIntentRequest stripePaymentIntentRequest = createOneOffStripePaymentIntentRequest();
 
-        String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
+        String payload = stripePaymentIntentRequest.getGatewayOrder().payload();
         assertThat(payload, containsString("payment_method=" + paymentMethodId));
         assertThat(payload, containsString("amount=" + amount));
         assertThat(payload, containsString("confirmation_method=automatic"));
@@ -123,7 +123,7 @@ class StripePaymentIntentRequestTest {
 
         StripePaymentIntentRequest stripePaymentIntentRequest = createOneOffStripePaymentIntentRequest();
 
-        String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
+        String payload = stripePaymentIntentRequest.getGatewayOrder().payload();
         assertThat(payload, containsString(URLEncoder.encode("payment_method_options[card[moto]]", UTF_8) + "=true"));
     }
     
@@ -133,7 +133,7 @@ class StripePaymentIntentRequestTest {
 
         StripePaymentIntentRequest stripePaymentIntentRequest = createOneOffStripePaymentIntentRequest();
 
-        String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
+        String payload = stripePaymentIntentRequest.getGatewayOrder().payload();
         assertThat(payload, not(containsString(URLEncoder.encode("payment_method_options[card[moto]]", UTF_8))));
     }
 
@@ -142,7 +142,7 @@ class StripePaymentIntentRequestTest {
         var authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, new AuthCardDetails());
         var stripePaymentIntentRequest = StripePaymentIntentRequest.createPaymentIntentRequestWithSetupFutureUsage(
                 authorisationGatewayRequest, paymentMethodId, customerId, stripeGatewayConfig, frontendUrl);
-        String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
+        String payload = stripePaymentIntentRequest.getGatewayOrder().payload();
 
         assertThat(payload, containsString("customer=" + customerId));
         assertThat(payload, containsString("setup_future_usage=off_session"));
@@ -154,7 +154,7 @@ class StripePaymentIntentRequestTest {
         RecurringPaymentAuthorisationGatewayRequest authRequest = RecurringPaymentAuthorisationGatewayRequest.valueOf(charge);
         StripePaymentIntentRequest paymentIntentRequest = StripePaymentIntentRequest.createPaymentIntentRequestUseSavedPaymentDetails(
                 authRequest, paymentMethodId, customerId, stripeGatewayConfig, frontendUrl);
-        String payload = paymentIntentRequest.getGatewayOrder().getPayload();
+        String payload = paymentIntentRequest.getGatewayOrder().payload();
 
         assertThat(payload, containsString("customer=" + customerId));
         assertThat(payload, containsString("off_session=true"));
@@ -169,7 +169,7 @@ class StripePaymentIntentRequestTest {
         var authRequest = ApplePayAuthorisationGatewayRequest.valueOf(charge, applePayAuthRequest);
         StripePaymentIntentRequest paymentIntentRequest = StripePaymentIntentRequest.createPaymentIntentRequestWithToken(
                 authRequest, tokenId, stripeGatewayConfig, frontendUrl);
-        String payload = paymentIntentRequest.getGatewayOrder().getPayload();
+        String payload = paymentIntentRequest.getGatewayOrder().payload();
 
         assertThat(payload, containsString(URLEncoder.encode("payment_method_data[type]", UTF_8) + "=" + "card"));
         assertThat(payload, containsString(URLEncoder.encode("payment_method_data[card][token]", UTF_8) + "=" + tokenId));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
@@ -99,7 +99,7 @@ class StripePaymentMethodRequestTest {
 
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
 
-        String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
+        String payload = stripePaymentMethodRequest.getGatewayOrder().payload();
         assertThat(payload, containsString("card%5Bcvc%5D=" + cvc));
         assertThat(payload, containsString("card%5Bnumber%5D=" + cardNo));
         assertThat(payload, containsString("billing_details%5Bname%5D=" + cardHolder));
@@ -125,7 +125,7 @@ class StripePaymentMethodRequestTest {
 
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
 
-        String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
+        String payload = stripePaymentMethodRequest.getGatewayOrder().payload();
 
         assertThat(payload, containsString("billing_details%5Baddress%5Bstate%5D%5D=Nunavut"));
         assertThat(payload, containsString("billing_details%5Baddress%5Bcountry%5D%5D=CA"));
@@ -145,7 +145,7 @@ class StripePaymentMethodRequestTest {
 
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
 
-        String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
+        String payload = stripePaymentMethodRequest.getGatewayOrder().payload();
 
         assertThat(payload, containsString("billing_details%5Baddress%5Bstate%5D%5D=California"));
         assertThat(payload, containsString("billing_details%5Baddress%5Bcountry%5D%5D=US"));
@@ -157,7 +157,7 @@ class StripePaymentMethodRequestTest {
         CardAuthorisationGatewayRequest authorisationGatewayRequest = CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails);
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
         
-        String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
+        String payload = stripePaymentMethodRequest.getGatewayOrder().payload();
         assertThat(payload, containsString("card%5Bcvc%5D=" + cvc));
         assertThat(payload, containsString("card%5Bnumber%5D=" + cardNo));
         assertThat(payload, containsString("billing_details%5Bname%5D=" + cardHolder));
@@ -178,7 +178,7 @@ class StripePaymentMethodRequestTest {
 
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
 
-        String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
+        String payload = stripePaymentMethodRequest.getGatewayOrder().payload();
         assertThat(payload, containsString("card%5Bcvc%5D=" + cvc));
         assertThat(payload, not(containsString("city")));
         assertThat(payload, not(containsString("country")));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
@@ -73,7 +73,7 @@ class StripeRefundRequestTest {
 
     @Test
     void createsCorrectRefundPayload() {
-        String payload = stripeRefundRequest.getGatewayOrder().getPayload();
+        String payload = stripeRefundRequest.getGatewayOrder().payload();
         
         assertThat(payload, containsString("charge=" + stripeChargeId));
         assertThat(payload, containsString("amount=" + refundAmount));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeSubmitTestDisputeEvidenceRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeSubmitTestDisputeEvidenceRequestTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
+import jakarta.ws.rs.core.MediaType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,7 +11,6 @@ import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
-import jakarta.ws.rs.core.MediaType;
 import java.net.URI;
 import java.util.Map;
 
@@ -51,9 +51,9 @@ class StripeSubmitTestDisputeEvidenceRequestTest {
     @Test
     void shouldCreateGatewayOrder() {
         GatewayOrder gatewayOrder = request.getGatewayOrder();
-        assertThat(gatewayOrder.getOrderRequestType(), is(OrderRequestType.STRIPE_UPDATE_DISPUTE));
-        assertThat(gatewayOrder.getMediaType().toString(), is(MediaType.APPLICATION_FORM_URLENCODED));
-        assertThat(gatewayOrder.getPayload(), is("evidence%5Buncategorized_text%5D=winning_evidence"));
+        assertThat(gatewayOrder.orderRequestType(), is(OrderRequestType.STRIPE_UPDATE_DISPUTE));
+        assertThat(gatewayOrder.mediaType().toString(), is(MediaType.APPLICATION_FORM_URLENCODED));
+        assertThat(gatewayOrder.payload(), is("evidence%5Buncategorized_text%5D=winning_evidence"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTokenRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTokenRequestTest.java
@@ -94,7 +94,7 @@ class StripeTokenRequestTest {
         ApplePayAuthorisationGatewayRequest gatewayRequest = buildWalletGatewayAuthorisationRequest();
         StripeTokenRequest stripeTokenRequest = StripeTokenRequest.of(gatewayRequest, stripeGatewayConfig);
         
-        String payload = stripeTokenRequest.getGatewayOrder().getPayload();
+        String payload = stripeTokenRequest.getGatewayOrder().payload();
         assertThat(payload, containsString("pk_token=" + paymentData));
         assertThat(payload, containsString("pk_token_instrument_name=" + displayName));
         assertThat(payload, containsString("pk_token_payment_network=" + network));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
@@ -91,7 +91,7 @@ class StripeTransferInRequestTest {
     @Test
     void shouldCreateCorrectPayload_forRefundTransfer() {
         when(stripeGatewayConfig.getPlatformAccountId()).thenReturn(stripePlatformAccountId);
-        String payload = refundTransferInRequest.getGatewayOrder().getPayload();
+        String payload = refundTransferInRequest.getGatewayOrder().payload();
 
         assertThat(payload, containsString("destination=" + stripePlatformAccountId));
         assertThat(payload, containsString("amount=" + refundAmount));
@@ -107,7 +107,7 @@ class StripeTransferInRequestTest {
     @Test
     void shouldCreateCorrectPayload_forFeeTransfer() {
         when(stripeGatewayConfig.getPlatformAccountId()).thenReturn(stripePlatformAccountId);
-        String payload = feeTransferInRequest.getGatewayOrder().getPayload();
+        String payload = feeTransferInRequest.getGatewayOrder().payload();
 
         assertThat(payload, containsString("destination=" + stripePlatformAccountId));
         assertThat(payload, containsString("amount=" + feeAmount));
@@ -123,7 +123,7 @@ class StripeTransferInRequestTest {
     @Test
     void shouldCreateCorrectPayload_forDisputeTransfer() {
         when(stripeGatewayConfig.getPlatformAccountId()).thenReturn(stripePlatformAccountId);
-        String payload = disputeTransferInRequest.getGatewayOrder().getPayload();
+        String payload = disputeTransferInRequest.getGatewayOrder().payload();
 
         assertThat(payload, containsString("destination=" + stripePlatformAccountId));
         assertThat(payload, containsString("amount=" + disputeAmount));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
@@ -74,7 +74,7 @@ class StripeTransferOutRequestTest {
 
     @Test
     void shouldCreateCorrectPayload() {
-        String payload = stripeTransferOutRequest.getGatewayOrder().getPayload();
+        String payload = stripeTransferOutRequest.getGatewayOrder().payload();
 
         assertThat(payload, containsString("destination=" + stripeConnectAccountId));
         assertThat(payload, containsString("source_transaction=" + stripeChargeId));

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -211,7 +211,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS))
                 .areIdentical();
     }
@@ -237,7 +237,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITH_IP_ADDRESS))
                 .areIdentical();
 
@@ -268,7 +268,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS))
                 .areIdentical();
 
@@ -315,7 +315,7 @@ class WorldpayAuthoriseHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        String payload = gatewayOrderArgumentCaptor.getValue().getPayload();
+        String payload = gatewayOrderArgumentCaptor.getValue().payload();
         XmlAssertions.assertThat(payload)
                 .valueByXPath("/paymentService/submit/order/exemption/@type")
                 .isEqualTo(expectedExemptionType);
@@ -346,7 +346,7 @@ class WorldpayAuthoriseHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .valueByXPath("/paymentService/submit/order/exemption")
                 .isEmpty();
     }
@@ -370,7 +370,7 @@ class WorldpayAuthoriseHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        String payload = gatewayOrderArgumentCaptor.getValue().getPayload();
+        String payload = gatewayOrderArgumentCaptor.getValue().payload();
         XmlAssertions.assertThat(payload)
                 .valueByXPath("/paymentService/submit/order/additional3DSData")
                 .isEmpty();
@@ -404,7 +404,7 @@ class WorldpayAuthoriseHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        String payload = gatewayOrderArgumentCaptor.getValue().getPayload();
+        String payload = gatewayOrderArgumentCaptor.getValue().payload();
         XmlAssertions.assertThat(payload)
                 .valueByXPath("/paymentService/submit/order/additional3DSData/@dfReferenceId")
                 .isEqualTo(authCardDetails.getWorldpay3dsFlexDdcResult().get());
@@ -447,7 +447,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS))
                 .areIdentical();
     }
@@ -474,7 +474,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITH_EMAIL))
                 .areIdentical();
 
@@ -506,7 +506,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS))
                 .areIdentical();
     }
@@ -533,7 +533,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS))
                 .areIdentical();
     }
@@ -560,7 +560,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS))
                 .areIdentical();
     }
@@ -587,7 +587,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS))
                 .areIdentical();
     }
@@ -623,7 +623,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(templatePath))
                 .areIdentical();
     }
@@ -654,7 +654,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_SETUP_AGREEMENT))
                 .areIdentical();
     }
@@ -685,7 +685,7 @@ class WorldpayAuthoriseHandlerTest {
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_SETUP_AGREEMENT_WITH_EMAIL_AND_IP_ADDRESS))
                 .areIdentical();
     }
@@ -725,7 +725,7 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(worldpayTemplate))
                 .areIdentical();
     }
@@ -763,7 +763,7 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER))
                 .areIdentical();
     }
@@ -790,7 +790,7 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITH_REFERENCE_IN_DESCRIPTION)
                         .replace("{{description}}", "service-payment-reference"))
                 .areIdentical();
@@ -818,7 +818,7 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITH_REFERENCE_IN_DESCRIPTION)
                         .replace("{{description}}", "This is a description"))
                 .areIdentical();
@@ -847,7 +847,7 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_REQUEST_3DS_FLEX_NON_JS))
                 .areIdentical();
     }
@@ -930,7 +930,7 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER))
                 .areIdentical();
     }
@@ -972,7 +972,7 @@ class WorldpayAuthoriseHandlerTest {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(authoriseClient).postRequestFor(eq(TEST_WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER))
                 .areIdentical();
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -114,7 +114,7 @@ class WorldpayCaptureHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .valueByXPath("/paymentService/modify/orderModification/capture/amount/@value")
                 .isEqualTo(chargeEntity.getAmount() + chargeEntity.getCorporateSurcharge().orElse(0L));
     }
@@ -149,7 +149,7 @@ class WorldpayCaptureHandlerTest {
                 gatewayOrderArgumentCaptor.capture(),
                 anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .valueByXPath("/paymentService/modify/orderModification/capture/amount/@value")
                 .isEqualTo(chargeEntity.getAmount() + chargeEntity.getCorporateSurcharge().orElse(0L));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilderTest.java
@@ -75,8 +75,8 @@ class WorldpayOrderBuilderTest {
 
         var gatewayOrder = WorldpayOrderBuilder.buildAuthoriseOrder(request, DO_NOT_SEND_EXEMPTION_REQUEST, new AcceptLanguageHeaderParser()).build();
         
-        assertThat(gatewayOrder.getOrderRequestType(), is(OrderRequestType.AUTHORISE));
-        assertThat(gatewayOrder.getPayload().contains("shopperEmailAddress"), is(includeEmail));
-        assertThat(gatewayOrder.getPayload().contains("shopperIPAddress"), is(includeIP));
+        assertThat(gatewayOrder.orderRequestType(), is(OrderRequestType.AUTHORISE));
+        assertThat(gatewayOrder.payload().contains("shopperEmailAddress"), is(includeEmail));
+        assertThat(gatewayOrder.payload().contains("shopperIPAddress"), is(includeIP));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -100,10 +100,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.orderRequestType());
     }
 
     @Test
@@ -119,10 +119,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITH_SCHEME_IDENTIFIER))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.orderRequestType());
     }
 
     @Test
@@ -137,10 +137,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_RECURRING_WORLDPAY_REQUEST_WITHOUT_SCHEME_IDENTIFIER))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.orderRequestType());
     }
 
     @Test
@@ -162,10 +162,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.orderRequestType());
     }
 
     @Test
@@ -185,10 +185,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.orderRequestType());
     }
 
     @Test
@@ -210,10 +210,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.orderRequestType());
     }
 
     @Test
@@ -233,10 +233,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.orderRequestType());
     }
 
     @Test
@@ -256,10 +256,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.orderRequestType());
     }
 
     @Test
@@ -277,10 +277,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCardDetails)
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.orderRequestType());
     }
 
     @Test
@@ -292,10 +292,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withMerchantCode("MERCHANTCODE")
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE_3DS, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE_3DS, actualRequest.orderRequestType());
     }
 
     @Test
@@ -311,10 +311,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE_APPLE_PAY, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE_APPLE_PAY, actualRequest.orderRequestType());
     }
 
     @Test
@@ -338,10 +338,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE_APPLE_PAY, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE_APPLE_PAY, actualRequest.orderRequestType());
     }
 
     @Test
@@ -357,10 +357,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.orderRequestType());
     }
 
     @Test
@@ -379,10 +379,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.orderRequestType());
     }
 
     @Test
@@ -402,10 +402,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.orderRequestType());
     }
 
     @Test
@@ -422,10 +422,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAmount("500")
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.orderRequestType());
     }
 
     @Test
@@ -439,10 +439,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withTransactionId("MyUniqueTransactionId!")
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_VALID_CAPTURE_WORLDPAY_REQUEST))
                 .areIdentical();
-        assertEquals(OrderRequestType.CAPTURE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.CAPTURE, actualRequest.orderRequestType());
     }
 
     @Test
@@ -456,10 +456,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withTransactionId("MyUniqueTransactionId <!-- & > ")
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(WORLDPAY_SPECIAL_CHAR_VALID_CAPTURE_WORLDPAY_REQUEST))
                 .areIdentical();
-        assertEquals(OrderRequestType.CAPTURE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.CAPTURE, actualRequest.orderRequestType());
     }
 
     @Test
@@ -473,10 +473,10 @@ class WorldpayOrderRequestBuilderTest {
                 .replace("{{merchantCode}}", "MERCHANTCODE")
                 .replace("{{transactionId}}", "MyUniqueTransactionId!");
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(expectedRequestBody)
                 .areIdentical();
-        assertEquals(OrderRequestType.CANCEL, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.CANCEL, actualRequest.orderRequestType());
     }
 
     @Test
@@ -494,10 +494,10 @@ class WorldpayOrderRequestBuilderTest {
                 .replace("{{refundReference}}", "reference")
                 .replace("{{amount}}", "200");
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(expectedRequestBody)
                 .areIdentical();
-        assertEquals(OrderRequestType.REFUND, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.REFUND, actualRequest.orderRequestType());
     }
 
     @Test
@@ -513,10 +513,10 @@ class WorldpayOrderRequestBuilderTest {
                 .replace("{{agreementId}}", "test-agreement-123")
                 .replace("{{paymentTokenId}}", "test-paymentToken-789");
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(expectedRequestBody)
                 .areIdentical();
-        assertEquals(OrderRequestType.DELETE_STORED_PAYMENT_DETAILS, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.DELETE_STORED_PAYMENT_DETAILS, actualRequest.orderRequestType());
     }
 
     @ParameterizedTest
@@ -547,10 +547,10 @@ class WorldpayOrderRequestBuilderTest {
                 .withAuthorisationDetails(authCorporateCardDetails)
                 .build();
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(testTemplatePath))
                 .areIdentical();
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.orderRequestType());
     }
 
     @ParameterizedTest
@@ -590,9 +590,9 @@ class WorldpayOrderRequestBuilderTest {
         }
 
         GatewayOrder actualRequest = builder.build();
-        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.orderRequestType());
 
-        assertThat(actualRequest.getPayload())
+        assertThat(actualRequest.payload())
                 .and(TestTemplateResourceLoader.load(testTemplatePath))
                 .areIdentical();
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -879,7 +879,7 @@ class WorldpayPaymentProviderTest {
                 anyList(),
                 anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST))
                 .areIdentical();
     }
@@ -906,7 +906,7 @@ class WorldpayPaymentProviderTest {
                 anyList(),
                 anyMap());
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(load(WORLDPAY_VALID_3DS_FLEX_RESPONSE_AUTH_WORLDPAY_REQUEST))
                 .areIdentical();
     }
@@ -934,7 +934,7 @@ class WorldpayPaymentProviderTest {
                 .replace("{{agreementId}}", agreement.getExternalId())
                 .replace("{{paymentTokenId}}", token);
 
-        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+        XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                 .and(expectedRequestBody)
                 .areIdentical();
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandlerTest.java
@@ -123,8 +123,8 @@ class WorldpayRefundHandlerTest {
                 anyMap());
 
         GatewayOrder gatewayOrder = gatewayOrderCaptor.getValue();
-        assertThat(gatewayOrder.getPayload(), is(expectedRefundRequest));
-        assertThat(gatewayOrder.getOrderRequestType(), is(OrderRequestType.REFUND));
+        assertThat(gatewayOrder.payload(), is(expectedRefundRequest));
+        assertThat(gatewayOrder.orderRequestType(), is(OrderRequestType.REFUND));
     }
 
     @Test
@@ -182,8 +182,8 @@ class WorldpayRefundHandlerTest {
                 anyMap());
 
         GatewayOrder gatewayOrder = gatewayOrderCaptor.getValue();
-        assertThat(gatewayOrder.getPayload(), is(expectedRefundRequest));
-        assertThat(gatewayOrder.getOrderRequestType(), is(OrderRequestType.REFUND));
+        assertThat(gatewayOrder.payload(), is(expectedRefundRequest));
+        assertThat(gatewayOrder.orderRequestType(), is(OrderRequestType.REFUND));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -122,7 +122,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -139,7 +139,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(true));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -156,7 +156,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(true));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -173,7 +173,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -190,7 +190,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseApplePay(getApplePayGatewayAuthorisationRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION))
                     .areIdentical();
         }
@@ -202,7 +202,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -218,7 +218,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(true));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -234,7 +234,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_REFERENCE_AS_DESCRIPTION))
                     .areIdentical();
         }
@@ -247,7 +247,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(true));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -263,7 +263,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequest(false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -278,7 +278,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, true, false, true));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_GOOGLE_PAY_3DS_REQUEST_WITH_DDC_RESULT))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -293,7 +293,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, false, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -308,7 +308,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, true, false, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -323,7 +323,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(false, true, false, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -339,7 +339,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, true, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_EMAIL))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -355,7 +355,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, true, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));
@@ -371,7 +371,7 @@ class WorldpayWalletAuthorisationHandlerTest {
             worldpayWalletAuthorisationHandler.authoriseGooglePay(getGooglePayAuthorisationGatewayRequestFor3ds(true, false, false, false));
         } catch (GatewayErrorException _) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().getPayload())
+            XmlAssertions.assertThat(gatewayOrderArgumentCaptor.getValue().payload())
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS))
                     .areIdentical();
             assertThat(headers.getValue().size(), is(1));

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
@@ -275,9 +275,9 @@ public class GatewayClientTest {
         when(mockWebTarget.request()).thenReturn(mockBuilder).thenReturn(mockBuilder);
         when(mockBuilder.post(Entity.entity(orderPayload, mediaType))).thenReturn(mockResponse);
 
-        when(mockGatewayOrder.getOrderRequestType()).thenReturn(OrderRequestType.AUTHORISE);
-        when(mockGatewayOrder.getPayload()).thenReturn(orderPayload);
-        when(mockGatewayOrder.getMediaType()).thenReturn(mediaType);
+        when(mockGatewayOrder.orderRequestType()).thenReturn(OrderRequestType.AUTHORISE);
+        when(mockGatewayOrder.payload()).thenReturn(orderPayload);
+        when(mockGatewayOrder.mediaType()).thenReturn(mediaType);
     }
 
     private void setupGetRequestMocks() {


### PR DESCRIPTION
Override `toString()` to not include the payload because it may contain card numbers or other sensitive information etc.