### PR TITLE
PP-15683 Refactor AdyenTokenWebhookNotificationHandler to remove unnecessary calls to DB

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.agreement.dao.AgreementDao;
 import uk.gov.pay.connector.agreement.model.AgreementEntity;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementService;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.events.model.agreement.AgreementInactivated;
@@ -98,47 +99,53 @@ public class AdyenTokenWebhookNotificationHandler {
             return;
         }
 
-        chargeDao.findLatestChargeForAgreementId(webhookAgreementExternalId).ifPresentOrElse(latestCharge ->
-                        paymentInstrumentDao.findByChargeExternalId(webhookChargeExternalId).ifPresentOrElse(paymentInstrument -> {
-                                    paymentInstrument.setRecurringAuthToken(Map.of(STORED_PAYMENT_METHOD_ID,
-                                            notification.data().storedPaymentMethodId()));
-
-                                    var latestChargeId = latestCharge.getExternalId();
-
-                                    processWebhooks(latestChargeId, paymentInstrument, webhookChargeExternalId, webhookAgreementExternalId, agreementEntity.get());
-                                },
-                                () -> logPaymentInstrumentNotFound(webhookChargeExternalId)),
+        chargeDao.findLatestChargeForAgreementId(webhookAgreementExternalId).ifPresentOrElse(
+                latestCharge -> processWebhooks(latestCharge, webhookChargeExternalId, webhookAgreementExternalId, agreementEntity.get(), notification),
                 () -> LOGGER.atInfo()
                         .setMessage("No charges for the agreement were found with payment instruments in a valid state (ACTIVE or CREATED)")
                         .addKeyValue(AGREEMENT_EXTERNAL_ID, webhookAgreementExternalId)
                         .log());
     }
 
