### PR TITLE
PP-15739: add notification eventType checking for Adyen webhooks

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
@@ -59,7 +59,7 @@ public class AdyenNotificationService {
             return false;
         }
     }
-    
+
     private boolean handlePaymentNotifications(String payload) {
 
         NotificationRequest notificationRequest = deserialisePayloadToNotificationRequest(payload);
@@ -73,15 +73,17 @@ public class AdyenNotificationService {
             if (!adyenNotificationValidator.isValidHmac(item, hmacKey)) {
                 return false;
             }
-        }
 
-        addNotificationToTaskQueue(payload, TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION);
-        
+            if (!AdyenPaymentEvent.contains(item.getEventCode())) {
+                return false;
+            }
+            addNotificationToTaskQueue(payload, TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION);
+        }
         return true;
     }
 
     private boolean handleTokenNotifications(String payload, String hmacSignature) {
-        
+
         if (hmacSignature.isBlank()) {
             logInvalidHmacSignature();
             return false;
@@ -92,12 +94,16 @@ public class AdyenNotificationService {
                 .environment()
                 .equalsIgnoreCase("live");
 
-        String hmacKey = getTokenHmacKey(adyenGatewayConfig, live);
+        if (!AdyenTokenEvent.contains(adyenTokenResponse.type())) {
+            return false;
+        }
 
+        String hmacKey = getTokenHmacKey(adyenGatewayConfig, live);
         if (!adyenNotificationValidator.isValidHmac(hmacSignature, hmacKey, payload)) {
             logInvalidHmacSignature();
             return false;
         }
+
         addNotificationToTaskQueue(payload, TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION);
 
         return true;

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenTokenEvent.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenTokenEvent.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.connector.gateway.adyen.webhook;
+
+public enum AdyenTokenEvent {
+
+    RECURRING_TOKEN_CREATED("recurring.token.created"),
+    RECURRING_TOKEN_DISABLED("recurring.token.disabled");
+
+    private final String name;
+
+    AdyenTokenEvent(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+    
+    public static boolean contains(String eventName) {
+        for (AdyenTokenEvent e : AdyenTokenEvent.values()) {
+            if (e.getName().equals(eventName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.WebApplicationException;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -54,9 +55,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_NOTIFICATION;
-
-
-
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -102,325 +101,24 @@ class AdyenNotificationServiceTest {
 
         String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
 
-        boolean result = adyenNotificationService.handleNotificationFor(payload, null,"5.6.7.8");
+        boolean result = adyenNotificationService.handleNotificationFor(payload, null, "5.6.7.8");
 
         assertTrue(result);
-    }
-
-    @Test
-    void shouldRejectNotificationWhenHmacSignatureIsInvalid() {
-        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-        when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(false);
-
-        String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
-
-        boolean result = adyenNotificationService.handleNotificationFor(payload, null,"5.6.7.8");
-
-        assertFalse(result);
     }
 
     @Test
     void shouldRejectNotificationWhenForwardedIpDoesNotMatchConfiguredDomain() {
         when(mockAdyenNotificationValidator.isValidIpAddress("8.8.8.8")).thenReturn(false);
 
-        boolean result = adyenNotificationService.handleNotificationFor("{\"notificationItems\":[]}", null,"8.8.8.8");
+        boolean result = adyenNotificationService.handleNotificationFor("{\"notificationItems\":[]}", null, "8.8.8.8");
 
         assertFalse(result);
     }
 
     @Test
-    void shouldNotAddToTaskQueWhenHmacSignatureIsInvalid() {
-        String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
-                .replace("{{HMAC_SIGNATURE}}", "WrongSignature");
-
-        boolean result = adyenNotificationService.handleNotificationFor(payload, null,"5.6.7.8");
-
-        assertFalse(result);
-        verify(mockTaskQueueService, never()).add(any(Task.class));
-    }
-
-    @Test
-    void shouldThrowWebApplicationExceptionWhenPayloadIsInvalidJson() {
-        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-        assertThrows(WebApplicationException.class,
-                () -> adyenNotificationService.handleNotificationFor("not-json", null,"5.6.7.8"));
-
-        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-        assertThat(loggingEvents
-                .stream()
-                .anyMatch(event -> event
-                        .getFormattedMessage()
-                        .equals("Error deserialising Adyen notification payload")), is(true));
-    }
-
-    @Test
-    void shouldReturnFalseWhenPayloadIsValidJsonAndNotificationIsNull() {
-        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-        String validJsonButMissingExpectedFields = """ 
-                {
-                    "live": false
-                }
-                """;
-        boolean result = adyenNotificationService.handleNotificationFor(validJsonButMissingExpectedFields, null, 
-                "5.6.7.8");
-
-        assertFalse(result);
-
-        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-        assertThat(loggingEvents
-                .getFirst()
-                .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
-        assertThat(loggingEvents
-                .get(1)
-                .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
-    }
-
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {""" 
-                {
-                    "live": false,
-                    "notificationItems": [
-                    ]
-                }
-                """})
-    void shouldReturnFalseWhenPayloadIsValidJsonAndNotificationRequestItemsIsEmpty(String payload) {
-        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-        boolean result = adyenNotificationService.handleNotificationFor(payload, null, 
-                "5.6.7.8");
-
-        assertFalse(result);
-        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-        assertThat(loggingEvents
-                .getFirst()
-                .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
-        assertThat(loggingEvents
-                .get(1)
-                .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
-    }
-
-    @Test
-    void shouldReturnFalseWhenPayloadIsValidJsonAndNotificationRequestIsNull() {
-        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-   
-        boolean result = adyenNotificationService.handleNotificationFor(null, null,
-                "5.6.7.8");
-
-        assertFalse(result);
-        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-        assertThat(loggingEvents
-                .getFirst()
-                .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
-        assertThat(loggingEvents
-                .get(1)
-                .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
-    }
-
-    @Test
-    void shouldRejectTokenNotificationWhenHmacSignatureIsBlank() {
-        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
-        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
-
-        boolean result = adyenNotificationService.handleNotificationFor(payload, "", FORWARDED_IP);
-
-        assertFalse(result);
-        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-        assertThat(loggingEvents
-                .stream()
-                .anyMatch(event -> event
-                        .getFormattedMessage()
-                        .equals("Hmac signature is invalid or missing, rejecting Adyen token notification")), is(true));
-    }
-
-    @Test
-    void shouldRejectTokenNotificationWhenHmacSignatureIsInvalid() {
+    void shouldRejectNotificationWhenExceptionIsThrown() {
         var primaryTestKey = "primaryTest";
-        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
-        var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
-                new WebhookHmacKeys("primaryLive", "secondaryLive"));
-        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
-        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
-        when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey,
-                payload)).thenReturn(false);
-
-        boolean result = adyenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP);
-
-        assertFalse(result);
-        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-        assertThat(loggingEvents
-                        .stream()
-                        .anyMatch(event -> event
-                                .getFormattedMessage()
-                                .equals("Hmac signature is invalid or missing, rejecting Adyen token notification")),
-                is(true));
-        verifyNoInteractions(mockTaskQueueService);
-    }
-
-    @Test
-    void shouldAcceptValidTokenNotification() {
-        var primaryTestKey = "primaryTest";
-        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
-        var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
-                new WebhookHmacKeys("primaryLive", "secondaryLive"));
-        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
-        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
-        when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey,
-                payload)).thenReturn(true);
-
-        boolean result = adyenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP);
-
-        assertTrue(result);
-
-        ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
-
-        verify(mockTaskQueueService).add(taskCaptor.capture());
-
-        Task task = taskCaptor.getValue();
-
-        assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION));
-
-        assertThat(task.getData(), is(payload));
-    }
-
-    @Test
-    void shouldThrowWebApplicationExceptionWhenTokenNotificationCannotBeDeserialised() {
-        String payload = "invalidJson";
-
-        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
-
-        WebApplicationException exception = Assert.assertThrows(WebApplicationException.class,
-                () -> adyenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP));
-
-        assertThat(exception.getMessage(), is("Error deserialising token webhook Json"));
-
-        verifyNoInteractions(mockTaskQueueService);
-        verify(mockAppender, atLeastOnce())
-                .doAppend(loggingEventArgumentCaptor.capture());
-
-        List<LoggingEvent> loggingEvents =
-                loggingEventArgumentCaptor.getAllValues();
-
-        assertThat(loggingEvents
-                .stream()
-                .anyMatch(event -> event
-                        .getFormattedMessage()
-                        .equals(
-                                "Error deserialising token notification payload")), is(true));
-    }
-
-
-    @ParameterizedTest
-    @EnumSource(AdyenPaymentEvent.class)
-    void shouldAddValidPaymentNotificationToTaskQueue(AdyenPaymentEvent eventCode) {
-        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-        when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
-
-
-        String payload = getNotificationWithValidHmacSignature(eventCode.toString());
-
-        boolean result = adyenNotificationService.handleNotificationFor(payload,  null, "5.6.7.8");
-
-        assertTrue(result);
-
-        ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
-        verify(mockTaskQueueService).add(taskCaptor.capture());
-
-        Task task = taskCaptor.getValue();
-        assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION));
-        assertThat(task.getData(), is(payload));
-    }
-
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"SOME_INVALID_VALUE"})
-    void shouldAddValidPaymentNotificationToTaskQueueRegardlessOfEventType(String eventCode) {
-        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-        when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
-        String payload = getNotificationWithValidHmacSignature(eventCode);
-
-        boolean result = adyenNotificationService.handleNotificationFor(payload, null,  "5.6.7.8");
-
-        assertTrue(result);
-
-        ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
-
-        verify(mockTaskQueueService).add(taskCaptor.capture());
-
-        Task task = taskCaptor.getValue();
-
-        assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION));
-
-        assertThat(task.getData(), is(payload));
-    }
-
-    @ParameterizedTest
-    @EnumSource(AdyenPaymentEvent.class)
-    void shouldThrowWebApplicationExceptionWhenSendingNotificationToTaskQueueFails(AdyenPaymentEvent eventCode) {
-        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-        when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
-
-        String payload = getNotificationWithValidHmacSignature(eventCode.toString());
-
-        doThrow(new RuntimeException("SQS unavailable"))
-                .when(mockTaskQueueService)
-                .add(any(Task.class));
-
-        WebApplicationException exception = assertThrows(WebApplicationException.class, () ->
-                adyenNotificationService.handleNotificationFor(payload,  null, "5.6.7.8"));
-
-        verify(mockTaskQueueService).add(any(Task.class));
-        assertThat(exception
-                .getResponse()
-                .getStatus(), is(500));
-        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-        assertThat(loggingEvents
-                .getFirst()
-                .getFormattedMessage(), is("Error sending Adyen webhook notification to task SQS queue"));
-    }
-
-
-    @Test
-    void shouldRejectTokenNotificationWhenForwardedIpHeaderIsMissing() {
-        boolean result = adyenNotificationService.handleNotificationFor("{}", HMAC_SIGNATURE, null);
-
-        assertFalse(result);
-    }
-
-    @Test
-    void shouldThrowExceptionWhenTokenNotificationPayloadIsInvalid() {
-        WebApplicationException exception = Assert.assertThrows(
-                WebApplicationException.class,
-                () -> adyenNotificationService.deserialiseTokenPayload("invalidJson", AdyenTokenNotification.class)
-        );
-
-        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-        assertThat(loggingEvents
-                        .stream()
-                        .anyMatch(event -> event
-                                .getFormattedMessage()
-                                .equals("Error deserialising token notification payload")),
-                is(true));
-
-        assertThat("Error deserialising token webhook Json", is(exception.getMessage()));
-    }
-
-
-    @Test
-    void shouldRejectTokenNotificationWhenExceptionIsThrown() {
-        var primaryTestKey = "primaryTest";
-        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
+        String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION);
         var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
                 new WebhookHmacKeys("primaryLive", "secondaryLive"));
         when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
