### PR TITLE
PP-15647 - Added AdyenAuthoriseRequestLogGenerator So that we can use…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -545,28 +545,28 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 151
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "fd9f851472586dc75f7a60ee311842ec64ecf527",
         "is_verified": false,
-        "line_number": 153
+        "line_number": 154
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "9367c8305bd1afe815ffc0cc3ebf95af9cb6d157",
         "is_verified": false,
-        "line_number": 156
+        "line_number": 157
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 1174
+        "line_number": 1175
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-29T12:09:58Z"
+  "generated_at": "2026-08-04T10:12:10Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestLogGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestLogGenerator.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.gateway.adyen.utils;
+
+import net.logstash.logback.argument.StructuredArgument;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenAuthoriseRequest;
+import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
+import uk.gov.pay.connector.wallets.WalletType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.BILLING_ADDRESS;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.EMAIL;
+import static uk.gov.service.payments.logging.LoggingKeys.WALLET;
+
+public class AdyenAuthoriseRequestLogGenerator {
+
+    public static String GATEWAY_REQUEST_RECORD = "gateway_request_record";
+
+    public AuthorisationRequestLog generate(AdyenAuthoriseRequest adyenAuthoriseRequest, AuthCardDetails authCardDetails) {
+        return switch (adyenAuthoriseRequest) {
+            case AdyenApplePayAuthoriseRequest adyenApplePayAuthoriseRequest -> generate(adyenApplePayAuthoriseRequest, authCardDetails);
+        };
+    }
+
+    private AuthorisationRequestLog generate(AdyenApplePayAuthoriseRequest adyenApplePayAuthoriseRequest, AuthCardDetails authCardDetails) {
+        List<StructuredArgument> structuredArguments = new ArrayList<>();
+        structuredArguments.add(kv(GATEWAY_REQUEST_RECORD, true));
+
+        var stringJoiner = new StringJoiner(" and ", " ", "");
+
+        stringJoiner.add("with Apple Pay");
+        structuredArguments.add(kv(WALLET, WalletType.APPLE_PAY));
+
+        structuredArguments.add(kv(BILLING_ADDRESS, false));
+        structuredArguments.add(kv(EMAIL, false));
+
+        return new AuthorisationRequestLog(stringJoiner.toString(), List.copyOf(structuredArguments));
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/utils/WorldpayAuthoriseRequestLogGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/utils/WorldpayAuthoriseRequestLogGenerator.java
@@ -1,10 +1,11 @@
-package uk.gov.pay.connector.gateway.util;
+package uk.gov.pay.connector.gateway.worldpay.utils;
 
 
 import net.logstash.logback.argument.StructuredArgument;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.records.WorldpayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/uk/gov/pay/connector/logging/AuthorisationLogger.java
+++ b/src/main/java/uk/gov/pay/connector/logging/AuthorisationLogger.java
@@ -6,15 +6,17 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.adyen.utils.AdyenAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
-import uk.gov.pay.connector.gateway.model.request.records.CardAuthoriseRequest;
-import uk.gov.pay.connector.gateway.model.request.records.WorldpayCardAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
-import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
+import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator;
 
 import java.util.Locale;
 import java.util.Optional;
@@ -23,14 +25,17 @@ public class AuthorisationLogger {
 
     private final AuthorisationRequestSummaryStringifier authorisationRequestSummaryStringifier;
     private final AuthorisationRequestSummaryStructuredLogging authorisationRequestSummaryStructuredLogging;
+    private final AdyenAuthoriseRequestLogGenerator adyenAuthoriseRequestLogGenerator;
     private final WorldpayAuthoriseRequestLogGenerator worldpayAuthoriseRequestLogGenerator;
 
     @Inject
     public AuthorisationLogger(AuthorisationRequestSummaryStringifier authorisationRequestSummaryStringifier, 
                                AuthorisationRequestSummaryStructuredLogging authorisationRequestSummaryStructuredLogging,
+                               AdyenAuthoriseRequestLogGenerator adyenAuthoriseRequestLogGenerator,
                                WorldpayAuthoriseRequestLogGenerator worldpayAuthoriseRequestLogGenerator) {
         this.authorisationRequestSummaryStringifier = authorisationRequestSummaryStringifier;
         this.authorisationRequestSummaryStructuredLogging = authorisationRequestSummaryStructuredLogging;
+        this.adyenAuthoriseRequestLogGenerator = adyenAuthoriseRequestLogGenerator;
         this.worldpayAuthoriseRequestLogGenerator = worldpayAuthoriseRequestLogGenerator;
     }
 
@@ -55,7 +60,7 @@ public class AuthorisationLogger {
     }
 
     public void logChargeAuthorisation(Logger logger,
-                                       CardAuthoriseRequest authoriseRequest,
+                                       AuthoriseRequest authoriseRequest,
                                        AuthCardDetails authCardDetails,
                                        ChargeEntity charge,
                                        String transactionId,
@@ -63,21 +68,21 @@ public class AuthorisationLogger {
                                        ChargeStatus oldStatus,
                                        ChargeStatus newStatus) {
 
-        switch (authoriseRequest) {
-            case WorldpayCardAuthoriseRequest worldpayAuthoriseRequest -> {
-                AuthorisationRequestLog authoriseRequestLog = worldpayAuthoriseRequestLogGenerator.generate(
-                        worldpayAuthoriseRequest, authCardDetails);
+        AuthorisationRequestLog authoriseRequestLog = switch (authoriseRequest) {
+            case WorldpayAuthoriseRequest worldpayAuthoriseRequest -> 
+                    worldpayAuthoriseRequestLogGenerator.generate(worldpayAuthoriseRequest, authCardDetails);
+            case AdyenAuthoriseRequest applePayAuthoriseRequest -> 
+                    adyenAuthoriseRequestLogGenerator.generate(applePayAuthoriseRequest, authCardDetails);
+        };
 
-                logChargeAuthorisation(logger,
-                        authoriseRequestLog.authorisationRequest(),
-                        authoriseRequestLog.structuredArguments().toArray(new StructuredArgument[0]),
-                        charge,
-                        transactionId,
-                        gatewayResponse,
-                        oldStatus,
-                        newStatus);
-            }
-        }
+        logChargeAuthorisation(logger,
+                authoriseRequestLog.authorisationRequest(),
+                authoriseRequestLog.structuredArguments().toArray(new StructuredArgument[0]),
+                charge,
+                transactionId,
+                gatewayResponse,
+                oldStatus,
+                newStatus);
     }
 
     public void logChargeAuthorisation(Logger logger,

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestLogGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestLogGeneratorTest.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.connector.gateway.adyen.utils;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.gateway.adyen.request.json.AdyenApplePayPaymentMethod;
+import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
+import uk.gov.pay.connector.wallets.WalletType;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.BILLING_ADDRESS;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.EMAIL;
+import static uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator.GATEWAY_REQUEST_RECORD;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+import static uk.gov.service.payments.logging.LoggingKeys.WALLET;
+
+class AdyenAuthoriseRequestLogGeneratorTest {
+
+    private final AdyenAuthoriseRequestLogGenerator generator = new AdyenAuthoriseRequestLogGenerator();
+
+    @Test
+    public void generatesWorldpayMotoAuthoriseRequestLogWithCorporateCard() {
+        AdyenApplePayAuthoriseRequest request = new AdyenApplePayAuthoriseRequest(
+                "merchantAccount",
+                "store",
+                "reference",
+                new Amount("GBP", 1000L),
+                new AdyenApplePayPaymentMethod("applePayToken"),
+                "https://govpay.com"
+        );
+        
+        AuthCardDetails authCardDetails = anAuthCardDetails().build();
+
+        AuthorisationRequestLog result = generator.generate(request, authCardDetails);
+
+        assertThat(result.authorisationRequest(), is(" with Apple Pay"));
+
+        assertThat(result.structuredArguments(), containsInAnyOrder(
+                kv(GATEWAY_REQUEST_RECORD, true),
+                kv(BILLING_ADDRESS, false),
+                kv(WALLET, WalletType.APPLE_PAY),
+                kv(EMAIL, false)
+        ));
+    }
+    
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGeneratorTest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.util;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,14 +15,14 @@ import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStruc
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.EMAIL;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.IP_ADDRESS;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.MOTO;
-import static uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator.GATEWAY_REQUEST_RECORD;
+import static uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator.GATEWAY_REQUEST_RECORD;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 
 class WorldpayAuthoriseRequestLogGeneratorTest {
 
     private static final String IP = "203.0.113.1";
 
-    private final WorldpayAuthoriseRequestLogGenerator  generator = new WorldpayAuthoriseRequestLogGenerator();
+    private final WorldpayAuthoriseRequestLogGenerator generator = new WorldpayAuthoriseRequestLogGenerator();
 
     @Test
     public void generatesWorldpayMotoAuthoriseRequestLogWithCorporateCard() {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -30,6 +30,7 @@ import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.adyen.utils.AdyenAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
@@ -41,7 +42,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
-import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
+import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.worldpay.wallets.WorldpayWalletAuthorisationHandler;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
@@ -203,7 +204,7 @@ class WorldpayPaymentProviderTest {
                 worldpayRefundHandler,
                 refundEntityFactory,
                 new AuthorisationService(mock(CardExecutorService.class), mock(Environment.class), mock(ConnectorConfiguration.class)),
-                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new WorldpayAuthoriseRequestLogGenerator()),
+                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new AdyenAuthoriseRequestLogGenerator(), new WorldpayAuthoriseRequestLogGenerator()),
                 chargeDao,
                 eventService,
                 instantSource);

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -25,6 +25,7 @@ import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.adyen.utils.AdyenAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -38,12 +39,12 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.templates.WorldpayRequestTemplateBuilder;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
-import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthoriseHandler;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayCaptureHandler;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayRefundHandler;
+import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.worldpay.wallets.WorldpayWalletAuthorisationHandler;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
@@ -682,7 +683,7 @@ class WorldpayPaymentProviderTest {
                 new WorldpayRefundHandler(gatewayClient, gatewayUrlMap()),
                 new WorldpayRefundEntityFactory(),
                 new AuthorisationService(mockCardExecutorService, mockEnvironment, mockConnectorConfiguration),
-                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new WorldpayAuthoriseRequestLogGenerator()),
+                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new AdyenAuthoriseRequestLogGenerator(), new WorldpayAuthoriseRequestLogGenerator()),
                 mock(ChargeDao.class),
                 mock(EventService.class),
                 instantSource);

--- a/src/test/java/uk/gov/pay/connector/logging/AuthorisationLoggerTest.java
+++ b/src/test/java/uk/gov/pay/connector/logging/AuthorisationLoggerTest.java
@@ -16,14 +16,16 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.adyen.utils.AdyenAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.request.records.WorldpayCardAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
-import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
+import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 
@@ -37,6 +39,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequestFixture.anAdyenApplePayAuthoriseRequestFixture;
 import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,6 +61,9 @@ class AuthorisationLoggerTest {
     private WorldpayAuthoriseRequestLogGenerator mockWorldpayAuthoriseRequestLogGenerator;
 
     @Mock
+    private AdyenAuthoriseRequestLogGenerator mockAdyenAuthoriseRequestLogGenerator;
+    
+    @Mock
     private GatewayResponse<?> mockGatewayResponse;
 
     @Mock
@@ -66,6 +72,8 @@ class AuthorisationLoggerTest {
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
+    private final AdyenAuthoriseRequest adyenAuthoriseRequest = anAdyenApplePayAuthoriseRequestFixture().build();
+    
     private final WorldpayCardAuthoriseRequest worldpayAuthoriseRequest = aWorldpayMotoAuthoriseRequestFixture().build();
 
     private final GatewayAccountEntity gatewayAccountEntity = GatewayAccountEntityFixture.aGatewayAccountEntity()
@@ -73,12 +81,19 @@ class AuthorisationLoggerTest {
             .withAnalyticsId("AnalyticsId")
             .build();
 
-    private final ChargeEntity chargeEntity = aValidChargeEntity()
+
+    private final ChargeEntity adyenChargeEntity = aValidChargeEntity()
+            .withExternalId("abcdefghijklmnopqrstuvwxyz")
+            .withGatewayAccountEntity(gatewayAccountEntity)
+            .withPaymentProvider(PaymentGatewayName.ADYEN.getName())
+            .build();
+
+    private final ChargeEntity worldpayChargeEntity = aValidChargeEntity()
             .withExternalId("abcdefghijklmnopqrstuvwxyz")
             .withGatewayAccountEntity(gatewayAccountEntity)
             .withPaymentProvider(PaymentGatewayName.WORLDPAY.getName())
             .build();
-
+    
     private Logger logger;
 
     private AuthorisationLogger authorisationLogger;
@@ -90,7 +105,7 @@ class AuthorisationLoggerTest {
         logger.setLevel(INFO);
 
         authorisationLogger = new AuthorisationLogger(mockAuthorisationRequestSummaryStringifier,
-                mockAuthorisationRequestSummaryStructuredLogging, mockWorldpayAuthoriseRequestLogGenerator);
+                mockAuthorisationRequestSummaryStructuredLogging, mockAdyenAuthoriseRequestLogGenerator, mockWorldpayAuthoriseRequestLogGenerator);
     }
 
     @Test
@@ -101,7 +116,7 @@ class AuthorisationLoggerTest {
         given(mockAuthorisationRequestSummaryStructuredLogging.createArgs(mockAuthorisationRequestSummary))
                 .willReturn(null);
 
-        authorisationLogger.logChargeAuthorisation(logger, mockAuthorisationRequestSummary, chargeEntity,
+        authorisationLogger.logChargeAuthorisation(logger, mockAuthorisationRequestSummary, worldpayChargeEntity,
                 "payment-12345", mockGatewayResponse, ChargeStatus.ENTERING_CARD_DETAILS, ChargeStatus.AUTHORISATION_SUCCESS);
 
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
@@ -122,7 +137,7 @@ class AuthorisationLoggerTest {
         given(mockAuthorisationRequestSummaryStructuredLogging.createArgs(mockAuthorisationRequestSummary))
                 .willReturn(new StructuredArgument[]{ kv("some", "fun"), kv("structured", "args") });
 
-        authorisationLogger.logChargeAuthorisation(logger, mockAuthorisationRequestSummary, chargeEntity,
+        authorisationLogger.logChargeAuthorisation(logger, mockAuthorisationRequestSummary, worldpayChargeEntity,
                 "payment-12345", mockGatewayResponse, ChargeStatus.ENTERING_CARD_DETAILS, ChargeStatus.AUTHORISATION_SUCCESS);
 
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
@@ -139,12 +154,34 @@ class AuthorisationLoggerTest {
     }
 
     @Test
+    void logsWithAdyenAuthorisationRequest() {
+        given(mockAdyenAuthoriseRequestLogGenerator.generate(adyenAuthoriseRequest, mockAuthCardDetails))
+                .willReturn(new AuthorisationRequestLog(" with all the fancy details",
+                        List.of(kv("some", "fun"), kv("structured", "args"))));
+
+        authorisationLogger.logChargeAuthorisation(logger, adyenAuthoriseRequest, mockAuthCardDetails, adyenChargeEntity,
+                "payment-12345", mockGatewayResponse, ChargeStatus.ENTERING_CARD_DETAILS, ChargeStatus.AUTHORISATION_SUCCESS);
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+
+        var loggingEvent = loggingEventArgumentCaptor.getAllValues().getFirst();
+
+        assertThat(loggingEvent.getFormattedMessage(), is(
+                "Authorisation with all the fancy details for abcdefghijklmnopqrstuvwxyz " +
+                        "(adyen payment-12345) for AnalyticsId (123) - " +
+                        "mockGatewayResponse .'. ENTERING CARD DETAILS -> AUTHORISATION SUCCESS"));
+
+        assertThat(loggingEvent.getArgumentArray(), hasItemInArray(kv("some", "fun")));
+        assertThat(loggingEvent.getArgumentArray(), hasItemInArray(kv("structured", "args")));
+    }
+
+    @Test
     void logsWithWorldpayAuthorisationRequest() {
         given(mockWorldpayAuthoriseRequestLogGenerator.generate(worldpayAuthoriseRequest, mockAuthCardDetails))
                         .willReturn(new AuthorisationRequestLog(" with all the fancy details",
                                 List.of(kv("some", "fun"), kv("structured", "args"))));
 
-        authorisationLogger.logChargeAuthorisation(logger, worldpayAuthoriseRequest, mockAuthCardDetails, chargeEntity,
+        authorisationLogger.logChargeAuthorisation(logger, worldpayAuthoriseRequest, mockAuthCardDetails, worldpayChargeEntity,
                 "payment-12345", mockGatewayResponse, ChargeStatus.ENTERING_CARD_DETAILS, ChargeStatus.AUTHORISATION_SUCCESS);
 
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
@@ -162,7 +199,7 @@ class AuthorisationLoggerTest {
 
     @Test
     void logsWithNoAuthorisationRequest() {
-        authorisationLogger.logChargeAuthorisation(logger, chargeEntity,
+        authorisationLogger.logChargeAuthorisation(logger, worldpayChargeEntity,
                 "payment-12345", mockGatewayResponse, ChargeStatus.ENTERING_CARD_DETAILS, ChargeStatus.AUTHORISATION_SUCCESS);
 
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -47,6 +47,7 @@ import uk.gov.pay.connector.events.model.charge.GatewayDoesNotRequire3dsAuthoris
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.adyen.utils.AdyenAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 import uk.gov.pay.connector.gateway.model.CardAuthoriseRequestFactory;
@@ -62,9 +63,9 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayRespon
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
-import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider;
+import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
@@ -132,7 +133,7 @@ import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR
 import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REJECTED;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
-import static uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator.GATEWAY_REQUEST_RECORD;
+import static uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator.GATEWAY_REQUEST_RECORD;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity.PaymentInstrumentEntityBuilder.aPaymentInstrumentEntity;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.COMPLETED;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.IN_PROGRESS;
@@ -207,6 +208,9 @@ class CardAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private WorldpayAuthoriseRequestLogGenerator mockWorldpayAuthoriseRequestLogGenerator;
+    
+    @Mock
+    private AdyenAuthoriseRequestLogGenerator mockAdyenAuthoriseRequestLogGenerator;
 
     @Mock
     private TaskQueueService mockTaskQueueService;
@@ -271,7 +275,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
                 authorisationService,
                 chargeService,
                 mockCardAuthoriseRequestFactory,
-                new AuthorisationLogger(mockAuthorisationRequestSummaryStringifier, mockAuthorisationRequestSummaryStructuredLogging, mockWorldpayAuthoriseRequestLogGenerator),
+                new AuthorisationLogger(mockAuthorisationRequestSummaryStringifier, mockAuthorisationRequestSummaryStructuredLogging, mockAdyenAuthoriseRequestLogGenerator, mockWorldpayAuthoriseRequestLogGenerator),
                 chargeEligibleForCaptureService,
                 mockPaymentInstrumentEntityToAuthCardDetailsConverter,
                 mockEnvironment);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -27,6 +27,7 @@ import uk.gov.pay.connector.common.model.api.ExternalTransactionStateFactory;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.model.charge.GatewayDoesNotRequire3dsAuthorisation;
 import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.adyen.utils.AdyenAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.CardAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
@@ -35,9 +36,9 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
-import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthorisationRequestSummary;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
@@ -157,7 +158,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
                 new AuthorisationService(mockExecutorService, environment, mockConfiguration),
                 chargeService,
                 mockCardAuthoriseRequestFactory,
-                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new WorldpayAuthoriseRequestLogGenerator()),
+                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new AdyenAuthoriseRequestLogGenerator(), new WorldpayAuthoriseRequestLogGenerator()),
                 mockChargeEligibleForCaptureService,
                 mock(PaymentInstrumentEntityToAuthCardDetailsConverter.class),
                 environment);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutExc
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.adyen.AdyenPaymentProvider;
+import uk.gov.pay.connector.gateway.adyen.utils.AdyenAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.model.ApplePayAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
@@ -46,8 +47,8 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.Authori
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
-import uk.gov.pay.connector.gateway.util.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.idempotency.dao.IdempotencyDao;
@@ -216,7 +217,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
                 authorisationService,
                 mockApplePayAuthoriseRequestFactory,
                 mockWalletPaymentInfoToAuthCardDetailsConverter,
-                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new WorldpayAuthoriseRequestLogGenerator()),
+                new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new AdyenAuthoriseRequestLogGenerator(), new WorldpayAuthoriseRequestLogGenerator()),
                 mockEnvironment);
     }
 


### PR DESCRIPTION
What we did:
- Added `AdyenAuthoriseRequestLogGenerator` So that we can use `AdyenApplePayAuthoriseRequest`
- Gave `AuthorisationLogger` the capability to work with `AdyenAuthoriseRequest`
- Added and updated tests where necessary
