### PR TITLE
PP-15722 - Add support for handling Adyen Google Pay payments to WalletAuthoriseService

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationG
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.records.ApplePayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.request.records.CardAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.GooglePayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
@@ -60,6 +61,10 @@ public interface PaymentProvider {
     }
 
     default GatewayResponse<BaseAuthoriseResponse> authoriseGooglePay(GooglePayAuthorisationGatewayRequest authorisationGatewayRequest) throws GatewayException {
+        throw new UnsupportedOperationException("Google Pay is not supported for " + getPaymentGatewayName());
+    }
+
+    default GatewayResponse<BaseAuthoriseResponse> authoriseGooglePay(GooglePayAuthoriseRequest googlePayAuthoriseRequest, GatewayAccountType gatewayAccountType) throws GatewayException {
         throw new UnsupportedOperationException("Google Pay is not supported for " + getPaymentGatewayName());
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenGooglePayAuthorisePayloadFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenGooglePayAuthorisePayloadFactory.java
@@ -35,7 +35,7 @@ public class AdyenGooglePayAuthorisePayloadFactory {
                 adyenCredentialsHelper.getStore(request),
                 request.getGovUkPayPaymentId(),
                 new Amount("GBP", Long.valueOf(request.getAmount())),
-                new AdyenGooglePayPaymentMethod(googlePayAuthRequest.getPaymentInfo().toString()), // slight confusion about this
+                new AdyenGooglePayPaymentMethod(googlePayAuthRequest.token()),
                 new AdyenBrowserInfoFactory().create(googlePayAuthRequest.getPaymentInfo()),
                 chargeFrontendUrlHelper.getFrontendUrlForCharge(request.getGovUkPayPaymentId())
         );

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenPaymentProvider.java
@@ -32,7 +32,9 @@ import uk.gov.pay.connector.gateway.model.request.DeleteStoredPaymentDetailsGate
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenGooglePayAuthorisePayload;
 import uk.gov.pay.connector.gateway.model.request.records.ApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.GooglePayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
@@ -101,6 +103,15 @@ public class AdyenPaymentProvider implements PaymentProvider {
             return adyenAuthoriseHandler.authorise(adyenApplePayAuthorisePayload, gatewayAccountType);
         } else {
             throw new IllegalArgumentException("ApplePayAuthoriseRequest is not of type AdyenApplePayAuthoriseRequest");
+        }
+    }
+    
+    @Override
+    public GatewayResponse authoriseGooglePay(GooglePayAuthoriseRequest googlePayAuthoriseRequest, GatewayAccountType gatewayAccountType) throws GatewayException {
+        if (googlePayAuthoriseRequest instanceof AdyenGooglePayAuthorisePayload adyenGooglePayAuthorisePayload) {
+            return adyenAuthoriseHandler.authorise(adyenGooglePayAuthorisePayload, gatewayAccountType);
+        } else {
+            throw new IllegalArgumentException("GooglePayAuthoriseRequest is not of type AdyenGooglePayAuthoriseRequest");
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestLogGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestLogGenerator.java
@@ -24,7 +24,7 @@ public class AdyenAuthoriseRequestLogGenerator {
     public AuthorisationRequestLog generate(AdyenAuthoriseRequest adyenAuthoriseRequest, AuthCardDetails authCardDetails) {
         return switch (adyenAuthoriseRequest) {
             case AdyenApplePayAuthorisePayload adyenApplePayAuthorisePayload -> generate(adyenApplePayAuthorisePayload, authCardDetails);
-            case AdyenGooglePayAuthorisePayload adyenGooglePayAuthorisePayload -> null;
+            case AdyenGooglePayAuthorisePayload adyenGooglePayAuthorisePayload -> null; // TODO: Implement this resolves correctly in PP-15723
         };
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestToGatewayOrderConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestToGatewayOrderConverter.java
@@ -6,10 +6,12 @@ import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.records.AdyenAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.request.records.ApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.GooglePayAuthoriseRequest;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import static uk.gov.pay.connector.gateway.model.OrderRequestType.AUTHORISE;
 import static uk.gov.pay.connector.gateway.model.OrderRequestType.AUTHORISE_APPLE_PAY;
+import static uk.gov.pay.connector.gateway.model.OrderRequestType.AUTHORISE_GOOGLE_PAY;
 
 public class AdyenAuthoriseRequestToGatewayOrderConverter {
 
@@ -22,8 +24,13 @@ public class AdyenAuthoriseRequestToGatewayOrderConverter {
 
     public GatewayOrder convert(AdyenAuthoriseRequest adyenAuthoriseRequest) {
         String json = jsonObjectMapper.objectToString(adyenAuthoriseRequest);
-        OrderRequestType orderRequestType = adyenAuthoriseRequest instanceof ApplePayAuthoriseRequest
-                ? AUTHORISE_APPLE_PAY : AUTHORISE;
+        
+        OrderRequestType orderRequestType = switch (adyenAuthoriseRequest) {
+            case ApplePayAuthoriseRequest _ -> AUTHORISE_APPLE_PAY;
+            case GooglePayAuthoriseRequest _ -> AUTHORISE_GOOGLE_PAY;
+            default -> AUTHORISE;
+        };
+
         return new GatewayOrder(orderRequestType, json, MediaType.APPLICATION_JSON_TYPE);
     }
 

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -20,8 +20,10 @@ import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.adyen.AdyenPaymentProvider;
 import uk.gov.pay.connector.gateway.model.ApplePayAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.GooglePayAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenGooglePayAuthorisePayload;
 import uk.gov.pay.connector.gateway.model.request.records.WalletAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -32,7 +34,7 @@ import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
 import uk.gov.pay.connector.wallets.googlepay.GooglePayAuthorisationGatewayRequest;
-import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
+import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthorisationRequest;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.util.Optional;
@@ -44,6 +46,7 @@ public class WalletAuthoriseService {
     private static final Logger LOGGER = LoggerFactory.getLogger(WalletAuthoriseService.class);
     private final AuthorisationService authorisationService;
     private final ApplePayAuthoriseRequestFactory applePayAuthoriseRequestFactory;
+    private final GooglePayAuthoriseRequestFactory googlePayAuthoriseRequestFactory;
     private final ChargeService chargeService;
     private final PaymentProviders paymentProviders;
     private final WalletPaymentInfoToAuthCardDetailsConverter walletPaymentInfoToAuthCardDetailsConverter;
@@ -66,12 +69,14 @@ public class WalletAuthoriseService {
                                   ChargeService chargeService,
                                   AuthorisationService authorisationService,
                                   ApplePayAuthoriseRequestFactory applePayAuthoriseRequestFactory,
+                                  GooglePayAuthoriseRequestFactory googlePayAuthoriseRequestFactory,
                                   WalletPaymentInfoToAuthCardDetailsConverter walletPaymentInfoToAuthCardDetailsConverter,
                                   AuthorisationLogger authorisationLogger,
                                   Environment environment) {
         this.paymentProviders = paymentProviders;
         this.authorisationService = authorisationService;
         this.applePayAuthoriseRequestFactory = applePayAuthoriseRequestFactory;
+        this.googlePayAuthoriseRequestFactory = googlePayAuthoriseRequestFactory;
         this.walletPaymentInfoToAuthCardDetailsConverter = walletPaymentInfoToAuthCardDetailsConverter;
         this.chargeService = chargeService;
         this.authorisationLogger = authorisationLogger;
@@ -238,7 +243,6 @@ public class WalletAuthoriseService {
         var authorisationGatewayRequest = ApplePayAuthorisationGatewayRequest.valueOf
                 (chargeEntity, (ApplePayAuthRequest) walletAuthorisationRequest);
 
-        
         var applePayAuthoriseRequest = applePayAuthoriseRequestFactory.create(authorisationGatewayRequest).orElse(null);
         PaymentProvider paymentProvider = getPaymentProviderFor(chargeEntity);
         
@@ -253,11 +257,27 @@ public class WalletAuthoriseService {
         return new RequestAndResponse(applePayAuthoriseRequest, response);
     }
 
-    private RequestAndResponse authoriseGooglePay(ChargeEntity chargeEntity, WalletAuthorisationRequest walletAuthorisationRequest)
-            throws GatewayException {
-        var authorisationGatewayRequest = GooglePayAuthorisationGatewayRequest.valueOf
-                (chargeEntity, (GooglePayAuthRequest) walletAuthorisationRequest);
-        GatewayResponse<BaseAuthoriseResponse> response = getPaymentProviderFor(chargeEntity).authoriseGooglePay(authorisationGatewayRequest);
+    private RequestAndResponse authoriseGooglePay(
+            ChargeEntity chargeEntity, 
+            WalletAuthorisationRequest walletAuthorisationRequest
+    ) throws GatewayException {
+
+        var authorisationGatewayRequest = GooglePayAuthorisationGatewayRequest.valueOf(
+                chargeEntity,
+                (GooglePayAuthorisationRequest) walletAuthorisationRequest
+        );
+        
+        var googlePayAuthoriseRequest = googlePayAuthoriseRequestFactory.create(authorisationGatewayRequest).orElse(null);
+        PaymentProvider paymentProvider = getPaymentProviderFor(chargeEntity);
+
+        GatewayResponse<BaseAuthoriseResponse> response = switch (googlePayAuthoriseRequest) {
+            case AdyenGooglePayAuthorisePayload adyenGooglePayAuthorisePayload when paymentProvider instanceof AdyenPaymentProvider ->
+                    paymentProvider.authoriseGooglePay(
+                            adyenGooglePayAuthorisePayload,
+                            authorisationGatewayRequest.getGatewayAccount().getGatewayAccountType()
+                    );
+            case null, default ->  getPaymentProviderFor(chargeEntity).authoriseGooglePay(authorisationGatewayRequest);
+        };
 
         return new RequestAndResponse(null, response);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestToGatewayOrderConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenAuthoriseRequestToGatewayOrderConverterTest.java
@@ -3,17 +3,20 @@ package uk.gov.pay.connector.gateway.adyen.utils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonassert.JsonAssert;
 import jakarta.ws.rs.core.MediaType;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.adyen.AdyenBrowserInfoFactory;
 import uk.gov.pay.connector.gateway.adyen.request.json.AdyenApplePayPaymentMethod;
+import uk.gov.pay.connector.gateway.adyen.request.json.AdyenGooglePayPaymentMethod;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenGooglePayAuthorisePayload;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.model.domain.googlepay.GooglePayPaymentInfoFixture.aGooglePayPaymentInfo;
 
 class AdyenAuthoriseRequestToGatewayOrderConverterTest {
 
@@ -22,8 +25,10 @@ class AdyenAuthoriseRequestToGatewayOrderConverterTest {
     private static final String REFERENCE = "reference";
     private static final String AMOUNT_CURRENCY = "GBP";
     private static final long AMOUNT_VALUE = 232_87L;
-    private static final String APPLE_PAY_TOKEN = "apple_pay_token";
+    private static final String APPLE_PAY_TOKEN = "apple_pay_token";    
+    private static final String GOOGLE_PAY_TOKEN = "google_pay_token";
     private static final String RETURN_URL = "https://return_url.test/";
+    private static final String TEXT_HTML = "text/html";
 
     private final AdyenAuthoriseRequestToGatewayOrderConverter adyenAuthoriseRequestToGatewayOrderConverter = 
             new AdyenAuthoriseRequestToGatewayOrderConverter(new JsonObjectMapper(new ObjectMapper()));
@@ -43,14 +48,40 @@ class AdyenAuthoriseRequestToGatewayOrderConverterTest {
         assertThat(gatewayOrder.orderRequestType(), is(OrderRequestType.AUTHORISE_APPLE_PAY));
         assertThat(gatewayOrder.mediaType(), is(MediaType.APPLICATION_JSON_TYPE));
         JsonAssert.with(gatewayOrder.payload())
-                .assertThat("$.merchantAccount", Matchers.is(MERCHANT_ACCOUNT))
-                .assertThat("$.store", Matchers.is(STORE))
-                .assertThat("$.reference", Matchers.is(REFERENCE))
-                .assertThat("$.amount.currency", Matchers.is(AMOUNT_CURRENCY))
-                .assertThat("$.amount.value", Matchers.is((int) AMOUNT_VALUE))
-                .assertThat("$.paymentMethod.applePayToken", Matchers.is(APPLE_PAY_TOKEN))
-                .assertThat("$.paymentMethod.type", Matchers.is("applepay"))
-                .assertThat("$.returnUrl", Matchers.is(RETURN_URL));
+                .assertThat("$.merchantAccount", is(MERCHANT_ACCOUNT))
+                .assertThat("$.store", is(STORE))
+                .assertThat("$.reference", is(REFERENCE))
+                .assertThat("$.amount.currency", is(AMOUNT_CURRENCY))
+                .assertThat("$.amount.value", is((int) AMOUNT_VALUE))
+                .assertThat("$.paymentMethod.applePayToken", is(APPLE_PAY_TOKEN))
+                .assertThat("$.paymentMethod.type", is("applepay"))
+                .assertThat("$.returnUrl", is(RETURN_URL));
     }
 
+    @Test
+    void convertsAdyenGooglePayAuthoriseRequest() {
+        var request = new AdyenGooglePayAuthorisePayload(
+                MERCHANT_ACCOUNT,
+                STORE,
+                REFERENCE,
+                new Amount(AMOUNT_CURRENCY, AMOUNT_VALUE),
+                new AdyenGooglePayPaymentMethod(GOOGLE_PAY_TOKEN),
+                new AdyenBrowserInfoFactory().create(aGooglePayPaymentInfo().withAcceptHeader(TEXT_HTML).build()),
+                RETURN_URL);
+
+        GatewayOrder gatewayOrder = adyenAuthoriseRequestToGatewayOrderConverter.convert(request);
+
+        assertThat(gatewayOrder.orderRequestType(), is(OrderRequestType.AUTHORISE_GOOGLE_PAY));
+        assertThat(gatewayOrder.mediaType(), is(MediaType.APPLICATION_JSON_TYPE));
+        JsonAssert.with(gatewayOrder.payload())
+                .assertThat("$.merchantAccount", is(MERCHANT_ACCOUNT))
+                .assertThat("$.store", is(STORE))
+                .assertThat("$.reference", is(REFERENCE))
+                .assertThat("$.amount.currency", is(AMOUNT_CURRENCY))
+                .assertThat("$.amount.value", is((int) AMOUNT_VALUE))
+                .assertThat("$.paymentMethod.googlePayToken", is(GOOGLE_PAY_TOKEN))
+                .assertThat("$.paymentMethod.type", is("googlepay"))
+                .assertThat("$.returnUrl", is(RETURN_URL))
+                .assertThat("$.browserInfo.acceptHeader", is(TEXT_HTML));
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/model/AdyenGooglePayAuthorisePayloadFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/AdyenGooglePayAuthorisePayloadFactoryTest.java
@@ -45,6 +45,7 @@ class AdyenGooglePayAuthorisePayloadFactoryTest {
         String merchantAccountId = "merchantAccountId";
         String storeId = "storeId";
         String frontendUrl = "http://frontend.test/card_details/" + externalId;
+        String token = "token";
         GooglePayPaymentInfo googlePaymentInfo = aGooglePayPaymentInfo().build();
         
         GatewayAccountEntity gatewayAccountEntity = GatewayAccountEntityFixture.aGatewayAccountEntity().build();
@@ -55,7 +56,10 @@ class AdyenGooglePayAuthorisePayloadFactoryTest {
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .build();
 
-        AdyenGooglePayAuthRequest googlePayAuthRequest = AdyenGooglePayAuthRequestFixture.aGooglePayAuthRequest().withGooglePaymentInfo(googlePaymentInfo).build();
+        AdyenGooglePayAuthRequest googlePayAuthRequest = AdyenGooglePayAuthRequestFixture.aGooglePayAuthRequest()
+                .withGooglePaymentInfo(googlePaymentInfo)
+                .withToken(token)
+                .build();
 
         GooglePayAuthorisationGatewayRequest googlePayAuthorisationGatewayRequest = GooglePayAuthorisationGatewayRequest.valueOf(chargeEntity, googlePayAuthRequest);
 
@@ -74,7 +78,7 @@ class AdyenGooglePayAuthorisePayloadFactoryTest {
                 storeId,
                 externalId, 
                 new Amount("GBP", amountInPence),
-                new AdyenGooglePayPaymentMethod(googlePaymentInfo.toString()),
+                new AdyenGooglePayPaymentMethod(token),
                 adyenBrowserInfo,
                 frontendUrl
         );

--- a/src/test/java/uk/gov/pay/connector/model/domain/googlepay/AdyenGooglePayAuthRequestFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/googlepay/AdyenGooglePayAuthRequestFixture.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.wallets.googlepay.api.GooglePayPaymentInfo;
 
 public final class AdyenGooglePayAuthRequestFixture {
     private GooglePayPaymentInfo googlePaymentInfo;
+    private String token;
     
     private AdyenGooglePayAuthRequestFixture() {
     }
@@ -16,12 +17,17 @@ public final class AdyenGooglePayAuthRequestFixture {
     public AdyenGooglePayAuthRequest build() {
         return new AdyenGooglePayAuthRequest(
                 googlePaymentInfo,
-                "token"
+                token
         );
     }
 
     public AdyenGooglePayAuthRequestFixture withGooglePaymentInfo(GooglePayPaymentInfo googlePaymentInfo) {
         this.googlePaymentInfo = googlePaymentInfo;
+        return this;
+    }
+    
+    public AdyenGooglePayAuthRequestFixture withToken(String token) {
+        this.token = token;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
@@ -25,6 +25,7 @@ import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.ApplePayAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.GooglePayAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
@@ -100,6 +101,9 @@ class WalletAuthoriseServiceForGooglePay3dsTest {
     
     @Mock
     private ApplePayAuthoriseRequestFactory mockApplePayAuthoriseRequestFactory;
+    
+    @Mock
+    private GooglePayAuthoriseRequestFactory mockGooglePayAuthoriseRequestFactory;
 
     @Mock
     EventService mockEventService;
@@ -127,6 +131,7 @@ class WalletAuthoriseServiceForGooglePay3dsTest {
                 chargeService,
                 authorisationService,
                 mockApplePayAuthoriseRequestFactory,
+                mockGooglePayAuthoriseRequestFactory,
                 mockWalletPaymentInfoToAuthCardDetailsConverter,
                 mock(AuthorisationLogger.class), 
                 mockEnvironment);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -40,9 +40,12 @@ import uk.gov.pay.connector.gateway.adyen.AdyenPaymentProvider;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenAuthoriseRequestLogGenerator;
 import uk.gov.pay.connector.gateway.model.ApplePayAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.GooglePayAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequestFixture;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenGooglePayAuthoriseRequestFixture;
 import uk.gov.pay.connector.gateway.model.request.records.ApplePayAuthoriseRequest;
+import uk.gov.pay.connector.gateway.model.request.records.GooglePayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -110,6 +113,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.UNDEFINED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.model.domain.applepay.ApplePayAuthRequestFixture.anApplePayAuthRequest;
+import static uk.gov.pay.connector.model.domain.googlepay.GooglePayAuthRequestFixture.aGooglePayAuthRequest;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.COMPLETED;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.IN_PROGRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
@@ -178,13 +182,18 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
     
     @Mock
     private ApplePayAuthoriseRequestFactory mockApplePayAuthoriseRequestFactory;
+    
+    @Mock
+    private GooglePayAuthoriseRequestFactory mockGooglePayAuthoriseRequestFactory;
 
     private WalletAuthoriseService walletAuthoriseService;
 
     private final ApplePayAuthRequest validApplePayDetails =
             anApplePayAuthRequest()
                     .build();
-
+    
+    private final GooglePayAuthRequest validGooglePayDetails = aGooglePayAuthRequest().build();
+    
     @Mock
     private EventService mockEventService;
 
@@ -219,6 +228,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
                 chargeService,
                 authorisationService,
                 mockApplePayAuthoriseRequestFactory,
+                mockGooglePayAuthoriseRequestFactory,
                 mockWalletPaymentInfoToAuthCardDetailsConverter,
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging(), new AdyenAuthoriseRequestLogGenerator(), new WorldpayAuthoriseRequestLogGenerator()),
                 mockEnvironment);
@@ -331,6 +341,49 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
                 "wallet=" + WalletType.APPLE_PAY
         ));
 
+
+        verifyGatewayDoesNotRequire3dsEventWasEmitted(charge);
+    }
+
+    @Test
+    void doAuthoriseCard_googlePay_with_AdyenGooglePayAuthoriseRequest_shouldRespondAuthorisationSuccess() throws Exception {
+
+        ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
+        GooglePayAuthoriseRequest googlePayAuthoriseRequest = AdyenGooglePayAuthoriseRequestFixture.anAdyenGooglePayAuthoriseRequestFixture().build();
+
+        charge.setPaymentProvider(ADYEN.getName());
+
+        AdyenPaymentProvider mockAdyenPaymentProvider = mock(AdyenPaymentProvider.class);
+        providerWillAuthoriseGooglePayWithGooglePayAuthoriseRequest(mockAdyenPaymentProvider);
+
+        doReturn(Optional.of(googlePayAuthoriseRequest))
+                .when(mockGooglePayAuthoriseRequestFactory)
+                .create(any(GooglePayAuthorisationGatewayRequest.class));
+        when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
+
+        GatewayResponse response = walletAuthoriseService.authorise(charge.getExternalId(), validGooglePayDetails);
+
+        assertThat(response.getBaseResponse().isPresent(), is(true));
+        assertThat(response.getSessionIdentifier().isPresent(), is(true));
+        assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
+
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
+        assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
+        assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
+        verify(mockedChargeEventDao).persistChargeEventOf(eq(charge), isNull());
+        assertThat(charge.get3dsRequiredDetails(), is(nullValue()));
+        assertThat(charge.getCardDetails(), is(mockCardDetailsEntity));
+        assertThat(charge.getWalletType(), is(WalletType.GOOGLE_PAY));
+        assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
+        assertThat(charge.getEmail(), is(validGooglePayDetails.getPaymentInfo().getEmail()));
+        assertThat(charge.getRequires3ds(), is(false));
+
+        verify(mockStateTransitionService).offerPaymentStateTransition(charge.getExternalId(), AUTHORISATION_READY, AUTHORISATION_SUCCESS, chargeEventEntity);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(mockEventService, times(2)).emitAndRecordEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getAllValues().getFirst().getResourceExternalId(), is(charge.getExternalId()));
+        assertThat(eventCaptor.getAllValues().getFirst().getEventType(), is("PAYMENT_DETAILS_ENTERED"));
 
         verifyGatewayDoesNotRequire3dsEventWasEmitted(charge);
     }
@@ -652,6 +705,13 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
         when(mockedProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockPaymentProvider);
         GatewayResponse authResponse = mockAuthResponse(TRANSACTION_ID, AuthoriseStatus.AUTHORISED, null, EXPIRY_DATE);
         when(mockPaymentProvider.authoriseApplePay(any(ApplePayAuthoriseRequest.class), any(GatewayAccountType.class))).thenReturn(authResponse);
+        return authResponse;
+    }
+
+    private GatewayResponse providerWillAuthoriseGooglePayWithGooglePayAuthoriseRequest(PaymentProvider mockPaymentProvider) throws Exception {
+        when(mockedProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockPaymentProvider);
+        GatewayResponse authResponse = mockAuthResponse(TRANSACTION_ID, AuthoriseStatus.AUTHORISED, null, EXPIRY_DATE);
+        when(mockPaymentProvider.authoriseGooglePay(any(GooglePayAuthoriseRequest.class), any(GatewayAccountType.class))).thenReturn(authResponse);
         return authResponse;
     }
 


### PR DESCRIPTION
- Add support for handling Adyen Google Pay payments to `WalletAuthoriseService`
- Added `authoriseGooglePay` to `PaymentProvider` & `AdyenPaymentProvider` Interfaces
- Updated tests where appropriate
