### PR TITLE
PP-15635 Enable creation of Adyen switching credentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -639,7 +639,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java",
         "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
         "is_verified": false,
-        "line_number": 169
+        "line_number": 207
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-04T10:12:10Z"
+  "generated_at": "2026-08-11T11:00:08Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -4725,7 +4725,7 @@ components:
             stripe_account_id: accnt_id
         payment_provider:
           type: string
-          description: "Payment provider. Accepted values - stripe, worldpay"
+          description: "Payment provider. Accepted values - stripe, worldpay, adyen"
           example: stripe
     GatewayAccountCredentialsWithInternalId:
       type: object

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentialsRequest.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record GatewayAccountCredentialsRequest (
-        @Schema(example = "stripe", description = "Payment provider. Accepted values - stripe, worldpay")
+        @Schema(example = "stripe", description = "Payment provider. Accepted values - stripe, worldpay, adyen")
         @JsonProperty(PAYMENT_PROVIDER_FIELD_NAME)
         String paymentProvider,
         

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidator.java
@@ -18,7 +18,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toUnmodifiableList;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsRequest.PAYMENT_PROVIDER_FIELD_NAME;
@@ -49,7 +49,7 @@ public class GatewayAccountCredentialsRequestValidator {
 
         var paymentGatewayName = PaymentGatewayName.valueFrom(gatewayAccountCredentialsRequest.paymentProvider());
 
-        if (!(paymentGatewayName == WORLDPAY || paymentGatewayName == STRIPE)) {
+        if (!List.of(ADYEN, WORLDPAY, STRIPE).contains(paymentGatewayName)) {
             throw new ValidationException(List.of("Operation not supported for payment provider '"
                     + paymentGatewayName.getName() + "'"));
         }
@@ -113,25 +113,23 @@ public class GatewayAccountCredentialsRequestValidator {
         return getRequiredCredentialsFields(paymentProvider, path)
                 .stream()
                 .filter(requiredField -> !credentials.containsKey(requiredField))
-                .collect(toUnmodifiableList());
+                .toList();
     }
 
     private List<String> getRequiredCredentialsFields(PaymentGatewayName paymentProvider, String path) {
-        switch (paymentProvider) {
-            case WORLDPAY:
+        return switch (paymentProvider) {
+            case WORLDPAY -> {
                 if (FIELD_CREDENTIALS.equals(path)) {
                     throw new UnsupportedOperationException(format("Path [%s] is not supported for updating Worldpay credentials", path));
                 }
-                return WORLDPAY_CREDENTIALS_KEYS;
-            case STRIPE:
-                return STRIPE_CREDENTIALS_KEYS;
-            case EPDQ:
-                return EPDQ_CREDENTIALS_KEYS;
-            case SMARTPAY:
-            case SANDBOX:
-            default:
-                throw new UnsupportedOperationException("Cannot perform operation for payment provider [ " + paymentProvider.getName() + ']');
-        }
+                yield WORLDPAY_CREDENTIALS_KEYS;
+            }
+            case STRIPE -> STRIPE_CREDENTIALS_KEYS;
+            case EPDQ -> EPDQ_CREDENTIALS_KEYS;
+            case ADYEN -> List.of();
+            default ->
+                    throw new UnsupportedOperationException("Cannot perform operation for payment provider [ " + paymentProvider.getName() + ']');
+        };
     }
 
     private void validateReplaceStateOperation(JsonPatchRequest request) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -8,7 +8,9 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.WebApplicationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.exception.ConflictWebApplicationException;
 import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountCredentialsNotFoundException;
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
@@ -104,8 +106,8 @@ public class GatewayAccountCredentialsService {
         boolean credentialsPrePopulated = !credentials.isEmpty();
         var gatewayAccountType = GatewayAccountType.fromString(gatewayAccountEntity.getType());
         
-        if (paymentGatewayName == ADYEN && gatewayAccountType == TEST && !credentialsPrePopulated) {
-            throw new BadRequestException("Switching credential cannot be created for an Adyen test account.");
+        if (paymentGatewayName == ADYEN && gatewayAccountType == TEST && credentials.isEmpty()) {
+            throw new ConflictWebApplicationException("Cannot create empty Adyen credentials on a test account.");
         }
 
         if (paymentGatewayName == SANDBOX ||

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -33,11 +33,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Comparator.comparing;
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
@@ -103,6 +103,10 @@ public class GatewayAccountCredentialsService {
         boolean isFirstCredentials = !gatewayAccountCredentialsDao.hasActiveCredentials(gatewayAccountEntity.getId());
         boolean credentialsPrePopulated = !credentials.isEmpty();
         var gatewayAccountType = GatewayAccountType.fromString(gatewayAccountEntity.getType());
+        
+        if (paymentGatewayName == ADYEN && gatewayAccountType == TEST && !credentialsPrePopulated) {
+            throw new BadRequestException("Switching credential cannot be created for an Adyen test account.");
+        }
 
         if (paymentGatewayName == SANDBOX ||
                 (paymentGatewayName == STRIPE && gatewayAccountType == TEST)) {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
@@ -24,7 +24,7 @@ import static jakarta.ws.rs.core.Response.Status.OK;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
-import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_CONFLICT;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -119,13 +119,13 @@ public class GatewayAccountCredentialsResourceIT {
             }
 
             @Test
-            void invalidRequest_shouldNotCreateAdyenSwitchingCredentials_andReturn400() {
+            void invalidRequest_shouldNotCreateAdyenSwitchingCredentials_andReturn409() {
                 app.givenSetup()
                         .body(toJson(Map.of("payment_provider", "adyen", "credentials", emptyMap())))
                         .post("/v1/api/accounts/" + accountId + "/credentials")
                         .then()
-                        .statusCode(SC_BAD_REQUEST)
-                        .body("message", is("Switching credential cannot be created for an Adyen test account."));
+                        .statusCode(SC_CONFLICT)
+                        .body("message", is(List.of("Cannot create empty Adyen credentials on a test account.")));
             }
         }
 
@@ -360,7 +360,7 @@ public class GatewayAccountCredentialsResourceIT {
             }
 
             @Test
-            void invalidRequest_shouldNotCreateAdyenSwitchingCredentials_andReturn400() {
+            void invalidRequest_shouldNotCreateAdyenSwitchingCredentials_andReturn409() {
                 app.givenSetup()
                         .body(toJson(Map.of(
                                 "payment_provider", "stripe",
@@ -375,8 +375,8 @@ public class GatewayAccountCredentialsResourceIT {
                         .body(toJson(Map.of("payment_provider", "adyen", "credentials", emptyMap())))
                         .post(format("/v1/api/service/%s/account/%s/credentials", VALID_SERVICE_ID, TEST))
                         .then()
-                        .statusCode(SC_BAD_REQUEST)
-                        .body("message", is("Switching credential cannot be created for an Adyen test account."));
+                        .statusCode(SC_CONFLICT)
+                        .body("message", is(List.of("Cannot create empty Adyen credentials on a test account.")));
             }
 
             @Test

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java
@@ -22,15 +22,19 @@ import java.util.Map;
 
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
 import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
@@ -88,6 +92,40 @@ public class GatewayAccountCredentialsResourceIT {
                         .post("/v1/api/accounts/10000/credentials")
                         .then()
                         .statusCode(400);
+            }
+
+            @Test
+            void validRequest_shouldCreateAdyenSwitchingCredentials_andReturn200() {
+                var liveAccount = addGatewayAccountAndCredential("stripe", ACTIVE, LIVE, 
+                        Map.of("stripe_account_id", "some-account-id"));
+                var liveAccountId = liveAccount.getAccountId();
+
+                credentialsId = liveAccount.getCredentials().getFirst().getId();
+
+                app.givenSetup()
+                        .body(toJson(Map.of("payment_provider", "adyen", "credentials", emptyMap())))
+                        .post("/v1/api/accounts/" + liveAccountId + "/credentials")
+                        .then()
+                        .statusCode(OK.getStatusCode());
+                
+                app.givenSetup()
+                        .get("/v1/api/accounts/" + liveAccountId)
+                        .then()
+                        .statusCode(OK.getStatusCode())
+                        .body("gateway_account_credentials.size()", is(2))
+                        .body("gateway_account_credentials[1].payment_provider", is("adyen"))
+                        .body("gateway_account_credentials[1].state", is(CREATED.toString()))
+                        .body("gateway_account_credentials[1].external_id", is(notNullValue(String.class)));
+            }
+
+            @Test
+            void invalidRequest_shouldNotCreateAdyenSwitchingCredentials_andReturn400() {
+                app.givenSetup()
+                        .body(toJson(Map.of("payment_provider", "adyen", "credentials", emptyMap())))
+                        .post("/v1/api/accounts/" + accountId + "/credentials")
+                        .then()
+                        .statusCode(SC_BAD_REQUEST)
+                        .body("message", is("Switching credential cannot be created for an Adyen test account."));
             }
         }
 
@@ -290,6 +328,55 @@ public class GatewayAccountCredentialsResourceIT {
                         .body("gateway_account_credentials[1].payment_provider", is("stripe"))
                         .body("gateway_account_credentials[1].credentials.stripe_account_id", is("some-account-id"))
                         .body("gateway_account_credentials[1].external_id", is(notNullValue(String.class)));
+            }
+
+            @Test
+            void validRequest_shouldCreateAdyenSwitchingCredentials_andReturn200() {
+                String gatewayAccountId = app.givenSetup()
+                        .body(toJson(Map.of(
+                                "payment_provider", "stripe",
+                                "service_id", VALID_SERVICE_ID,
+                                "service_name", VALID_SERVICE_NAME,
+                                "type", "live"
+                        )))
+                        .post("/v1/api/accounts")
+                        .then().extract().path("gateway_account_id");
+
+                app.givenSetup()
+                        .body(toJson(Map.of("payment_provider", "adyen", "credentials", emptyMap())))
+                        .post(format("/v1/api/service/%s/account/%s/credentials", VALID_SERVICE_ID, LIVE))
+                        .then()
+                        .statusCode(OK.getStatusCode())
+                        .body(not(hasKey("gateway_account_credential_id")));
+
+                app.givenSetup()
+                        .get("/v1/api/accounts/" + gatewayAccountId)
+                        .then()
+                        .statusCode(OK.getStatusCode())
+                        .body("gateway_account_credentials.size()", is(2))
+                        .body("gateway_account_credentials[1].payment_provider", is("adyen"))
+                        .body("gateway_account_credentials[1].state", is(CREATED.toString()))
+                        .body("gateway_account_credentials[1].external_id", is(notNullValue(String.class)));
+            }
+
+            @Test
+            void invalidRequest_shouldNotCreateAdyenSwitchingCredentials_andReturn400() {
+                app.givenSetup()
+                        .body(toJson(Map.of(
+                                "payment_provider", "stripe",
+                                "service_id", VALID_SERVICE_ID,
+                                "service_name", VALID_SERVICE_NAME,
+                                "type", "test"
+                        )))
+                        .post("/v1/api/accounts")
+                        .then().extract().path("gateway_account_id");
+
+                app.givenSetup()
+                        .body(toJson(Map.of("payment_provider", "adyen", "credentials", emptyMap())))
+                        .post(format("/v1/api/service/%s/account/%s/credentials", VALID_SERVICE_ID, TEST))
+                        .then()
+                        .statusCode(SC_BAD_REQUEST)
+                        .body("message", is("Switching credential cannot be created for an Adyen test account."));
             }
 
             @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
@@ -328,7 +328,7 @@ public class GatewayAccountResourceCreateIT {
             var requestBodyWithoutCredentials = """
                     {
                       "payment_provider": "adyen",
-                      "type": "test",
+                      "type": "live",
                       "service_name": "new service",
                       "service_id": "service-external-id"
                     }""";
@@ -340,7 +340,7 @@ public class GatewayAccountResourceCreateIT {
                     .statusCode(201)
                     .body("gateway_account_id", not(emptyString()))
                     .body("external_id", not(emptyString()))
-                    .body("type", is("test"))
+                    .body("type", is("live"))
                     .body("service_name", is("new service"))
                     .body("description", nullValue())
                     .body("analytics_id", nullValue())

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceCreateIT.java
@@ -323,7 +323,7 @@ public class GatewayAccountResourceCreateIT {
         }
 
         @Test
-        void should_create_Adyen_gateway_account_without_credentials() {
+        void should_create_live_Adyen_gateway_account_without_credentials() {
             // language=JSON
             var requestBodyWithoutCredentials = """
                     {


### PR DESCRIPTION
## WHAT YOU DID

- Update `GatewayAccountCredentialsRequestValidator.java` to accept Adyen gateway accounts
- Update `GatewayAccountCredentialsService.java` to throw an error for Adyen test accounts

These changes allow for the creation of a switching credential for Adyen live accounts only, when calling 
POST `/v1/api/accounts/{accountId}/credentials` or POST `/v1/api/service/{serviceId}/account/{accountType}/credentials`

 We already have functionaly to create Adyen test accounts. This is done via POST `/v1/api/service/{serviceId}/request-adyen-test-account` for new accounts, or POST `/v1/api/service/{serviceId}/switch-to-adyen-test-account` for existing Stripe accounts. 

Calls to either of these endpoints will fail if an Adyen credential exists in any state, so while unlikely to happen, we should guard against this. Additionally, when creating Adyen test accounts using the existing endpoints, we receive credentials from Adyen, so we should prevent test accounts being created with an empty credential object. 