@@ -441,68 +139,302 @@ class AdyenNotificationServiceTest {
                 is(true));
     }
 
-    @Test
-    void shouldThrowWebApplicationExceptionWhenAddingTokenNotificationToTaskQueueFails() {
-        var primaryTestKey = "primaryTest";
+    @Nested
+    class PaymentNotifications {
+        @Test
+        void shouldRejectPaymentNotificationWhenHmacSignatureIsInvalid() {
+            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+            when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(false);
 
-        String payload = TestTemplateResourceLoader.load(
-                TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION
-        );
+            String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
 
-        var tokenKeys = new HmacKeys.WebhookHmacKeyPair(
-                new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
-                new WebhookHmacKeys("primaryLive", "secondaryLive")
-        );
+            boolean result = adyenNotificationService.handleNotificationFor(payload, null, "5.6.7.8");
 
-        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP))
-                .thenReturn(true);
+            assertFalse(result);
+        }
 
-        when(mockAdyenGatewayConfig.getHmacKeys())
-                .thenReturn(new HmacKeys(null, tokenKeys));
+        @Test
+        void shouldNotAddPaymentNotificationToTaskQueueWhenHmacSignatureIsInvalid() {
+            String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
+                    .replace("{{HMAC_SIGNATURE}}", "WrongSignature");
 
-        when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey, payload)).thenReturn(true);
+            boolean result = adyenNotificationService.handleNotificationFor(payload, null, "5.6.7.8");
 
