### PR TITLE
PP-15558- Implement AdyenTokenWebhookNotificationHandler and linkPaymentInstrumentToAgreement

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -778,7 +778,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/util/RandomIdGeneratorTest.java",
         "hashed_secret": "3a765b5dd17a80a147bfc1211664c2326f2659a5",
         "is_verified": false,
-        "line_number": 72
+        "line_number": 77
       }
     ],
     "src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java": [
@@ -1101,5 +1101,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T13:48:15Z"
+  "generated_at": "2026-08-14T12:54:06Z"
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.function.Predicate.not;
-import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_INSTRUMENT_EXTERNAL_ID;
 
@@ -45,25 +44,32 @@ public class LinkPaymentInstrumentToAgreementService {
 
     @Transactional
     public void linkPaymentInstrumentFromChargeToAgreement(ChargeEntity chargeEntity) {
-        chargeEntity.getPaymentInstrument().ifPresentOrElse(paymentInstrumentEntity -> {
-            chargeEntity.getAgreement().ifPresentOrElse(agreementEntity -> {
-                paymentInstrumentEntity.getRecurringAuthToken().filter(not(Map::isEmpty)).ifPresentOrElse(_ -> {
-                    cancelActivePaymentInstruments(agreementEntity);
-                    agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
-                    paymentInstrumentEntity.setAgreementExternalId(agreementEntity.getExternalId());
-                    paymentInstrumentEntity.setStatus(PaymentInstrumentStatus.ACTIVE);
-                    ledgerService.postEvent(List.of(
-                            AgreementSetUp.from(agreementEntity, instantSource.instant()),
-                            PaymentInstrumentConfirmed.from(agreementEntity, instantSource.instant())
-                    ));
-                    LOGGER.info("Agreement successfully set up with payment instrument",
-                            kv(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId()),
-                            kv(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrumentEntity.getExternalId()));
-                }, () -> LOGGER.info("Payment instrument doesn't have a token associated. Not linked the payment instrument to the agreement",
-                        kv(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId()),
-                        kv(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrumentEntity.getExternalId())));
-            }, () -> LOGGER.error("Expected charge {} to have an agreement but it does not have one", chargeEntity.getExternalId()));
-        }, () -> LOGGER.error("Expected charge {} to have a payment instrument but it does not have one", chargeEntity.getExternalId()));
+        chargeEntity.getPaymentInstrument().ifPresentOrElse(paymentInstrumentEntity ->
+                chargeEntity.getAgreement().ifPresentOrElse(agreementEntity ->
+                        paymentInstrumentEntity.getRecurringAuthToken().filter(not(Map::isEmpty)).ifPresentOrElse(_ ->
+                                linkPaymentInstrumentToAgreement(agreementEntity, paymentInstrumentEntity), () -> LOGGER.atInfo()
+                                .setMessage("Payment instrument doesn't have a token associated. Not linked the payment instrument to the agreement")
+                                .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrumentEntity.getExternalId())
+                                .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId())
+                                .log()
+                        ), () -> LOGGER.error("Expected charge {} to have an agreement but it does not have one", chargeEntity.getExternalId())), () -> LOGGER.error("Expected charge {} to have a payment instrument but it does not have one", chargeEntity.getExternalId()));
+    }
+
+    @Transactional
+    public void linkPaymentInstrumentToAgreement(AgreementEntity agreementEntity, PaymentInstrumentEntity paymentInstrumentEntity) {
+        cancelActivePaymentInstruments(agreementEntity);
+        agreementEntity.setPaymentInstrument(paymentInstrumentEntity);
+        paymentInstrumentEntity.setAgreementExternalId(agreementEntity.getExternalId());
+        paymentInstrumentEntity.setStatus(PaymentInstrumentStatus.ACTIVE);
+        ledgerService.postEvent(List.of(
+                AgreementSetUp.from(agreementEntity, instantSource.instant()),
+                PaymentInstrumentConfirmed.from(agreementEntity, instantSource.instant())
+        ));
+        LOGGER.atInfo()
+                .setMessage("Agreement successfully set up with payment instrument")
+                .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId())
+                .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrumentEntity.getExternalId())
+                .log();
     }
 
     private void cancelActivePaymentInstruments(AgreementEntity agreement) {

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenRequestFactory.java
@@ -36,7 +36,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public class AdyenRequestFactory {
 
     public static final String STORED_PAYMENT_METHOD_ID = "storedPaymentMethodId";
-    
+    public static final String SHOPPER_REFERENCE_DELIMITER = "-";
+
     private final ConnectorConfiguration configuration;
     private final AdyenMerchantAccountHelper adyenMerchantAccountHelper;
     private final AdyenCredentialsHelper adyenCredentialsHelper;
@@ -137,7 +138,7 @@ public class AdyenRequestFactory {
         if (agreementId == null || chargeExternalId == null || isBlank(agreementId) || isBlank(chargeExternalId)) {
             throw new IllegalArgumentException("shopperReference could not be derived as charge external ID or agreement external ID are missing");
         }
-        return String.format("%s-%s", agreementId, chargeExternalId);
+        return agreementId + SHOPPER_REFERENCE_DELIMITER + chargeExternalId;
     }
 
     private static String getShopperInteraction(CardAuthorisationGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
@@ -1,0 +1,93 @@
+package uk.gov.pay.connector.queue.tasks.handlers.adyen;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.agreement.dao.AgreementDao;
+import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementService;
+import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
+import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenRecurringTokenNotificationService;
+import uk.gov.pay.connector.paymentinstrument.dao.PaymentInstrumentDao;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.util.Map;
+
+import static uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory.SHOPPER_REFERENCE_DELIMITER;
+import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_INSTRUMENT_EXTERNAL_ID;
+
+public class AdyenTokenWebhookNotificationHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdyenTokenWebhookNotificationHandler.class);
+    private static final String RECURRING_TOKEN_CREATED = "recurring.token.created";
+
+    private final PaymentInstrumentDao paymentInstrumentDao;
+    private final LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
+    private final AdyenRecurringTokenNotificationService adyenRecurringTokenNotificationService;
+    private final AgreementDao agreementDao;
+
+    @Inject
+    public AdyenTokenWebhookNotificationHandler(PaymentInstrumentDao paymentInstrumentDao, AgreementDao agreementDao, LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService, AdyenRecurringTokenNotificationService adyenRecurringTokenNotificationService) {
+
+        this.paymentInstrumentDao = paymentInstrumentDao;
+        this.agreementDao = agreementDao;
+        this.linkPaymentInstrumentToAgreementService = linkPaymentInstrumentToAgreementService;
+        this.adyenRecurringTokenNotificationService = adyenRecurringTokenNotificationService;
+    }
+
+    @Transactional
+    public void process(String payload) {
+        AdyenTokenNotification notification = adyenRecurringTokenNotificationService.deserialisePayload(payload, AdyenTokenNotification.class);
+
+        if (!RECURRING_TOKEN_CREATED.equals(notification.type())) {
+            LOGGER.atInfo().setMessage("Ignoring Adyen token webhook notification with unsupported type").addKeyValue("type", notification.type()).log();
+            return;
+        }
+
+        var shopperReference = notification.data().shopperReference();
+
+        if (shopperReference == null || shopperReference.isBlank()) {
+            logInvalidShopperReference();
+            return;
+        }
+
+        // shopperReference format: "{agreementExternalId}-{chargeExternalId}"
+        var splitShopperReference = shopperReference.split(SHOPPER_REFERENCE_DELIMITER);
+
+        if (splitShopperReference.length != 2 || !RandomIdGenerator.isValidIdLength(splitShopperReference)) {
+            logInvalidShopperReference();
+            return;
+        }
+
+        var agreementExternalId = splitShopperReference[0];
+
+        var agreementEntity = agreementDao.findByExternalId(agreementExternalId);
+        if (agreementEntity.isEmpty()) {
+            LOGGER.atInfo().setMessage("Agreement not found, ignoring Adyen token webhook").addKeyValue(AGREEMENT_EXTERNAL_ID, agreementExternalId).log();
+            return;
+        }
+
+        var chargeExternalId = splitShopperReference[1];
+
+        paymentInstrumentDao.findByChargeExternalId(chargeExternalId).ifPresentOrElse(paymentInstrument -> {
+            if (paymentInstrument.getStatus() == PaymentInstrumentStatus.ACTIVE) {
+                LOGGER.atInfo().setMessage("Payment instrument is already in ACTIVE state, ignoring Adyen token webhook")
+                        .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementExternalId).addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
+                        .log();
+                return;
+            }
+            paymentInstrument.setRecurringAuthToken(Map.of(AdyenRequestFactory.STORED_PAYMENT_METHOD_ID, notification.data().storedPaymentMethodId()));
+
+            linkPaymentInstrumentToAgreementService.linkPaymentInstrumentToAgreement(agreementEntity.get(), paymentInstrument);
+        }, () -> LOGGER.atInfo().setMessage("Payment instrument not found for charge in Adyen token webhook, ignoring")
+                .addKeyValue("EXTERNAL_CHARGE_ID", chargeExternalId)
+                .log());
+    }
+
+    private static void logInvalidShopperReference() {
+        LOGGER.atInfo().setMessage("Invalid shopper reference").log();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/RandomIdGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/util/RandomIdGenerator.java
@@ -7,6 +7,8 @@ import java.security.SecureRandom;
 import java.util.Locale;
 import java.util.UUID;
 
+import static java.util.Arrays.stream;
+
 public class RandomIdGenerator {
 
     private static final SecureRandom RANDOM = new SecureRandom();
@@ -22,10 +24,13 @@ public class RandomIdGenerator {
      *
      * @return a random number in base32 (in string format)
      */
+
+    public static int ID_LENGTH = 26;
+
     public static String newId() {
         String id = new BigInteger(130, RANDOM).toString(32);
 
-        return StringUtils.leftPad(id, 26, '0');
+        return StringUtils.leftPad(id, ID_LENGTH, '0');
     }
 
     public static String randomUuid() {
@@ -36,19 +41,24 @@ public class RandomIdGenerator {
         return UUID.nameUUIDFromBytes(externalEntityId.getBytes()).toString()
                 .replace("-", "")
                 .toLowerCase(Locale.ENGLISH)
-                .substring(0, 26);
+                .substring(0, ID_LENGTH);
     }
 
-    public  String random13ByteHexGenerator() {
+    // This method can accept single/multiple parameters or a String array of Ids
+    public static Boolean isValidIdLength(String... ids) {
+        return ids.length > 0 && stream(ids).allMatch(id -> id.length() == ID_LENGTH);
+    }
+
+    public String random13ByteHexGenerator() {
         byte[] bytes = new byte[13];
         RANDOM.nextBytes(bytes);
-        StringBuilder sb = new StringBuilder(26);
+        StringBuilder sb = new StringBuilder(ID_LENGTH);
         for (byte b : bytes) {
             sb.append(String.format("%02x", b));
         }
         return sb.toString();
     }
-    
+
     public static long randomLong() {
         return RANDOM.nextLong();
     }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
@@ -1,0 +1,172 @@
+package uk.gov.pay.connector.queue.tasks.handlers.adyen;
+
+import io.github.netmikey.logunit.api.LogCapturer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.agreement.dao.AgreementDao;
+import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementService;
+import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
+import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenEventData;
+import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenRecurringTokenNotificationService;
+import uk.gov.pay.connector.paymentinstrument.dao.PaymentInstrumentDao;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntityFixture.aPaymentInstrumentEntity;
+
+@ExtendWith(MockitoExtension.class)
+class AdyenTokenWebhookNotificationHandlerTest {
+
+    private static final String AGREEMENT_EXTERNAL_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String CHARGE_EXTERNAL_ID    = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String SHOPPER_REFERENCE = AGREEMENT_EXTERNAL_ID + "-" + CHARGE_EXTERNAL_ID;
+    private static final String STORED_PAYMENT_METHOD_ID = "pm-id-123";
+    private static final String PAYLOAD = "{}";
+
+    @RegisterExtension
+    LogCapturer logs = LogCapturer.create().captureForType(AdyenTokenWebhookNotificationHandler.class);
+
+    @Mock private AgreementDao agreementDao;
+    @Mock private PaymentInstrumentDao paymentInstrumentDao;
+    @Mock private LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
+    @Mock private AdyenRecurringTokenNotificationService adyenRecurringTokenNotificationService;
+
+    @Captor
+    private ArgumentCaptor<PaymentInstrumentEntity> paymentInstrumentCaptor;
+
+    @InjectMocks
+    private AdyenTokenWebhookNotificationHandler handler;
+
+    @Test
+    void shouldSetTokenAndLinkPaymentInstrumentToAgreement() {
+        var paymentInstrument = aPaymentInstrumentEntity()
+                .withPaymentInstrumentStatus(PaymentInstrumentStatus.CREATED)
+                .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                .build();
+        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+
+        given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
+        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+
+        handler.process(PAYLOAD);
+
+        then(linkPaymentInstrumentToAgreementService)
+                .should()
+                .linkPaymentInstrumentToAgreement(eq(agreement), paymentInstrumentCaptor.capture());
+
+        var captured = paymentInstrumentCaptor.getValue();
+        assertThat(captured.getRecurringAuthToken().orElseThrow().get(AdyenRequestFactory.STORED_PAYMENT_METHOD_ID),
+                is(STORED_PAYMENT_METHOD_ID));
+    }
+
+    @Test
+    void shouldIgnoreAndLogWhenPaymentInstrumentIsAlreadyActive() {
+        var paymentInstrument = aPaymentInstrumentEntity()
+                .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
+                .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                .build();
+        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+
+        given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
+        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+
+        handler.process(PAYLOAD);
+
+        then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
+        logs.assertContains("Payment instrument is already in ACTIVE state, ignoring Adyen token webhook");
+    }
+
+    @Test
+    void shouldIgnoreAndLogWhenAgreementNotFound() {
+        given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
+        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.empty());
+
+        handler.process(PAYLOAD);
+
+        then(paymentInstrumentDao).shouldHaveNoInteractions();
+        then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
+        logs.assertContains("Agreement not found, ignoring Adyen token webhook");
+    }
+
+    @Test
+    void shouldIgnoreUnsupportedWebhookType() {
+        given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                .willReturn(new AdyenTokenNotification(null, null, null,
+                        new AdyenTokenEventData(null, STORED_PAYMENT_METHOD_ID, null, null, SHOPPER_REFERENCE),
+                        "recurring.token.deleted"));
+
+        handler.process(PAYLOAD);
+
+        then(agreementDao).shouldHaveNoInteractions();
+        then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
+        logs.assertContains("Ignoring Adyen token webhook notification with unsupported type");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"badId", "one-two-three", "aaaaaaaaaaaaaaaaaaaaaaaaaa-short", "short-bbbbbbbbbbbbbbbbbbbbbbbbbb"})
+    void shouldLogErrorForInvalidShopperReferenceLengthFormat(String invalidShopperReference) {
+        given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                .willReturn(tokenCreatedNotification(invalidShopperReference, STORED_PAYMENT_METHOD_ID));
+
+        handler.process(PAYLOAD);
+
+        then(agreementDao).shouldHaveNoInteractions();
+        then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
+        logs.assertContains("Invalid shopper reference");
+
+    }
+
+    @Test
+    void shouldNotLogStoredPaymentMethodId() {
+        var paymentInstrument = aPaymentInstrumentEntity()
+                .withPaymentInstrumentStatus(PaymentInstrumentStatus.CREATED)
+                .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                .build();
+        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+
+        given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
+        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+
+        handler.process(PAYLOAD);
+
+        logs.getEvents().forEach(event ->
+                assertThat("Log must not contain storedPaymentMethodId value",
+                        event.getMessage().contains(STORED_PAYMENT_METHOD_ID), is(false)));
+    }
+
+    private AdyenTokenNotification tokenCreatedNotification(String shopperReference, String storedPaymentMethodId) {
+        return new AdyenTokenNotification(
+                "2026-07-14T18:10:49+01:00",
+                "event-id-123",
+                "test",
+                new AdyenTokenEventData("YOUR_MERCHANT_ACCOUNT", storedPaymentMethodId, "visa", "created", shopperReference),
+                "recurring.token.created"
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/RandomIdGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/RandomIdGeneratorTest.java
@@ -1,20 +1,25 @@
 package uk.gov.pay.connector.util;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static com.google.common.primitives.Chars.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.pay.connector.util.RandomIdGenerator.newId;
 import static uk.gov.pay.connector.util.RandomIdGenerator.idFromExternalId;
+import static uk.gov.pay.connector.util.RandomIdGenerator.newId;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 class RandomIdGeneratorTest {
@@ -24,9 +29,9 @@ class RandomIdGeneratorTest {
     @Test
     void shouldGenerateUniqueRandomIds() {
         Set<String> randomIds = IntStream.range(0, 100)
-            .parallel()
-            .mapToObj(value -> newId())
-            .collect(Collectors.toSet());
+                .parallel()
+                .mapToObj(value -> newId())
+                .collect(Collectors.toSet());
 
         assertEquals(100, randomIds.size());
     }
@@ -34,18 +39,18 @@ class RandomIdGeneratorTest {
     @Test
     void shouldGenerateRandomIdsInBase32() {
         IntStream.range(0, 100)
-            .parallel()
-            .mapToObj(value -> newId())
-            .map(id -> asList(id.toCharArray()))
-            .forEach(idArray -> assertTrue(BASE32_DICTIONARY.containsAll(idArray)));
+                .parallel()
+                .mapToObj(value -> newId())
+                .map(id -> asList(id.toCharArray()))
+                .forEach(idArray -> assertTrue(BASE32_DICTIONARY.containsAll(idArray)));
     }
 
     @Test
     void shouldGenerateIdsOf26CharsInLength() {
         IntStream.range(0, 100)
-            .parallel()
-            .mapToObj(value -> newId())
-            .forEach(id -> assertEquals(26, id.length()));
+                .parallel()
+                .mapToObj(value -> newId())
+                .forEach(id -> assertEquals(26, id.length()));
     }
 
     @Test
@@ -79,4 +84,35 @@ class RandomIdGeneratorTest {
         assertEquals(26, correctionPaymentId.length(), "The length of the correction payment ID should be 26 characters");
         assertTrue(correctionPaymentId.matches("[0-9a-f]+"), "The correction payment ID should contain only hexadecimal characters");
     }
+
+    private static final String VALID_ID = "12345678901234567890123456";
+    private static final String SHORT_ID = "1234567890123456789012345";
+    private static final String LONG_ID = "123456789012345678901234567";
+
+    @ParameterizedTest
+    @MethodSource("idLengthCases")
+    void shouldValidateIdLength(String[] ids, boolean expected) {
+        assertEquals(expected, RandomIdGenerator.isValidIdLength(ids));
+    }
+
+    private static Stream<Arguments> idLengthCases() {
+        return Stream.of(
+                Arguments.of(new String[]{VALID_ID}, true),
+                Arguments.of(
+                        new String[]{
+                                VALID_ID,
+                                "abcdefghijklmnopqrstuvwxyz",
+                                "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                        },
+                        true
+                ),
+
+                Arguments.of(new String[]{SHORT_ID}, false),
+                Arguments.of(new String[]{LONG_ID}, false),
+                Arguments.of(new String[]{VALID_ID, SHORT_ID}, false),
+
+                Arguments.of(new String[]{}, false)
+        );
+    }
+    
 }


### PR DESCRIPTION
## WHAT YOU DID
_A brief description of the pull request:_
Implement AdyenTokenWebhookNotificationHandler and linkPaymentInstrumentToAgreement

- Implemented ValidIdLength method in RandomIdGenerator
- Simplified string concat for ShopperReference in AdyenRequestFactory
- Split link Payment Instrument To Agreement from linkPaymentInstrumentFromChargeToAgreement
- Process token-created message
- Ignore webhook when payment instrument is already in ACTIVE state
- Ignore webhook when Agreement not found
- Added unit test

## How to test

- How should it be reviewed? PR 
- What feedback do you need? PR comments/DM/Call
- If manual testing is needed, give suggested testing steps. Na

## Code review checklist
- [x] Clean code
- [X] Tested code 
- [X] Performant code 
- [X] No code smells 


### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

Co-authored-by: Joshua Pook <Joshua.Pook@digital.cabinet-office.gov.uk>