### PR TITLE
PP-15682: Store chargeExternalId on payment instrument

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
@@ -67,16 +67,20 @@ public class PaymentInstrumentEntity {
     @JsonSerialize(using = ToLowerCaseStringSerializer.class)
     private PaymentInstrumentStatus status;
 
+    @Column(name = "charge_external_id")
+    private String chargeExternalId;
+
     @Embedded
     private CardDetailsEntity cardDetails;
 
-    private PaymentInstrumentEntity(Instant createdDate, Map<String, String> recurringAuthToken, Instant startDate, CardDetailsEntity cardDetails, PaymentInstrumentStatus status) {
+    private PaymentInstrumentEntity(Instant createdDate, Map<String, String> recurringAuthToken, Instant startDate, CardDetailsEntity cardDetails, PaymentInstrumentStatus status, String chargeExternalId) {
         this.createdDate = createdDate;
         this.externalId = RandomIdGenerator.newId();
         this.recurringAuthToken = recurringAuthToken;
         this.startDate = startDate;
         this.cardDetails = cardDetails;
         this.status = status;
+        this.chargeExternalId = chargeExternalId;
     }
 
     public Optional<Map<String, String>> getRecurringAuthToken() {
@@ -143,12 +147,17 @@ public class PaymentInstrumentEntity {
         // For JPA
     }
 
+    public String getChargeExternalId() {
+        return chargeExternalId;
+    }
+
     public static class PaymentInstrumentEntityBuilder {
         private CardDetailsEntity cardDetails;
         private Instant createdDate;
         private PaymentInstrumentStatus status;
         private Instant startDate;
         private Map<String, String> recurringAuthToken;
+        private String chargeExternalId;
 
         public static PaymentInstrumentEntity.PaymentInstrumentEntityBuilder aPaymentInstrumentEntity(Instant createdDate) {
             var paymentInstrumentEntityBuilder = new PaymentInstrumentEntityBuilder();
@@ -180,10 +189,15 @@ public class PaymentInstrumentEntity {
             this.recurringAuthToken = recurringAuthToken;
             return this;
         }
+        
+        public PaymentInstrumentEntity.PaymentInstrumentEntityBuilder withExternalChargeId(String chargeExternalId) {
+            this.chargeExternalId = chargeExternalId;
+            return this;
+        }
 
 
         public PaymentInstrumentEntity build() {
-            return new PaymentInstrumentEntity(createdDate, recurringAuthToken, startDate, cardDetails, status);
+            return new PaymentInstrumentEntity(createdDate, recurringAuthToken, startDate, cardDetails, status, chargeExternalId);
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentService.java
@@ -39,6 +39,7 @@ public class PaymentInstrumentService {
                 .withCardDetails(charge.getCardDetails())
                 .withStatus(PaymentInstrumentStatus.CREATED) 
                 .withStartDate(now)
+                .withExternalChargeId(charge.getExternalId())
                 .build();
         paymentInstrumentDao.persist(paymentInstrument);
         ledgerService.postEvent(PaymentInstrumentCreated.from(paymentInstrument, charge.getGatewayAccount()));

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
@@ -67,7 +67,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         verifyResponseForRecurringPayment(chargeId);
 
-        getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+        getAndVerifyChargeEntity(chargeId);
     }
 
     @Test
@@ -79,11 +79,13 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         verifyResponseForRecurringPayment(chargeId);
 
-        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+        ChargeEntity charge = getAndVerifyChargeEntity(chargeId);
 
         var storedPaymentMethodId = getStoredPaymentMethodId(charge);
+        var paymentInstrumentChargeExternalId = getChargeExternalIdFromPaymentInstrument(charge);
 
         assertThat(storedPaymentMethodId, is(expectedStoredPaymentMethodId));
+        assertThat(paymentInstrumentChargeExternalId, is(charge.getExternalId()));
     }
 
     @Test
@@ -93,12 +95,14 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         verifyResponseForRecurringPayment(chargeId);
 
-        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+        ChargeEntity charge = getAndVerifyChargeEntity(chargeId);
 
-        var paymentInstrument = charge.get().getPaymentInstrument();
+        var paymentInstrument = charge.getPaymentInstrument();
+        var paymentInstrumentChargeExternalId = getChargeExternalIdFromPaymentInstrument(charge);
 
         assertThat(paymentInstrument.isEmpty(), is(false));
         assertThat(paymentInstrument.get().getRecurringAuthToken().isEmpty(), is(true));
+        assertThat(paymentInstrumentChargeExternalId, is(charge.getExternalId()));
     }
 
     @Test
@@ -110,11 +114,13 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         verifyResponseForRecurringPaymentWith3ds(chargeId, 200, AUTH_SUCCESS);
 
-        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+        ChargeEntity charge = getAndVerifyChargeEntity(chargeId);
 
         var storedPaymentMethodId = getStoredPaymentMethodId(charge);
+        var paymentInstrumentChargeExternalId = getChargeExternalIdFromPaymentInstrument(charge);
 
         assertThat(storedPaymentMethodId, is(expectedStoredPaymentMethodId));
+        assertThat(paymentInstrumentChargeExternalId, is(charge.getExternalId()));
     }
 
     @Test
@@ -125,12 +131,14 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         verifyResponseForRecurringPaymentWith3ds(chargeId, 200, AUTH_SUCCESS);
 
-        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+        ChargeEntity charge = getAndVerifyChargeEntity(chargeId);
 
-        var paymentInstrument = charge.get().getPaymentInstrument();
+        var paymentInstrument = charge.getPaymentInstrument();
+        var paymentInstrumentChargeExternalId = getChargeExternalIdFromPaymentInstrument(charge);
 
         assertThat(paymentInstrument.isEmpty(), is(false));
         assertThat(paymentInstrument.get().getRecurringAuthToken().isEmpty(), is(true));
+        assertThat(paymentInstrumentChargeExternalId, is(charge.getExternalId()));
     }
 
     @Test
@@ -238,12 +246,12 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
                         .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
     }
     
-    private Optional<ChargeEntity> getAndVerifyChargeEntity(String chargeId, String pspReferenceFromAdyen) {
+    private ChargeEntity getAndVerifyChargeEntity(String chargeId) {
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is(AUTH_SUCCESS));
-        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
-        return charge;
+        assertThat(charge.get().getGatewayTransactionId(), is(PSP_REFERENCE_FROM_ADYEN));
+        return charge.get();
     }
 
     private void getAndVerifyChargeEntityForFailedAuthorisation(String chargeId, String status, @Nullable String pspReferenceFromAdyen) {
@@ -257,7 +265,11 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
         }
     }
 
