### PR TITLE
PP-15767: add platform-bom and bump pay-java-commons to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <pay-java-commons.version>1.0.20260817082240</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20260825154634</pay-java-commons.version>
         <surefire.version>3.5.6</surefire.version>
         <jjwt.version>0.13.0</jjwt.version>
         <pact.version>4.7.5</pact.version>
@@ -26,6 +26,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>uk.gov.service.payments</groupId>
+                <artifactId>platform-bom</artifactId>
+                <version>${pay-java-commons.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>


### PR DESCRIPTION
Add the new GOV.UK Pay platform BOM to temporarily override patch versions Dropwizard-managed dependencies. Bump pay-java-commons to version that includes the BOM.