### PR TITLE
PP-15557 Add recurring token webhooks to task queue

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationService.java
@@ -79,8 +79,7 @@ public class AdyenRecurringTokenNotificationService {
 
                 return true;
             }
-            taskQueueService.add(new Task(payload, TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION));
-            
+            addNotificationToTaskQueue(payload);
             LOGGER.atInfo()
                     .setMessage("Processed Adyen token notification")
                     .addKeyValue(PROVIDER, ADYEN.getName())
@@ -103,6 +102,18 @@ public class AdyenRecurringTokenNotificationService {
     }
     private boolean isSupportedEventType(String eventType) {
         return SUPPORTED_EVENT_TYPES.contains(eventType);
+    }
+    
+    private void addNotificationToTaskQueue(String payload) {
+        try {
+            taskQueueService.add(
+                    new Task(payload, TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION)
+            );
+        } catch (Exception e) {
+            LOGGER.error("Error sending Adyen token webhook notification to task SQS queue", e);
+            
+            throw new WebApplicationException("Error sending message to task SQS queue", e);
+        }
     }
 }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenRecurringTokenNotificationServiceTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -241,6 +242,64 @@ class AdyenRecurringTokenNotificationServiceTest {
                                                 "Ignoring unsupported Adyen token notification")), is(true)
         );
     }
+
+    @Test
+    void shouldThrowWebApplicationExceptionWhenAddingTokenNotificationToTaskQueueFails() {
+        var primaryTestKey = "primaryTest";
+
+        String payload = TestTemplateResourceLoader.load(
+                TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION
+        );
+
+        var tokenKeys = new HmacKeys.WebhookHmacKeyPair(
+                new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
+                new WebhookHmacKeys("primaryLive", "secondaryLive")
+        );
+
+        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP))
+                .thenReturn(true);
+
+        when(adyenGatewayConfig.getHmacKeys())
+                .thenReturn(new HmacKeys(null, tokenKeys));
+
+        when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey, payload)).thenReturn(true);
+
+        doThrow(new RuntimeException("SQS unavailable")).when(mockTaskQueueService).add(any(Task.class));
+
+        assertThrows(WebApplicationException.class, () -> adyenRecurringTokenNotificationService.handleNotificationFor(
+                        payload, HMAC_SIGNATURE, FORWARDED_IP));
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(loggingEvents.stream().anyMatch(event -> event.getFormattedMessage().equals(
+                                                "Error sending Adyen token webhook notification to task SQS queue")),
+                is(true)
+        );
+    }
+    
+    @Test
+    void shouldThrowWebApplicationExceptionWhenTokenNotificationCannotBeDeserialised() {
+        String payload = "invalidJson";
+
+        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
+
+        WebApplicationException exception = assertThrows(WebApplicationException.class, 
+                () -> adyenRecurringTokenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP));
+
+        assertThat(exception.getMessage(), is("Error deserialising token webhook Json"));
+
+        verifyNoInteractions(mockTaskQueueService);
+        verify(mockAppender, atLeastOnce())
+                .doAppend(loggingEventArgumentCaptor.capture());
+
+        List<LoggingEvent> loggingEvents =
+                loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(loggingEvents.stream().anyMatch(event -> event.getFormattedMessage().equals(
+                "Error deserialising token notification payload")), is(true));
+    }
+    
     @ParameterizedTest
     @ValueSource(strings = {
             "recurring.token.created",

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenTokensNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenTokensNotificationResourceIT.java
@@ -30,6 +30,7 @@ public class AdyenTokensNotificationResourceIT {
     private static final String ADYEN_IP_ADDRESS = "192.168.0.1";
     private static final String UNEXPECTED_IP_ADDRESS = "8.8.8.8";
     private static final String HMAC_SIGNATURE = "hLz2zuhuylC8q36sCWWH7PpvbVpyaWDpoBqoEeTjj7w="; // pragma: allowlist secret
+    private final String HMAC_SIGNATURE_FOR_PAYLOAD_WITH_UPDATED_TOKEN = "+309uQLT5A/L658R+4GlsOVwQ0rDTDcm2e5yln6+KGM="; // pragma: allowlist secret
 
     @BeforeAll
     static void before() {
@@ -104,4 +105,42 @@ public class AdyenTokensNotificationResourceIT {
                 .statusCode(415);
     }
 
+    @Test
+    void shouldIgnoreUnsupportedRecurringTokenNotification() {
+        String payload = TestTemplateResourceLoader.load(
+                TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION
+        ).replace(
+                "\"type\": \"recurring.token.created\"",
+                "\"type\": \"recurring.token.updated\""
+        );
+        
+        given()
+                .port(app.getLocalPort())
+                .body(payload)
+                .header("X-Forwarded-For", ADYEN_IP_ADDRESS)
+                .header("hmacSignature", HMAC_SIGNATURE_FOR_PAYLOAD_WITH_UPDATED_TOKEN)
+                .contentType(APPLICATION_JSON)
+                .post(NOTIFICATION_PATH)
+                .then()
+                .statusCode(200);
+
+        logs.assertContains(
+                "Ignoring unsupported Adyen token notification"
+        );
+        
+    }
+    @Test
+    void shouldReturn500WhenRecurringTokenNotificationCannotBeDeserialised() {
+        given()
+                .port(app.getLocalPort())
+                .body("invalidJson")
+                .header("X-Forwarded-For", ADYEN_IP_ADDRESS)
+                .header("hmacSignature", HMAC_SIGNATURE)
+                .contentType(APPLICATION_JSON)
+                .post(NOTIFICATION_PATH)
+                .then()
+                .statusCode(500);
+
+        logs.assertContains("Error deserialising token notification payload");
+    }
 }


### PR DESCRIPTION
## WHAT YOU DID

- enqueueing recurring.token.created and recurring.token.disabled events using handle_adyen_token_webhook_notification
- ignoring unsupported token event types and logging the notification details
- returning an error when a notification cannot be sent to the SQS task queue
