### PR TITLE
PP-15726: Update shopperReference to include chargeExternalId when deleting store payment details for Adyen agreement.

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenDeleteStoredPaymentHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenDeleteStoredPaymentHandler.java
@@ -40,7 +40,7 @@ public class AdyenDeleteStoredPaymentHandler {
                 getApiKeyHeader(adyenGatewayConfig, request.isLive()),
                 Map.of(
                         "merchantAccount", adyenMerchantAccountHelper.getMerchantAccount(request.isLive()),
-                        "shopperReference", request.getAgreementExternalId()
+                        "shopperReference", String.format("%s-%s",request.getAgreementExternalId(), request.getChargeExternalId())
                 ),
                 request.getGatewayAccountType());
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/DeleteStoredPaymentDetailsGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/DeleteStoredPaymentDetailsGatewayRequest.java
@@ -8,17 +8,20 @@ import java.util.Map;
 
 public class DeleteStoredPaymentDetailsGatewayRequest {
     private String agreementExternalId;
+    private String chargeExternalId;
     private Map<String, String> recurringAuthToken;
     private String gatewayAccountType;
     private boolean live;
     private GatewayCredentials gatewayCredentials;
 
     private DeleteStoredPaymentDetailsGatewayRequest(String agreementExternalId,
+                                                     String chargeExternalId,
                                                      Map<String, String> recurringAuthToken,
                                                      String gatewayAccountType,
                                                      boolean live,
                                                      GatewayCredentials gatewayCredentials) {
         this.agreementExternalId = agreementExternalId;
+        this.chargeExternalId = chargeExternalId;
         this.recurringAuthToken = recurringAuthToken;
         this.gatewayAccountType = gatewayAccountType;
         this.live = live;
@@ -30,6 +33,7 @@ public class DeleteStoredPaymentDetailsGatewayRequest {
                 .orElseThrow(() -> new IllegalArgumentException("Expected payment instrument to have recurring auth token set"));
         return new DeleteStoredPaymentDetailsGatewayRequest(
                 agreement.getExternalId(),
+                paymentInstrument.getChargeExternalId(),
                 recurringAuthToken,
                 agreement.getGatewayAccount().getType(),
                 agreement.isLive(),
@@ -55,5 +59,9 @@ public class DeleteStoredPaymentDetailsGatewayRequest {
 
     public GatewayCredentials getGatewayCredentials() {
         return gatewayCredentials;
+    }
+
+    public String getChargeExternalId() {
+        return chargeExternalId;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenDeleteStoredPaymentHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenDeleteStoredPaymentHandlerTest.java
@@ -73,7 +73,7 @@ class AdyenDeleteStoredPaymentHandlerTest {
         assertThat(gatewayRequest.getUrl().toString(), is("https://example.com/test/version/storedPaymentMethods/storedPaymentMethodId-123"));
         assertThat(gatewayRequest.getHeaders(), hasEntry("X-API-Key", "test-api-key"));
         assertThat(gatewayRequest.getQueryParams(), hasEntry("merchantAccount", "merchant-account-test"));
-        assertThat(gatewayRequest.getQueryParams(), hasEntry("shopperReference", "agreement-external-id-123"));
+        assertThat(gatewayRequest.getQueryParams(), hasEntry("shopperReference", "agreement-external-id-123-charge-external-id-123"));
     }
 
     @Test
@@ -88,6 +88,7 @@ class AdyenDeleteStoredPaymentHandlerTest {
     private DeleteStoredPaymentDetailsGatewayRequest createDeleteStoredPaymentDetailsGatewayRequest() {
         PaymentInstrumentEntity paymentInstrumentEntity = aPaymentInstrumentEntity()
                 .withExternalId("payment-instrument-ext-id-123")
+                .withChargeExternalId("charge-external-id-123")
                 .withRecurringAuthToken(Map.of("storedPaymentMethodId", "storedPaymentMethodId-123"))
                 .build();
 

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/DeleteStoredPaymentDetailsTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/DeleteStoredPaymentDetailsTaskHandlerIT.java
@@ -23,6 +23,7 @@ class DeleteStoredPaymentDetailsTaskHandlerIT {
     private static final String AGREEMENT_EXTERNAL_ID = "agreement-external-id-123";
     private static final String PAYMENT_INSTRUMENT_EXTERNAL_ID = "payment-instrument-ext-id-123";
     private static final String STORED_PAYMENT_METHOD_ID = "stored-payment-method-id-123";
+    private static final String CHARGE_EXTERNAL_ID = "charged-external-id-123";
 
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
@@ -40,7 +41,7 @@ class DeleteStoredPaymentDetailsTaskHandlerIT {
 
         app.getAdyenWireMockServer().stubFor(delete(urlPathEqualTo("/storedPaymentMethods/" + STORED_PAYMENT_METHOD_ID))
                 .withQueryParam("merchantAccount", equalTo("adyen-test-merchant-account-id"))
-                .withQueryParam("shopperReference", equalTo(AGREEMENT_EXTERNAL_ID))
+                .withQueryParam("shopperReference", equalTo(AGREEMENT_EXTERNAL_ID+"-"+CHARGE_EXTERNAL_ID))
                 .willReturn(aResponse().withStatus(204)));
 
         deleteStoredPaymentDetailsTaskHandler.process(AGREEMENT_EXTERNAL_ID, PAYMENT_INSTRUMENT_EXTERNAL_ID);
@@ -48,7 +49,7 @@ class DeleteStoredPaymentDetailsTaskHandlerIT {
         app.getAdyenWireMockServer().verify(deleteRequestedFor(urlPathEqualTo("/storedPaymentMethods/" + STORED_PAYMENT_METHOD_ID))
                 .withHeader("X-API-Key", equalTo("adyen-test-company-api-key"))
                 .withQueryParam("merchantAccount", equalTo("adyen-test-merchant-account-id"))
-                .withQueryParam("shopperReference", equalTo(AGREEMENT_EXTERNAL_ID)));
+                .withQueryParam("shopperReference", equalTo(AGREEMENT_EXTERNAL_ID+"-"+CHARGE_EXTERNAL_ID)));
     }
 
     @Test
@@ -57,7 +58,7 @@ class DeleteStoredPaymentDetailsTaskHandlerIT {
 
         app.getAdyenWireMockServer().stubFor(delete(urlPathEqualTo("/storedPaymentMethods/" + STORED_PAYMENT_METHOD_ID))
                 .withQueryParam("merchantAccount", equalTo("adyen-test-merchant-account-id"))
-                .withQueryParam("shopperReference", equalTo(AGREEMENT_EXTERNAL_ID))
+                .withQueryParam("shopperReference", equalTo(AGREEMENT_EXTERNAL_ID+"-"+CHARGE_EXTERNAL_ID))
                 .willReturn(aResponse().withStatus(500).withBody("{\"error\":\"gateway error\"}")));
 
         assertThrows(GatewayException.GatewayErrorException.class,
@@ -83,6 +84,7 @@ class DeleteStoredPaymentDetailsTaskHandlerIT {
                 .withPaymentInstrumentId(424242L)
                 .withExternalPaymentInstrumentId(PAYMENT_INSTRUMENT_EXTERNAL_ID)
                 .withAgreementExternalId(AGREEMENT_EXTERNAL_ID)
+                        .withChargeExternalId(CHARGE_EXTERNAL_ID)
                 .withRecurringAuthToken(Map.of("storedPaymentMethodId", STORED_PAYMENT_METHOD_ID))
                 .build());
     }


### PR DESCRIPTION
## WHAT YOU DID
- Added `chargeExternalId` from the `paymentInstrument` to the `shooperReference` on a `AdyenDeleteStoredPaymentDetailsRequest` so that whena n agreement is cancelled the stored payment details on Adyen can be found and deleted. 

This relates to the update `shopperReference` work to make the `shopperReference` unique for recurring payments with Adyen, see https://payments-platform.atlassian.net/browse/PP-15681 
