### PR TITLE
PP-15681: Update shopperReference for recurring Adyen payments to be a unique combination of agreementExternalId and chargeExternalId

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -101,7 +101,7 @@ public class AdyenRequestFactory {
         var recurringAuthToken = paymentInstrument.getRecurringAuthToken()
                 .orElseThrow(() -> new IllegalArgumentException("Payment instrument does not have recurring auth token set"));
 
-        String shopperReference = request.getAgreementId();
+        String shopperReference = createShopperReferenceForRecurringPayments(request);
         String storedPaymentMethodId = recurringAuthToken.get(STORED_PAYMENT_METHOD_ID);
 
         if (shopperReference == null || storedPaymentMethodId.isBlank()) {
@@ -127,6 +127,16 @@ public class AdyenRequestFactory {
                 null,
                 fromAgreementPaymentType(request.getAgreementPaymentType())
         );
+    }
+
+    private String createShopperReferenceForRecurringPayments(RecurringPaymentAuthorisationGatewayRequest request) {
+        var chargeExternalId = request.getPaymentInstrument().isPresent()
+                ? request.getPaymentInstrument().get().getChargeExternalId()
+                : request.getGovUkPayPaymentId();
+        if (chargeExternalId == null || request.getAgreementId() == null) {
+            return null;
+        }
+        return String.format("%s-%s", request.getAgreementId(), chargeExternalId);
     }
 
     private static String getShopperInteraction(CardAuthorisationGatewayRequest request) {

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
@@ -61,6 +61,8 @@ import static uk.gov.service.payments.commons.model.AgreementPaymentType.UNSCHED
 
 class AdyenRequestFactoryTest {
 
+    private static final String RECURRING_CHARGE_EXTERNAL_ID = "extcharge123";
+    
     final String acceptHeader = "text/html";
     final String userAgent = "Mozilla/5.0";
     final String shopperIp = "127.0.0.1";
@@ -425,6 +427,7 @@ class AdyenRequestFactoryTest {
         var paymentInstrument = aPaymentInstrumentEntity()
                 .withRecurringAuthToken(Map.of(
                         STORED_PAYMENT_METHOD_ID, storedPaymentMethodId))
+                .withChargeExternalId("extcharge123")
                 .build();
 
         var charge = setupChargeEntityForRecurringPayment(agreement, paymentInstrument);
@@ -433,7 +436,7 @@ class AdyenRequestFactoryTest {
 
         var request = adyenRequestFactory.createRecurringPaymentRequest(authoriseRequest);
 
-        assertThat(request.shopperReference(), is(agreementId));
+        assertThat(request.shopperReference(), is(agreementId + "-" + RECURRING_CHARGE_EXTERNAL_ID));
         assertThat(request.storePaymentMethod(), is(nullValue()));
         assertThat(request.recurringProcessingModel(), is("Subscription"));
         assertThat(request.paymentMethod().storedPaymentMethodId(), is(storedPaymentMethodId));
@@ -444,6 +447,9 @@ class AdyenRequestFactoryTest {
     void should_throw_illegalArgumentException_if_shopperReference_is_null_for_recurring_payment() {
         var agreement = anAgreementEntity()
                 .withExternalId(null)
+                .withPaymentInstrument(new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
+                        .withChargeExternalId(null)
+                        .build())
                 .build();
         var storedPaymentMethodId = "42";
         var paymentInstrument = aPaymentInstrumentEntity()
@@ -502,6 +508,7 @@ class AdyenRequestFactoryTest {
                 .build();
 
         return aValidChargeEntity()
+                .withExternalId(RECURRING_CHARGE_EXTERNAL_ID)
                 .withAgreementPaymentType(RECURRING)
                 .withAgreementEntity(agreement)
                 .withPaymentInstrument(paymentInstrument)

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
@@ -263,6 +263,7 @@ class AdyenAuthoriseHandlerTest {
         var paymentInstrument = aPaymentInstrumentEntity()
                 .withRecurringAuthToken(Map.of(
                         STORED_PAYMENT_METHOD_ID, storedPaymentMethodId))
+                .withChargeExternalId("extcharge123")
                 .build();
 
         var charge = setupChargeEntityForRecurringPayment(agreement, paymentInstrument);
@@ -295,6 +296,7 @@ class AdyenAuthoriseHandlerTest {
         var paymentInstrument = aPaymentInstrumentEntity()
                 .withRecurringAuthToken(Map.of(
                         STORED_PAYMENT_METHOD_ID, storedPaymentMethodId))
+                .withChargeExternalId("extcharge123")
                 .build();
 
         var charge = setupChargeEntityForRecurringPayment(agreement, paymentInstrument);

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/AdyenAuthoriseWithUserNotPresentTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/AdyenAuthoriseWithUserNotPresentTaskHandlerIT.java
@@ -86,9 +86,10 @@ public class AdyenAuthoriseWithUserNotPresentTaskHandlerIT {
         testBaseExtension.assertFrontendChargeStatusIs(chargeId, expectedStatus);
         testBaseExtension.assertApiStateIs(chargeId, EXTERNAL_FAILED_REJECTED.getStatus());
 
-        verifyRequestToAdyenPaymentsEndpoint(chargeId, storedPaymentMethodId);
-
         var charge = getChargeEntity(chargeId);
+
+        assertThat(charge.getPaymentInstrument().isPresent(), is(true));
+        verifyRequestToAdyenPaymentsEndpoint(chargeId, storedPaymentMethodId, charge.getPaymentInstrument().get().getChargeExternalId());
         verifyChargeEntity(charge, storedPaymentMethodId, expectedStatus);
         assertThat(charge.getGatewayRejectionReason(), Matchers.is(expectedReasonCode + " - " + expectedReason));
     }
@@ -108,9 +109,10 @@ public class AdyenAuthoriseWithUserNotPresentTaskHandlerIT {
         testBaseExtension.assertFrontendChargeStatusIs(chargeId, expectedStatus);
         testBaseExtension.assertApiStateIs(chargeId, EXTERNAL_ERROR_GATEWAY.getStatus());
 
-        verifyRequestToAdyenPaymentsEndpoint(chargeId, storedPaymentMethodId);
-
         var charge = getChargeEntity(chargeId);
+
+        assertThat(charge.getPaymentInstrument().isPresent(), is(true));
+        verifyRequestToAdyenPaymentsEndpoint(chargeId, storedPaymentMethodId, charge.getPaymentInstrument().get().getChargeExternalId());
         verifyChargeEntity(charge, storedPaymentMethodId, expectedStatus);
     }
 
@@ -128,18 +130,19 @@ public class AdyenAuthoriseWithUserNotPresentTaskHandlerIT {
         testBaseExtension.assertFrontendChargeStatusIs(chargeId, expectedStatus);
         testBaseExtension.assertApiStateIs(chargeId, EXTERNAL_ERROR_GATEWAY.getStatus());
 
-        verifyRequestToAdyenPaymentsEndpoint(chargeId, storedPaymentMethodId);
-
         var charge = getChargeEntity(chargeId);
+        
+        assertThat(charge.getPaymentInstrument().isPresent(), is(true));
+        verifyRequestToAdyenPaymentsEndpoint(chargeId, storedPaymentMethodId, charge.getPaymentInstrument().get().getChargeExternalId());
         assertThat(charge.getStatus(), is(expectedStatus));
     }
 
-    private void verifyRequestToAdyenPaymentsEndpoint(String chargeId, String storedPaymentMethodId) {
+    private void verifyRequestToAdyenPaymentsEndpoint(String chargeId, String storedPaymentMethodId, String chargeExternalId) {
         app.getAdyenWireMockServer()
                 .verify(postRequestedFor(urlEqualTo("/payments"))
                         .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
                         .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
-                        .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(JSON_VALID_AGREEMENT_ID_VALUE)))
+                        .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(JSON_VALID_AGREEMENT_ID_VALUE + "-" + chargeExternalId)))
                         .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("UnscheduledCardOnFile")))
                         .withRequestBody(matchingJsonPath("$.paymentMethod.storedPaymentMethodId", equalTo(storedPaymentMethodId)))
                         .withRequestBody(matchingJsonPath("$.paymentMethod.type", equalTo("scheme")))


### PR DESCRIPTION
## WHAT YOU DID
- created a method in AdyenRequestFactory which is only used for recurring payments to build the new shopper reference with a structure of `agreementExternalId-chargeExternalId`
  - When setting up a recurring payment, the charge_external_id of the payment being authorised is appended to the `shopperReference` for Adyen.
  - When taking a recurring payment, the charge_external_id on the payment instrument is appended to the `shopperReference` for Adyen.

## How to test

I have updated tests for recurring payments with Adyen to show the new change.
