### PR TITLE
PP-15683 Add DAO method to find latest charge for agreement

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -2,6 +2,13 @@ package uk.gov.pay.connector.charge.dao;
 
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
@@ -10,13 +17,6 @@ import uk.gov.pay.connector.events.model.ResourceType;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 
-import jakarta.inject.Inject;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
@@ -32,6 +32,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_QUEUED;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.ACTIVE;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CREATED;
 
 @Transactional
 public class ChargeDao extends JpaDao<ChargeEntity> {
@@ -357,5 +359,22 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .setParameter("authorisationModes", authorisationModes)
                 .setMaxResults(limit)
                 .getResultList();
+    }
+
+    public Optional<ChargeEntity> findLatestChargeForAgreementId(String agreementExternalId) {
+        return entityManager.get()
+                .createQuery("""
+                        SELECT c FROM ChargeEntity c
+                        WHERE c.agreementEntity.externalId = :agreementExternalId
+                          AND c.paymentInstrument IS NOT NULL
+                         AND c.paymentInstrument.status IN :statuses
+                        ORDER BY c.paymentInstrument.createdDate DESC
+                        """, ChargeEntity.class)
+                .setParameter("agreementExternalId", agreementExternalId)
+                .setParameter("statuses", List.of(ACTIVE, CREATED))
+                .setMaxResults(1)
+                .getResultList()
+                .stream()
+                .findFirst();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -16,7 +16,10 @@ import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures.TestCharge;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
+import uk.gov.pay.connector.util.AddChargeParams;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.service.payments.commons.model.AgreementPaymentType;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
@@ -67,6 +70,10 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 import static uk.gov.pay.connector.model.domain.Auth3dsRequiredEntityFixture.anAuth3dsRequiredEntity;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CANCELLED;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.INACTIVE;
+import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
+import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
 import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.randomAlphanumeric;
 import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRandomLong;
 import static uk.gov.service.payments.commons.model.AuthorisationMode.EXTERNAL;
@@ -103,7 +110,7 @@ public class ChargeDaoIT {
                 .build();
         gatewayAccountCredentialsEntity.setId(defaultTestAccount.getCredentials().getFirst().getId());
     }
-    
+
 
     @Test
     void chargeEvents_shouldRecordTransactionIdWithEachStatusChange() {
@@ -1166,6 +1173,129 @@ public class ChargeDaoIT {
 
         assertThat(optionalCharge.isPresent(), is(true));
         assertThat(optionalCharge.get().getAgreementPaymentType(), is(nullValue()));
+    }
+
+    @Nested
+    class TestFindLatestChargeForAgreementId {
+        long firstPaymentInstrumentId;
+        long secondPaymentInstrumentId;
+        long latestPaymentInstrumentId;
+
+        String agreementExternalId;
+        String firstChargeExternalId;
+        String secondChargeExternalId;
+        String latestChargeExternalId;
+
+        @BeforeEach
+        void setUp() {
+            agreementExternalId = randomAlphanumeric(26);
+
+            firstPaymentInstrumentId = secureRandomLong();
+            secondPaymentInstrumentId = secureRandomLong();
+            latestPaymentInstrumentId = secureRandomLong();
+
+            firstChargeExternalId = randomAlphanumeric(26);
+            secondChargeExternalId = randomAlphanumeric(26);
+            latestChargeExternalId = randomAlphanumeric(26);
+        }
+
+        @Test
+        void shouldFindLatestChargeForAgreementWhenMultipleChargesExistsAndPaymentInstrumentsAreInCreatedOrActiveState() {
+            insertAgreement(agreementExternalId);
+
+            insertPaymentInstrument(firstPaymentInstrumentId, agreementExternalId, firstChargeExternalId, Instant.now(),
+                    PaymentInstrumentStatus.CREATED);
+            insertPaymentInstrument(secondPaymentInstrumentId, agreementExternalId, secondChargeExternalId,
+                    now().plusMinutes(10).toInstant(), PaymentInstrumentStatus.ACTIVE);
+            insertPaymentInstrument(latestPaymentInstrumentId, agreementExternalId, latestChargeExternalId,
+                    now().plusMinutes(100).toInstant(), PaymentInstrumentStatus.CREATED);
+
+            insertChargeForAgreement(firstChargeExternalId, agreementExternalId, firstPaymentInstrumentId);
+            insertChargeForAgreement(secondChargeExternalId, agreementExternalId, secondPaymentInstrumentId);
+            insertChargeForAgreement(latestChargeExternalId, agreementExternalId, latestPaymentInstrumentId);
+
+            Optional<ChargeEntity> optionalChargeEntity = chargeDao.findLatestChargeForAgreementId(agreementExternalId);
+
+            assertThat(optionalChargeEntity.isPresent(), is(true));
+
+            ChargeEntity latestChargeEntity = optionalChargeEntity.get();
+            assertThat(latestChargeEntity.getExternalId(), is(latestChargeExternalId));
+            assertThat(latestChargeEntity.getPaymentInstrument().isPresent(), is(true));
+
+            PaymentInstrumentEntity paymentInstrumentEntity = latestChargeEntity.getPaymentInstrument().get();
+            assertThat(paymentInstrumentEntity.getChargeExternalId(), is(latestChargeExternalId));
+            assertThat(paymentInstrumentEntity.getStatus(), is(PaymentInstrumentStatus.CREATED));
+        }
+
+        @Test
+        void shouldNotReturnAChargeForAgreementIfNoneExistsForAgreementExternalId() {
+            insertAgreement(agreementExternalId);
+            insertPaymentInstrument(latestPaymentInstrumentId, agreementExternalId, latestChargeExternalId,
+                    now().plusMinutes(100).toInstant(), PaymentInstrumentStatus.CREATED);
+            insertChargeForAgreement(latestChargeExternalId, agreementExternalId, latestPaymentInstrumentId);
+
+            Optional<ChargeEntity> latestChargeForAgreementId = chargeDao.findLatestChargeForAgreementId("non-existent-external-id");
+
+            assertThat(latestChargeForAgreementId.isPresent(), is(false));
+        }
+
+        @Test
+        void shouldNotReturnAChargeIfNoPaymentInstrumentsExistsInCreatedOrActiveState() {
+            insertAgreement(agreementExternalId);
+            insertPaymentInstrument(firstPaymentInstrumentId, agreementExternalId, firstChargeExternalId,
+                    Instant.now(), INACTIVE);
+            insertPaymentInstrument(secondPaymentInstrumentId, agreementExternalId, secondChargeExternalId,
+                    Instant.now(), CANCELLED);
+
+            insertChargeForAgreement(firstChargeExternalId, agreementExternalId, firstPaymentInstrumentId);
+            insertChargeForAgreement(secondChargeExternalId, agreementExternalId, secondPaymentInstrumentId);
+
+            Optional<ChargeEntity> latestChargeForAgreementId = chargeDao.findLatestChargeForAgreementId(agreementExternalId);
+            assertThat(latestChargeForAgreementId.isPresent(), is(false));
+        }
+
+        @Test
+        void shouldNotReturnAChargeWhenChargesExistsAreForSubsequentRecurringPaymentWhichWontHavePaymentInstrumentId() {
+            insertAgreement(agreementExternalId);
+            insertChargeForAgreement(firstChargeExternalId, agreementExternalId, null);
+            insertChargeForAgreement(secondChargeExternalId, agreementExternalId, null);
+
+            Optional<ChargeEntity> latestChargeForAgreementId = chargeDao.findLatestChargeForAgreementId(agreementExternalId);
+            assertThat(latestChargeForAgreementId.isPresent(), is(false));
+        }
+
+        private void insertAgreement(String agreementExternalId) {
+            app.getDatabaseTestHelper().addAgreement(
+                    anAddAgreementParams()
+                            .withExternalAgreementId(agreementExternalId)
+                            .withGatewayAccountId(String.valueOf(defaultTestAccount.getAccountId()))
+                            .build()
+            );
+        }
+
+        private static void insertPaymentInstrument(long paymentInstrumentId, String agreementExternalId,
+                                                    String chargeExternalId, Instant createdDate, PaymentInstrumentStatus status) {
+            app.getDatabaseTestHelper().addPaymentInstrument(
+                    anAddPaymentInstrumentParams()
+                            .withPaymentInstrumentId(paymentInstrumentId)
+                            .withCreatedDate(createdDate)
+                            .withAgreementExternalId(agreementExternalId)
+                            .withChargeExternalId(chargeExternalId)
+                            .withPaymentInstrumentStatus(status)
+                            .build());
+        }
+
+        private void insertChargeForAgreement(String chargeExternalId2, String agreementExternalId, Long paymentInstrumentIdLatest) {
+            app.getDatabaseTestHelper().addCharge(
+                    AddChargeParams.AddChargeParamsBuilder
+                            .anAddChargeParams()
+                            .withExternalChargeId(chargeExternalId2)
+                            .withGatewayAccountId(String.valueOf(defaultTestAccount.getAccountId()))
+                            .withAgreementExternalId(agreementExternalId)
+                            .withPaymentInstrumentId(paymentInstrumentIdLatest)
+                            .build()
+            );
+        }
     }
 
     private void insertTestAccount() {


### PR DESCRIPTION
## WHAT
- For Adyen integration, when setting up an agreement, the payment instrument may not be linked to the agreement immediately (when the user confirms the payment) and will be in the CREATED state until we receive a webhook (recurring.token.created) from Adyen. Although unlikely, it is technically possible that multiple payments are setting up an agreement, and we need to ensure that the latest charge and payment instrument are linked to the agreement to take subsequent recurring payments when processing webhooks.

- The DAO method will be used to find the latest charge and process webhooks (if multiple exist) for an agreement correctly.