-        doThrow(new RuntimeException("SQS unavailable"))
-                .when(mockTaskQueueService)
-                .add(any(Task.class));
+            assertFalse(result);
+            verify(mockTaskQueueService, never()).add(any(Task.class));
+        }
 
-        Assert.assertThrows(WebApplicationException.class, () -> adyenNotificationService.handleNotificationFor(
-                payload, HMAC_SIGNATURE, FORWARDED_IP));
-        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+        @Test
+        void shouldThrowWebApplicationExceptionWhenPaymentNotificationPayloadIsInvalidJson() {
+            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+            assertThrows(WebApplicationException.class,
+                    () -> adyenNotificationService.handleNotificationFor("not-json", null, "5.6.7.8"));
 
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .stream()
+                    .anyMatch(event -> event
+                            .getFormattedMessage()
+                            .equals("Error deserialising Adyen notification payload")), is(true));
+        }
 
-        assertThat(loggingEvents
-                        .stream()
-                        .anyMatch(event -> event
-                                .getFormattedMessage()
-                                .equals(
-                                        "Error sending Adyen webhook notification to task SQS queue")),
-                is(true)
-        );
+        @Test
+        void shouldReturnFalseWhenPayloadIsValidJsonAndPaymentNotificationIsNull() {
+            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+            String validJsonButMissingExpectedFields = """ 
+                    {
+                        "live": false
+                    }
+                    """;
+            boolean result = adyenNotificationService.handleNotificationFor(validJsonButMissingExpectedFields, null,
+                    "5.6.7.8");
+
+            assertFalse(result);
+
+            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .getFirst()
+                    .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
+            assertThat(loggingEvents
+                    .get(1)
+                    .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {""" 
+                {
+                    "live": false,
+                    "notificationItems": [
+                    ]
+                }
+                """})
+        void shouldReturnFalseWhenPayloadIsValidJsonAndNotificationRequestItemsIsEmptyOrNull(String payload) {
+            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+            boolean result = adyenNotificationService.handleNotificationFor(payload, null,
+                    "5.6.7.8");
+
+            assertFalse(result);
+            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .getFirst()
+                    .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
+            assertThat(loggingEvents
+                    .get(1)
+                    .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"SOME_INVALID_VALUE"})
+        void shouldNotAddInvalidPaymentNotificationTypeToTaskQueue(String eventCode) {
+            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+            when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
+            String payload = getNotificationWithValidHmacSignature(eventCode);
+
+            boolean result = adyenNotificationService.handleNotificationFor(payload, null, "5.6.7.8");
+
+            assertFalse(result);
+
+            verifyNoInteractions(mockTaskQueueService);
+        }
+
+        @ParameterizedTest
+        @EnumSource(AdyenPaymentEvent.class)
+        void shouldThrowWebApplicationExceptionWhenSendingPaymentNotificationToTaskQueueFails(AdyenPaymentEvent eventCode) {
+            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+            when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
+
+            String payload = getNotificationWithValidHmacSignature(eventCode.toString());
+
+            doThrow(new RuntimeException("SQS unavailable"))
+                    .when(mockTaskQueueService)
+                    .add(any(Task.class));
+
+            WebApplicationException exception = assertThrows(WebApplicationException.class, () ->
+                    adyenNotificationService.handleNotificationFor(payload, null, "5.6.7.8"));
+
+            verify(mockTaskQueueService).add(any(Task.class));
+            assertThat(exception
+                    .getResponse()
+                    .getStatus(), is(500));
+            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .getFirst()
+                    .getFormattedMessage(), is("Error sending Adyen webhook notification to task SQS queue"));
+        }
+
+        @ParameterizedTest
+        @EnumSource(AdyenPaymentEvent.class)
+        void shouldAddValidPaymentNotificationToTaskQueue(AdyenPaymentEvent eventCode) {
+            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
+            when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
+
+
+            String payload = getNotificationWithValidHmacSignature(eventCode.toString());
+
+            boolean result = adyenNotificationService.handleNotificationFor(payload, null, "5.6.7.8");
+
+            assertTrue(result);
+
+            ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
+            verify(mockTaskQueueService).add(taskCaptor.capture());
+
+            Task task = taskCaptor.getValue();
+            assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION));
+            assertThat(task.getData(), is(payload));
+        }
     }
