### PR TITLE
PP-15836 add Dependabot exclude cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
         # org.eclipse.persistence.jpa 5 is incompatible with Guice 7, needs a lot of work on our end
         versions:
           - ">= 5"
+    cooldown:
+      exclude:
+        - "uk.gov.service.payments:*"
     open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
## WHAT YOU DID

Exclude pay-java-commons from the cooldown period of dependabot updates.

