### PR TITLE
PP-15559: add inactivateAgreement method to handle "recurring.token.disabled" webhooks

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
@@ -5,44 +5,59 @@ import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementService;
-import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
+import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.events.model.agreement.AgreementInactivated;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
 import uk.gov.pay.connector.gateway.adyen.webhook.AdyenRecurringTokenNotificationService;
 import uk.gov.pay.connector.paymentinstrument.dao.PaymentInstrumentDao;
-import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
+import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
+import java.time.Instant;
 import java.util.Map;
+import java.util.Set;
 
+import static com.adyen.model.tokenizationwebhooks.TokenizationCreatedDetailsNotificationRequest.TypeEnum.RECURRING_TOKEN_CREATED;
 import static uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory.SHOPPER_REFERENCE_DELIMITER;
+import static uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory.STORED_PAYMENT_METHOD_ID;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.ACTIVE;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CANCELLED;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CREATED;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.INACTIVE;
 import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_INSTRUMENT_EXTERNAL_ID;
 
 public class AdyenTokenWebhookNotificationHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AdyenTokenWebhookNotificationHandler.class);
-    private static final String RECURRING_TOKEN_CREATED = "recurring.token.created";
+    private static final Set<String> SUPPORTED_EVENT_TYPES = Set.of(
+            "recurring.token.created",
+            "recurring.token.disabled"
+    );
 
     private final PaymentInstrumentDao paymentInstrumentDao;
     private final LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
     private final AdyenRecurringTokenNotificationService adyenRecurringTokenNotificationService;
     private final AgreementDao agreementDao;
+    private LedgerService ledgerService;
 
     @Inject
-    public AdyenTokenWebhookNotificationHandler(PaymentInstrumentDao paymentInstrumentDao, AgreementDao agreementDao, LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService, AdyenRecurringTokenNotificationService adyenRecurringTokenNotificationService) {
+    public AdyenTokenWebhookNotificationHandler(PaymentInstrumentDao paymentInstrumentDao, AgreementDao agreementDao, LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService, AdyenRecurringTokenNotificationService adyenRecurringTokenNotificationService, LedgerService ledgerService) {
 
         this.paymentInstrumentDao = paymentInstrumentDao;
         this.agreementDao = agreementDao;
         this.linkPaymentInstrumentToAgreementService = linkPaymentInstrumentToAgreementService;
         this.adyenRecurringTokenNotificationService = adyenRecurringTokenNotificationService;
+        this.ledgerService = ledgerService;
     }
 
     @Transactional
     public void process(String payload) {
         AdyenTokenNotification notification = adyenRecurringTokenNotificationService.deserialisePayload(payload, AdyenTokenNotification.class);
 
-        if (!RECURRING_TOKEN_CREATED.equals(notification.type())) {
+        if (!SUPPORTED_EVENT_TYPES.contains(notification.type())) {
             LOGGER.atInfo().setMessage("Ignoring Adyen token webhook notification with unsupported type").addKeyValue("type", notification.type()).log();
             return;
         }
@@ -73,21 +88,58 @@ public class AdyenTokenWebhookNotificationHandler {
         var chargeExternalId = splitShopperReference[1];
 
         paymentInstrumentDao.findByChargeExternalId(chargeExternalId).ifPresentOrElse(paymentInstrument -> {
-            if (paymentInstrument.getStatus() == PaymentInstrumentStatus.ACTIVE) {
-                LOGGER.atInfo().setMessage("Payment instrument is already in ACTIVE state, ignoring Adyen token webhook")
-                        .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementExternalId).addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
-                        .log();
-                return;
+            if (RECURRING_TOKEN_CREATED.getValue().equals(notification.type())) {
+                activateAgreement(agreementEntity.get(), paymentInstrument, notification);
+            } else {
+                inactivateAgreement(agreementEntity.get(), paymentInstrument);
             }
-            paymentInstrument.setRecurringAuthToken(Map.of(AdyenRequestFactory.STORED_PAYMENT_METHOD_ID, notification.data().storedPaymentMethodId()));
-
-            linkPaymentInstrumentToAgreementService.linkPaymentInstrumentToAgreement(agreementEntity.get(), paymentInstrument);
         }, () -> LOGGER.atInfo().setMessage("Payment instrument not found for charge in Adyen token webhook, ignoring")
                 .addKeyValue("EXTERNAL_CHARGE_ID", chargeExternalId)
                 .log());
     }
 
+    private void activateAgreement(AgreementEntity agreementEntity, PaymentInstrumentEntity paymentInstrument, AdyenTokenNotification notification) {
+        if (paymentInstrument.getStatus() == ACTIVE) {
+            logIgnoreWebhookBasedOnDuplicateStatus(paymentInstrument, agreementEntity.getExternalId());
+            return;
+        }
+        paymentInstrument.setRecurringAuthToken(Map.of(STORED_PAYMENT_METHOD_ID, notification.data().storedPaymentMethodId()));
+
+        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentToAgreement(agreementEntity, paymentInstrument);
+    }
+
+    private void inactivateAgreement(AgreementEntity agreementEntity, PaymentInstrumentEntity paymentInstrument) {
+        if (paymentInstrument.getStatus() == INACTIVE || paymentInstrument.getStatus() == CANCELLED) {
+            logIgnoreWebhookBasedOnDuplicateStatus(paymentInstrument, agreementEntity.getExternalId());
+            return;
+        }
+
+        if (paymentInstrument.getStatus() == CREATED) {
+            LOGGER.atError().setMessage("Payment instrument is not in the correct state to be inactivated, ignoring Adyen token webhook")
+                    .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId())
+                    .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
+                    .log();
+            return;
+        }
+        var inactivatedEvent = AgreementInactivated.from(agreementEntity, "Adyen agreement inactivated", Instant.now());
+        ledgerService.postEvent(inactivatedEvent);
+
+        paymentInstrument.setStatus(INACTIVE);
+        LOGGER.atInfo().setMessage("Payment instrument and agreement successfully inactivated")
+                .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId())
+                .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
+                .log();
+    }
+
     private static void logInvalidShopperReference() {
         LOGGER.atInfo().setMessage("Invalid shopper reference").log();
     }
+
+    private static void logIgnoreWebhookBasedOnDuplicateStatus(PaymentInstrumentEntity paymentInstrument, String agreementExternalId) {
+        LOGGER.atInfo().setMessage("Payment instrument is already in " + paymentInstrument.getStatus() + " state, ignoring Adyen token webhook")
+                .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementExternalId)
+                .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
+                .log();
+    }
+
 }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerIT.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory.STORED_PAYMENT_METHOD_ID;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.ACTIVE;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CREATED;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.INACTIVE;
 import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
 import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
 import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRandomLong;
