### PR TITLE
PP-15761 - Increase Thread.sleep from 500 ms to 800 ms makeChargeSubmitCaptureAndCheckSettlementSummary intimately failing

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -102,7 +102,7 @@ public class ChargesApiResourceIT {
                 .then()
                 .statusCode(204);
 
-        Thread.sleep(1000);
+        Thread.sleep(2000);
 
         // Trigger the capture process programmatically which normally would be invoked by the scheduler.
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).handleCaptureMessages();

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -102,7 +102,7 @@ public class ChargesApiResourceIT {
                 .then()
                 .statusCode(204);
 
-        Thread.sleep(800);
+        Thread.sleep(1000);
 
         // Trigger the capture process programmatically which normally would be invoked by the scheduler.
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).handleCaptureMessages();

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -102,7 +102,7 @@ public class ChargesApiResourceIT {
                 .then()
                 .statusCode(204);
 
-        Thread.sleep(500);
+        Thread.sleep(800);
 
         // Trigger the capture process programmatically which normally would be invoked by the scheduler.
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).handleCaptureMessages();


### PR DESCRIPTION
## WHAT YOU DID
_A brief description of the pull request:_
PP-15761 - Increase Thread.sleep from 500 ms to 800 ms  to makeChargeSubmitCaptureAndCheckSettlementSummary which is intimately failing

## How to test

- How should it be reviewed? PR 
- What feedback do you need? PR comments/DM/Call
- If manual testing is needed, give suggested testing steps. Na

## Code review checklist
- [x] Clean code
- [X] Tested code 
- [X] Performant code 
- [X] No code smells 

### Logging

- [X] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
