### PR TITLE
PP-15715 Implement BrowserDataFor3ds for GooglePayPaymentInfo

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -168,42 +168,42 @@
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "a1f69fc9bf1984c89e57ee993c7392c3d702bb93",
         "is_verified": false,
-        "line_number": 4218
+        "line_number": 4220
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "b7b82fee3d8bb620476c30e98864525528a30dc5",
         "is_verified": false,
-        "line_number": 4648
+        "line_number": 4650
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 4684
+        "line_number": 4686
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 5616
+        "line_number": 5618
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "40a714e4a70aa9b75e73dc27be3a978fa98ee4e3",
         "is_verified": false,
-        "line_number": 6169
+        "line_number": 6191
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/connector_spec.yaml",
         "hashed_secret": "ec969b7613112e3df2b11d8f64ce37f0d20bf29d",
         "is_verified": false,
-        "line_number": 6180
+        "line_number": 6202
       }
     ],
     "src/main/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResource.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T16:12:23Z"
+  "generated_at": "2026-08-13T13:48:15Z"
 }

--- a/openapi/connector_spec.yaml
+++ b/openapi/connector_spec.yaml
@@ -3799,6 +3799,8 @@ components:
           type: string
         browserColorDepth:
           type: string
+        browserIpAddress:
+          type: string
         browserJavaScriptEnabled:
           type: boolean
         browserLanguage:
@@ -5634,6 +5636,8 @@ components:
           type: string
         browser_color_depth:
           type: string
+        browser_ip_address:
+          type: string
         browser_java_script_enabled:
           type: boolean
         browser_language:
@@ -5664,6 +5668,24 @@ components:
         ip_address:
           type: string
           example: 203.0.113.1
