### PR TITLE
PP-15644 Rename gateway request records to end in “Payload”

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenApplePayAuthoriseRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenApplePayAuthoriseRequestFactory.java
@@ -5,7 +5,7 @@ import uk.gov.pay.connector.gateway.adyen.request.json.AdyenApplePayPaymentMetho
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenCredentialsHelper;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenMerchantAccountHelper;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
 import uk.gov.pay.connector.gateway.util.ChargeFrontendUrlHelper;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
 
@@ -26,8 +26,8 @@ public class AdyenApplePayAuthoriseRequestFactory {
         this.adyenCredentialsHelper = adyenCredentialsHelper;
     }
 
-    public AdyenApplePayAuthoriseRequest create(ApplePayAuthorisationGatewayRequest request) {
-        return new AdyenApplePayAuthoriseRequest(
+    public AdyenApplePayAuthorisePayload create(ApplePayAuthorisationGatewayRequest request) {
+        return new AdyenApplePayAuthorisePayload(
                 adyenMerchantAccountHelper.getMerchantAccount(request.getGatewayAccount()),
                 adyenCredentialsHelper.getStore(request),
                 request.getGovUkPayPaymentId(),

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
@@ -31,7 +31,7 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.DeleteStoredPaymentDetailsGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
 import uk.gov.pay.connector.gateway.model.request.records.ApplePayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
@@ -97,8 +97,8 @@ public class AdyenPaymentProvider implements PaymentProvider {
     
     @Override
     public GatewayResponse authoriseApplePay(ApplePayAuthoriseRequest applePayAuthoriseRequest, GatewayAccountType gatewayAccountType) throws GatewayException {
-        if (applePayAuthoriseRequest instanceof AdyenApplePayAuthoriseRequest adyenApplePayAuthoriseRequest) {
-            return adyenAuthoriseHandler.authorise(adyenApplePayAuthoriseRequest, gatewayAccountType);
+        if (applePayAuthoriseRequest instanceof AdyenApplePayAuthorisePayload adyenApplePayAuthorisePayload) {
+            return adyenAuthoriseHandler.authorise(adyenApplePayAuthorisePayload, gatewayAccountType);
         } else {
             throw new IllegalArgumentException("ApplePayAuthoriseRequest is not of type AdyenApplePayAuthoriseRequest");
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestLogGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestLogGenerator.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.adyen.utils;
 
 import net.logstash.logback.argument.StructuredArgument;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
 import uk.gov.pay.connector.gateway.model.request.records.AdyenAuthoriseRequest;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
 import uk.gov.pay.connector.wallets.WalletType;
@@ -22,11 +22,11 @@ public class AdyenAuthoriseRequestLogGenerator {
 
     public AuthorisationRequestLog generate(AdyenAuthoriseRequest adyenAuthoriseRequest, AuthCardDetails authCardDetails) {
         return switch (adyenAuthoriseRequest) {
-            case AdyenApplePayAuthoriseRequest adyenApplePayAuthoriseRequest -> generate(adyenApplePayAuthoriseRequest, authCardDetails);
+            case AdyenApplePayAuthorisePayload adyenApplePayAuthorisePayload -> generate(adyenApplePayAuthorisePayload, authCardDetails);
         };
     }
 
-    private AuthorisationRequestLog generate(AdyenApplePayAuthoriseRequest adyenApplePayAuthoriseRequest, AuthCardDetails authCardDetails) {
+    private AuthorisationRequestLog generate(AdyenApplePayAuthorisePayload adyenApplePayAuthorisePayload, AuthCardDetails authCardDetails) {
         List<StructuredArgument> structuredArguments = new ArrayList<>();
         structuredArguments.add(kv(GATEWAY_REQUEST_RECORD, true));
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AdyenApplePayAuthorisePayload.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AdyenApplePayAuthorisePayload.java
@@ -6,7 +6,7 @@ import uk.gov.pay.connector.gateway.adyen.request.json.AdyenApplePayPaymentMetho
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 
 @NullMarked
-public record AdyenApplePayAuthoriseRequest(
+public record AdyenApplePayAuthorisePayload(
         @JsonProperty("merchantAccount")
         String merchantAccount,
         

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AdyenAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/AdyenAuthoriseRequest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.model.request.records;
 
 public sealed interface AdyenAuthoriseRequest extends AdyenRequest, AuthoriseRequest
-        permits AdyenApplePayAuthoriseRequest {
+        permits AdyenApplePayAuthorisePayload {
 
     String reference();
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/ApplePayAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/ApplePayAuthoriseRequest.java
@@ -1,4 +1,4 @@
 package uk.gov.pay.connector.gateway.model.request.records;
 
-public sealed interface ApplePayAuthoriseRequest extends WalletAuthoriseRequest permits AdyenApplePayAuthoriseRequest {
+public sealed interface ApplePayAuthoriseRequest extends WalletAuthoriseRequest permits AdyenApplePayAuthorisePayload {
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayCardAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayCardAuthoriseRequest.java
@@ -1,5 +1,5 @@
 package uk.gov.pay.connector.gateway.model.request.records;
 
 public sealed interface WorldpayCardAuthoriseRequest extends CardAuthoriseRequest, WorldpayAuthoriseRequest
-        permits WorldpayMotoAuthoriseRequest {
+        permits WorldpayMotoAuthorisePayload {
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthorisePayload.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthorisePayload.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.gateway.model.request.records;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public record WorldpayMotoAuthoriseRequest(
+public record WorldpayMotoAuthorisePayload(
         String username,
         String password,
         String merchantCode,

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayMotoAuthoriseRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayMotoAuthoriseRequestFactory.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.worldpay;
 
 import jakarta.inject.Inject;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayload;
 import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseCredentialsHelper;
 import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseDescriptionHelper;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
@@ -18,9 +18,9 @@ public class WorldpayMotoAuthoriseRequestFactory {
         this.credentialsHelper = credentialsHelper;
     }
     
-    public WorldpayMotoAuthoriseRequest create(CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest){
+    public WorldpayMotoAuthorisePayload create(CardAuthorisationGatewayRequest cardAuthorisationGatewayRequest){
         WorldpayMerchantCodeCredentials credentials = credentialsHelper.getOneOffCredentials(cardAuthorisationGatewayRequest);
-        return new WorldpayMotoAuthoriseRequest(
+        return new WorldpayMotoAuthorisePayload(
                 credentials.getUsername(),
                 credentials.getPassword(),
                 credentials.getMerchantCode(),

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/utils/WorldpayAuthoriseRequestLogGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/utils/WorldpayAuthoriseRequestLogGenerator.java
@@ -4,7 +4,7 @@ package uk.gov.pay.connector.gateway.worldpay.utils;
 import net.logstash.logback.argument.StructuredArgument;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.records.WorldpayAuthoriseRequest;
-import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayload;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
 
 import java.util.ArrayList;
@@ -25,11 +25,11 @@ public class WorldpayAuthoriseRequestLogGenerator {
 
     public AuthorisationRequestLog generate(WorldpayAuthoriseRequest worldpayAuthoriseRequest, AuthCardDetails authCardDetails) {
         return switch (worldpayAuthoriseRequest) {
-            case WorldpayMotoAuthoriseRequest worldpayMotoAuthoriseRequest -> generate(worldpayMotoAuthoriseRequest, authCardDetails);
+            case WorldpayMotoAuthorisePayload worldpayMotoAuthorisePayload -> generate(worldpayMotoAuthorisePayload, authCardDetails);
         };
     }
 
-    private AuthorisationRequestLog generate(WorldpayMotoAuthoriseRequest worldpayMotoAuthoriseRequest, AuthCardDetails authCardDetails) {
+    private AuthorisationRequestLog generate(WorldpayMotoAuthorisePayload worldpayMotoAuthorisePayload, AuthCardDetails authCardDetails) {
         List<StructuredArgument> structuredArguments = new ArrayList<>();
         structuredArguments.add(kv(GATEWAY_REQUEST_RECORD, true));
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -33,7 +33,7 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.records.CardAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.request.records.WorldpayCardAuthoriseRequest;
-import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayload;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
@@ -322,7 +322,7 @@ public class CardAuthoriseService {
                                                    CardAuthoriseRequest cardAuthoriseRequest,
                                                    AuthCardDetails authCardDetails) {
         switch (cardAuthoriseRequest) {
-            case WorldpayMotoAuthoriseRequest _ -> {
+            case WorldpayMotoAuthorisePayload _ -> {
                 AUTHORISATION_RESULT_COUNTER.labels(
                         updatedCharge.getPaymentProvider().toLowerCase(),
                         updatedCharge.getGatewayAccount().getType().toLowerCase(),

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -21,7 +21,7 @@ import uk.gov.pay.connector.gateway.adyen.AdyenPaymentProvider;
 import uk.gov.pay.connector.gateway.model.ApplePayAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
 import uk.gov.pay.connector.gateway.model.request.records.WalletAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -38,8 +38,6 @@ import uk.gov.service.payments.commons.model.CardExpiryDate;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 
 public class WalletAuthoriseService {
     
@@ -245,7 +243,7 @@ public class WalletAuthoriseService {
         PaymentProvider paymentProvider = getPaymentProviderFor(chargeEntity);
         
         GatewayResponse<BaseAuthoriseResponse> response = switch (applePayAuthoriseRequest) {
-            case AdyenApplePayAuthoriseRequest adyenApplePayAuthoriseRequest when paymentProvider instanceof AdyenPaymentProvider ->
+            case AdyenApplePayAuthorisePayload adyenApplePayAuthoriseRequest when paymentProvider instanceof AdyenPaymentProvider ->
                     paymentProvider.authoriseApplePay(
                             adyenApplePayAuthoriseRequest, 
                             authorisationGatewayRequest.getGatewayAccount().getGatewayAccountType());

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestLogGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestLogGeneratorTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.gateway.adyen.request.json.AdyenApplePayPaymentMethod;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestLog;
 import uk.gov.pay.connector.wallets.WalletType;
 
@@ -24,7 +24,7 @@ class AdyenAuthoriseRequestLogGeneratorTest {
 
     @Test
     public void generatesWorldpayMotoAuthoriseRequestLogWithCorporateCard() {
-        AdyenApplePayAuthoriseRequest request = new AdyenApplePayAuthoriseRequest(
+        AdyenApplePayAuthorisePayload request = new AdyenApplePayAuthorisePayload(
                 "merchantAccount",
                 "store",
                 "reference",

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestToGatewayOrderConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestToGatewayOrderConverterTest.java
@@ -9,7 +9,7 @@ import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.adyen.request.json.AdyenApplePayPaymentMethod;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -30,7 +30,7 @@ class AdyenAuthoriseRequestToGatewayOrderConverterTest {
 
     @Test
     void convertsAdyenApplePayAuthoriseRequest() {
-        var request = new AdyenApplePayAuthoriseRequest(
+        var request = new AdyenApplePayAuthorisePayload(
                 MERCHANT_ACCOUNT,
                 STORE,
                 REFERENCE,

--- a/src/test/java/uk/gov/pay/connector/gateway/gateway/worldpay/WorldpayMotoAuthorisePayloadFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/gateway/worldpay/WorldpayMotoAuthorisePayloadFactoryTest.java
@@ -11,7 +11,7 @@ import uk.gov.pay.connector.client.cardid.model.CardInformation;
 import uk.gov.pay.connector.client.cardid.model.CardInformationFixture;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayload;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayMotoAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseCredentialsHelper;
 import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseDescriptionHelper;
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
-class WorldpayMotoAuthoriseRequestFactoryTest {
+class WorldpayMotoAuthorisePayloadFactoryTest {
     private WorldpayMotoAuthoriseRequestFactory worldpayMotoAuthoriseRequestFactory;
     
     @Mock
@@ -68,8 +68,8 @@ class WorldpayMotoAuthoriseRequestFactoryTest {
         given(mockDescriptionHelper.getDescription(cardAuthorisationGatewayRequest)).willReturn(descriptionOrReference);
         given(mockCredentialsHelper.getOneOffCredentials(cardAuthorisationGatewayRequest)).willReturn(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
         
-        WorldpayMotoAuthoriseRequest actual = worldpayMotoAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest);
-        WorldpayMotoAuthoriseRequest expected = new WorldpayMotoAuthoriseRequest(
+        WorldpayMotoAuthorisePayload actual = worldpayMotoAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest);
+        WorldpayMotoAuthorisePayload expected = new WorldpayMotoAuthorisePayload(
                 username, 
                 password, 
                 merchantCode, 

--- a/src/test/java/uk/gov/pay/connector/gateway/model/AdyenApplePayAuthorisePayloadFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/AdyenApplePayAuthorisePayloadFactoryTest.java
@@ -12,7 +12,7 @@ import uk.gov.pay.connector.gateway.adyen.request.json.AdyenApplePayPaymentMetho
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenCredentialsHelper;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenMerchantAccountHelper;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
 import uk.gov.pay.connector.gateway.util.ChargeFrontendUrlHelper;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
-class AdyenApplePayAuthoriseRequestFactoryTest {
+class AdyenApplePayAuthorisePayloadFactoryTest {
     
     @Mock
     private AdyenMerchantAccountHelper mockAdyenMerchantAccountHelper;
@@ -63,7 +63,7 @@ class AdyenApplePayAuthoriseRequestFactoryTest {
         
         var actual = adyenApplePayAuthoriseRequestFactory.create(applePayAuthorisationGatewayRequest);
 
-        var expected = new AdyenApplePayAuthoriseRequest(
+        var expected = new AdyenApplePayAuthorisePayload(
                 merchantAccountId,
                 storeId,
                 externalId, 

--- a/src/test/java/uk/gov/pay/connector/gateway/model/ApplePayAuthoriseRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/ApplePayAuthoriseRequestFactoryTest.java
@@ -13,7 +13,7 @@ import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.adyen.AdyenApplePayAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenCredentialsHelper;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenMerchantAccountHelper;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
 import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequestFixture;
 import uk.gov.pay.connector.gateway.model.request.records.ApplePayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.util.ChargeFrontendUrlHelper;
@@ -79,14 +79,14 @@ class ApplePayAuthoriseRequestFactoryTest {
 
         ApplePayAuthorisationGatewayRequest applePayAuthorisationGatewayRequest = ApplePayAuthorisationGatewayRequest.valueOf(chargeEntity, applePayAuthRequest);
         
-        AdyenApplePayAuthoriseRequest adyenApplePayAuthoriseRequest = AdyenApplePayAuthoriseRequestFixture.anAdyenApplePayAuthoriseRequestFixture().build();
+        AdyenApplePayAuthorisePayload adyenApplePayAuthorisePayload = AdyenApplePayAuthoriseRequestFixture.anAdyenApplePayAuthoriseRequestFixture().build();
 
-        given(mockAdyenApplePayAuthoriseRequestFactory.create(applePayAuthorisationGatewayRequest)).willReturn(adyenApplePayAuthoriseRequest);
+        given(mockAdyenApplePayAuthoriseRequestFactory.create(applePayAuthorisationGatewayRequest)).willReturn(adyenApplePayAuthorisePayload);
 
         Optional<? extends ApplePayAuthoriseRequest> applePayAuthoriseRequest = authoriseRequestFactory.create(applePayAuthorisationGatewayRequest);
         
         assertThat(applePayAuthoriseRequest.isPresent(), is(true));
-        assertThat(applePayAuthoriseRequest.get(), is(adyenApplePayAuthoriseRequest));
+        assertThat(applePayAuthoriseRequest.get(), is(adyenApplePayAuthorisePayload));
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/AdyenApplePayAuthoriseRequestFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/AdyenApplePayAuthoriseRequestFixture.java
@@ -46,7 +46,7 @@ public class AdyenApplePayAuthoriseRequestFixture {
         return this;
     }
     
-    public AdyenApplePayAuthoriseRequest build() {
-        return new AdyenApplePayAuthoriseRequest(merchantAccount, store, reference, amount, paymentMethod, returnUrl);
+    public AdyenApplePayAuthorisePayload build() {
+        return new AdyenApplePayAuthorisePayload(merchantAccount, store, reference, amount, paymentMethod, returnUrl);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthoriseRequestFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthoriseRequestFixture.java
@@ -73,8 +73,8 @@ public class WorldpayMotoAuthoriseRequestFixture {
         return this;
     }
 
-    public WorldpayMotoAuthoriseRequest build() {
-        return new WorldpayMotoAuthoriseRequest(
+    public WorldpayMotoAuthorisePayload build() {
+        return new WorldpayMotoAuthorisePayload(
                 username,
                 password,
                 merchantCode,

--- a/src/test/java/uk/gov/pay/connector/gateway/templates/WorldpayRequestTemplateBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/templates/WorldpayRequestTemplateBuilderTest.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.templates;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayload;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -20,7 +20,7 @@ class WorldpayRequestTemplateBuilderTest {
     class MotoAuthorisationRequest {
         @Test
         void shouldGenerateValidAuthoriseOrderRequestForWorldpayMotoAuthorisationRequest() {
-            WorldpayMotoAuthoriseRequest motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
+            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
 
             assertThat(worldpayRequestTemplateBuilder.buildWith("/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx", motoOrder))
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_MOTO_AUTHORISATION_REQUEST))
@@ -32,7 +32,7 @@ class WorldpayRequestTemplateBuilderTest {
     class TemplateBuilderAppliesAutoEscape {
         @Test
         void shouldGenerateValidAuthoriseOrderRequestWithAutoEscape() {
-            WorldpayMotoAuthoriseRequest motoOrder = aWorldpayMotoAuthoriseRequestFixture()
+            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthoriseRequestFixture()
                     .withMerchantCode("MERCHANT\"\"CODE")
                     .withCardholderName("Alec & Barley").build();
             String renderedAuthoriseOrder = worldpayRequestTemplateBuilder.buildWith("/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx", motoOrder);
@@ -46,7 +46,7 @@ class WorldpayRequestTemplateBuilderTest {
     class InvalidActionsThrowingException {
         @Test
         void shouldThrowRuntimeExceptionWhenTemplateIsNotFound() {
-            WorldpayMotoAuthoriseRequest motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
+            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
             var thrown = assertThrows(RuntimeException.class, () -> worldpayRequestTemplateBuilder.buildWith("/worldpay/NonExistentOrderTemplate.xml", motoOrder));
             
             assertThat(thrown.getMessage(), is("Could not load template /worldpay/NonExistentOrderTemplate.xml in dir /templates"));
@@ -54,7 +54,7 @@ class WorldpayRequestTemplateBuilderTest {
 
         @Test
         void shouldThrowRuntimeExceptionWhenCannotRenderTemplate() {
-            WorldpayMotoAuthoriseRequest motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
+            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
 
             var thrown = assertThrows(RuntimeException.class, () -> {
                 worldpayRequestTemplateBuilder.buildWith("/worldpay/WorldpayCancelOrderTemplate.xml", motoOrder);

--- a/src/test/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/WorldpayAuthoriseRequestLogGeneratorTest.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.util;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayload;
 import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
@@ -26,7 +26,7 @@ class WorldpayAuthoriseRequestLogGeneratorTest {
 
     @Test
     public void generatesWorldpayMotoAuthoriseRequestLogWithCorporateCard() {
-        WorldpayMotoAuthoriseRequest request = new WorldpayMotoAuthoriseRequest(
+        WorldpayMotoAuthorisePayload request = new WorldpayMotoAuthorisePayload(
                 "username", "password", "merchant code", "order code",
                 "description", "1000", "4242424242424242",
                 "12", "2030", "Cardholder Name", "123");
@@ -50,7 +50,7 @@ class WorldpayAuthoriseRequestLogGeneratorTest {
 
     @Test
     public void generatesWorldpayMotoAuthoriseRequestLogWithoutCorporateCard() {
-        WorldpayMotoAuthoriseRequest request = new WorldpayMotoAuthoriseRequest(
+        WorldpayMotoAuthorisePayload request = new WorldpayMotoAuthorisePayload(
                 "username", "password", "merchant code", "order code",
                 "description", "1000", "4242424242424242",
                 "12", "2030", "Cardholder Name", "123");
@@ -73,7 +73,7 @@ class WorldpayAuthoriseRequestLogGeneratorTest {
 
     @Test
     public void generatesWorldpayMotoAuthoriseRequestLogWithoutIPAddress() {
-        WorldpayMotoAuthoriseRequest request = new WorldpayMotoAuthoriseRequest(
+        WorldpayMotoAuthorisePayload request = new WorldpayMotoAuthorisePayload(
                 "username", "password", "merchant code", "order code",
                 "description", "1000", "4242424242424242",
                 "12", "2030", "Cardholder Name", "123");

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCardAuthoriseRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCardAuthoriseRequestFactoryTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.records.WorldpayCardAuthoriseRequest;
-import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayload;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.util.Optional;
@@ -42,14 +42,14 @@ class WorldpayCardAuthoriseRequestFactoryTest {
                 .withSavePaymentInstrumentToAgreement(false)
                 .build();
 
-        WorldpayMotoAuthoriseRequest worldpayMotoAuthoriseRequest = aWorldpayMotoAuthoriseRequestFixture().build();
+        WorldpayMotoAuthorisePayload worldpayMotoAuthorisePayload = aWorldpayMotoAuthoriseRequestFixture().build();
 
-        given(mockWorldpayMotoAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest)).willReturn(worldpayMotoAuthoriseRequest);
+        given(mockWorldpayMotoAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest)).willReturn(worldpayMotoAuthorisePayload);
 
         Optional<WorldpayCardAuthoriseRequest> result = worldpayCardAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest);
 
         assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is(worldpayMotoAuthoriseRequest));
+        assertThat(result.get(), is(worldpayMotoAuthorisePayload));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -33,7 +33,7 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.DeleteStoredPaymentDetailsGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayload;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.templates.WorldpayRequestTemplateBuilder;
@@ -506,7 +506,7 @@ class WorldpayPaymentProviderTest {
 
         @SuppressWarnings("unchecked")
         Map<String, String> worldpayCredentials = (Map<String, String>) validCredentials.get(ONE_OFF_CUSTOMER_INITIATED);
-        WorldpayMotoAuthoriseRequest worldpayMotoAuthoriseRequest = aWorldpayMotoAuthoriseRequestFixture()
+        WorldpayMotoAuthorisePayload worldpayMotoAuthorisePayload = aWorldpayMotoAuthoriseRequestFixture()
                 .withMerchantCode(worldpayCredentials.get(CREDENTIALS_MERCHANT_CODE))
                 .withUsername(worldpayCredentials.get(CREDENTIALS_USERNAME))
                 .withPassword(worldpayCredentials.get(CREDENTIALS_PASSWORD))
@@ -514,7 +514,7 @@ class WorldpayPaymentProviderTest {
                 .withCardNumber(cardNumber)
                 .build();
 
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(worldpayMotoAuthoriseRequest, TEST);
+        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(worldpayMotoAuthorisePayload, TEST);
         assertTrue(response.getBaseResponse().isPresent());
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenApplePayAuthorisePayloadIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenApplePayAuthorisePayloadIT.java
@@ -25,7 +25,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.it.base.AddChargeParameters.Builder.anAddChargeParameters;
 
-public class AdyenApplePayAuthoriseRequestIT {
+public class AdyenApplePayAuthorisePayloadIT {
 
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/gatewayrequestrecords/WorldpayMotoAuthorisePayloadIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/gatewayrequestrecords/WorldpayMotoAuthorisePayloadIT.java
@@ -27,7 +27,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CAR
 import static uk.gov.pay.connector.it.base.AddChargeParameters.Builder.anAddChargeParameters;
 import static uk.gov.pay.connector.rules.WorldpayMockClient.WORLDPAY_URL;
 
-public class WorldpayMotoAuthoriseRequestIT {
+public class WorldpayMotoAuthorisePayloadIT {
 
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();


### PR DESCRIPTION
Rename gateway request records — specifically `AdyenApplePayAuthoriseRequest` and `WorldpayMotoAuthoriseRequest` — to instead end in `Payload` — that is: `AdyenApplePayAuthorisePayload` and `WorldpayMotoAuthorisePayload` — in order to be more consistent with other Adyen records that represent payloads sent to Adyen and to make them more distinguishable from interfaces like `AdyenAuthoriseRequest` or `WorldpayCardAuthoriseRequest` that due to the limitations of sealed classes have to be in the same package.

We’re using `AdyenApplePayAuthorisePayload` or similar rather than `AdyenApplePayAuthoriseRequestPayload` because the latter is rather long.

New convention:
- Interfaces implemented by gateway request records end in `Request`
- Gateway request records that implement the aforementioned interfaces end in `Payload`