### PR TITLE
PP-15557 add recurring token webhooks to task queue

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationService.java
@@ -7,7 +7,12 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
 import uk.gov.pay.connector.gateway.exception.AdyenNotificationException;
+import uk.gov.pay.connector.queue.tasks.TaskQueueService;
+import uk.gov.pay.connector.queue.tasks.TaskType;
+import uk.gov.pay.connector.queue.tasks.model.Task;
 import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import java.util.Set;
 
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getTokenHmacKey;
@@ -20,14 +25,21 @@ public class AdyenRecurringTokenNotificationService {
     private static final String NOTIFICATION_SOURCE = "notification_source";
     private final AdyenGatewayConfig adyenGatewayConfig;
     private final JsonObjectMapper jsonObjectMapper;
+    private final  TaskQueueService taskQueueService;
+    private static final Set<String> SUPPORTED_EVENT_TYPES = Set.of(
+            "recurring.token.created",
+            "recurring.token.disabled"
+    );
 
     @Inject
     public AdyenRecurringTokenNotificationService(AdyenGatewayConfig adyenGatewayConfig,
                                                   AdyenNotificationValidator adyenNotificationValidator,
-                                                  JsonObjectMapper jsonObjectMapper) {
+                                                  JsonObjectMapper jsonObjectMapper,
+                                                  TaskQueueService taskQueueService) {
         this.adyenNotificationValidator = adyenNotificationValidator;
         this.adyenGatewayConfig = adyenGatewayConfig;
         this.jsonObjectMapper = jsonObjectMapper;
+        this.taskQueueService = taskQueueService;
     }
 
     public boolean handleNotificationFor(String payload, String hmacSignature, String forwardedIpAddresses) {
@@ -56,6 +68,19 @@ public class AdyenRecurringTokenNotificationService {
                 return false;
             }
 
+            if (!isSupportedEventType(adyenTokenResponse.type())) {
+                LOGGER.atInfo()
+                        .setMessage("Ignoring unsupported Adyen token notification")
+                        .addKeyValue("type", adyenTokenResponse.type())
+                        .addKeyValue("shopperReference", adyenTokenResponse.data().shopperReference())
+                        .addKeyValue("environment", adyenTokenResponse.environment())
+                        .addKeyValue("eventId", adyenTokenResponse.eventId())
+                        .log();
+
+                return true;
+            }
+            taskQueueService.add(new Task(payload, TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION));
+            
             LOGGER.atInfo()
                     .setMessage("Processed Adyen token notification")
                     .addKeyValue(PROVIDER, ADYEN.getName())
@@ -75,6 +100,9 @@ public class AdyenRecurringTokenNotificationService {
             LOGGER.info("Error deserialising token notification payload", e);
             throw new WebApplicationException("Error deserialising token webhook Json", e);
         }
+    }
+    private boolean isSupportedEventType(String eventType) {
+        return SUPPORTED_EVENT_TYPES.contains(eventType);
     }
 }
 

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskType.java
@@ -6,6 +6,7 @@ public enum TaskType {
     COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT("collect_fee_for_stripe_failed_payment"),
     HANDLE_STRIPE_WEBHOOK_NOTIFICATION("handle_stripe_webhook_notification"),
     HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION("handle_adyen_payments_webhook_notification"),
+    HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION("handle_adyen_token_webhook_notification"),
     AUTHORISE_WITH_USER_NOT_PRESENT("authorise_with_user_not_present"),
     DELETE_STORED_PAYMENT_DETAILS("delete_stored_payment_details"),
     RETRY_FAILED_PAYMENT_OR_REFUND_EMAIL("retry_failed_payment_or_refund_email"), 

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationServiceTest.java
@@ -10,6 +10,8 @@ import jakarta.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -20,6 +22,9 @@ import uk.gov.pay.connector.app.adyen.HmacKeys;
 import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
 import uk.gov.pay.connector.gateway.exception.AdyenNotificationException;
+import uk.gov.pay.connector.queue.tasks.TaskQueueService;
+import uk.gov.pay.connector.queue.tasks.TaskType;
+import uk.gov.pay.connector.queue.tasks.model.Task;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
@@ -33,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,13 +63,17 @@ class AdyenRecurringTokenNotificationServiceTest {
     private AdyenRecurringTokenNotificationService adyenRecurringTokenNotificationService;
 
     private static final JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(new ObjectMapper());
+    
+    @Mock
+    private TaskQueueService mockTaskQueueService;
 
     @BeforeEach
     void setUp() {
         adyenRecurringTokenNotificationService = new AdyenRecurringTokenNotificationService(
                 adyenGatewayConfig,
                 mockAdyenNotificationValidator,
-                jsonObjectMapper);
+                jsonObjectMapper,
+                mockTaskQueueService);
         Logger logger = (Logger) LoggerFactory.getLogger(AdyenRecurringTokenNotificationService.class);
         logger.setLevel(Level.INFO);
         logger.addAppender(mockAppender);
@@ -172,6 +182,7 @@ class AdyenRecurringTokenNotificationServiceTest {
         assertThat(loggingEvents.stream()
                         .anyMatch(event -> event.getFormattedMessage().equals("Hmac signature is invalid, rejecting Adyen token notification")),
                 is(true));
+        verifyNoInteractions(mockTaskQueueService);
     }
 
     @Test
@@ -192,5 +203,90 @@ class AdyenRecurringTokenNotificationServiceTest {
         assertThat(loggingEvents.stream()
                         .anyMatch(event -> event.getFormattedMessage().equals("Failed to validate Adyen token notification payload")),
                 is(true));
+    }
+
+    @Test
+    void shouldIgnoreUnsupportedTokenNotification() {
+        var primaryTestKey = "primaryTest";
+
+        String payload = TestTemplateResourceLoader
+                .load(
+                        TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION).replace(
+                        "\"type\": \"recurring.token.created\"",
+                        "\"type\": \"recurring.token.updated\""
+                );
+
+        var tokenKeys =
+                new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
+                        new WebhookHmacKeys("primaryLive", "secondaryLive"));
+
+        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
+
+        when(adyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
+
+        when(mockAdyenNotificationValidator.isValidHmac( HMAC_SIGNATURE, primaryTestKey, payload)).thenReturn(true);
+
+        boolean result = 
+                adyenRecurringTokenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP);
+
+        assertTrue(result);
+
+        verifyNoInteractions(mockTaskQueueService);
+
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(loggingEvents.stream().anyMatch(event -> event.getFormattedMessage().equals(
+                                                "Ignoring unsupported Adyen token notification")), is(true)
+        );
+    }
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "recurring.token.created",
+            "recurring.token.disabled"
+    })
+    void shouldAddSupportedTokenNotificationToTaskQueue(String eventType) {
+        var primaryTestKey = "primaryTest";
+
+        String payload = TestTemplateResourceLoader.load(
+                TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION
+        ).replace(
+                "\"type\": \"recurring.token.created\"",
+                "\"type\": \"" + eventType + "\""
+        );
+
+        var tokenKeys = new HmacKeys.WebhookHmacKeyPair(
+                new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
+                new WebhookHmacKeys("primaryLive", "secondaryLive")
+        );
+
+        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP))
+                .thenReturn(true);
+
+        when(adyenGatewayConfig.getHmacKeys())
+                .thenReturn(new HmacKeys(null, tokenKeys));
+
+        when(mockAdyenNotificationValidator.isValidHmac(
+                HMAC_SIGNATURE,
+                primaryTestKey,
+                payload
+        )).thenReturn(true);
+
+        boolean result =
+                adyenRecurringTokenNotificationService.handleNotificationFor(
+                        payload,
+                        HMAC_SIGNATURE,
+                        FORWARDED_IP
+                );
+
+        assertTrue(result);
+
+        verify(mockTaskQueueService).add(
+                new Task(
+                        payload,
+                        TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION
+                )
+        );
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Added support for event types: 
  -` recurring.token.created` and `recurring.token.disabled`
- ignore unsupported token webhook event types and log the notification details
- prevent notifications with an invalid HMAC signature from being added to the task queu