+        js_enabled:
+          type: boolean
+          example: true
+        js_navigator_language:
+          type: string
+          example: en-GB
+        js_screen_color_depth:
+          type: string
+          example: "32"
+        js_screen_height:
+          type: string
+          example: "982"
+        js_screen_width:
+          type: string
+          example: "1512"
+        js_timezone_offset_mins:
+          type: string
+          example: "-60"
         last_digits_card_number:
           type: string
           description: last digits card number

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -309,4 +309,9 @@ public class AuthCardDetails implements BrowserDataFor3ds {
     public Optional<String> getBrowserUserAgent() {
         return Optional.ofNullable(userAgentHeader);
     }
+
+    public Optional<String> getBrowserIpAddress() {
+        return Optional.ofNullable(ipAddress);
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/BrowserDataFor3ds.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/BrowserDataFor3ds.java
@@ -35,4 +35,8 @@ public interface BrowserDataFor3ds {
     default Optional<String> getBrowserUserAgent() {
         return Optional.empty();
     }
+
+    default Optional<String> getBrowserIpAddress() {
+        return Optional.empty();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayPaymentInfo.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayPaymentInfo.java
@@ -19,6 +19,30 @@ public class GooglePayPaymentInfo extends WalletPaymentInfo implements BrowserDa
     @Schema(example = "203.0.113.1")
     private String ipAddress;
     
+    @Schema(example = "true")
+    @JsonProperty("js_enabled")
+    private Boolean jsEnabled;
+
+    @Schema(example = "en-GB")
+    @JsonProperty("js_navigator_language")
+    private String jsNavigatorLanguage;
+
+    @Schema(example = "32")
+    @JsonProperty("js_screen_color_depth")
+    private String jsScreenColorDepth;
+
+    @Schema(example = "982")
+    @JsonProperty("js_screen_height")
+    private String jsScreenHeight;
+
+    @Schema(example = "1512")
+    @JsonProperty("js_screen_width")
+    private String jsScreenWidth;
+
+    @Schema(example = "-60")
+    @JsonProperty("js_timezone_offset_mins")
+    private String jsTimezoneOffsetMins;
+
     @Schema(example = "1f1154b7-620d-4654-801b-893b5bb22db1", description = "SessionId returned by Worldpay/CardinalCommerce as part of device data collection. Applicable for Google Pay payments only")
     @JsonProperty("worldpay_3ds_flex_ddc_result")
     private String worldpay3dsFlexDdcResult;
@@ -54,6 +78,52 @@ public class GooglePayPaymentInfo extends WalletPaymentInfo implements BrowserDa
     public String getIpAddress() {
         return ipAddress;
     }
+
+    @Override
+    public Optional<Boolean> getBrowserJavaScriptEnabled() {
+        return Optional.ofNullable(jsEnabled);
+    }
+
+    @Override
+    public Optional<String> getBrowserLanguage() {
+        return Optional.ofNullable(jsNavigatorLanguage);
+    }
+
+    @Override
+    public Optional<String> getBrowserColorDepth() {
+        return Optional.ofNullable(jsScreenColorDepth);
+    }
+
+    @Override
+    public Optional<String> getBrowserScreenHeight() {
+        return Optional.ofNullable(jsScreenHeight);
+    }
+
+    @Override
+    public Optional<String> getBrowserScreenWidth() {
+        return Optional.ofNullable(jsScreenWidth);
+    }
+
+    @Override
+    public Optional<String> getBrowserTZ() {
+        return Optional.ofNullable(jsTimezoneOffsetMins);
+    }
+
+    @Override
+    public Optional<String> getBrowserAcceptHeader() {
+        return Optional.ofNullable(acceptHeader);
+    }
+
+    @Override
+    public Optional<String> getBrowserUserAgent() {
+        return Optional.ofNullable(userAgentHeader);
+    }
+
+    @Override
+    public Optional<String> getBrowserIpAddress() {
+        return Optional.ofNullable(ipAddress);
+    }
+
 
     public Optional<String> getWorldpay3dsFlexDdcResult() {
         return Optional.ofNullable(worldpay3dsFlexDdcResult);

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayPaymentInfoTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayPaymentInfoTest.java
@@ -1,0 +1,68 @@
+package uk.gov.pay.connector.wallets.googlepay.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class GooglePayPaymentInfoTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void testDeserialisation() throws JsonProcessingException {
+        var json = """
+                {
+                    "accept_header": "text/html;q=1.0, */*;q=0.9",
+                    "user_agent_header": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:153.0) Gecko/20100101 Firefox/153.0",
+                    "ip_address": "203.0.113.1",
+                    "js_enabled": true,
+                    "js_navigator_language": "en-GB",
+                    "js_screen_color_depth": 32,
+                    "js_screen_height": 982,
+                    "js_screen_width": 1512,
+                    "js_timezone_offset_mins": -60
+                }
+                """;
+
+        GooglePayPaymentInfo result = objectMapper.readValue(json, GooglePayPaymentInfo.class);
+
+        assertThat(result.getBrowserAcceptHeader(), is(Optional.of("text/html;q=1.0, */*;q=0.9")));
+        assertThat(result.getBrowserUserAgent(), is(Optional.of("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:153.0) Gecko/20100101 Firefox/153.0")));
+        assertThat(result.getBrowserIpAddress(), is(Optional.of("203.0.113.1")));
+        assertThat(result.getBrowserJavaScriptEnabled(), is(Optional.of(Boolean.TRUE)));
+        assertThat(result.getBrowserLanguage(), is(Optional.of("en-GB")));
+        assertThat(result.getBrowserColorDepth(), is(Optional.of("32")));
+        assertThat(result.getBrowserScreenHeight(), is(Optional.of("982")));
+        assertThat(result.getBrowserScreenWidth(), is(Optional.of("1512")));
+        assertThat(result.getBrowserTZ(), is(Optional.of("-60")));
+    }
+
+    @Test
+    void testDeserialisationWithSomeMissingValues() throws JsonProcessingException {
+        var json = """
+                {
+                    "accept_header": "text/html;q=1.0, */*;q=0.9",
+                    "user_agent_header": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:153.0) Gecko/20100101 Firefox/153.0",
+                    "ip_address": "203.0.113.1"
+                }
+                """;
+
+        GooglePayPaymentInfo result = objectMapper.readValue(json, GooglePayPaymentInfo.class);
+
+        assertThat(result.getBrowserAcceptHeader(), is(Optional.of("text/html;q=1.0, */*;q=0.9")));
+        assertThat(result.getBrowserUserAgent(), is(Optional.of("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:153.0) Gecko/20100101 Firefox/153.0")));
+        assertThat(result.getBrowserIpAddress(), is(Optional.of("203.0.113.1")));
+        assertThat(result.getBrowserJavaScriptEnabled(), is(Optional.empty()));
+        assertThat(result.getBrowserLanguage(), is(Optional.empty()));
+        assertThat(result.getBrowserColorDepth(), is(Optional.empty()));
+        assertThat(result.getBrowserScreenHeight(), is(Optional.empty()));
+        assertThat(result.getBrowserScreenWidth(), is(Optional.empty()));
+        assertThat(result.getBrowserTZ(), is(Optional.empty()));
+    }
+
+}


### PR DESCRIPTION
Implement the `BrowserDataFor3ds` interface for`GooglePayPaymentInfo`. This adds support for deserialising additional browser information that’s used by 3D Secure when sent from frontend (which will collect it from the paying user’s browser). Continue to support this data not being present because it is not currently sent and even when it is, there’s no guarantees it will be sent (because, for example, JavaScript could be disabled or the browser could give us something completely bonkers that fails frontend’s validation).