### PR TITLE
BAU — Disable failing test

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -4,6 +4,7 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -91,6 +92,7 @@ public class ChargesApiResourceIT {
     private final String accountId = testBaseExtension.getAccountId();
 
     @Test
+    @Disabled
     void makeChargeSubmitCaptureAndCheckSettlementSummary() throws QueueException, InterruptedException {
         Instant startOfTest = Instant.now();
         String expectedDayOfCapture = ISO_LOCAL_DATE_IN_UTC.format(startOfTest);


### PR DESCRIPTION
Disable a test that is failing in GitHub Actions (seems fine locally) and we do not know why.