### PR TITLE
PP-15682: Store chargeExternalId to payment instrument after a charge…

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntity.java
@@ -67,16 +67,20 @@ public class PaymentInstrumentEntity {
     @JsonSerialize(using = ToLowerCaseStringSerializer.class)
     private PaymentInstrumentStatus status;
 
+    @Column(name = "charge_external_id")
+    private String chargeExternalId;
+
     @Embedded
     private CardDetailsEntity cardDetails;
 
-    private PaymentInstrumentEntity(Instant createdDate, Map<String, String> recurringAuthToken, Instant startDate, CardDetailsEntity cardDetails, PaymentInstrumentStatus status) {
+    private PaymentInstrumentEntity(Instant createdDate, Map<String, String> recurringAuthToken, Instant startDate, CardDetailsEntity cardDetails, PaymentInstrumentStatus status, String chargeExternalId) {
         this.createdDate = createdDate;
         this.externalId = RandomIdGenerator.newId();
         this.recurringAuthToken = recurringAuthToken;
         this.startDate = startDate;
         this.cardDetails = cardDetails;
         this.status = status;
+        this.chargeExternalId = chargeExternalId;
     }
 
     public Optional<Map<String, String>> getRecurringAuthToken() {
@@ -115,6 +119,12 @@ public class PaymentInstrumentEntity {
         return status;
     }
 
+    public String getChargeExternalId() { return chargeExternalId; }
+
+    public void setChargeExternalId(String chargeExternalId) {
+        this.chargeExternalId = chargeExternalId;
+    }
+
     public void setStatus(PaymentInstrumentStatus newStatus) {
         logger.info(format("Changing payment instrument status for externalId [%s] [%s]->[%s]", this.externalId, this.status, newStatus),
                 kv(PAYMENT_INSTRUMENT_EXTERNAL_ID, this.externalId),
@@ -149,6 +159,7 @@ public class PaymentInstrumentEntity {
         private PaymentInstrumentStatus status;
         private Instant startDate;
         private Map<String, String> recurringAuthToken;
+        private String chargeExternalId;
 
         public static PaymentInstrumentEntity.PaymentInstrumentEntityBuilder aPaymentInstrumentEntity(Instant createdDate) {
             var paymentInstrumentEntityBuilder = new PaymentInstrumentEntityBuilder();
@@ -180,10 +191,15 @@ public class PaymentInstrumentEntity {
             this.recurringAuthToken = recurringAuthToken;
             return this;
         }
+        
+        public PaymentInstrumentEntity.PaymentInstrumentEntityBuilder withChargeExternalId(String chargeExternalId) {
+            this.chargeExternalId = chargeExternalId;
+            return this;
+        }
 
 
         public PaymentInstrumentEntity build() {
-            return new PaymentInstrumentEntity(createdDate, recurringAuthToken, startDate, cardDetails, status);
+            return new PaymentInstrumentEntity(createdDate, recurringAuthToken, startDate, cardDetails, status, chargeExternalId);
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentService.java
@@ -39,6 +39,7 @@ public class PaymentInstrumentService {
                 .withCardDetails(charge.getCardDetails())
                 .withStatus(PaymentInstrumentStatus.CREATED) 
                 .withStartDate(now)
+                .withChargeExternalId(charge.getExternalId())
                 .build();
         paymentInstrumentDao.persist(paymentInstrument);
         ledgerService.postEvent(PaymentInstrumentCreated.from(paymentInstrument, charge.getGatewayAccount()));

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
@@ -48,9 +48,9 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
     private AuthCardDetails authCardDetails;
 
     private static final String REDIRECT_RESULT = "eyJ0cmFuc1N0YXR1cyI6IlkifQ==";
-    
+
     private static final String AUTH_SUCCESS = "AUTHORISATION SUCCESS";
-    
+
     private static final String PSP_REFERENCE_FROM_ADYEN = "993617895215577D";
 
 
@@ -67,7 +67,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         verifyResponseForRecurringPayment(chargeId);
 
-        getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+        getAndVerifyChargeEntity(chargeId);
     }
 
     @Test
@@ -79,11 +79,13 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         verifyResponseForRecurringPayment(chargeId);
 
-        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+        ChargeEntity charge = getAndVerifyChargeEntity(chargeId);
 
         var storedPaymentMethodId = getStoredPaymentMethodId(charge);
+        var paymentInstrumentChargeExternalId = getChargeExternalIdFromPaymentInstrument(charge);
 
         assertThat(storedPaymentMethodId, is(expectedStoredPaymentMethodId));
+        assertThat(paymentInstrumentChargeExternalId, is(charge.getExternalId()));
     }
 
     @Test
@@ -93,12 +95,14 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         verifyResponseForRecurringPayment(chargeId);
 
-        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+        ChargeEntity charge = getAndVerifyChargeEntity(chargeId);
 
-        var paymentInstrument = charge.get().getPaymentInstrument();
+        var paymentInstrument = charge.getPaymentInstrument();
+        var paymentInstrumentChargeExternalId = getChargeExternalIdFromPaymentInstrument(charge);
 
         assertThat(paymentInstrument.isEmpty(), is(false));
         assertThat(paymentInstrument.get().getRecurringAuthToken().isEmpty(), is(true));
+        assertThat(paymentInstrumentChargeExternalId, is(charge.getExternalId()));
     }
 
     @Test
@@ -110,11 +114,13 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         verifyResponseForRecurringPaymentWith3ds(chargeId, 200, AUTH_SUCCESS);
 
-        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+        ChargeEntity charge = getAndVerifyChargeEntity(chargeId);
 
         var storedPaymentMethodId = getStoredPaymentMethodId(charge);
+        var paymentInstrumentChargeExternalId = getChargeExternalIdFromPaymentInstrument(charge);
 
         assertThat(storedPaymentMethodId, is(expectedStoredPaymentMethodId));
+        assertThat(paymentInstrumentChargeExternalId, is(charge.getExternalId()));
     }
 
     @Test
@@ -125,12 +131,14 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         verifyResponseForRecurringPaymentWith3ds(chargeId, 200, AUTH_SUCCESS);
 
-        Optional<ChargeEntity> charge = getAndVerifyChargeEntity(chargeId, PSP_REFERENCE_FROM_ADYEN);
+        ChargeEntity charge = getAndVerifyChargeEntity(chargeId);
 
-        var paymentInstrument = charge.get().getPaymentInstrument();
+        var paymentInstrument = charge.getPaymentInstrument();
+        var paymentInstrumentChargeExternalId = getChargeExternalIdFromPaymentInstrument(charge);
 
         assertThat(paymentInstrument.isEmpty(), is(false));
         assertThat(paymentInstrument.get().getRecurringAuthToken().isEmpty(), is(true));
+        assertThat(paymentInstrumentChargeExternalId, is(charge.getExternalId()));
     }
 
     @Test
@@ -165,7 +173,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
 
         getAndVerifyChargeEntityForFailedAuthorisation(chargeId, "AUTHORISATION ERROR", null);
     }
-    
+
     private String createChargeWithAgreement(ChargeStatus chargeStatus) {
         app.getDatabaseTestHelper().enableRecurring(Long.parseLong(testBaseExtension.getAccountId()));
 
@@ -209,7 +217,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
         if (expectedStatus != null) {
             response.body("status", is(expectedStatus));
         }
-        
+
         app.getAdyenWireMockServer()
                 .verify(postRequestedFor(urlEqualTo("/payments/details"))
                         .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
@@ -237,13 +245,13 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
                         .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
                         .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
     }
-    
-    private Optional<ChargeEntity> getAndVerifyChargeEntity(String chargeId, String pspReferenceFromAdyen) {
+
+    private ChargeEntity getAndVerifyChargeEntity(String chargeId) {
         Optional<ChargeEntity> charge = chargeDao.findByExternalId(chargeId);
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is(AUTH_SUCCESS));
-        assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
-        return charge;
+        assertThat(charge.get().getGatewayTransactionId(), is(PSP_REFERENCE_FROM_ADYEN));
+        return charge.get();
     }
 
     private void getAndVerifyChargeEntityForFailedAuthorisation(String chargeId, String status, @Nullable String pspReferenceFromAdyen) {
@@ -251,13 +259,17 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
         assertThat(charge.isPresent(), is(true));
         assertThat(charge.get().getStatus(), is(status));
         assertThat(charge.get().getPaymentInstrument().isEmpty(), is(true));
-        
+
         if (pspReferenceFromAdyen != null) {
             assertThat(charge.get().getGatewayTransactionId(), is(pspReferenceFromAdyen));
         }
     }
 
-    private static String getStoredPaymentMethodId(Optional<ChargeEntity> charge) {
-        return charge.get().getPaymentInstrument().orElseThrow().getRecurringAuthToken().orElseThrow().get("storedPaymentMethodId");
+    private static String getStoredPaymentMethodId(ChargeEntity charge) {
+        return charge.getPaymentInstrument().orElseThrow().getRecurringAuthToken().orElseThrow().get("storedPaymentMethodId");
+    }
+
+    private static String getChargeExternalIdFromPaymentInstrument(ChargeEntity charge) {
+        return charge.getPaymentInstrument().orElseThrow().getChargeExternalId();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentinstrument/service/PaymentInstrumentServiceTest.java
@@ -27,7 +27,7 @@ class PaymentInstrumentServiceTest {
     @Mock
     private PaymentInstrumentDao mockPaymentInstrumentDao;        
 
-    private ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+    private final ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
 
     private static final Instant NOW = Instant.parse("2022-03-31T15:15:00Z");  
 
@@ -54,6 +54,7 @@ class PaymentInstrumentServiceTest {
         assertThat(actualPaymentInstrumentEntity.getCardDetails(), is(chargeEntity.getCardDetails()));
         assertThat(actualPaymentInstrumentEntity.getStartDate(), is(NOW));
         assertThat(actualPaymentInstrumentEntity.getStatus(), is(PaymentInstrumentStatus.CREATED));
+        assertThat(actualPaymentInstrumentEntity.getChargeExternalId(), is(chargeEntity.getExternalId()));
         assertThat(actualPaymentInstrumentEntity, is(paymentInstrument));
     }
 }


### PR DESCRIPTION
WHAT YOU DID
Stored `chargeExternalId` to payment instrument after a charge has been successfully authorised
small refactor of `AdyenCardResourceAuthoriseRecurringPaymentsIT.java` to remove SonarQube warnings