@@ -52,6 +53,34 @@ class AdyenTokenWebhookNotificationHandlerIT {
 
     @Test
     void shouldActivatePaymentInstrumentAndLinkToAgreement() throws Exception {
+        SetUpAndAcceptTokenCreatedEvent();
+
+        var updatedAgreement = app.getDatabaseTestHelper().getAgreementByExternalId(AGREEMENT_EXTERNAL_ID);
+        var updatedCreatedPaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(CREATED_PAYMENT_INSTRUMENT_ID);
+        var updatedActivePaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(ACTIVE_PAYMENT_INSTRUMENT_ID);
+
+        assertThat(((Number) updatedAgreement.get("payment_instrument_id")).longValue(), is(CREATED_PAYMENT_INSTRUMENT_ID));
+        assertThat(updatedCreatedPaymentInstrument.get("status"), is(ACTIVE.name()));
+        assertThat(updatedCreatedPaymentInstrument.get("agreement_external_id"), is(AGREEMENT_EXTERNAL_ID));
+        assertThat(recurringAuthToken(updatedCreatedPaymentInstrument), is(Map.of(STORED_PAYMENT_METHOD_ID, STORED_PAYMENT_METHOD_ID_VALUE)));
+        assertThat(updatedActivePaymentInstrument.get("status"), is(PaymentInstrumentStatus.CANCELLED.name()));
+    }
+
+    @Test
+    void shouldInactivatePaymentInstrument() {
+        SetUpAndAcceptTokenCreatedEvent();
+
+        handler.process(tokenNotificationPayload("recurring.token.disabled"));
+
+        var agreement = app.getDatabaseTestHelper().getAgreementByExternalId(AGREEMENT_EXTERNAL_ID);
+        var paymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(CREATED_PAYMENT_INSTRUMENT_ID);
+
+        assertThat(agreement.get("payment_instrument_id"), is(CREATED_PAYMENT_INSTRUMENT_ID));
+        assertThat(paymentInstrument.get("status"), is(INACTIVE.name()));
+        logs.assertContains("Payment instrument and agreement successfully inactivated");
+    }
+
+    private void SetUpAndAcceptTokenCreatedEvent() {
         insertAgreement();
         insertPaymentInstrument(
                 CREATED_PAYMENT_INSTRUMENT_ID,
@@ -70,17 +99,7 @@ class AdyenTokenWebhookNotificationHandlerIT {
                 "old-token"
         );
 
-        handler.process(tokenNotificationPayload());
-
-        var updatedAgreement = app.getDatabaseTestHelper().getAgreementByExternalId(AGREEMENT_EXTERNAL_ID);
-        var updatedCreatedPaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(CREATED_PAYMENT_INSTRUMENT_ID);
-        var updatedActivePaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(ACTIVE_PAYMENT_INSTRUMENT_ID);
-
-        assertThat(((Number) updatedAgreement.get("payment_instrument_id")).longValue(), is(CREATED_PAYMENT_INSTRUMENT_ID));
-        assertThat(updatedCreatedPaymentInstrument.get("status"), is(ACTIVE.name()));
-        assertThat(updatedCreatedPaymentInstrument.get("agreement_external_id"), is(AGREEMENT_EXTERNAL_ID));
-        assertThat(recurringAuthToken(updatedCreatedPaymentInstrument), is(Map.of(STORED_PAYMENT_METHOD_ID, STORED_PAYMENT_METHOD_ID_VALUE)));
-        assertThat(updatedActivePaymentInstrument.get("status"), is(PaymentInstrumentStatus.CANCELLED.name()));
+        handler.process(tokenNotificationPayload("recurring.token.created"));
     }
 
 
@@ -119,9 +138,10 @@ class AdyenTokenWebhookNotificationHandlerIT {
         app.getDatabaseTestHelper().getPaymentInstrument(paymentInstrumentId);
     }
 
-    private String tokenNotificationPayload() {
+    private String tokenNotificationPayload(String operation) {
         return load(ADYEN_TOKEN_NOTIFICATION)
                 .replace("YOUR_SHOPPER_REFERENCE", SHOPPER_REFERENCE)
-                .replace("M5N7TQ4TG5PFWR50", STORED_PAYMENT_METHOD_ID_VALUE);
+                .replace("M5N7TQ4TG5PFWR50", STORED_PAYMENT_METHOD_ID_VALUE)
+                .replace("recurring.token.created", operation);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
@@ -1,10 +1,13 @@
 package uk.gov.pay.connector.queue.tasks.handlers.adyen;
 
 import io.github.netmikey.logunit.api.LogCapturer;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -14,6 +17,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementService;
+import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.events.model.agreement.AgreementInactivated;
+import uk.gov.pay.connector.events.model.agreement.AgreementInactivated.AgreementInactivatedEventDetails;
 import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenEventData;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
@@ -24,19 +30,26 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 
 import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.slf4j.event.Level.ERROR;
 import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntityFixture.aPaymentInstrumentEntity;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CREATED;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.INACTIVE;
 
 @ExtendWith(MockitoExtension.class)
 class AdyenTokenWebhookNotificationHandlerTest {
 
     private static final String AGREEMENT_EXTERNAL_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaa";
-    private static final String CHARGE_EXTERNAL_ID    = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String CHARGE_EXTERNAL_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
     private static final String SHOPPER_REFERENCE = AGREEMENT_EXTERNAL_ID + "-" + CHARGE_EXTERNAL_ID;
     private static final String STORED_PAYMENT_METHOD_ID = "pm-id-123";
     private static final String PAYLOAD = "{}";
@@ -44,10 +57,16 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @RegisterExtension
     LogCapturer logs = LogCapturer.create().captureForType(AdyenTokenWebhookNotificationHandler.class);
 
-    @Mock private AgreementDao agreementDao;
-    @Mock private PaymentInstrumentDao paymentInstrumentDao;
-    @Mock private LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
-    @Mock private AdyenRecurringTokenNotificationService adyenRecurringTokenNotificationService;
+    @Mock
+    private AgreementDao agreementDao;
+    @Mock
+    private PaymentInstrumentDao paymentInstrumentDao;
+    @Mock
+    private LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
+    @Mock
+    private AdyenRecurringTokenNotificationService adyenRecurringTokenNotificationService;
+    @Mock
+    private LedgerService ledgerService;
 
     @Captor
     private ArgumentCaptor<PaymentInstrumentEntity> paymentInstrumentCaptor;
@@ -55,53 +74,123 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @InjectMocks
     private AdyenTokenWebhookNotificationHandler handler;
 
-    @Test
-    void shouldSetTokenAndLinkPaymentInstrumentToAgreement() {
-        var paymentInstrument = aPaymentInstrumentEntity()
-                .withPaymentInstrumentStatus(PaymentInstrumentStatus.CREATED)
-                .withChargeExternalId(CHARGE_EXTERNAL_ID)
-                .build();
-        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+    @Nested
+    class TokenCreatedWebhooks {
+        @Test
+        void shouldSetTokenAndLinkPaymentInstrumentToAgreement() {
+            var paymentInstrument = aPaymentInstrumentEntity()
+                    .withPaymentInstrumentStatus(PaymentInstrumentStatus.CREATED)
+                    .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                    .build();
+            var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).withGatewayAccount(aGatewayAccountEntity().build()).build();
 
-        given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
-        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
-        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+            given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                    .willReturn(tokenNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID, "created"));
+            given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+            given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
 
-        handler.process(PAYLOAD);
+            handler.process(PAYLOAD);
 
-        then(linkPaymentInstrumentToAgreementService)
-                .should()
-                .linkPaymentInstrumentToAgreement(eq(agreement), paymentInstrumentCaptor.capture());
+            then(linkPaymentInstrumentToAgreementService)
+                    .should()
+                    .linkPaymentInstrumentToAgreement(eq(agreement), paymentInstrumentCaptor.capture());
 
-        var captured = paymentInstrumentCaptor.getValue();
-        assertThat(captured.getRecurringAuthToken().orElseThrow().get(AdyenRequestFactory.STORED_PAYMENT_METHOD_ID),
-                is(STORED_PAYMENT_METHOD_ID));
+            var captured = paymentInstrumentCaptor.getValue();
+            assertThat(captured.getRecurringAuthToken().orElseThrow().get(AdyenRequestFactory.STORED_PAYMENT_METHOD_ID),
+                    is(STORED_PAYMENT_METHOD_ID));
+        }
+
+        @Test
+        void shouldIgnoreAndLogWhenPaymentInstrumentIsAlreadyActive() {
+            var paymentInstrument = aPaymentInstrumentEntity()
+                    .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
+                    .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                    .build();
+            var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+
+            given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                    .willReturn(tokenNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID, "created"));
+            given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+            given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+
+            handler.process(PAYLOAD);
+
+            then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
+            logs.assertContains("Payment instrument is already in ACTIVE state, ignoring Adyen token webhook");
+        }
     }
 
-    @Test
-    void shouldIgnoreAndLogWhenPaymentInstrumentIsAlreadyActive() {
-        var paymentInstrument = aPaymentInstrumentEntity()
-                .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
-                .withChargeExternalId(CHARGE_EXTERNAL_ID)
-                .build();
-        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+    @Nested
+    class TokenDisabledWebhooks {
 
-        given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
-        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
-        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+        @Captor
+        private ArgumentCaptor<AgreementInactivated> agreementInactivatedArgumentCaptor;
 
-        handler.process(PAYLOAD);
+        @Test
+        void shouldSetPaymentInstrumentToInactive() {
+            var paymentInstrument = createAndMockPaymentInstrument(PaymentInstrumentStatus.ACTIVE);
 
-        then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
-        logs.assertContains("Payment instrument is already in ACTIVE state, ignoring Adyen token webhook");
+            handler.process(PAYLOAD);
+
+            assertThat(paymentInstrument.getStatus(), is(INACTIVE));
+            logs.assertContains("Payment instrument and agreement successfully inactivated");
+        }
+
+        @Test
+        void shouldEmitAgreementInactivatedEventToLedger() {
+            createAndMockPaymentInstrument(PaymentInstrumentStatus.ACTIVE);
+
+            handler.process(PAYLOAD);
+
+            verify(ledgerService).postEvent(agreementInactivatedArgumentCaptor.capture());
+
+            var event = agreementInactivatedArgumentCaptor.getValue();
+            assertThat(event.getEventType(), is("AGREEMENT_INACTIVATED"));
+            var eventDetails = (AgreementInactivatedEventDetails) event.getEventDetails();
+            assertThat(eventDetails.getReason(), equalTo("Adyen agreement inactivated"));
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = PaymentInstrumentStatus.class, names = {"CANCELLED", "INACTIVE"})
+        void shouldIgnoreWhenInvalidPaymentInstrumentStatus(PaymentInstrumentStatus status) {
+            var paymentInstrument = createAndMockPaymentInstrument(status);
+
+            handler.process(PAYLOAD);
+            assertThat(paymentInstrument.getStatus(), is(status));
+            verifyNoInteractions(ledgerService);
+            logs.assertContains("Payment instrument is already in " + status + " state, ignoring Adyen token webhook");
+        }
+
+        @Test
+        void shouldIgnoreAndErrorWhenDisablingPaymentInstrumentWithCreatedStatus() {
+            var paymentInstrument = createAndMockPaymentInstrument(PaymentInstrumentStatus.CREATED);
+
+            handler.process(PAYLOAD);
+            assertThat(paymentInstrument.getStatus(), is(CREATED));
+            verifyNoInteractions(ledgerService);
+            logs.forLevel(ERROR).assertContains("Payment instrument is not in the correct state to be inactivated, ignoring Adyen token webhook");
+        }
+
+        private @NotNull PaymentInstrumentEntity createAndMockPaymentInstrument(PaymentInstrumentStatus active) {
+            var paymentInstrument = aPaymentInstrumentEntity()
+                    .withPaymentInstrumentStatus(active)
+                    .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                    .build();
+            var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).withGatewayAccount(aGatewayAccountEntity().build()).build();
+
+            given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                    .willReturn(tokenNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID, "disabled"));
+            given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+            given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+            return paymentInstrument;
+        }
     }
 
-    @Test
-    void shouldIgnoreAndLogWhenAgreementNotFound() {
+    @ParameterizedTest
+    @ValueSource(strings = {"created", "disabled"})
+    void shouldIgnoreAndLogWhenAgreementNotFound(String operationType) {
         given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID, operationType));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.empty());
 
         handler.process(PAYLOAD);
@@ -109,6 +198,24 @@ class AdyenTokenWebhookNotificationHandlerTest {
         then(paymentInstrumentDao).shouldHaveNoInteractions();
         then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
         logs.assertContains("Agreement not found, ignoring Adyen token webhook");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"created", "disabled"})
