### PR TITLE
PP-15683 - Rework Adyen token webhook logic to handle edge cases

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/LinkPaymentInstrumentToAgreementService.java
@@ -75,11 +75,14 @@ public class LinkPaymentInstrumentToAgreementService {
     private void cancelActivePaymentInstruments(AgreementEntity agreement) {
         List<PaymentInstrumentEntity> paymentInstruments = paymentInstrumentDao.findPaymentInstrumentsByAgreementAndStatus(
                 agreement.getExternalId(), PaymentInstrumentStatus.ACTIVE);
-        paymentInstruments.forEach(paymentInstrument -> {
-            paymentInstrument.setStatus(PaymentInstrumentStatus.CANCELLED);
-            taskQueueService.addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
-        });
+        paymentInstruments.forEach(paymentInstrument -> 
+                cancelPaymentInstrument(agreement, paymentInstrument));
+    }
 
+    @Transactional
+    public void cancelPaymentInstrument(AgreementEntity agreement, PaymentInstrumentEntity paymentInstrument) {
+        paymentInstrument.setStatus(PaymentInstrumentStatus.CANCELLED);
+        taskQueueService.addDeleteStoredPaymentDetailsTask(agreement, paymentInstrument);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
@@ -5,17 +5,20 @@ import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementService;
-import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
 import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
 import uk.gov.pay.connector.paymentinstrument.dao.PaymentInstrumentDao;
-import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.util.Map;
 
 import static uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory.SHOPPER_REFERENCE_DELIMITER;
+import static uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory.STORED_PAYMENT_METHOD_ID;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.ACTIVE;
 import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_INSTRUMENT_EXTERNAL_ID;
 
@@ -25,15 +28,17 @@ public class AdyenTokenWebhookNotificationHandler {
     private static final String RECURRING_TOKEN_CREATED = "recurring.token.created";
 
     private final PaymentInstrumentDao paymentInstrumentDao;
+    private final ChargeDao chargeDao;
     private final LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
     private final AdyenNotificationService adyenNotificationService;
     private final AgreementDao agreementDao;
 
     @Inject
-    public AdyenTokenWebhookNotificationHandler(PaymentInstrumentDao paymentInstrumentDao, AgreementDao agreementDao, LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService, AdyenNotificationService adyenNotificationService) {
+    public AdyenTokenWebhookNotificationHandler(PaymentInstrumentDao paymentInstrumentDao, AgreementDao agreementDao, ChargeDao chargeDao, LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService, AdyenNotificationService adyenNotificationService) {
 
         this.paymentInstrumentDao = paymentInstrumentDao;
         this.agreementDao = agreementDao;
+        this.chargeDao = chargeDao;
         this.linkPaymentInstrumentToAgreementService = linkPaymentInstrumentToAgreementService;
         this.adyenNotificationService = adyenNotificationService;
     }
@@ -62,29 +67,50 @@ public class AdyenTokenWebhookNotificationHandler {
             return;
         }
 
-        var agreementExternalId = splitShopperReference[0];
+        var webhookAgreementExternalId = splitShopperReference[0];
+        var webhookChargeExternalId = splitShopperReference[1];
 
-        var agreementEntity = agreementDao.findByExternalId(agreementExternalId);
+        var agreementEntity = agreementDao.findByExternalId(webhookAgreementExternalId);
         if (agreementEntity.isEmpty()) {
-            LOGGER.atInfo().setMessage("Agreement not found, ignoring Adyen token webhook").addKeyValue(AGREEMENT_EXTERNAL_ID, agreementExternalId).log();
+            LOGGER.atInfo().setMessage("Agreement not found, ignoring Adyen token webhook").addKeyValue(AGREEMENT_EXTERNAL_ID, webhookAgreementExternalId).log();
             return;
         }
+        chargeDao.findLatestChargeForAgreementId(webhookAgreementExternalId).ifPresentOrElse(latestCharge ->
+                        paymentInstrumentDao.findByChargeExternalId(webhookChargeExternalId).ifPresentOrElse(paymentInstrument -> {
+                                    paymentInstrument.setRecurringAuthToken(Map.of(STORED_PAYMENT_METHOD_ID,
+                                            notification.data().storedPaymentMethodId()));
 
-        var chargeExternalId = splitShopperReference[1];
+                                    var latestChargeId = latestCharge.getExternalId();
 
-        paymentInstrumentDao.findByChargeExternalId(chargeExternalId).ifPresentOrElse(paymentInstrument -> {
-            if (paymentInstrument.getStatus() == PaymentInstrumentStatus.ACTIVE) {
+                                    processWebhooks(latestChargeId, paymentInstrument, webhookChargeExternalId, webhookAgreementExternalId, agreementEntity.get());
+                                },
+                                () -> LOGGER.atInfo()
+                                        .setMessage("Payment instrument not found for charge in Adyen token webhook, ignoring")
+                                        .addKeyValue("EXTERNAL_CHARGE_ID", webhookChargeExternalId)
+                                        .log()),
+                () -> LOGGER.atInfo()
+                        .setMessage("No charges for the agreement were found with payment instruments in a valid state (ACTIVE or CREATED)")
+                        .addKeyValue(AGREEMENT_EXTERNAL_ID, webhookAgreementExternalId)
+                        .log());
+    }
+
+    private void processWebhooks(String latestChargeId, PaymentInstrumentEntity paymentInstrument, String webhookChargeExternalId,
+                                 String webhookAgreementExternalId, AgreementEntity agreementEntity) {
+        // Webhook refers to latest Payment Instrument
+        if (latestChargeId.equals(webhookChargeExternalId)) {
+            if (paymentInstrument.getStatus() == ACTIVE) {
                 LOGGER.atInfo().setMessage("Payment instrument is already in ACTIVE state, ignoring Adyen token webhook")
-                        .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementExternalId).addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
+                        .addKeyValue(AGREEMENT_EXTERNAL_ID, webhookAgreementExternalId)
+                        .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
                         .log();
                 return;
             }
-            paymentInstrument.setRecurringAuthToken(Map.of(AdyenRequestFactory.STORED_PAYMENT_METHOD_ID, notification.data().storedPaymentMethodId()));
-
-            linkPaymentInstrumentToAgreementService.linkPaymentInstrumentToAgreement(agreementEntity.get(), paymentInstrument);
-        }, () -> LOGGER.atInfo().setMessage("Payment instrument not found for charge in Adyen token webhook, ignoring")
-                .addKeyValue("EXTERNAL_CHARGE_ID", chargeExternalId)
-                .log());
+            linkPaymentInstrumentToAgreementService.linkPaymentInstrumentToAgreement(agreementEntity, paymentInstrument);
+        }
+        // Webhook does not refer to latest - cancel payment instrument
+        else {
+            linkPaymentInstrumentToAgreementService.cancelPaymentInstrument(agreementEntity, paymentInstrument);
+        }
     }
 
     private static void logInvalidShopperReference() {

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerIT.java
@@ -6,15 +6,27 @@ import io.github.netmikey.logunit.api.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.pay.connector.extension.AppWithPostgresAndSqsExtension;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.pay.connector.util.AddChargeParams;
 
+import java.time.Instant;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory.STORED_PAYMENT_METHOD_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.ACTIVE;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CANCELLED;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CREATED;
 import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
 import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
@@ -25,16 +37,16 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 class AdyenTokenWebhookNotificationHandlerIT {
 
     private static final String AGREEMENT_EXTERNAL_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaa";
-    private static final String CHARGE_EXTERNAL_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
-    private static final String SHOPPER_REFERENCE = AGREEMENT_EXTERNAL_ID + "-" + CHARGE_EXTERNAL_ID;
+    private static final String WEBHOOK_CHARGE_EXTERNAL_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String SHOPPER_REFERENCE = AGREEMENT_EXTERNAL_ID + "-" + WEBHOOK_CHARGE_EXTERNAL_ID;
     private static final String STORED_PAYMENT_METHOD_ID_VALUE = "pm-id-123";
-    private static final String CREATED_PAYMENT_INSTRUMENT_EXTERNAL_ID = "cccccccccccccccccccccccccc";
-    private static final String ACTIVE_PAYMENT_INSTRUMENT_EXTERNAL_ID = "dddddddddddddddddddddddddd";
+    private static final String FIRST_PAYMENT_INSTRUMENT_EXTERNAL_ID = "cccccccccccccccccccccccccc";
+    private static final String SECOND_PAYMENT_INSTRUMENT_EXTERNAL_ID = "dddddddddddddddddddddddddd";
     private static final String OTHER_CHARGE_EXTERNAL_ID = "eeeeeeeeeeeeeeeeeeeeeeeeee";
 
     private static final long AGREEMENT_ID = secureRandomLong();
-    private static final long CREATED_PAYMENT_INSTRUMENT_ID = secureRandomLong();
-    private static final long ACTIVE_PAYMENT_INSTRUMENT_ID = secureRandomLong();
+    private static final long FIRST_PAYMENT_INSTRUMENT_ID = secureRandomLong();
+    private static final long SECOND_PAYMENT_INSTRUMENT_ID = secureRandomLong();
 
     @RegisterExtension
     public static AppWithPostgresAndSqsExtension app = new AppWithPostgresAndSqsExtension();
@@ -45,44 +57,117 @@ class AdyenTokenWebhookNotificationHandlerIT {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private AdyenTokenWebhookNotificationHandler handler;
 
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+
     @BeforeEach
     void setUp() {
         handler = app.getInstanceFromGuiceContainer(AdyenTokenWebhookNotificationHandler.class);
+
+        app.getDatabaseFixtures().validTestCardDetails();
+        insertTestAccount();
+
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(TEST);
+        gatewayAccount.setId(defaultTestAccount.getAccountId());
+
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+                .withCredentials(Map.of())
+                .withGatewayAccountEntity(gatewayAccount)
+                .withPaymentProvider(defaultTestAccount.getPaymentProvider())
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build();
+        gatewayAccountCredentialsEntity.setId(defaultTestAccount.getCredentials().getFirst().getId());
     }
 
     @Test
     void shouldActivatePaymentInstrumentAndLinkToAgreement() throws Exception {
         insertAgreement();
         insertPaymentInstrument(
-                CREATED_PAYMENT_INSTRUMENT_ID,
-                CREATED_PAYMENT_INSTRUMENT_EXTERNAL_ID,
-                CREATED,
-                null,
-                CHARGE_EXTERNAL_ID,
-                STORED_PAYMENT_METHOD_ID_VALUE
-        );
-        insertPaymentInstrument(
-                ACTIVE_PAYMENT_INSTRUMENT_ID,
-                ACTIVE_PAYMENT_INSTRUMENT_EXTERNAL_ID,
+                FIRST_PAYMENT_INSTRUMENT_ID,
+                FIRST_PAYMENT_INSTRUMENT_EXTERNAL_ID,
                 ACTIVE,
                 AGREEMENT_EXTERNAL_ID,
                 OTHER_CHARGE_EXTERNAL_ID,
-                "old-token"
+                "old-token",
+                Instant.now()
         );
+        insertPaymentInstrument(
+                SECOND_PAYMENT_INSTRUMENT_ID,
+                SECOND_PAYMENT_INSTRUMENT_EXTERNAL_ID,
+                CREATED,
+                null,
+                WEBHOOK_CHARGE_EXTERNAL_ID,
+                STORED_PAYMENT_METHOD_ID_VALUE,
+                Instant.now().plusSeconds(120)
+        );
+
+
+        insertChargeForAgreement(OTHER_CHARGE_EXTERNAL_ID, FIRST_PAYMENT_INSTRUMENT_ID);
+        insertChargeForAgreement(WEBHOOK_CHARGE_EXTERNAL_ID, SECOND_PAYMENT_INSTRUMENT_ID);
 
         handler.process(tokenNotificationPayload());
 
         var updatedAgreement = app.getDatabaseTestHelper().getAgreementByExternalId(AGREEMENT_EXTERNAL_ID);
-        var updatedCreatedPaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(CREATED_PAYMENT_INSTRUMENT_ID);
-        var updatedActivePaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(ACTIVE_PAYMENT_INSTRUMENT_ID);
+        var updatedFirstPaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(FIRST_PAYMENT_INSTRUMENT_ID);
+        var updatedSecondPaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(SECOND_PAYMENT_INSTRUMENT_ID);
 
-        assertThat(((Number) updatedAgreement.get("payment_instrument_id")).longValue(), is(CREATED_PAYMENT_INSTRUMENT_ID));
-        assertThat(updatedCreatedPaymentInstrument.get("status"), is(ACTIVE.name()));
-        assertThat(updatedCreatedPaymentInstrument.get("agreement_external_id"), is(AGREEMENT_EXTERNAL_ID));
-        assertThat(recurringAuthToken(updatedCreatedPaymentInstrument), is(Map.of(STORED_PAYMENT_METHOD_ID, STORED_PAYMENT_METHOD_ID_VALUE)));
-        assertThat(updatedActivePaymentInstrument.get("status"), is(PaymentInstrumentStatus.CANCELLED.name()));
+        assertThat(((Number) updatedAgreement.get("payment_instrument_id")).longValue(), is(SECOND_PAYMENT_INSTRUMENT_ID));
+        assertThat(updatedSecondPaymentInstrument.get("status"), is(ACTIVE.name()));
+        assertThat(updatedSecondPaymentInstrument.get("agreement_external_id"), is(AGREEMENT_EXTERNAL_ID));
+        assertThat(recurringAuthToken(updatedSecondPaymentInstrument), is(Map.of(STORED_PAYMENT_METHOD_ID, STORED_PAYMENT_METHOD_ID_VALUE)));
+        assertThat(updatedFirstPaymentInstrument.get("status"), is(PaymentInstrumentStatus.CANCELLED.name()));
     }
 
+    @ParameterizedTest
+    @EnumSource(value = PaymentInstrumentStatus.class, names = {"CREATED", "ACTIVE"})
+    void shouldCancelWebhookPaymentInstrumentWhenNewerActiveOneExists(PaymentInstrumentStatus paymentInstrumentTwoStatus) {
+        insertAgreement();
+        //First Payment Instrument
+        insertPaymentInstrument(
+                FIRST_PAYMENT_INSTRUMENT_ID,
+                FIRST_PAYMENT_INSTRUMENT_EXTERNAL_ID,
+                CREATED,
+                null,
+                WEBHOOK_CHARGE_EXTERNAL_ID,
+                "",
+                Instant.parse("2026-08-17T10:43:52Z")
+        );
+        // Second Payment Instrument
+        insertPaymentInstrument(
+                SECOND_PAYMENT_INSTRUMENT_ID,
+                SECOND_PAYMENT_INSTRUMENT_EXTERNAL_ID,
+                paymentInstrumentTwoStatus,
+                AGREEMENT_EXTERNAL_ID,
+                OTHER_CHARGE_EXTERNAL_ID,
+                STORED_PAYMENT_METHOD_ID_VALUE,
+                Instant.parse("2026-08-18T10:43:52Z")
+        );
+
+        insertChargeForAgreement(WEBHOOK_CHARGE_EXTERNAL_ID, FIRST_PAYMENT_INSTRUMENT_ID);
+        insertChargeForAgreement(OTHER_CHARGE_EXTERNAL_ID, SECOND_PAYMENT_INSTRUMENT_ID);
+
+        handler.process(tokenNotificationPayload());
+
+        var firstPaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(FIRST_PAYMENT_INSTRUMENT_ID);
+        var secondPaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(SECOND_PAYMENT_INSTRUMENT_ID);
+
+        assertThat(firstPaymentInstrument.get("status"), is(CANCELLED.name()));
+        assertThat(firstPaymentInstrument.get("recurring_auth_token").toString(), containsString(STORED_PAYMENT_METHOD_ID_VALUE));
+        assertThat(secondPaymentInstrument.get("status"), is(paymentInstrumentTwoStatus.name()));
+        assertThat(secondPaymentInstrument.get("recurring_auth_token").toString(), containsString(STORED_PAYMENT_METHOD_ID_VALUE));
+    }
+
+
+    private void insertChargeForAgreement(String chargeExternalId2, Long paymentInstrumentIdLatest) {
+        app.getDatabaseTestHelper().addCharge(
+                AddChargeParams.AddChargeParamsBuilder
+                        .anAddChargeParams()
+                        .withExternalChargeId(chargeExternalId2)
+                        .withGatewayAccountId(String.valueOf(defaultTestAccount.getAccountId()))
+                        .withAgreementExternalId(AGREEMENT_EXTERNAL_ID)
+                        .withPaymentInstrumentId(paymentInstrumentIdLatest)
+                        .build()
+        );
+    }
 
     private void insertAgreement() {
         var testAccount = app.getDatabaseFixtures()
@@ -107,7 +192,8 @@ class AdyenTokenWebhookNotificationHandlerIT {
                                          PaymentInstrumentStatus status,
                                          String agreementExternalId,
                                          String chargeExternalId,
-                                         String storedPaymentMethodId) {
+                                         String storedPaymentMethodId,
+                                         Instant createdDate) {
         app.getDatabaseTestHelper().addPaymentInstrument(anAddPaymentInstrumentParams()
                 .withPaymentInstrumentId(paymentInstrumentId)
                 .withExternalPaymentInstrumentId(externalPaymentInstrumentId)
@@ -115,6 +201,7 @@ class AdyenTokenWebhookNotificationHandlerIT {
                 .withAgreementExternalId(agreementExternalId)
                 .withChargeExternalId(chargeExternalId)
                 .withRecurringAuthToken(Map.of(STORED_PAYMENT_METHOD_ID, storedPaymentMethodId))
+                .withCreatedDate(createdDate)
                 .build());
         app.getDatabaseTestHelper().getPaymentInstrument(paymentInstrumentId);
     }
@@ -123,5 +210,12 @@ class AdyenTokenWebhookNotificationHandlerIT {
         return load(ADYEN_TOKEN_NOTIFICATION)
                 .replace("YOUR_SHOPPER_REFERENCE", SHOPPER_REFERENCE)
                 .replace("M5N7TQ4TG5PFWR50", STORED_PAYMENT_METHOD_ID_VALUE);
+    }
+
+    private void insertTestAccount() {
+        this.defaultTestAccount = app.getDatabaseFixtures()
+                .aTestAccount()
+                .withAccountId(secureRandomLong())
+                .insert();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
@@ -13,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementService;
 import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenEventData;
@@ -30,13 +31,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntityFixture.aPaymentInstrumentEntity;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CREATED;
 
 @ExtendWith(MockitoExtension.class)
 class AdyenTokenWebhookNotificationHandlerTest {
 
     private static final String AGREEMENT_EXTERNAL_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaa";
-    private static final String CHARGE_EXTERNAL_ID    = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String CHARGE_EXTERNAL_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String LATEST_CHARGE_EXTERNAL_ID = "cccccccccccccccccccccccccc";
     private static final String SHOPPER_REFERENCE = AGREEMENT_EXTERNAL_ID + "-" + CHARGE_EXTERNAL_ID;
     private static final String STORED_PAYMENT_METHOD_ID = "pm-id-123";
     private static final String PAYLOAD = "{}";
@@ -46,6 +50,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
 
     @Mock private AgreementDao agreementDao;
     @Mock private PaymentInstrumentDao paymentInstrumentDao;
+    @Mock private ChargeDao chargeDao;
     @Mock private LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
     @Mock private AdyenNotificationService adyenNotificationService;
 
@@ -58,14 +63,20 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @Test
     void shouldSetTokenAndLinkPaymentInstrumentToAgreement() {
         var paymentInstrument = aPaymentInstrumentEntity()
-                .withPaymentInstrumentStatus(PaymentInstrumentStatus.CREATED)
+                .withPaymentInstrumentStatus(CREATED)
                 .withChargeExternalId(CHARGE_EXTERNAL_ID)
                 .build();
         var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
 
+        var chargeEntity = aValidChargeEntity()
+                .withExternalId(CHARGE_EXTERNAL_ID)
+                .withPaymentInstrument(paymentInstrument)
+                .withAgreementEntity(agreement).build();
+
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
+                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+        given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
 
         handler.process(PAYLOAD);
@@ -87,9 +98,15 @@ class AdyenTokenWebhookNotificationHandlerTest {
                 .build();
         var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
 
+        var chargeEntity = aValidChargeEntity()
+                .withExternalId(CHARGE_EXTERNAL_ID)
+                .withPaymentInstrument(paymentInstrument)
+                .withAgreementEntity(agreement).build();
+        
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
+                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+        given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
 
         handler.process(PAYLOAD);
@@ -99,9 +116,36 @@ class AdyenTokenWebhookNotificationHandlerTest {
     }
 
     @Test
+    void shouldCancelPaymentInstrumentWhenNewerOneExists() {
+        var webhookPaymentInstrument = aPaymentInstrumentEntity()
+                .withPaymentInstrumentStatus(CREATED)
+                .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                .build();
+        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+
+        var latestChargeEntity = aValidChargeEntity()
+                .withExternalId(LATEST_CHARGE_EXTERNAL_ID)
+                .withAgreementEntity(agreement).build();
+
+        given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+        given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(latestChargeEntity));
+        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(webhookPaymentInstrument));
+
+        handler.process(PAYLOAD);
+
+        then(linkPaymentInstrumentToAgreementService)
+                .should()
+                .cancelPaymentInstrument(eq(agreement), paymentInstrumentCaptor.capture());
+
+        then(linkPaymentInstrumentToAgreementService).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
     void shouldIgnoreAndLogWhenAgreementNotFound() {
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
+                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.empty());
 
         handler.process(PAYLOAD);
@@ -109,6 +153,43 @@ class AdyenTokenWebhookNotificationHandlerTest {
         then(paymentInstrumentDao).shouldHaveNoInteractions();
         then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
         logs.assertContains("Agreement not found, ignoring Adyen token webhook");
+    }
+
+    @Test
+    void shouldIgnoreAndLogWhenValidChargesAreNotFound() {
+        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+
+        given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+        given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.empty());
+
+        handler.process(PAYLOAD);
+
+        then(paymentInstrumentDao).shouldHaveNoInteractions();
+        then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
+        logs.assertContains("No charges for the agreement were found with payment instruments in a valid state (ACTIVE or CREATED)");
+    }
+
+    @Test
+    void shouldIgnoreAndLogWhenPaymentInstrumentNotFound() {
+        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+
+        var chargeEntity = aValidChargeEntity()
+                .withExternalId(CHARGE_EXTERNAL_ID)
+                .withAgreementEntity(agreement).build();
+
+        given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+        given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
+        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.empty());
+
+
+        handler.process(PAYLOAD);
+
+        then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
+        logs.assertContains("Payment instrument not found for charge in Adyen token webhook, ignoring");
     }
 
     @Test
@@ -130,7 +211,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @ValueSource(strings = {"badId", "one-two-three", "aaaaaaaaaaaaaaaaaaaaaaaaaa-short", "short-bbbbbbbbbbbbbbbbbbbbbbbbbb"})
     void shouldLogErrorForInvalidShopperReferenceLengthFormat(String invalidShopperReference) {
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(invalidShopperReference, STORED_PAYMENT_METHOD_ID));
+                .willReturn(tokenCreatedNotification(invalidShopperReference));
 
         handler.process(PAYLOAD);
 
@@ -143,14 +224,20 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @Test
     void shouldNotLogStoredPaymentMethodId() {
         var paymentInstrument = aPaymentInstrumentEntity()
-                .withPaymentInstrumentStatus(PaymentInstrumentStatus.CREATED)
+                .withPaymentInstrumentStatus(CREATED)
                 .withChargeExternalId(CHARGE_EXTERNAL_ID)
                 .build();
         var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
 
+        var chargeEntity = aValidChargeEntity()
+                .withExternalId(CHARGE_EXTERNAL_ID)
+                .withPaymentInstrument(paymentInstrument)
+                .withAgreementEntity(agreement).build();
+
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
+                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+        given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
 
         handler.process(PAYLOAD);
@@ -160,12 +247,12 @@ class AdyenTokenWebhookNotificationHandlerTest {
                         event.getMessage().contains(STORED_PAYMENT_METHOD_ID), is(false)));
     }
 
-    private AdyenTokenNotification tokenCreatedNotification(String shopperReference, String storedPaymentMethodId) {
+    private AdyenTokenNotification tokenCreatedNotification(String shopperReference) {
         return new AdyenTokenNotification(
                 "2026-07-14T18:10:49+01:00",
                 "event-id-123",
                 "test",
-                new AdyenTokenEventData("YOUR_MERCHANT_ACCOUNT", storedPaymentMethodId, "visa", "created", shopperReference),
+                new AdyenTokenEventData("YOUR_MERCHANT_ACCOUNT", STORED_PAYMENT_METHOD_ID, "visa", "created", shopperReference),
                 "recurring.token.created"
         );
     }


### PR DESCRIPTION
- Reworked the logic in AdyenTokenWebhookNotificationHandler to properly handle cases where the webhook is for a payment instrument that is not the latest created one
- Added cancelPaymentInstrument method to LinkPaymentInstrumentToAgreementService that takes a specific payment instrument as a parameter