-    private static String getStoredPaymentMethodId(Optional<ChargeEntity> charge) {
-        return charge.get().getPaymentInstrument().orElseThrow().getRecurringAuthToken().orElseThrow().get("storedPaymentMethodId");
+    private static String getStoredPaymentMethodId(ChargeEntity charge) {
+        return charge.getPaymentInstrument().orElseThrow().getRecurringAuthToken().orElseThrow().get("storedPaymentMethodId");
+    }
+
+    private static String getChargeExternalIdFromPaymentInstrument(ChargeEntity charge) {
+        return charge.getPaymentInstrument().orElseThrow().getChargeExternalId();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentServiceTest.java
@@ -54,6 +54,7 @@ class PaymentInstrumentServiceTest {
         assertThat(actualPaymentInstrumentEntity.getCardDetails(), is(chargeEntity.getCardDetails()));
         assertThat(actualPaymentInstrumentEntity.getStartDate(), is(NOW));
         assertThat(actualPaymentInstrumentEntity.getStatus(), is(PaymentInstrumentStatus.CREATED));
+        assertThat(actualPaymentInstrumentEntity.getChargeExternalId(), is(chargeEntity.getExternalId()));
         assertThat(actualPaymentInstrumentEntity, is(paymentInstrument));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Stored `chargeExternalId` to payment instrument after a charge has been successfully authorised
- small refactor of `AdyenCardResourceAuthoriseRecurringPaymentsIT.java` to remove SonarQube warnings