-    private void processWebhooks(String latestChargeId, PaymentInstrumentEntity paymentInstrument, String webhookChargeExternalId,
-                                 String webhookAgreementExternalId, AgreementEntity agreementEntity) {
+
+    private void processWebhooks(ChargeEntity latestCharge, String webhookChargeExternalId,
+                                 String webhookAgreementExternalId, AgreementEntity agreementEntity, AdyenTokenNotification notification) {
         // Webhook refers to latest Payment Instrument
-        if (latestChargeId.equals(webhookChargeExternalId)) {
-            if (paymentInstrument.getStatus().equals(ACTIVE)) {
-                logIgnoreWebhookBasedOnDuplicateStatus(paymentInstrument.getStatus(), webhookAgreementExternalId, paymentInstrument.getExternalId());
-                return;
-            }
-            linkPaymentInstrumentToAgreementService.linkPaymentInstrumentToAgreement(agreementEntity, paymentInstrument);
+        if (latestCharge.getExternalId().equals(webhookChargeExternalId)) {
+            latestCharge.getPaymentInstrument().ifPresentOrElse(paymentInstrument -> {
+                        setRecurringAuthTokenIfMissing(webhookChargeExternalId, notification, paymentInstrument);
+
+                        if (paymentInstrument.getStatus().equals(ACTIVE)) {
+                            logIgnoreWebhookBasedOnDuplicateStatus(paymentInstrument.getStatus(), webhookAgreementExternalId, paymentInstrument.getExternalId());
+                            return;
+                        }
+                        linkPaymentInstrumentToAgreementService.linkPaymentInstrumentToAgreement(agreementEntity, paymentInstrument);
+                    },
+                    () -> logPaymentInstrumentNotFound(webhookChargeExternalId));
+
         }
         // Webhook does not refer to latest - cancel payment instrument
         else {
-            linkPaymentInstrumentToAgreementService.cancelPaymentInstrument(agreementEntity, paymentInstrument);
+            paymentInstrumentDao.findByChargeExternalId(webhookChargeExternalId).ifPresentOrElse(
+                    paymentInstrument -> {
+                        setRecurringAuthTokenIfMissing(webhookChargeExternalId, notification, paymentInstrument);
+
+                        linkPaymentInstrumentToAgreementService.cancelPaymentInstrument(agreementEntity, paymentInstrument);
+                    },
+                    () -> logPaymentInstrumentNotFound(webhookChargeExternalId));
         }
     }
 
-    private static void logInvalidShopperReference() {
-        LOGGER.atInfo().setMessage("Invalid shopper reference").log();
-    }
-
-    private static void logPaymentInstrumentNotFound(String webhookChargeExternalId) {
-        LOGGER.atInfo()
-                .setMessage("Ignoring Adyen token webhook notification as payment instrument is not found")
-                .addKeyValue("PAYMENT_EXTERNAL_ID", webhookChargeExternalId)
-                .log();
+    private static void setRecurringAuthTokenIfMissing(String webhookChargeExternalId, AdyenTokenNotification notification, PaymentInstrumentEntity paymentInstrument) {
+        var recurringAuthToken = paymentInstrument.getRecurringAuthToken();
+        if (recurringAuthToken.isEmpty() || recurringAuthToken.get().get(STORED_PAYMENT_METHOD_ID).isBlank()) {
+            paymentInstrument.setRecurringAuthToken(Map.of(STORED_PAYMENT_METHOD_ID,
+                    notification.data().storedPaymentMethodId()));
+            LOGGER.atInfo()
+                    .setMessage("storedPaymentMethodId has been used to set the recurring auth token asynchronously")
+                    .addKeyValue("EXTERNAL_CHARGE_ID", webhookChargeExternalId)
+                    .log();
+        }
     }
 
     private void inactivateAgreement(AgreementEntity agreementEntity, PaymentInstrumentEntity paymentInstrument) {
@@ -158,7 +165,19 @@ public class AdyenTokenWebhookNotificationHandler {
                 .log();
     }
 
-    private static void logIgnoreWebhookBasedOnDuplicateStatus(PaymentInstrumentStatus paymentInstrumentStatus, String agreementExternalId, String paymentInstrumentExternalId) {
+    private static void logInvalidShopperReference() {
+        LOGGER.atInfo().setMessage("Invalid shopper reference").log();
+    }
+
+    private static void logPaymentInstrumentNotFound(String webhookChargeExternalId) {
+        LOGGER.atInfo()
+                .setMessage("Ignoring Adyen token webhook notification as payment instrument is not found")
+                .addKeyValue("PAYMENT_EXTERNAL_ID", webhookChargeExternalId)
+                .log();
+    }
+    
+    private static void logIgnoreWebhookBasedOnDuplicateStatus(PaymentInstrumentStatus
+                                                                       paymentInstrumentStatus, String agreementExternalId, String paymentInstrumentExternalId) {
         LOGGER.atInfo().setMessage("Payment instrument is already in " + paymentInstrumentStatus + " state, ignoring Adyen token webhook")
                 .addKeyValue(AGREEMENT_EXTERNAL_ID, agreementExternalId)
                 .addKeyValue(PAYMENT_INSTRUMENT_EXTERNAL_ID, paymentInstrumentExternalId)

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
@@ -29,6 +29,7 @@ import uk.gov.pay.connector.paymentinstrument.dao.PaymentInstrumentDao;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -97,6 +98,38 @@ class AdyenTokenWebhookNotificationHandlerTest {
             var paymentInstrument = aPaymentInstrumentEntity()
                     .withPaymentInstrumentStatus(CREATED)
                     .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                    .withRecurringAuthToken(Map.of(AdyenRequestFactory.STORED_PAYMENT_METHOD_ID, STORED_PAYMENT_METHOD_ID))
+                    .build();
+
+            var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+
+            var chargeEntity = aValidChargeEntity()
+                    .withExternalId(CHARGE_EXTERNAL_ID)
+                    .withPaymentInstrument(paymentInstrument)
+                    .withAgreementEntity(agreement).build();
+
+            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                    .willReturn(tokenNotification(SHOPPER_REFERENCE));
+            given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+            given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
+
+            handler.process(PAYLOAD);
+
+            then(linkPaymentInstrumentToAgreementService)
+                    .should()
+                    .linkPaymentInstrumentToAgreement(eq(agreement), paymentInstrumentCaptor.capture());
+
+            var captured = paymentInstrumentCaptor.getValue();
+            assertThat(captured.getRecurringAuthToken().orElseThrow().get(AdyenRequestFactory.STORED_PAYMENT_METHOD_ID),
+                    is(STORED_PAYMENT_METHOD_ID));
+        }
+
+        @Test
+        void shouldSetRecurringAuthTokenOnPaymentInstrumentWhenItsMissing() {
+            var paymentInstrument = aPaymentInstrumentEntity()
+                    .withPaymentInstrumentStatus(CREATED)
+                    .withChargeExternalId(CHARGE_EXTERNAL_ID)
+                    .withRecurringAuthToken(null)
                     .build();
             var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
 
@@ -109,7 +142,6 @@ class AdyenTokenWebhookNotificationHandlerTest {
                     .willReturn(tokenNotification(SHOPPER_REFERENCE));
             given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
             given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
-            given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
 
             handler.process(PAYLOAD);
 
@@ -120,6 +152,9 @@ class AdyenTokenWebhookNotificationHandlerTest {
             var captured = paymentInstrumentCaptor.getValue();
             assertThat(captured.getRecurringAuthToken().orElseThrow().get(AdyenRequestFactory.STORED_PAYMENT_METHOD_ID),
                     is(STORED_PAYMENT_METHOD_ID));
+
+            logs.assertContains("storedPaymentMethodId has been used to set the recurring auth token asynchronously");
+
         }
 
         @Test
@@ -189,7 +224,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
         }
 
         @Test
-        void shouldIgnoreAndLogWhenPaymentInstrumentNotFound() {
+        void shouldIgnoreAndLogWhenPaymentInstrumentNotFoundForLatestCharge() {
             var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
 
             var chargeEntity = aValidChargeEntity()
@@ -200,8 +235,26 @@ class AdyenTokenWebhookNotificationHandlerTest {
                     .willReturn(tokenNotification(SHOPPER_REFERENCE));
             given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
             given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
-            given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.empty());
 
+            handler.process(PAYLOAD);
+
+            then(linkPaymentInstrumentToAgreementService).shouldHaveNoInteractions();
+            logs.assertContains("Ignoring Adyen token webhook notification as payment instrument is not found");
+        }
+
+        @Test
+        void shouldIgnoreAndLogWhenPaymentInstrumentNotFoundForWebhookCharge() {
+            var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
+
+            var chargeEntity = aValidChargeEntity()
+                    .withExternalId(LATEST_CHARGE_EXTERNAL_ID)
+                    .withAgreementEntity(agreement).build();
+
+            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+                    .willReturn(tokenNotification(SHOPPER_REFERENCE));
+            given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
+            given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
+            given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.empty());
 
             handler.process(PAYLOAD);
 
@@ -328,10 +381,12 @@ class AdyenTokenWebhookNotificationHandlerTest {
         given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                 .willReturn(tokenNotification(SHOPPER_REFERENCE));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
-        if (tokenOperation.equals("created")) {
+        if (tokenOperation.equals("disabled")) {
+            given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
+        } else {
             given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
+
         }
-        given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.of(paymentInstrument));
         return paymentInstrument;
     }
 


### PR DESCRIPTION
In AdyenTokenWebhookNotificationHandler:
- Added condition to check if the storedPaymentMethodId is already set as the recurring auth token before setting it
- Moved call to get webhook payment instrument until it's definitely needed
