### PR TITLE
PP-15559: add inactivateAgreement method to handle "recurring.token.disabled" webhooks

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
@@ -8,46 +8,61 @@ import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementService;
+import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.events.model.agreement.AgreementInactivated;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
 import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenTokenEvent;
 import uk.gov.pay.connector.paymentinstrument.dao.PaymentInstrumentDao;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
+import java.time.Instant;
 import java.util.Map;
 
 import static uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory.SHOPPER_REFERENCE_DELIMITER;
 import static uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory.STORED_PAYMENT_METHOD_ID;
+import static uk.gov.pay.connector.gateway.adyen.webhook.AdyenTokenEvent.RECURRING_TOKEN_CREATED;
+import static uk.gov.pay.connector.gateway.adyen.webhook.AdyenTokenEvent.RECURRING_TOKEN_DISABLED;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.ACTIVE;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CANCELLED;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CREATED;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.INACTIVE;
 import static uk.gov.service.payments.logging.LoggingKeys.AGREEMENT_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_INSTRUMENT_EXTERNAL_ID;
 
 public class AdyenTokenWebhookNotificationHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AdyenTokenWebhookNotificationHandler.class);
-    private static final String RECURRING_TOKEN_CREATED = "recurring.token.created";
 
     private final PaymentInstrumentDao paymentInstrumentDao;
     private final ChargeDao chargeDao;
     private final LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
     private final AdyenNotificationService adyenNotificationService;
     private final AgreementDao agreementDao;
+    private final LedgerService ledgerService;
 
     @Inject
