### PR TITLE
PP-15681: update shopperReference to include a charge's externalId

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -32,6 +32,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 public class AdyenRequestFactory {
 
     public static final String STORED_PAYMENT_METHOD_ID = "storedPaymentMethodId";
@@ -67,9 +69,10 @@ public class AdyenRequestFactory {
         Boolean storePaymentMethod = null;
         String recurringProcessingModel = null;
         if (request.isSavePaymentInstrumentToAgreement()) {
-            shopperReference = request.getAgreement()
+           var agreementExternalId = request.getAgreement()
                     .orElseThrow(() -> new IllegalArgumentException("Expected charge with savePaymentInstrumentToAgreement to have an agreement"))
                     .getExternalId();
+            shopperReference = createShopperReferenceForRecurringPayments(agreementExternalId, request.getGovUkPayPaymentId());
             storePaymentMethod = true;
             recurringProcessingModel = fromAgreementPaymentType(request.getAgreementPaymentType());
         }
@@ -101,11 +104,11 @@ public class AdyenRequestFactory {
         var recurringAuthToken = paymentInstrument.getRecurringAuthToken()
                 .orElseThrow(() -> new IllegalArgumentException("Payment instrument does not have recurring auth token set"));
 
-        String shopperReference = createShopperReferenceForRecurringPayments(request);
+        String shopperReference = createShopperReferenceForRecurringPayments(request.getAgreementId(), paymentInstrument.getChargeExternalId());
         String storedPaymentMethodId = recurringAuthToken.get(STORED_PAYMENT_METHOD_ID);
 
-        if (shopperReference == null || storedPaymentMethodId.isBlank()) {
-            throw new IllegalArgumentException("Adyen recurring auth token is missing shopperReference or storedPaymentMethodId");
+        if (isBlank(storedPaymentMethodId)) {
+            throw new IllegalArgumentException("Adyen recurring auth token is missing storedPaymentMethodId");
         }
 
         return new AuthoriseRequestPayload(
@@ -129,14 +132,11 @@ public class AdyenRequestFactory {
         );
     }
 
-    private String createShopperReferenceForRecurringPayments(RecurringPaymentAuthorisationGatewayRequest request) {
-        var chargeExternalId = request.getPaymentInstrument().isPresent()
-                ? request.getPaymentInstrument().get().getChargeExternalId()
-                : request.getGovUkPayPaymentId();
-        if (chargeExternalId == null || request.getAgreementId() == null) {
-            return null;
+    private String createShopperReferenceForRecurringPayments(String agreementId, String chargeExternalId) {
+        if (agreementId == null || chargeExternalId == null || isBlank(agreementId) || isBlank(chargeExternalId)) {
+            throw new IllegalArgumentException("shopperReference could not be derived as charge external ID or agreement external ID are missing");
         }
-        return String.format("%s-%s", request.getAgreementId(), chargeExternalId);
+        return String.format("%s-%s", agreementId, chargeExternalId);
     }
 
     private static String getShopperInteraction(CardAuthorisationGatewayRequest request) {

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactoryTest.java
@@ -62,7 +62,7 @@ import static uk.gov.service.payments.commons.model.AgreementPaymentType.UNSCHED
 class AdyenRequestFactoryTest {
 
     private static final String RECURRING_CHARGE_EXTERNAL_ID = "extcharge123";
-    
+
     final String acceptHeader = "text/html";
     final String userAgent = "Mozilla/5.0";
     final String shopperIp = "127.0.0.1";
@@ -216,7 +216,7 @@ class AdyenRequestFactoryTest {
 
         var request = adyenRequestFactory.createPaymentRequest(authoriseRequest);
 
-        assertThat(request.shopperReference(), is(agreementId));
+        assertThat(request.shopperReference(), is(agreementId + "-" + authoriseRequest.getGovUkPayPaymentId()));
         assertThat(request.storePaymentMethod(), is(true));
         assertThat(request.recurringProcessingModel(), is("Subscription"));
     }
@@ -444,7 +444,7 @@ class AdyenRequestFactoryTest {
     }
 
     @Test
-    void should_throw_illegalArgumentException_if_shopperReference_is_null_for_recurring_payment() {
+    void should_throw_illegalArgumentException_if_shopperReference_is_incomplete_for_recurring_payment() {
         var agreement = anAgreementEntity()
                 .withExternalId(null)
                 .withPaymentInstrument(new PaymentInstrumentEntity.PaymentInstrumentEntityBuilder()
@@ -463,7 +463,7 @@ class AdyenRequestFactoryTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> adyenRequestFactory.createRecurringPaymentRequest(authoriseRequest));
 
-        assertThat(exception.getMessage(), is("Adyen recurring auth token is missing shopperReference or storedPaymentMethodId"));
+        assertThat(exception.getMessage(), is("shopperReference could not be derived as charge external ID or agreement external ID are missing"));
     }
 
     @Test
@@ -475,6 +475,7 @@ class AdyenRequestFactoryTest {
         var paymentInstrument = aPaymentInstrumentEntity()
                 .withRecurringAuthToken(Map.of(
                         STORED_PAYMENT_METHOD_ID, " "))
+                .withChargeExternalId("charge-external-id123")
                 .build();
         var charge = setupChargeEntityForRecurringPayment(agreement, paymentInstrument);
 
@@ -483,7 +484,7 @@ class AdyenRequestFactoryTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> adyenRequestFactory.createRecurringPaymentRequest(authoriseRequest));
 
-        assertThat(exception.getMessage(), is("Adyen recurring auth token is missing shopperReference or storedPaymentMethodId"));
+        assertThat(exception.getMessage(), is("Adyen recurring auth token is missing storedPaymentMethodId"));
     }
 
     private static CancelGatewayRequest makeCancelGatewayRequestWithExternalChargeId(String externalChargeId) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
@@ -241,7 +241,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
                 .verify(postRequestedFor(urlEqualTo("/payments"))
                         .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
                         .withHeader("Idempotency-Key", equalTo("authorise-" + chargeId))
-                        .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId)))
+                        .withRequestBody(matchingJsonPath("$.shopperReference", equalTo(externalAgreementId + "-" + chargeId)))
                         .withRequestBody(matchingJsonPath("$.storePaymentMethod", equalTo("true")))
                         .withRequestBody(matchingJsonPath("$.recurringProcessingModel", equalTo("Subscription"))));
     }


### PR DESCRIPTION
## WHAT YOU DID

When initial payment is taken to set up an agreement the `chargeExternalId` (also known as `GovUkPayPaymentId`) should be used along with the `agreementExternalId` to set the `shopperReference` for an authorise request with Adyen.

I added this functionality to `createPaymentRequest` where I had previously missed it in this [PR](https://github.com/alphagov/pay-connector/pull/6611).
I also refactored `createShopperReferenceForRecurringPayments`