-    
 
-    @Test
-    void shouldAddValidTokenNotificationToTaskQueue() {
-        var primaryTestKey = "primaryTest";
+    @Nested
+    class TokenNotifications {
+        @Test
+        void shouldRejectTokenNotificationWhenHmacSignatureIsBlank() {
+            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION);
+            when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
 
-        String payload = TestTemplateResourceLoader.load(TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION);
+            boolean result = adyenNotificationService.handleNotificationFor(payload, "", FORWARDED_IP);
 
-        var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
-                new WebhookHmacKeys("primaryLive", "secondaryLive"));
+            assertFalse(result);
+            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                    .stream()
+                    .anyMatch(event -> event
+                            .getFormattedMessage()
+                            .equals("Hmac signature is invalid or missing, rejecting Adyen token notification")), is(true));
+        }
 
-        when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
+        @Test
+        void shouldRejectTokenNotificationWhenHmacSignatureIsInvalid() {
+            var primaryTestKey = "primaryTest";
+            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION);
+            var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
+                    new WebhookHmacKeys("primaryLive", "secondaryLive"));
+            when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
+            when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey,
+                    payload)).thenReturn(false);
 
-        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
+            boolean result = adyenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP);
 
-        when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey, payload)).thenReturn(true);
+            assertFalse(result);
+            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                            .stream()
+                            .anyMatch(event -> event
+                                    .getFormattedMessage()
+                                    .equals("Hmac signature is invalid or missing, rejecting Adyen token notification")),
+                    is(true));
+            verifyNoInteractions(mockTaskQueueService);
+        }
 