-    public AdyenTokenWebhookNotificationHandler(PaymentInstrumentDao paymentInstrumentDao, AgreementDao agreementDao, ChargeDao chargeDao, LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService, AdyenNotificationService adyenNotificationService) {
+    public AdyenTokenWebhookNotificationHandler(PaymentInstrumentDao paymentInstrumentDao,
+                                                AgreementDao agreementDao,
+                                                ChargeDao chargeDao,
+                                                LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService,
+                                                AdyenNotificationService adyenNotificationService,
+                                                LedgerService ledgerService) {
 
         this.paymentInstrumentDao = paymentInstrumentDao;
         this.agreementDao = agreementDao;
         this.chargeDao = chargeDao;
         this.linkPaymentInstrumentToAgreementService = linkPaymentInstrumentToAgreementService;
         this.adyenNotificationService = adyenNotificationService;
+        this.ledgerService = ledgerService;
     }
 
     @Transactional
     public void process(String payload) {
         AdyenTokenNotification notification = adyenNotificationService.deserialiseTokenPayload(payload, AdyenTokenNotification.class);
 
-        if (!RECURRING_TOKEN_CREATED.equals(notification.type())) {
+        if (!AdyenTokenEvent.contains(notification.type())) {
             LOGGER.atInfo().setMessage("Ignoring Adyen token webhook notification with unsupported type").addKeyValue("type", notification.type()).log();
             return;
         }
@@ -82,7 +97,7 @@ public class AdyenTokenWebhookNotificationHandler {
 
                                     var latestChargeId = latestCharge.getExternalId();
 
-                                    processWebhooks(latestChargeId, paymentInstrument, webhookChargeExternalId, webhookAgreementExternalId, agreementEntity.get());
+                                    processWebhooks(latestChargeId, paymentInstrument, webhookChargeExternalId, webhookAgreementExternalId, agreementEntity.get(), notification.type());
                                 },
                                 () -> LOGGER.atInfo()
                                         .setMessage("Payment instrument not found for charge in Adyen token webhook, ignoring")
@@ -95,17 +110,24 @@ public class AdyenTokenWebhookNotificationHandler {
     }
 
     private void processWebhooks(String latestChargeId, PaymentInstrumentEntity paymentInstrument, String webhookChargeExternalId,
-                                 String webhookAgreementExternalId, AgreementEntity agreementEntity) {
+                                 String webhookAgreementExternalId, AgreementEntity agreementEntity, String notificationType) {
         // Webhook refers to latest Payment Instrument
         if (latestChargeId.equals(webhookChargeExternalId)) {
-            if (paymentInstrument.getStatus() == ACTIVE) {
-                LOGGER.atInfo().setMessage("Payment instrument is already in ACTIVE state, ignoring Adyen token webhook")
-                        .addKeyValue(AGREEMENT_EXTERNAL_ID, webhookAgreementExternalId)
-                        .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
-                        .log();
-                return;
+            if (RECURRING_TOKEN_CREATED.getName().equals(notificationType)) {
+                if (paymentInstrument.getStatus() == ACTIVE) {
+                    LOGGER.atInfo().setMessage("Payment instrument is already in ACTIVE state, ignoring Adyen token webhook")
+                            .addKeyValue(AGREEMENT_EXTERNAL_ID, webhookAgreementExternalId)
+                            .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
+                            .log();
+                    return;
+                }
+                linkPaymentInstrumentToAgreementService.linkPaymentInstrumentToAgreement(agreementEntity, paymentInstrument);
             }
-            linkPaymentInstrumentToAgreementService.linkPaymentInstrumentToAgreement(agreementEntity, paymentInstrument);
+
+            if (RECURRING_TOKEN_DISABLED.getName().equals(notificationType)) {
+                inactivateAgreement(agreementEntity, paymentInstrument);
+            }
+
         }
         // Webhook does not refer to latest - cancel payment instrument
         else {
@@ -115,5 +137,35 @@ public class AdyenTokenWebhookNotificationHandler {
 
     private static void logInvalidShopperReference() {
         LOGGER.atInfo().setMessage("Invalid shopper reference").log();
+    }
+
+    private void inactivateAgreement(AgreementEntity agreementEntity, PaymentInstrumentEntity paymentInstrument) {
+        if (paymentInstrument.getStatus() == INACTIVE || paymentInstrument.getStatus() == CANCELLED) {
+            logIgnoreWebhookBasedOnDuplicateStatus(paymentInstrument, agreementEntity.getExternalId());
+            return;
+        }
+
+        if (paymentInstrument.getStatus() == CREATED) {
+            LOGGER.atError().setMessage("Payment instrument is not in the correct state to be inactivated, ignoring Adyen token webhook")
+                    .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId())
+                    .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
+                    .log();
+            return;
+        }
+        var inactivatedEvent = AgreementInactivated.from(agreementEntity, "Adyen agreement inactivated", Instant.now());
+        ledgerService.postEvent(inactivatedEvent);
+
+        paymentInstrument.setStatus(INACTIVE);
+        LOGGER.atInfo().setMessage("Payment instrument and agreement successfully inactivated")
+                .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementEntity.getExternalId())
+                .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
+                .log();
+    }
+
+    private static void logIgnoreWebhookBasedOnDuplicateStatus(PaymentInstrumentEntity paymentInstrument, String agreementExternalId) {
+        LOGGER.atInfo().setMessage("Payment instrument is already in " + paymentInstrument.getStatus() + " state, ignoring Adyen token webhook")
+                .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementExternalId)
+                .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrument.getExternalId())
+                .log();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerIT.java
@@ -28,6 +28,7 @@ import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccoun
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.ACTIVE;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CANCELLED;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CREATED;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.INACTIVE;
 import static uk.gov.pay.connector.util.AddAgreementParams.AddAgreementParamsBuilder.anAddAgreementParams;
 import static uk.gov.pay.connector.util.AddPaymentInstrumentParams.AddPaymentInstrumentParamsBuilder.anAddPaymentInstrumentParams;
 import static uk.gov.pay.connector.util.RandomTestDataGeneratorUtils.secureRandomLong;
@@ -104,7 +105,7 @@ class AdyenTokenWebhookNotificationHandlerIT {
         insertChargeForAgreement(OTHER_CHARGE_EXTERNAL_ID, FIRST_PAYMENT_INSTRUMENT_ID);
         insertChargeForAgreement(WEBHOOK_CHARGE_EXTERNAL_ID, SECOND_PAYMENT_INSTRUMENT_ID);
 
-        handler.process(tokenNotificationPayload());
+        handler.process(tokenNotificationPayload("recurring.token.created"));
 
         var updatedAgreement = app.getDatabaseTestHelper().getAgreementByExternalId(AGREEMENT_EXTERNAL_ID);
         var updatedFirstPaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(FIRST_PAYMENT_INSTRUMENT_ID);
@@ -115,6 +116,29 @@ class AdyenTokenWebhookNotificationHandlerIT {
         assertThat(updatedSecondPaymentInstrument.get("agreement_external_id"), is(AGREEMENT_EXTERNAL_ID));
         assertThat(recurringAuthToken(updatedSecondPaymentInstrument), is(Map.of(STORED_PAYMENT_METHOD_ID, STORED_PAYMENT_METHOD_ID_VALUE)));
         assertThat(updatedFirstPaymentInstrument.get("status"), is(PaymentInstrumentStatus.CANCELLED.name()));
+    }
+
+    @Test
+    void shouldInactivatePaymentInstrument() {
+        insertAgreement();
+        insertPaymentInstrument(
+                FIRST_PAYMENT_INSTRUMENT_ID,
+                FIRST_PAYMENT_INSTRUMENT_EXTERNAL_ID,
+                ACTIVE,
+                AGREEMENT_EXTERNAL_ID,
+                WEBHOOK_CHARGE_EXTERNAL_ID,
+                STORED_PAYMENT_METHOD_ID_VALUE,
+                Instant.now()
+        );
+
+        insertChargeForAgreement(WEBHOOK_CHARGE_EXTERNAL_ID, FIRST_PAYMENT_INSTRUMENT_ID);
+
+        handler.process(tokenNotificationPayload("recurring.token.disabled"));
+
+        var paymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(FIRST_PAYMENT_INSTRUMENT_ID);
+
+        assertThat(paymentInstrument.get("status"), is(INACTIVE.name()));
+        logs.assertContains("Payment instrument and agreement successfully inactivated");
     }
 
     @ParameterizedTest
@@ -145,7 +169,7 @@ class AdyenTokenWebhookNotificationHandlerIT {
         insertChargeForAgreement(WEBHOOK_CHARGE_EXTERNAL_ID, FIRST_PAYMENT_INSTRUMENT_ID);
         insertChargeForAgreement(OTHER_CHARGE_EXTERNAL_ID, SECOND_PAYMENT_INSTRUMENT_ID);
 
-        handler.process(tokenNotificationPayload());
+        handler.process(tokenNotificationPayload("recurring.token.created"));
 
         var firstPaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(FIRST_PAYMENT_INSTRUMENT_ID);
         var secondPaymentInstrument = app.getDatabaseTestHelper().getPaymentInstrument(SECOND_PAYMENT_INSTRUMENT_ID);
@@ -206,8 +230,9 @@ class AdyenTokenWebhookNotificationHandlerIT {
         app.getDatabaseTestHelper().getPaymentInstrument(paymentInstrumentId);
     }
 
-    private String tokenNotificationPayload() {
+    private String tokenNotificationPayload(String operation) {
         return load(ADYEN_TOKEN_NOTIFICATION)
+                .replace("recurring.token.created", operation)
                 .replace("YOUR_SHOPPER_REFERENCE", SHOPPER_REFERENCE)
                 .replace("M5N7TQ4TG5PFWR50", STORED_PAYMENT_METHOD_ID_VALUE);
     }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
@@ -1,10 +1,13 @@
 package uk.gov.pay.connector.queue.tasks.handlers.adyen;
 
 import io.github.netmikey.logunit.api.LogCapturer;
+import jakarta.validation.constraints.NotNull;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -15,6 +18,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementService;
+import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.events.model.agreement.AgreementInactivated;
 import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenEventData;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
@@ -26,14 +31,21 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.slf4j.event.Level.ERROR;
 import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntityFixture.aPaymentInstrumentEntity;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.ACTIVE;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CREATED;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.INACTIVE;
 
 @ExtendWith(MockitoExtension.class)
 class AdyenTokenWebhookNotificationHandlerTest {
@@ -53,6 +65,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @Mock private ChargeDao chargeDao;
     @Mock private LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
     @Mock private AdyenNotificationService adyenNotificationService;
+    @Mock private LedgerService ledgerService;
 
     @Captor
     private ArgumentCaptor<PaymentInstrumentEntity> paymentInstrumentCaptor;
@@ -74,7 +87,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                 .withAgreementEntity(agreement).build();
 
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created"));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
@@ -93,7 +106,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @Test
     void shouldIgnoreAndLogWhenPaymentInstrumentIsAlreadyActive() {
         var paymentInstrument = aPaymentInstrumentEntity()
-                .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
+                .withPaymentInstrumentStatus(ACTIVE)
                 .withChargeExternalId(CHARGE_EXTERNAL_ID)
                 .build();
         var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
@@ -104,7 +117,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                 .withAgreementEntity(agreement).build();
         
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created"));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
@@ -128,7 +141,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                 .withAgreementEntity(agreement).build();
 
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created"));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(latestChargeEntity));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(webhookPaymentInstrument));
@@ -145,7 +158,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @Test
     void shouldIgnoreAndLogWhenAgreementNotFound() {
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created"));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.empty());
 
         handler.process(PAYLOAD);
@@ -160,7 +173,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
         var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
 
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created"));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.empty());
 
@@ -180,7 +193,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                 .withAgreementEntity(agreement).build();
 
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created"));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.empty());
@@ -211,7 +224,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @ValueSource(strings = {"badId", "one-two-three", "aaaaaaaaaaaaaaaaaaaaaaaaaa-short", "short-bbbbbbbbbbbbbbbbbbbbbbbbbb"})
     void shouldLogErrorForInvalidShopperReferenceLengthFormat(String invalidShopperReference) {
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(invalidShopperReference));
+                .willReturn(tokenNotification(invalidShopperReference,"created"));
 
         handler.process(PAYLOAD);
 
@@ -235,7 +248,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                 .withAgreementEntity(agreement).build();
 
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created" ));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
@@ -247,13 +260,89 @@ class AdyenTokenWebhookNotificationHandlerTest {
                         event.getMessage().contains(STORED_PAYMENT_METHOD_ID), is(false)));
     }
 
-    private AdyenTokenNotification tokenCreatedNotification(String shopperReference) {
+    @Nested
+    class TokenDisabledWebhooks {
+
+        @Captor
+        private ArgumentCaptor<AgreementInactivated> agreementInactivatedArgumentCaptor;
+
+        @Test
+        void shouldSetPaymentInstrumentToInactive() {
+            var paymentInstrument = createAndMockPaymentInstrument(ACTIVE);
+
+            handler.process(PAYLOAD);
+
+            assertThat(paymentInstrument.getStatus(), is(INACTIVE));
+            logs.assertContains("Payment instrument and agreement successfully inactivated");
+        }
+
+        @Test
+        void shouldEmitAgreementInactivatedEventToLedger() {
+            createAndMockPaymentInstrument(ACTIVE);
+
+            handler.process(PAYLOAD);
+
+            verify(ledgerService).postEvent(agreementInactivatedArgumentCaptor.capture());
+
+            var event = agreementInactivatedArgumentCaptor.getValue();
+            assertThat(event.getEventType(), is("AGREEMENT_INACTIVATED"));
+            var eventDetails = (AgreementInactivated.AgreementInactivatedEventDetails) event.getEventDetails();
+            assertThat(eventDetails.getReason(), equalTo("Adyen agreement inactivated"));
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = PaymentInstrumentStatus.class, names = {"CANCELLED", "INACTIVE"})
+        void shouldIgnoreWhenInvalidPaymentInstrumentStatus(PaymentInstrumentStatus status) {
+            var paymentInstrument = createAndMockPaymentInstrument(status);
+
+            handler.process(PAYLOAD);
+            assertThat(paymentInstrument.getStatus(), is(status));
+            verifyNoInteractions(ledgerService);
+            logs.assertContains("Payment instrument is already in " + status + " state, ignoring Adyen token webhook");
+        }
+
+        @Test
+        void shouldIgnoreAndErrorWhenDisablingPaymentInstrumentWithCreatedStatus() {
+            var paymentInstrument = createAndMockPaymentInstrument(PaymentInstrumentStatus.CREATED);
+
+            handler.process(PAYLOAD);
+            assertThat(paymentInstrument.getStatus(), is(CREATED));
+            verifyNoInteractions(ledgerService);
+            logs.forLevel(ERROR).assertContains("Payment instrument is not in the correct state to be inactivated, ignoring Adyen token webhook");
+        }
+
+        private @NotNull PaymentInstrumentEntity createAndMockPaymentInstrument(PaymentInstrumentStatus active) {
+            var paymentInstrument = aPaymentInstrumentEntity()
+                    .withPaymentInstrumentStatus(active)
+                    .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                    .build();
+            var agreement = anAgreementEntity()
+                    .withExternalId(AGREEMENT_EXTERNAL_ID)
+                    .withGatewayAccount(aGatewayAccountEntity().build())
+                    .build();
+            
+            var chargeEntity = aValidChargeEntity()
+                    .withExternalId(CHARGE_EXTERNAL_ID)
+                    .withPaymentInstrument(paymentInstrument)
+                    .withAgreementEntity(agreement).build();
+            
+            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                    .willReturn(tokenNotification(SHOPPER_REFERENCE, "disabled"));
+            given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+            given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
+            given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+            return paymentInstrument;
+        }
+    }
+
+
+    private AdyenTokenNotification tokenNotification(String shopperReference, String operation) {
         return new AdyenTokenNotification(
                 "2026-07-14T18:10:49+01:00",
                 "event-id-123",
                 "test",
-                new AdyenTokenEventData("YOUR_MERCHANT_ACCOUNT", STORED_PAYMENT_METHOD_ID, "visa", "created", shopperReference),
-                "recurring.token.created"
+                new AdyenTokenEventData("YOUR_MERCHANT_ACCOUNT", STORED_PAYMENT_METHOD_ID, "visa", operation.equals("created") ? "created" : null, shopperReference),
+                "recurring.token." + operation
         );
     }
 }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.connector.queue.tasks.handlers.adyen;
 
 import io.github.netmikey.logunit.api.LogCapturer;
+import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -15,6 +17,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementService;
+import uk.gov.pay.connector.client.ledger.service.LedgerService;
+import uk.gov.pay.connector.events.model.agreement.AgreementInactivated;
 import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenEventData;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
@@ -26,14 +30,21 @@ import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.slf4j.event.Level.ERROR;
 import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntityFixture.aPaymentInstrumentEntity;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.ACTIVE;
 import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.CREATED;
+import static uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus.INACTIVE;
 
 @ExtendWith(MockitoExtension.class)
 class AdyenTokenWebhookNotificationHandlerTest {
@@ -48,11 +59,18 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @RegisterExtension
     LogCapturer logs = LogCapturer.create().captureForType(AdyenTokenWebhookNotificationHandler.class);
 
-    @Mock private AgreementDao agreementDao;
-    @Mock private PaymentInstrumentDao paymentInstrumentDao;
-    @Mock private ChargeDao chargeDao;
-    @Mock private LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
-    @Mock private AdyenNotificationService adyenNotificationService;
+    @Mock
+    private AgreementDao agreementDao;
+    @Mock
+    private PaymentInstrumentDao paymentInstrumentDao;
+    @Mock
+    private ChargeDao chargeDao;
+    @Mock
+    private LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
+    @Mock
+    private AdyenNotificationService adyenNotificationService;
+    @Mock
+    private LedgerService ledgerService;
 
     @Captor
     private ArgumentCaptor<PaymentInstrumentEntity> paymentInstrumentCaptor;
@@ -74,7 +92,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                 .withAgreementEntity(agreement).build();
 
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created"));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
@@ -92,22 +110,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
 
     @Test
     void shouldIgnoreAndLogWhenPaymentInstrumentIsAlreadyActive() {
-        var paymentInstrument = aPaymentInstrumentEntity()
-                .withPaymentInstrumentStatus(PaymentInstrumentStatus.ACTIVE)
-                .withChargeExternalId(CHARGE_EXTERNAL_ID)
-                .build();
-        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
-
-        var chargeEntity = aValidChargeEntity()
-                .withExternalId(CHARGE_EXTERNAL_ID)
-                .withPaymentInstrument(paymentInstrument)
-                .withAgreementEntity(agreement).build();
-        
-        given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
-        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
-        given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
-        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+        createAndMockPaymentInstrument(ACTIVE, "created");
 
         handler.process(PAYLOAD);
 
@@ -128,7 +131,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                 .withAgreementEntity(agreement).build();
 
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created"));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(latestChargeEntity));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(webhookPaymentInstrument));
@@ -145,7 +148,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @Test
     void shouldIgnoreAndLogWhenAgreementNotFound() {
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created"));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.empty());
 
         handler.process(PAYLOAD);
@@ -160,7 +163,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
         var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
 
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created"));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.empty());
 
@@ -180,7 +183,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                 .withAgreementEntity(agreement).build();
 
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, "created"));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
         given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.empty());
@@ -211,7 +214,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @ValueSource(strings = {"badId", "one-two-three", "aaaaaaaaaaaaaaaaaaaaaaaaaa-short", "short-bbbbbbbbbbbbbbbbbbbbbbbbbb"})
     void shouldLogErrorForInvalidShopperReferenceLengthFormat(String invalidShopperReference) {
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(invalidShopperReference));
+                .willReturn(tokenNotification(invalidShopperReference, "created"));
 
         handler.process(PAYLOAD);
 
@@ -223,22 +226,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
 
     @Test
     void shouldNotLogStoredPaymentMethodId() {
-        var paymentInstrument = aPaymentInstrumentEntity()
-                .withPaymentInstrumentStatus(CREATED)
-                .withChargeExternalId(CHARGE_EXTERNAL_ID)
-                .build();
-        var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
-
-        var chargeEntity = aValidChargeEntity()
-                .withExternalId(CHARGE_EXTERNAL_ID)
-                .withPaymentInstrument(paymentInstrument)
-                .withAgreementEntity(agreement).build();
-
-        given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
-                .willReturn(tokenCreatedNotification(SHOPPER_REFERENCE));
-        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
-        given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
-        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+        createAndMockPaymentInstrument(CREATED, "created");
 
         handler.process(PAYLOAD);
 
@@ -247,13 +235,85 @@ class AdyenTokenWebhookNotificationHandlerTest {
                         event.getMessage().contains(STORED_PAYMENT_METHOD_ID), is(false)));
     }
 
-    private AdyenTokenNotification tokenCreatedNotification(String shopperReference) {
+    @Captor
+    private ArgumentCaptor<AgreementInactivated> agreementInactivatedArgumentCaptor;
+
+    @Test
+    void shouldSetPaymentInstrumentToInactive() {
+        var paymentInstrument = createAndMockPaymentInstrument(ACTIVE, "disabled");
+
+        handler.process(PAYLOAD);
+
+        assertThat(paymentInstrument.getStatus(), is(INACTIVE));
+        logs.assertContains("Payment instrument and agreement successfully inactivated");
+    }
+
+    @Test
+    void shouldEmitAgreementInactivatedEventToLedger() {
+        createAndMockPaymentInstrument(ACTIVE, "disabled");
+
+        handler.process(PAYLOAD);
+
+        verify(ledgerService).postEvent(agreementInactivatedArgumentCaptor.capture());
+
+        var event = agreementInactivatedArgumentCaptor.getValue();
+        assertThat(event.getEventType(), is("AGREEMENT_INACTIVATED"));
+        var eventDetails = (AgreementInactivated.AgreementInactivatedEventDetails) event.getEventDetails();
+        assertThat(eventDetails.getReason(), equalTo("Adyen agreement inactivated"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = PaymentInstrumentStatus.class, names = {"CANCELLED", "INACTIVE"})
+    void shouldIgnoreWhenInvalidPaymentInstrumentStatus(PaymentInstrumentStatus status) {
+        var paymentInstrument = createAndMockPaymentInstrument(status, "disabled");
+
+        handler.process(PAYLOAD);
+        assertThat(paymentInstrument.getStatus(), is(status));
+        verifyNoInteractions(ledgerService);
+        logs.assertContains("Payment instrument is already in " + status + " state, ignoring Adyen token webhook");
+    }
+
+    @Test
+    void shouldIgnoreAndErrorWhenDisablingPaymentInstrumentWithCreatedStatus() {
+        var paymentInstrument = createAndMockPaymentInstrument(CREATED, "disabled");
+
+        handler.process(PAYLOAD);
+        assertThat(paymentInstrument.getStatus(), is(CREATED));
+        verifyNoInteractions(ledgerService);
+        logs.forLevel(ERROR).assertContains("Payment instrument is not in the correct state to be inactivated, ignoring Adyen token webhook");
+    }
+
+    private @NotNull PaymentInstrumentEntity createAndMockPaymentInstrument(PaymentInstrumentStatus active, String operation) {
+        var paymentInstrument = aPaymentInstrumentEntity()
+                .withPaymentInstrumentStatus(active)
+                .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                .build();
+        var agreement = anAgreementEntity()
+                .withExternalId(AGREEMENT_EXTERNAL_ID)
+                .withGatewayAccount(aGatewayAccountEntity().build())
+                .build();
+
+        var chargeEntity = aValidChargeEntity()
+                .withExternalId(CHARGE_EXTERNAL_ID)
+                .withPaymentInstrument(paymentInstrument)
+                .withAgreementEntity(agreement).build();
+
+        given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                .willReturn(tokenNotification(SHOPPER_REFERENCE, operation));
+        given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+        given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
+        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+        return paymentInstrument;
+    }
+
+
+    private AdyenTokenNotification tokenNotification(String shopperReference, String operation) {
         return new AdyenTokenNotification(
                 "2026-07-14T18:10:49+01:00",
                 "event-id-123",
                 "test",
-                new AdyenTokenEventData("YOUR_MERCHANT_ACCOUNT", STORED_PAYMENT_METHOD_ID, "visa", "created", shopperReference),
-                "recurring.token.created"
+                new AdyenTokenEventData("YOUR_MERCHANT_ACCOUNT", STORED_PAYMENT_METHOD_ID, "visa", operation.equals("created") ? "created" : null, shopperReference),
+                "recurring.token." + operation
         );
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Refactored and added `inactivateAgreement` method to `AdyenTokenWebhookNotificationHandler` so it can handle both "recurring.token.created" and "recurring.token.disabled" webhooks.
- For "recurring.token.disabled" webhooks I have set the `paymentInstrument` to `INACTIVE` and emitted an `AgreementInactivated` event to Ledger

## How to test

- I refactored the unit tests and added an integration test for handling "recurring.token.disabled" webhooks.

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