+    void shouldIgnoreAndLogWhenPaymentInstrumentNotFound(String operationType) {
+        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).withGatewayAccount(aGatewayAccountEntity().build()).build();
+
+        given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID, operationType));
+        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.empty());
+        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+
+        handler.process(PAYLOAD);
+
+        then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
+        verifyNoInteractions(ledgerService);
+
+        logs.assertContains("Payment instrument not found for charge in Adyen token webhook, ignoring");
     }
 
     @Test
@@ -130,7 +237,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @ValueSource(strings = {"badId", "one-two-three", "aaaaaaaaaaaaaaaaaaaaaaaaaa-short", "short-bbbbbbbbbbbbbbbbbbbbbbbbbb"})
     void shouldLogErrorForInvalidShopperReferenceLengthFormat(String invalidShopperReference) {
         given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(invalidShopperReference, STORED_PAYMENT_METHOD_ID));
+                .willReturn(tokenNotification(invalidShopperReference, STORED_PAYMENT_METHOD_ID, "created"));
 
         handler.process(PAYLOAD);
 
@@ -140,16 +247,17 @@ class AdyenTokenWebhookNotificationHandlerTest {
 
     }
 
-    @Test
-    void shouldNotLogStoredPaymentMethodId() {
+    @ParameterizedTest
+    @ValueSource(strings = {"created", "disabled"})
+    void shouldNotLogStoredPaymentMethodId(String operationType) {
         var paymentInstrument = aPaymentInstrumentEntity()
                 .withPaymentInstrumentStatus(PaymentInstrumentStatus.CREATED)
                 .withChargeExternalId(CHARGE_EXTERNAL_ID)
                 .build();
-        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).withGatewayAccount(aGatewayAccountEntity().build()).build();
 
         given(adyenRecurringTokenNotificationService.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, STORED_PAYMENT_METHOD_ID, operationType));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
 