-        boolean result = adyenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP);
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"recurring.token.deleted"})
+        void shouldNotAddInvalidTokenNotificationTypeToTaskQueue(String eventCode) {
+            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION).replace("\"recurring.token.created\"", "\"" + eventCode + "\"");
+            when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
 
-        assertTrue(result);
+            boolean result = adyenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, "5.6.7.8");
 
-        verify(mockTaskQueueService).add(new Task(payload, TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION));
+            assertFalse(result);
+            verifyNoInteractions(mockTaskQueueService);
+        }
+
+        @ParameterizedTest
+        @EnumSource(AdyenTokenEvent.class)
+        void shouldAcceptValidTokenNotification(AdyenTokenEvent eventCode) {
+            var primaryTestKey = "primaryTest";
+            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION).replace("recurring.token.created", eventCode.getName());
+            var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
+                    new WebhookHmacKeys("primaryLive", "secondaryLive"));
+            when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
+            when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey,
+                    payload)).thenReturn(true);
+
+            boolean result = adyenNotificationService.handleNotificationFor(payload, HMAC_SIGNATURE, FORWARDED_IP);
+
+            assertTrue(result);
+
+            ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
+
+            verify(mockTaskQueueService).add(taskCaptor.capture());
+
+            Task task = taskCaptor.getValue();
+
+            assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION));
+            assertThat(task.getData(), is(payload));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenTokenNotificationPayloadIsInvalid() {
+            WebApplicationException exception = Assert.assertThrows(
+                    WebApplicationException.class,
+                    () -> adyenNotificationService.deserialiseTokenPayload("invalidJson", AdyenTokenNotification.class)
+            );
+
+            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertThat(loggingEvents
+                            .stream()
+                            .anyMatch(event -> event
+                                    .getFormattedMessage()
+                                    .equals("Error deserialising token notification payload")),
+                    is(true));
+
+            assertThat("Error deserialising token webhook Json", is(exception.getMessage()));
+        }
+
+        @ParameterizedTest
+        @EnumSource(AdyenTokenEvent.class)
+        void shouldThrowWebApplicationExceptionWhenAddingTokenNotificationToTaskQueueFails(AdyenTokenEvent eventCode) {
+            var primaryTestKey = "primaryTest";
+
+            String payload = TestTemplateResourceLoader.load(
+                    ADYEN_TOKEN_NOTIFICATION
+            ).replace("recurring.token.created", eventCode.getName());
+
+            var tokenKeys = new HmacKeys.WebhookHmacKeyPair(
+                    new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
+                    new WebhookHmacKeys("primaryLive", "secondaryLive")
+            );
+
+            when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP))
+                    .thenReturn(true);
+
+            when(mockAdyenGatewayConfig.getHmacKeys())
+                    .thenReturn(new HmacKeys(null, tokenKeys));
+
+            when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey, payload)).thenReturn(true);
+
+            doThrow(new RuntimeException("SQS unavailable"))
+                    .when(mockTaskQueueService)
+                    .add(any(Task.class));
+
+            Assert.assertThrows(WebApplicationException.class, () -> adyenNotificationService.handleNotificationFor(
+                    payload, HMAC_SIGNATURE, FORWARDED_IP));
+            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+
+            assertThat(loggingEvents
+                    .stream()
+                    .anyMatch(event -> event
+                            .getFormattedMessage()
+                            .equals("Error sending Adyen webhook notification to task SQS queue")), is(true)
+            );
+        }
     }
 
     private HmacKeys getHmacKeys(String... testKey) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenTokensNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenTokensNotificationResourceIT.java
@@ -30,7 +30,7 @@ public class AdyenTokensNotificationResourceIT {
     private static final String ADYEN_IP_ADDRESS = "192.168.0.1";
     private static final String UNEXPECTED_IP_ADDRESS = "8.8.8.8";
     private static final String HMAC_SIGNATURE = "hLz2zuhuylC8q36sCWWH7PpvbVpyaWDpoBqoEeTjj7w="; // pragma: allowlist secret
-    private final String HMAC_SIGNATURE_FOR_PAYLOAD_WITH_UPDATED_TOKEN = "+309uQLT5A/L658R+4GlsOVwQ0rDTDcm2e5yln6+KGM="; // pragma: allowlist secret
+    private static final String HMAC_SIGNATURE_FOR_PAYLOAD_WITH_UPDATED_TOKEN = "+309uQLT5A/L658R+4GlsOVwQ0rDTDcm2e5yln6+KGM="; // pragma: allowlist secret
 
     @BeforeAll
     static void before() {
@@ -106,7 +106,7 @@ public class AdyenTokensNotificationResourceIT {
     }
 
     @Test
-    void shouldAcceptValidRecurringTokenNotificationWithUnrecognisedEventType() {
+    void shouldRejectInvalidRecurringTokenNotificationWithUnrecognisedEventType() {
         String payload = TestTemplateResourceLoader.load(
                 TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION
         ).replace(
@@ -122,7 +122,7 @@ public class AdyenTokensNotificationResourceIT {
                 .contentType(APPLICATION_JSON)
                 .post(NOTIFICATION_PATH)
                 .then()
-                .statusCode(200);
+                .statusCode(403);
         
     }
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- add notification eventType checking for Adyen webhooks
- refactored tests for `AdyenNotificationService`

## How to test

- Read through the `AdyenNotificationServiceTest` to check all behaviour is covereed (`AdyenNotificationService` currrently has 100% coverage)

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
