### PR TITLE
PP-15715 Rationalise duplicate getters in GooglePayPaymentInfo

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.worldpay.wallets;
 
 import com.google.inject.name.Named;
+import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
@@ -13,16 +14,15 @@ import uk.gov.pay.connector.gateway.util.AuthUtil;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthoriseOrderSessionId;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayGatewayResponseGenerator;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder;
-import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
-import uk.gov.pay.connector.wallets.googlepay.GooglePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
+import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.applepay.ApplePayDecrypter;
 import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
+import uk.gov.pay.connector.wallets.googlepay.GooglePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
 import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
 import uk.gov.service.payments.commons.api.exception.ValidationException;
 
-import jakarta.inject.Inject;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -73,12 +73,12 @@ public class WorldpayWalletAuthorisationHandler implements WorldpayGatewayRespon
         boolean is3dsRequired = authorisationGatewayRequest.getGatewayAccount().isRequires3ds();
         boolean isSendIpAddress = authorisationGatewayRequest.getGatewayAccount().isSendPayerIpAddressToGateway();
         worldpayOrderRequestBuilder
-                .withUserAgentHeader(googlePayAuthRequest.getPaymentInfo().getUserAgentHeader())
-                .withAcceptHeader(googlePayAuthRequest.getPaymentInfo().getAcceptHeader())
+                .withUserAgentHeader(googlePayAuthRequest.getPaymentInfo().getBrowserUserAgent().orElse(null))
+                .withAcceptHeader(googlePayAuthRequest.getPaymentInfo().getBrowserAcceptHeader().orElse(null))
         .with3dsRequired(is3dsRequired);
         
         if (is3dsRequired && isSendIpAddress) {
-            worldpayOrderRequestBuilder.withPayerIpAddress(googlePayAuthRequest.getPaymentInfo().getIpAddress());
+            worldpayOrderRequestBuilder.withPayerIpAddress(googlePayAuthRequest.getPaymentInfo().getBrowserIpAddress().orElse(null));
         }
         
         GatewayOrder gatewayOrder = buildWalletAuthoriseOrder(authorisationGatewayRequest, 

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayPaymentInfo.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayPaymentInfo.java
@@ -11,12 +11,15 @@ import java.util.Optional;
 public class GooglePayPaymentInfo extends WalletPaymentInfo implements BrowserDataFor3ds {
     
     @Schema(example = "text/html;q=1.0, */*;q=0.9")
+    @JsonProperty("accept_header")
     private String acceptHeader;
     
     @Schema(example = "Mozilla/5.0")
+    @JsonProperty("user_agent_header")
     private String userAgentHeader;
     
     @Schema(example = "203.0.113.1")
+    @JsonProperty("ip_address")
     private String ipAddress;
     
     @Schema(example = "true")
@@ -67,16 +70,19 @@ public class GooglePayPaymentInfo extends WalletPaymentInfo implements BrowserDa
         this.worldpay3dsFlexDdcResult = worldpay3dsFlexDdcResult;
     }
 
-    public String getAcceptHeader() {
-        return acceptHeader;
+    @Override
+    public Optional<String> getBrowserAcceptHeader() {
+        return Optional.ofNullable(acceptHeader);
     }
 
-    public String getUserAgentHeader() {
-        return userAgentHeader;
+    @Override
+    public Optional<String> getBrowserUserAgent() {
+        return Optional.ofNullable(userAgentHeader);
     }
 
-    public String getIpAddress() {
-        return ipAddress;
+    @Override
+    public Optional<String> getBrowserIpAddress() {
+        return Optional.ofNullable(ipAddress);
     }
 
     @Override
@@ -109,22 +115,6 @@ public class GooglePayPaymentInfo extends WalletPaymentInfo implements BrowserDa
         return Optional.ofNullable(jsTimezoneOffsetMins);
     }
 
-    @Override
-    public Optional<String> getBrowserAcceptHeader() {
-        return Optional.ofNullable(acceptHeader);
-    }
-
-    @Override
-    public Optional<String> getBrowserUserAgent() {
-        return Optional.ofNullable(userAgentHeader);
-    }
-
-    @Override
-    public Optional<String> getBrowserIpAddress() {
-        return Optional.ofNullable(ipAddress);
-    }
-
-
     public Optional<String> getWorldpay3dsFlexDdcResult() {
         return Optional.ofNullable(worldpay3dsFlexDdcResult);
     }
@@ -138,6 +128,12 @@ public class GooglePayPaymentInfo extends WalletPaymentInfo implements BrowserDa
                 ", acceptHeader=" + acceptHeader +
                 ", userAgentHeader=" + userAgentHeader +
                 ", ipAddress=" + Optional.ofNullable(ipAddress).map(x -> "ipAddress is present").orElse("ipAddress is not present") +
+                ". jsEnabled=" + jsEnabled +
+                ", jsNavigatorLanguage='" + jsNavigatorLanguage + '\'' +
+                ", jsScreenColorDepth='" + jsScreenColorDepth + '\'' +
+                ", jsScreenHeight='" + jsScreenHeight + '\'' +
+                ", jsScreenWidth='" + jsScreenWidth + '\'' +
+                ", jsTimezoneOffsetMins='" + jsTimezoneOffsetMins + '\'' +
                 ", worldpay3dsFlexDdcResult=" + getWorldpay3dsFlexDdcResult().map(x -> "present").orElse("not present") +
                 '}';
     }

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
@@ -22,9 +22,12 @@ class GooglePayAuthRequestTest {
         assertThat(actual.getPaymentInfo().getLastDigitsCardNumber(), is(paymentInfo.get("last_digits_card_number").asText()));
         assertThat(actual.getPaymentInfo().getBrand(), is(paymentInfo.get("brand").asText()));
         assertThat(actual.getPaymentInfo().getEmail(), is(paymentInfo.get("email").asText()));
-        assertThat(actual.getPaymentInfo().getAcceptHeader(), is(paymentInfo.get("accept_header").asText()));
-        assertThat(actual.getPaymentInfo().getUserAgentHeader(), is(paymentInfo.get("user_agent_header").asText()));
-        assertThat(actual.getPaymentInfo().getIpAddress(), is(paymentInfo.get("ip_address").asText()));
+        assertThat(actual.getPaymentInfo().getBrowserAcceptHeader().isPresent(), is(true));
+        assertThat(actual.getPaymentInfo().getBrowserAcceptHeader().get(), is(paymentInfo.get("accept_header").asText()));
+        assertThat(actual.getPaymentInfo().getBrowserUserAgent().isPresent(), is(true));
+        assertThat(actual.getPaymentInfo().getBrowserUserAgent().get(), is(paymentInfo.get("user_agent_header").asText()));
+        assertThat(actual.getPaymentInfo().getBrowserIpAddress().isPresent(), is(true));
+        assertThat(actual.getPaymentInfo().getBrowserIpAddress().get(), is(paymentInfo.get("ip_address").asText()));
 
         JsonNode encryptedPaymentData = expected.get("encrypted_payment_data");
         assertThat(actual.getEncryptedPaymentData().isPresent(), is(true));


### PR DESCRIPTION
Remove getters in `GooglePayPaymentInfo` that return the same fields as the getters specified in the `BrowserDataFor3ds` interface. This requires us to add `@JsonProperty` annotations to some fields because the getter names no longer match the JSON property names.