### PR TITLE
PP-15648 Replace ternary operators with switch expressions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -143,22 +143,30 @@ public class WalletAuthoriseService {
                             String requestStatus,
                             ChargeStatus chargeStatus,
                             WalletType walletType) {
-        String successOrFailure = (chargeStatus == AUTHORISATION_SUCCESS || chargeStatus == AUTHORISATION_3DS_REQUIRED)
-                ? "success"
-                : "failure";
+
+        String successOrFailureMetricLabel = switch (chargeStatus) {
+            case AUTHORISATION_SUCCESS, AUTHORISATION_3DS_REQUIRED -> "success";
+            default -> "failure";
+        };
+
+        String walletTypeMetricLabel = switch (walletType) {
+            case APPLE_PAY -> "apple-pay";
+            case GOOGLE_PAY -> "google-pay";
+        };
+
         LOGGER.info("{} authorisation - charge status={}, request status={}, charge_external_id={}, payment provider response={}",
-                walletType.toString(), chargeStatus, requestStatus, chargeEntity.getExternalId(), operationResponse.toString());
+                walletType, chargeStatus, requestStatus, chargeEntity.getExternalId(), operationResponse.toString());
         metricRegistry.counter(format("gateway-operations.%s.%s.authorise.%s.result.%s",
                 chargeEntity.getPaymentProvider(),
                 chargeEntity.getGatewayAccount().getType(),
-                walletType.equals(WalletType.GOOGLE_PAY) ? "google-pay" : "apple-pay",
-                successOrFailure)).inc();
+                walletTypeMetricLabel,
+                successOrFailureMetricLabel)).inc();
         walletPaymentAuthorisationSuccessCounter
                 .labels(
                     chargeEntity.getPaymentProvider(),
                     chargeEntity.getGatewayAccount().getType(),
-                    walletType.equals(WalletType.GOOGLE_PAY) ? "google-pay" : "apple-pay",
-                    successOrFailure
+                    walletTypeMetricLabel,
+                    successOrFailureMetricLabel
                 ).inc();
     }
 


### PR DESCRIPTION
When determining when a metric label should be `"success"` or `"failure"`, use a switch expression rather than a ternary operator.

When determining whether a metric label should be `"apple-pay"` or `"google-pay"`, use a switch expression rather than a ternary operator, which would have the incorrect behaviour if a third wallet type is added.