@@ -160,13 +268,13 @@ class AdyenTokenWebhookNotificationHandlerTest {
                         event.getMessage().contains(STORED_PAYMENT_METHOD_ID), is(false)));
     }
 
-    private AdyenTokenNotification tokenCreatedNotification(String shopperReference, String storedPaymentMethodId) {
+    private AdyenTokenNotification tokenNotification(String shopperReference, String storedPaymentMethodId, String operation) {
         return new AdyenTokenNotification(
                 "2026-07-14T18:10:49+01:00",
                 "event-id-123",
                 "test",
-                new AdyenTokenEventData("YOUR_MERCHANT_ACCOUNT", storedPaymentMethodId, "visa", "created", shopperReference),
-                "recurring.token.created"
+                new AdyenTokenEventData("YOUR_MERCHANT_ACCOUNT", storedPaymentMethodId, "visa", operation.equals("created") ? "created" : null, shopperReference),
+                "recurring.token." + operation
         );
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Refactored and added `inactivateAgreement` method to `AdyenTokenWebhookNotificationHandler` so it can handle both "recurring.token.created" and "recurring.token.disabled" webhooks.
- For "recurring.token.disabled" webhooks I have set the `paymentInstrument` to `INACTIVE` and emitted an `AgreementInactivated` event to Ledger

## How to test

- I refactored the unit tests and added an integration test for handling "recurring.token.disabled" webhooks.

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
