### PR TITLE
PP-15698: add explicit metrics-graphite dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,16 @@
             <artifactId>dropwizard-db</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-graphite</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.rabbitmq</groupId>
+                    <artifactId>amqp-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>


### PR DESCRIPTION
The project has a dependency on `io.dropwizard.metrics:metrics-graphite`, but it is not used in any other service and will be removed from utils-dropwizard-5. 

We exclude `com.rabbitmq:amqp-client`, since only the UDP sender is used here and we do not want a compile scope dependency on Netty.