### PR TITLE
PP-15681: Add chargeExternalId to paymentInstrument in test fixtures and helpers

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/util/RecurringPaymentSetupUtil.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/RecurringPaymentSetupUtil.java
@@ -34,6 +34,7 @@ public class RecurringPaymentSetupUtil {
     public static final String JSON_VALID_AGREEMENT_ID_VALUE = "12345678901234567890123456";
     public static final String JSON_AUTH_MODE_AGREEMENT = "agreement";
     public static final String JSON_AGREEMENT_PAYMENT_TYPE = UNSCHEDULED.getName();
+    public static final String CHARGE_ID = String.valueOf(secureRandomLong());
 
     public static String setupChargeWithAgreementAndPaymentInstrument(ITestBaseExtension testBaseExtension, AppWithPostgresAndSqsExtension app, String storedPaymentMethodId) {
         Long paymentInstrumentId = secureRandomLong();
@@ -43,6 +44,7 @@ public class RecurringPaymentSetupUtil {
                 .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
                 .withRecurringAuthToken(Map.of(
                         STORED_PAYMENT_METHOD_ID, storedPaymentMethodId))
+                .withChargeExternalId(CHARGE_ID)
                 .build();
         app.getDatabaseTestHelper().addPaymentInstrument(paymentInstrumentParams);
 

--- a/src/test/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/paymentinstrument/model/PaymentInstrumentEntityFixture.java
@@ -15,6 +15,7 @@ public final class PaymentInstrumentEntityFixture {
     private String externalId = "a-payment-instrument-external-id";
     private PaymentInstrumentStatus paymentInstrumentStatus = PaymentInstrumentStatus.CREATED;
     private CardDetailsEntity cardDetails;
+    private String chargeExternalId;
 
     private PaymentInstrumentEntityFixture() {
     }
@@ -59,6 +60,11 @@ public final class PaymentInstrumentEntityFixture {
         this.cardDetails = cardDetails;
         return this;
     }
+    
+    public PaymentInstrumentEntityFixture withChargeExternalId(String chargeExternalId) {
+        this.chargeExternalId = chargeExternalId;
+        return this;
+    }
 
     public PaymentInstrumentEntity build() {
         PaymentInstrumentEntity paymentInstrumentEntity = new PaymentInstrumentEntity();
@@ -68,6 +74,7 @@ public final class PaymentInstrumentEntityFixture {
         paymentInstrumentEntity.setExternalId(externalId);
         paymentInstrumentEntity.setStatus(paymentInstrumentStatus);
         paymentInstrumentEntity.setCardDetails(cardDetails);
+        paymentInstrumentEntity.setChargeExternalId(chargeExternalId);
         return paymentInstrumentEntity;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/AddPaymentInstrumentParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddPaymentInstrumentParams.java
@@ -31,6 +31,7 @@ public class AddPaymentInstrumentParams {
     private final String stateOrProvince;
     private final String postcode;
     private final String countryCode;
+    private final String chargeExternalId;
     
     private Map<String, String> recurringAuthToken;
 
@@ -56,6 +57,10 @@ public class AddPaymentInstrumentParams {
 
     public String getAgreementExternalId() {
         return agreementExternalId;
+    }
+    
+    public String getChargeExternalId() {
+        return chargeExternalId;
     }
 
     public CardType getCardType() {
@@ -117,6 +122,7 @@ public class AddPaymentInstrumentParams {
         startDate = builder.startDate;
         paymentInstrumentStatus = builder.paymentInstrumentStatus;
         agreementExternalId = builder.agreementExternalId;
+        chargeExternalId = builder.chargeExternalId;
         cardType = builder.cardType;
         cardBrand = builder.cardBrand;
         expiryDate = builder.expiryDate;
@@ -152,6 +158,7 @@ public class AddPaymentInstrumentParams {
         private String postcode = "PAY ME";
         private String countryCode = "GB";
         private Map<String, String> recurringAuthToken;
+        private String chargeExternalId;
 
         private AddPaymentInstrumentParamsBuilder() {
         }
@@ -252,6 +259,11 @@ public class AddPaymentInstrumentParams {
         
         public AddPaymentInstrumentParamsBuilder withRecurringAuthToken(Map<String, String> recurringAuthToken) {
             this.recurringAuthToken = recurringAuthToken;
+            return this;
+        }
+
+        public AddPaymentInstrumentParamsBuilder withChargeExternalId(String chargeExternalId) {
+            this.chargeExternalId = chargeExternalId;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -199,6 +199,7 @@ public class DatabaseTestHelper {
                                 "start_date, " +
                                 "status, " +
                                 "agreement_external_id, " +
+                                "charge_external_id, " +
                                 "card_type, " +
                                 "card_brand, " +
                                 "expiry_date, " +
@@ -219,6 +220,7 @@ public class DatabaseTestHelper {
                                 ":start_date, " +
                                 ":status, " +
                                 ":agreement_external_id, " +
+                                ":charge_external_id, " +
                                 ":card_type, " +
                                 ":card_brand, " +
                                 ":expiry_date, " +
@@ -239,6 +241,7 @@ public class DatabaseTestHelper {
                         .bind("start_date", LocalDateTime.ofInstant(addPaymentInstrumentParams.getStartDate(), UTC))
                         .bind("status", addPaymentInstrumentParams.getPaymentInstrumentStatus())
                         .bind("agreement_external_id", addPaymentInstrumentParams.getAgreementExternalId())
+                        .bind("charge_external_id", addPaymentInstrumentParams.getChargeExternalId())
                         .bind("card_type", addPaymentInstrumentParams.getCardType())
                         .bind("card_brand", addPaymentInstrumentParams.getCardBrand())
                         .bind("expiry_date", addPaymentInstrumentParams.getExpiryDate().toString())


### PR DESCRIPTION
## WHAT YOU DID
Added `chargeExternalID` to test fixtures and helpers associated with recurring card payment tests.

## How to test

Ensure all existing tests still pass
