### PR TITLE
PP-15837 Consistent naming for payload gateway request records

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -29,7 +29,7 @@ import uk.gov.pay.connector.gateway.stripe.StripeSdkClientFactory;
 import uk.gov.pay.connector.gateway.stripe.StripeSdkWrapper;
 import uk.gov.pay.connector.gateway.templates.WorldpayRequestTemplateBuilder;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayCardAuthoriseRequestFactory;
-import uk.gov.pay.connector.gateway.worldpay.WorldpayMotoAuthoriseRequestFactory;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayMotoAuthorisePayloadFactory;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
@@ -85,7 +85,7 @@ public class ConnectorModule extends AbstractModule {
         bind(GatewayAccountRequestValidator.class).in(Singleton.class);
         bind(InetAddressValidator.class).in(Singleton.class);
         bind(WorldpayRequestTemplateBuilder.class).in(Singleton.class);
-        bind(WorldpayMotoAuthoriseRequestFactory.class).in(Singleton.class);
+        bind(WorldpayMotoAuthorisePayloadFactory.class).in(Singleton.class);
         bind(WorldpayCardAuthoriseRequestFactory.class).in(Singleton.class);
         bind(CardAuthoriseRequestFactory.class).in(Singleton.class);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenApplePayAuthorisePayloadFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/AdyenApplePayAuthorisePayloadFactory.java
@@ -9,14 +9,14 @@ import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorise
 import uk.gov.pay.connector.gateway.util.ChargeFrontendUrlHelper;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
 
-public class AdyenApplePayAuthoriseRequestFactory {
+public class AdyenApplePayAuthorisePayloadFactory {
 
     private final ChargeFrontendUrlHelper chargeFrontendUrlHelper;
     private final AdyenMerchantAccountHelper adyenMerchantAccountHelper;
     private final AdyenCredentialsHelper adyenCredentialsHelper;
     
     @Inject
-    public AdyenApplePayAuthoriseRequestFactory(
+    public AdyenApplePayAuthorisePayloadFactory(
             AdyenMerchantAccountHelper adyenMerchantAccountHelper, 
             AdyenCredentialsHelper adyenCredentialsHelper,
             ChargeFrontendUrlHelper chargeFrontendUrlHelper

--- a/src/main/java/uk/gov/pay/connector/gateway/model/ApplePayAuthoriseRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/ApplePayAuthoriseRequestFactory.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.model;
 
 import jakarta.inject.Inject;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.adyen.AdyenApplePayAuthoriseRequestFactory;
+import uk.gov.pay.connector.gateway.adyen.AdyenApplePayAuthorisePayloadFactory;
 import uk.gov.pay.connector.gateway.model.request.records.ApplePayAuthoriseRequest;
 import uk.gov.pay.connector.wallets.applepay.ApplePayAuthorisationGatewayRequest;
 
@@ -10,16 +10,16 @@ import java.util.Optional;
 
 public class ApplePayAuthoriseRequestFactory {
 
-    private final AdyenApplePayAuthoriseRequestFactory adyenApplePayAuthoriseRequestFactory;
+    private final AdyenApplePayAuthorisePayloadFactory adyenApplePayAuthorisePayloadFactory;
 
     @Inject
-    public ApplePayAuthoriseRequestFactory(AdyenApplePayAuthoriseRequestFactory adyenApplePayAuthoriseRequestFactory) {
-        this.adyenApplePayAuthoriseRequestFactory = adyenApplePayAuthoriseRequestFactory;
+    public ApplePayAuthoriseRequestFactory(AdyenApplePayAuthorisePayloadFactory adyenApplePayAuthorisePayloadFactory) {
+        this.adyenApplePayAuthorisePayloadFactory = adyenApplePayAuthorisePayloadFactory;
     }
     
     public Optional<? extends ApplePayAuthoriseRequest> create(ApplePayAuthorisationGatewayRequest request) {
         if (PaymentGatewayName.ADYEN.getName().equals(request.getGatewayAccount().getGatewayName())) {
-            return Optional.of(adyenApplePayAuthoriseRequestFactory.create(request));
+            return Optional.of(adyenApplePayAuthorisePayloadFactory.create(request));
         }
 
         return Optional.empty();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCardAuthoriseRequestFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCardAuthoriseRequestFactory.java
@@ -9,17 +9,17 @@ import java.util.Optional;
 
 public class WorldpayCardAuthoriseRequestFactory {
 
-    private final WorldpayMotoAuthoriseRequestFactory worldpayMotoAuthoriseRequestFactory;
+    private final WorldpayMotoAuthorisePayloadFactory worldpayMotoAuthorisePayloadFactory;
 
     @Inject
-    public WorldpayCardAuthoriseRequestFactory(WorldpayMotoAuthoriseRequestFactory worldpayMotoAuthoriseRequestFactory) {
-        this.worldpayMotoAuthoriseRequestFactory = worldpayMotoAuthoriseRequestFactory;
+    public WorldpayCardAuthoriseRequestFactory(WorldpayMotoAuthorisePayloadFactory worldpayMotoAuthorisePayloadFactory) {
+        this.worldpayMotoAuthorisePayloadFactory = worldpayMotoAuthorisePayloadFactory;
     }
 
     public Optional<WorldpayCardAuthoriseRequest> create(CardAuthorisationGatewayRequest request) {
         if (request.isMoto() && !request.isSavePaymentInstrumentToAgreement()
                 && request.getAuthorisationMode() == AuthorisationMode.WEB) {
-            return Optional.of(worldpayMotoAuthoriseRequestFactory.create(request));
+            return Optional.of(worldpayMotoAuthorisePayloadFactory.create(request));
         }
 
         return Optional.empty();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayMotoAuthorisePayloadFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayMotoAuthorisePayloadFactory.java
@@ -7,13 +7,13 @@ import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseCredentialsH
 import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseDescriptionHelper;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
 
-public class WorldpayMotoAuthoriseRequestFactory {
+public class WorldpayMotoAuthorisePayloadFactory {
 
     private final WorldpayAuthoriseDescriptionHelper descriptionHelper;
     private final WorldpayAuthoriseCredentialsHelper credentialsHelper;
 
     @Inject
-    public WorldpayMotoAuthoriseRequestFactory(WorldpayAuthoriseDescriptionHelper descriptionHelper, WorldpayAuthoriseCredentialsHelper credentialsHelper) {
+    public WorldpayMotoAuthorisePayloadFactory(WorldpayAuthoriseDescriptionHelper descriptionHelper, WorldpayAuthoriseCredentialsHelper credentialsHelper) {
         this.descriptionHelper = descriptionHelper;
         this.credentialsHelper = credentialsHelper;
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthoriseHandlerTest.java
@@ -26,7 +26,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenAuthoriseRequestToGatewayOrderConverter;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
 import uk.gov.pay.connector.gateway.model.request.RecurringPaymentAuthorisationGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequestFixture;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayloadFixture;
 import uk.gov.pay.connector.gateway.model.request.records.AdyenAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -316,7 +316,7 @@ class AdyenAuthoriseHandlerTest {
     void should_return_a_GatewayResponse_for_successful_AydenAuthoriseRequest_authorisation() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
         givenAdyenReturnsASuccessResponse();
  
-        AdyenAuthoriseRequest adyenAuthoriseRequest = AdyenApplePayAuthoriseRequestFixture.anAdyenApplePayAuthoriseRequestFixture().build();
+        AdyenAuthoriseRequest adyenAuthoriseRequest = AdyenApplePayAuthorisePayloadFixture.anAdyenApplePayAuthorisePayloadFixture().build();
 
         GatewayResponse<BaseAuthoriseResponse> response = authoriseHandler.authorise(adyenAuthoriseRequest, GatewayAccountType.TEST);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/gateway/worldpay/WorldpayMotoAuthorisePayloadFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/gateway/worldpay/WorldpayMotoAuthorisePayloadFactoryTest.java
@@ -12,7 +12,7 @@ import uk.gov.pay.connector.client.cardid.model.CardInformationFixture;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayload;
-import uk.gov.pay.connector.gateway.worldpay.WorldpayMotoAuthoriseRequestFactory;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayMotoAuthorisePayloadFactory;
 import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseCredentialsHelper;
 import uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseDescriptionHelper;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayMerchantCodeCredentials;
@@ -24,7 +24,7 @@ import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class WorldpayMotoAuthorisePayloadFactoryTest {
-    private WorldpayMotoAuthoriseRequestFactory worldpayMotoAuthoriseRequestFactory;
+    private WorldpayMotoAuthorisePayloadFactory worldpayMotoAuthorisePayloadFactory;
     
     @Mock
     private WorldpayAuthoriseDescriptionHelper mockDescriptionHelper;
@@ -34,7 +34,7 @@ class WorldpayMotoAuthorisePayloadFactoryTest {
     
     @BeforeEach
     void setUp(){
-        this.worldpayMotoAuthoriseRequestFactory = new WorldpayMotoAuthoriseRequestFactory(mockDescriptionHelper, mockCredentialsHelper);
+        this.worldpayMotoAuthorisePayloadFactory = new WorldpayMotoAuthorisePayloadFactory(mockDescriptionHelper, mockCredentialsHelper);
     }
     
     @Test
@@ -68,7 +68,7 @@ class WorldpayMotoAuthorisePayloadFactoryTest {
         given(mockDescriptionHelper.getDescription(cardAuthorisationGatewayRequest)).willReturn(descriptionOrReference);
         given(mockCredentialsHelper.getOneOffCredentials(cardAuthorisationGatewayRequest)).willReturn(new WorldpayMerchantCodeCredentials(merchantCode, username, password));
         
-        WorldpayMotoAuthorisePayload actual = worldpayMotoAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest);
+        WorldpayMotoAuthorisePayload actual = worldpayMotoAuthorisePayloadFactory.create(cardAuthorisationGatewayRequest);
         WorldpayMotoAuthorisePayload expected = new WorldpayMotoAuthorisePayload(
                 username, 
                 password, 

--- a/src/test/java/uk/gov/pay/connector/gateway/model/AdyenApplePayAuthorisePayloadFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/AdyenApplePayAuthorisePayloadFactoryTest.java
@@ -7,7 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
-import uk.gov.pay.connector.gateway.adyen.AdyenApplePayAuthoriseRequestFactory;
+import uk.gov.pay.connector.gateway.adyen.AdyenApplePayAuthorisePayloadFactory;
 import uk.gov.pay.connector.gateway.adyen.request.json.AdyenApplePayPaymentMethod;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenCredentialsHelper;
@@ -59,9 +59,9 @@ class AdyenApplePayAuthorisePayloadFactoryTest {
         given(mockAdyenCredentialsHelper.getStore(applePayAuthorisationGatewayRequest)).willReturn(storeId);
         given(mockChargeFrontendUrlHelper.getFrontendUrlForCharge(externalId)).willReturn(frontendUrl);
         
-        AdyenApplePayAuthoriseRequestFactory adyenApplePayAuthoriseRequestFactory = new AdyenApplePayAuthoriseRequestFactory(mockAdyenMerchantAccountHelper, mockAdyenCredentialsHelper, mockChargeFrontendUrlHelper);
+        AdyenApplePayAuthorisePayloadFactory adyenApplePayAuthorisePayloadFactory = new AdyenApplePayAuthorisePayloadFactory(mockAdyenMerchantAccountHelper, mockAdyenCredentialsHelper, mockChargeFrontendUrlHelper);
         
-        var actual = adyenApplePayAuthoriseRequestFactory.create(applePayAuthorisationGatewayRequest);
+        var actual = adyenApplePayAuthorisePayloadFactory.create(applePayAuthorisationGatewayRequest);
 
         var expected = new AdyenApplePayAuthorisePayload(
                 merchantAccountId,

--- a/src/test/java/uk/gov/pay/connector/gateway/model/ApplePayAuthoriseRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/ApplePayAuthoriseRequestFactoryTest.java
@@ -10,11 +10,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.adyen.AdyenApplePayAuthoriseRequestFactory;
+import uk.gov.pay.connector.gateway.adyen.AdyenApplePayAuthorisePayloadFactory;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenCredentialsHelper;
 import uk.gov.pay.connector.gateway.adyen.utils.AdyenMerchantAccountHelper;
 import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayload;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequestFixture;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayloadFixture;
 import uk.gov.pay.connector.gateway.model.request.records.ApplePayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.util.ChargeFrontendUrlHelper;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
@@ -38,7 +38,7 @@ import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccoun
 class ApplePayAuthoriseRequestFactoryTest {
 
     @Mock
-    private AdyenApplePayAuthoriseRequestFactory mockAdyenApplePayAuthoriseRequestFactory;
+    private AdyenApplePayAuthorisePayloadFactory mockAdyenApplePayAuthorisePayloadFactory;
     @Mock
     private AdyenMerchantAccountHelper mockAdyenMerchantAccountHelper;
     @Mock
@@ -57,7 +57,7 @@ class ApplePayAuthoriseRequestFactoryTest {
 
     @BeforeEach
     void setUp() {
-        authoriseRequestFactory = new ApplePayAuthoriseRequestFactory(mockAdyenApplePayAuthoriseRequestFactory);
+        authoriseRequestFactory = new ApplePayAuthoriseRequestFactory(mockAdyenApplePayAuthorisePayloadFactory);
 
     }
 
@@ -79,9 +79,9 @@ class ApplePayAuthoriseRequestFactoryTest {
 
         ApplePayAuthorisationGatewayRequest applePayAuthorisationGatewayRequest = ApplePayAuthorisationGatewayRequest.valueOf(chargeEntity, applePayAuthRequest);
         
-        AdyenApplePayAuthorisePayload adyenApplePayAuthorisePayload = AdyenApplePayAuthoriseRequestFixture.anAdyenApplePayAuthoriseRequestFixture().build();
+        AdyenApplePayAuthorisePayload adyenApplePayAuthorisePayload = AdyenApplePayAuthorisePayloadFixture.anAdyenApplePayAuthorisePayloadFixture().build();
 
-        given(mockAdyenApplePayAuthoriseRequestFactory.create(applePayAuthorisationGatewayRequest)).willReturn(adyenApplePayAuthorisePayload);
+        given(mockAdyenApplePayAuthorisePayloadFactory.create(applePayAuthorisationGatewayRequest)).willReturn(adyenApplePayAuthorisePayload);
 
         Optional<? extends ApplePayAuthoriseRequest> applePayAuthoriseRequest = authoriseRequestFactory.create(applePayAuthorisationGatewayRequest);
         

--- a/src/test/java/uk/gov/pay/connector/gateway/model/GooglePayAuthoriseRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/GooglePayAuthoriseRequestFactoryTest.java
@@ -12,7 +12,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.adyen.AdyenGooglePayAuthorisePayloadFactory;
 import uk.gov.pay.connector.gateway.model.request.records.AdyenGooglePayAuthorisePayload;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenGooglePayAuthoriseRequestFixture;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenGooglePayAuthorisePayloadFixture;
 import uk.gov.pay.connector.gateway.model.request.records.GooglePayAuthoriseRequest;
 import uk.gov.pay.connector.gatewayaccount.model.AdyenCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -69,7 +69,7 @@ class GooglePayAuthoriseRequestFactoryTest {
 
         GooglePayAuthorisationGatewayRequest googlePayAuthorisationGatewayRequest = GooglePayAuthorisationGatewayRequest.valueOf(chargeEntity, googlePayAuthRequest);
 
-        AdyenGooglePayAuthorisePayload adyenGooglePayAuthorisePayload = AdyenGooglePayAuthoriseRequestFixture.anAdyenGooglePayAuthoriseRequestFixture().build();
+        AdyenGooglePayAuthorisePayload adyenGooglePayAuthorisePayload = AdyenGooglePayAuthorisePayloadFixture.anAdyenGooglePayAuthorisePayloadFixture().build();
 
         given(mockAdyenGooglePayAuthoriseRequestFactory.create(googlePayAuthorisationGatewayRequest)).willReturn(adyenGooglePayAuthorisePayload);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/AdyenApplePayAuthorisePayloadFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/AdyenApplePayAuthorisePayloadFixture.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.gateway.model.request.records;
 import uk.gov.pay.connector.gateway.adyen.request.json.AdyenApplePayPaymentMethod;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 
-public class AdyenApplePayAuthoriseRequestFixture {
+public class AdyenApplePayAuthorisePayloadFixture {
 
     private String merchantAccount = "live";
     private String store = "storeId";
@@ -12,36 +12,36 @@ public class AdyenApplePayAuthoriseRequestFixture {
     private AdyenApplePayPaymentMethod paymentMethod = new AdyenApplePayPaymentMethod("token");
     private String returnUrl = "http://frontend.test/card_details/abcdefghijklmnopqrstuvwxyz";
 
-    public static AdyenApplePayAuthoriseRequestFixture anAdyenApplePayAuthoriseRequestFixture() {
-        return new AdyenApplePayAuthoriseRequestFixture();
+    public static AdyenApplePayAuthorisePayloadFixture anAdyenApplePayAuthorisePayloadFixture() {
+        return new AdyenApplePayAuthorisePayloadFixture();
     }
     
-    public AdyenApplePayAuthoriseRequestFixture withMerchantAccount(String merchantAccount) {
+    public AdyenApplePayAuthorisePayloadFixture withMerchantAccount(String merchantAccount) {
         this.merchantAccount = merchantAccount;
         return this;
     }
 
-    public AdyenApplePayAuthoriseRequestFixture withStore(String store) {
+    public AdyenApplePayAuthorisePayloadFixture withStore(String store) {
         this.store = store;
         return this;
     }
 
-    public AdyenApplePayAuthoriseRequestFixture withReference(String reference) {
+    public AdyenApplePayAuthorisePayloadFixture withReference(String reference) {
         this.reference = reference;
         return this;
     }
 
-    public AdyenApplePayAuthoriseRequestFixture withAmount(Amount amount) {
+    public AdyenApplePayAuthorisePayloadFixture withAmount(Amount amount) {
         this.amount = amount;
         return this;
     }
 
-    public AdyenApplePayAuthoriseRequestFixture withPaymentMethod(AdyenApplePayPaymentMethod paymentMethod) {
+    public AdyenApplePayAuthorisePayloadFixture withPaymentMethod(AdyenApplePayPaymentMethod paymentMethod) {
         this.paymentMethod = paymentMethod;
         return this;
     }
 
-    public AdyenApplePayAuthoriseRequestFixture withReturnUrl(String returnUrl) {
+    public AdyenApplePayAuthorisePayloadFixture withReturnUrl(String returnUrl) {
         this.returnUrl = returnUrl;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/AdyenGooglePayAuthorisePayloadFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/AdyenGooglePayAuthorisePayloadFixture.java
@@ -1,19 +1,17 @@
 package uk.gov.pay.connector.gateway.model.request.records;
 
-import com.adyen.model.payment.BrowserInfo;
 import uk.gov.pay.connector.gateway.adyen.AdyenBrowserInfoFactory;
 import uk.gov.pay.connector.gateway.adyen.request.json.AdyenGooglePayPaymentMethod;
 import uk.gov.pay.connector.gateway.adyen.request.json.Amount;
 import uk.gov.pay.connector.gateway.adyen.response.json.AdyenBrowserInfo;
-import uk.gov.pay.connector.model.domain.googlepay.AdyenGooglePayAuthRequestFixture;
 import uk.gov.pay.connector.wallets.googlepay.api.AdyenGooglePayAuthRequest;
-import uk.gov.pay.connector.wallets.googlepay.api.GooglePayPaymentInfo;
 
+import static uk.gov.pay.connector.model.domain.googlepay.AdyenGooglePayAuthRequestFixture.aGooglePayAuthRequest;
 import static uk.gov.pay.connector.model.domain.googlepay.GooglePayPaymentInfoFixture.aGooglePayPaymentInfo;
 
-public class AdyenGooglePayAuthoriseRequestFixture {
+public class AdyenGooglePayAuthorisePayloadFixture {
 
-    private AdyenGooglePayAuthRequest googlePayAuthRequest = AdyenGooglePayAuthRequestFixture.aGooglePayAuthRequest().withGooglePaymentInfo(aGooglePayPaymentInfo().build()).build();
+    private final AdyenGooglePayAuthRequest googlePayAuthRequest = aGooglePayAuthRequest().withGooglePaymentInfo(aGooglePayPaymentInfo().build()).build();
     private String merchantAccount = "live";
     private String store = "storeId";
     private String reference = "reference";
@@ -22,41 +20,41 @@ public class AdyenGooglePayAuthoriseRequestFixture {
     private AdyenBrowserInfo browserInfo = new AdyenBrowserInfoFactory().create(googlePayAuthRequest.getPaymentInfo());
     private String returnUrl = "http://frontend.test/card_details/abcdefghijklmnopqrstuvwxyz";
 
-    public static AdyenGooglePayAuthoriseRequestFixture anAdyenGooglePayAuthoriseRequestFixture() {
-        return new AdyenGooglePayAuthoriseRequestFixture();
+    public static AdyenGooglePayAuthorisePayloadFixture anAdyenGooglePayAuthorisePayloadFixture() {
+        return new AdyenGooglePayAuthorisePayloadFixture();
     }
     
-    public AdyenGooglePayAuthoriseRequestFixture withMerchantAccount(String merchantAccount) {
+    public AdyenGooglePayAuthorisePayloadFixture withMerchantAccount(String merchantAccount) {
         this.merchantAccount = merchantAccount;
         return this;
     }
 
-    public AdyenGooglePayAuthoriseRequestFixture withStore(String store) {
+    public AdyenGooglePayAuthorisePayloadFixture withStore(String store) {
         this.store = store;
         return this;
     }
 
-    public AdyenGooglePayAuthoriseRequestFixture withReference(String reference) {
+    public AdyenGooglePayAuthorisePayloadFixture withReference(String reference) {
         this.reference = reference;
         return this;
     }
 
-    public AdyenGooglePayAuthoriseRequestFixture withAmount(Amount amount) {
+    public AdyenGooglePayAuthorisePayloadFixture withAmount(Amount amount) {
         this.amount = amount;
         return this;
     }
 
-    public AdyenGooglePayAuthoriseRequestFixture withPaymentMethod(AdyenGooglePayPaymentMethod paymentMethod) {
+    public AdyenGooglePayAuthorisePayloadFixture withPaymentMethod(AdyenGooglePayPaymentMethod paymentMethod) {
         this.paymentMethod = paymentMethod;
         return this;
     }
 
-    public AdyenGooglePayAuthoriseRequestFixture withGoogleBrowserInfo(AdyenBrowserInfo googlePaymentInfo) {
+    public AdyenGooglePayAuthorisePayloadFixture withGoogleBrowserInfo(AdyenBrowserInfo googlePaymentInfo) {
         this.browserInfo = googlePaymentInfo;
         return this;
     }
 
-    public AdyenGooglePayAuthoriseRequestFixture withReturnUrl(String returnUrl) {
+    public AdyenGooglePayAuthorisePayloadFixture withReturnUrl(String returnUrl) {
         this.returnUrl = returnUrl;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/CardAuthoriseRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/CardAuthoriseRequestFactoryTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
-import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
+import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayloadFixture.aWorldpayMotoAuthorisePayloadFixture;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 
@@ -53,7 +53,7 @@ class CardAuthoriseRequestFactoryTest {
                 .withGatewayAccount(gatewayAccountEntity)
                 .build();
 
-        WorldpayCardAuthoriseRequest worldpayAuthoriseRequest = aWorldpayMotoAuthoriseRequestFixture().build();
+        WorldpayCardAuthoriseRequest worldpayAuthoriseRequest = aWorldpayMotoAuthorisePayloadFixture().build();
 
         given(mockWorldpayCardAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest))
                 .willReturn(Optional.of(worldpayAuthoriseRequest));

--- a/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthorisePayloadFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/model/request/records/WorldpayMotoAuthorisePayloadFixture.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.gateway.model.request.records;
 
-public class WorldpayMotoAuthoriseRequestFixture {
+public class WorldpayMotoAuthorisePayloadFixture {
 
     private String cardNumber = "4242424242424242";
     private String expiryDateMonth = "11";
@@ -14,61 +14,61 @@ public class WorldpayMotoAuthoriseRequestFixture {
     private String merchantCode = "MERCHANTCODE";
     private long amountInPence = 2000L;
 
-    public static WorldpayMotoAuthoriseRequestFixture aWorldpayMotoAuthoriseRequestFixture() {
-        return new WorldpayMotoAuthoriseRequestFixture();
+    public static WorldpayMotoAuthorisePayloadFixture aWorldpayMotoAuthorisePayloadFixture() {
+        return new WorldpayMotoAuthorisePayloadFixture();
     }
 
-    public WorldpayMotoAuthoriseRequestFixture withCardNumber(String cardNumber) {
+    public WorldpayMotoAuthorisePayloadFixture withCardNumber(String cardNumber) {
         this.cardNumber = cardNumber;
         return this;
     }
 
-    public WorldpayMotoAuthoriseRequestFixture withExpiryDateMonth(String expiryDateMonth) {
+    public WorldpayMotoAuthorisePayloadFixture withExpiryDateMonth(String expiryDateMonth) {
         this.expiryDateMonth = expiryDateMonth;
         return this;
     }
 
-    public WorldpayMotoAuthoriseRequestFixture withExpiryDateYear(String expiryDateYear) {
+    public WorldpayMotoAuthorisePayloadFixture withExpiryDateYear(String expiryDateYear) {
         this.expiryDateYear = expiryDateYear;
         return this;
     }
 
-    public WorldpayMotoAuthoriseRequestFixture withCardholderName(String cardholderName) {
+    public WorldpayMotoAuthorisePayloadFixture withCardholderName(String cardholderName) {
         this.cardholderName = cardholderName;
         return this;
     }
 
-    public WorldpayMotoAuthoriseRequestFixture withCvc(String cvc) {
+    public WorldpayMotoAuthorisePayloadFixture withCvc(String cvc) {
         this.cvc = cvc;
         return this;
     }
 
-    public WorldpayMotoAuthoriseRequestFixture withOrderCode(String orderCode) {
+    public WorldpayMotoAuthorisePayloadFixture withOrderCode(String orderCode) {
         this.orderCode = orderCode;
         return this;
     }
 
-    public WorldpayMotoAuthoriseRequestFixture withDescription(String description) {
+    public WorldpayMotoAuthorisePayloadFixture withDescription(String description) {
         this.description = description;
         return this;
     }
 
-    public WorldpayMotoAuthoriseRequestFixture withUsername(String username) {
+    public WorldpayMotoAuthorisePayloadFixture withUsername(String username) {
         this.username = username;
         return this;
     }
 
-    public WorldpayMotoAuthoriseRequestFixture withPassword(String password) {
+    public WorldpayMotoAuthorisePayloadFixture withPassword(String password) {
         this.password = password;
         return this;
     }
 
-    public WorldpayMotoAuthoriseRequestFixture withMerchantCode(String merchantCode) {
+    public WorldpayMotoAuthorisePayloadFixture withMerchantCode(String merchantCode) {
         this.merchantCode = merchantCode;
         return this;
     }
 
-    public WorldpayMotoAuthoriseRequestFixture withAmountInPence(long amountInPence) {
+    public WorldpayMotoAuthorisePayloadFixture withAmountInPence(long amountInPence) {
         this.amountInPence = amountInPence;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/templates/WorldpayRequestTemplateBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/templates/WorldpayRequestTemplateBuilderTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
+import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayloadFixture.aWorldpayMotoAuthorisePayloadFixture;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_MOTO_AUTHORISATION_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 import static uk.gov.pay.connector.util.XmlAssertions.assertThat;
@@ -20,7 +20,7 @@ class WorldpayRequestTemplateBuilderTest {
     class MotoAuthorisationRequest {
         @Test
         void shouldGenerateValidAuthoriseOrderRequestForWorldpayMotoAuthorisationRequest() {
-            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
+            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthorisePayloadFixture().build();
 
             assertThat(worldpayRequestTemplateBuilder.buildWith("/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx", motoOrder))
                     .and(load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_MOTO_AUTHORISATION_REQUEST))
@@ -32,7 +32,7 @@ class WorldpayRequestTemplateBuilderTest {
     class TemplateBuilderAppliesAutoEscape {
         @Test
         void shouldGenerateValidAuthoriseOrderRequestWithAutoEscape() {
-            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthoriseRequestFixture()
+            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthorisePayloadFixture()
                     .withMerchantCode("MERCHANT\"\"CODE")
                     .withCardholderName("Alec & Barley").build();
             String renderedAuthoriseOrder = worldpayRequestTemplateBuilder.buildWith("/worldpay/WorldpayAuthoriseMotoOrderTemplate.ftlx", motoOrder);
@@ -46,7 +46,7 @@ class WorldpayRequestTemplateBuilderTest {
     class InvalidActionsThrowingException {
         @Test
         void shouldThrowRuntimeExceptionWhenTemplateIsNotFound() {
-            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
+            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthorisePayloadFixture().build();
             var thrown = assertThrows(RuntimeException.class, () -> worldpayRequestTemplateBuilder.buildWith("/worldpay/NonExistentOrderTemplate.xml", motoOrder));
             
             assertThat(thrown.getMessage(), is("Could not load template /worldpay/NonExistentOrderTemplate.xml in dir /templates"));
@@ -54,7 +54,7 @@ class WorldpayRequestTemplateBuilderTest {
 
         @Test
         void shouldThrowRuntimeExceptionWhenCannotRenderTemplate() {
-            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthoriseRequestFixture().build();
+            WorldpayMotoAuthorisePayload motoOrder = aWorldpayMotoAuthorisePayloadFixture().build();
 
             var thrown = assertThrows(RuntimeException.class, () -> {
                 worldpayRequestTemplateBuilder.buildWith("/worldpay/WorldpayCancelOrderTemplate.xml", motoOrder);

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -80,7 +80,7 @@ import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgre
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
+import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayloadFixture.aWorldpayMotoAuthorisePayloadFixture;
 import static uk.gov.pay.connector.gateway.worldpay.SendWorldpayExemptionRequest.DO_NOT_SEND_EXEMPTION_REQUEST;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_TRANSACTION_IDENTIFIER_KEY;
@@ -173,7 +173,7 @@ class WorldpayAuthoriseHandlerTest {
         String password = "password"; // pragma: allowlist secret
         String worldpayRequestBody = "<xml><authorise this=\"payment\"></xml>";
 
-        WorldpayAuthoriseRequest worldpayAuthoriseRequest = aWorldpayMotoAuthoriseRequestFixture()
+        WorldpayAuthoriseRequest worldpayAuthoriseRequest = aWorldpayMotoAuthorisePayloadFixture()
                 .withUsername(username).withPassword(password).build();
 
         when(worldpayRequestTemplateBuilder.buildWith(WorldpayAuthoriseHandler.MOTO_TEMPLATE_PATH, 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCardAuthoriseRequestFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCardAuthoriseRequestFactoryTest.java
@@ -19,19 +19,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequestFixture.aCardAuthorisationGatewayRequest;
-import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
+import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayloadFixture.aWorldpayMotoAuthorisePayloadFixture;
 
 @ExtendWith(MockitoExtension.class)
 class WorldpayCardAuthoriseRequestFactoryTest {
 
     @Mock
-    private WorldpayMotoAuthoriseRequestFactory mockWorldpayMotoAuthoriseRequestFactory;
+    private WorldpayMotoAuthorisePayloadFactory mockWorldpayMotoAuthorisePayloadFactory;
     
     private WorldpayCardAuthoriseRequestFactory worldpayCardAuthoriseRequestFactory;
 
     @BeforeEach
     void setUp() {
-        worldpayCardAuthoriseRequestFactory = new WorldpayCardAuthoriseRequestFactory(mockWorldpayMotoAuthoriseRequestFactory);
+        worldpayCardAuthoriseRequestFactory = new WorldpayCardAuthoriseRequestFactory(mockWorldpayMotoAuthorisePayloadFactory);
     }
 
     @Test
@@ -42,9 +42,9 @@ class WorldpayCardAuthoriseRequestFactoryTest {
                 .withSavePaymentInstrumentToAgreement(false)
                 .build();
 
-        WorldpayMotoAuthorisePayload worldpayMotoAuthorisePayload = aWorldpayMotoAuthoriseRequestFixture().build();
+        WorldpayMotoAuthorisePayload worldpayMotoAuthorisePayload = aWorldpayMotoAuthorisePayloadFixture().build();
 
-        given(mockWorldpayMotoAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest)).willReturn(worldpayMotoAuthorisePayload);
+        given(mockWorldpayMotoAuthorisePayloadFactory.create(cardAuthorisationGatewayRequest)).willReturn(worldpayMotoAuthorisePayload);
 
         Optional<WorldpayCardAuthoriseRequest> result = worldpayCardAuthoriseRequestFactory.create(cardAuthorisationGatewayRequest);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -97,7 +97,7 @@ import static uk.gov.pay.connector.charge.model.domain.Exemption3dsType.CORPORAT
 import static uk.gov.pay.connector.charge.model.domain.Exemption3dsType.OPTIMISED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
-import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
+import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayloadFixture.aWorldpayMotoAuthorisePayloadFixture;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.gateway.util.XMLUnmarshaller.unmarshall;
 import static uk.gov.pay.connector.gateway.worldpay.SendWorldpayExemptionRequest.DO_NOT_SEND_EXEMPTION_REQUEST;
@@ -225,7 +225,7 @@ class WorldpayPaymentProviderTest {
 
     @Test
     void shouldPassWorldpayCardAuthoriseRequestToWorldpayAuthoriseHandler() throws GatewayException {
-        WorldpayCardAuthoriseRequest worldpayCardAuthoriseRequest = aWorldpayMotoAuthoriseRequestFixture().build();
+        WorldpayCardAuthoriseRequest worldpayCardAuthoriseRequest = aWorldpayMotoAuthorisePayloadFixture().build();
 
         @SuppressWarnings("unchecked")
         GatewayResponse<WorldpayOrderStatusResponse> expectedResponse =

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -88,7 +88,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.agreement.model.AgreementEntityFixture.anAgreementEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
+import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayloadFixture.aWorldpayMotoAuthorisePayloadFixture;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse.WORLDPAY_RECURRING_AUTH_TOKEN_PAYMENT_TOKEN_ID_KEY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_CODE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
@@ -506,7 +506,7 @@ class WorldpayPaymentProviderTest {
 
         @SuppressWarnings("unchecked")
         Map<String, String> worldpayCredentials = (Map<String, String>) validCredentials.get(ONE_OFF_CUSTOMER_INITIATED);
-        WorldpayMotoAuthorisePayload worldpayMotoAuthorisePayload = aWorldpayMotoAuthoriseRequestFixture()
+        WorldpayMotoAuthorisePayload worldpayMotoAuthorisePayload = aWorldpayMotoAuthorisePayloadFixture()
                 .withMerchantCode(worldpayCredentials.get(CREDENTIALS_MERCHANT_CODE))
                 .withUsername(worldpayCredentials.get(CREDENTIALS_USERNAME))
                 .withPassword(worldpayCredentials.get(CREDENTIALS_PASSWORD))

--- a/src/test/java/uk/gov/pay/connector/logging/AuthorisationLoggerTest.java
+++ b/src/test/java/uk/gov/pay/connector/logging/AuthorisationLoggerTest.java
@@ -39,8 +39,8 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
-import static uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequestFixture.anAdyenApplePayAuthoriseRequestFixture;
-import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
+import static uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayloadFixture.anAdyenApplePayAuthorisePayloadFixture;
+import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayloadFixture.aWorldpayMotoAuthorisePayloadFixture;
 
 @ExtendWith(MockitoExtension.class)
 class AuthorisationLoggerTest {
@@ -72,9 +72,9 @@ class AuthorisationLoggerTest {
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
-    private final AdyenAuthoriseRequest adyenAuthoriseRequest = anAdyenApplePayAuthoriseRequestFixture().build();
+    private final AdyenAuthoriseRequest adyenAuthoriseRequest = anAdyenApplePayAuthorisePayloadFixture().build();
     
-    private final WorldpayCardAuthoriseRequest worldpayAuthoriseRequest = aWorldpayMotoAuthoriseRequestFixture().build();
+    private final WorldpayCardAuthoriseRequest worldpayAuthoriseRequest = aWorldpayMotoAuthorisePayloadFixture().build();
 
     private final GatewayAccountEntity gatewayAccountEntity = GatewayAccountEntityFixture.aGatewayAccountEntity()
             .withId(123L)

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -130,7 +130,7 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_TIMEOUT_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
-import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthoriseRequestFixture.aWorldpayMotoAuthoriseRequestFixture;
+import static uk.gov.pay.connector.gateway.model.request.records.WorldpayMotoAuthorisePayloadFixture.aWorldpayMotoAuthorisePayloadFixture;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REJECTED;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.utils.WorldpayAuthoriseRequestLogGenerator.GATEWAY_REQUEST_RECORD;
@@ -1362,7 +1362,7 @@ class CardAuthoriseServiceTest extends CardServiceTest {
 
         WorldpayPaymentProvider mockWorldpayPaymentProvider = mock(WorldpayPaymentProvider.class);
 
-        WorldpayCardAuthoriseRequest authoriseRequest = aWorldpayMotoAuthoriseRequestFixture().build();
+        WorldpayCardAuthoriseRequest authoriseRequest = aWorldpayMotoAuthorisePayloadFixture().build();
 
         doReturn(Optional.of(authoriseRequest))
                 .when(mockCardAuthoriseRequestFactory)

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -42,8 +42,8 @@ import uk.gov.pay.connector.gateway.model.ApplePayAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GooglePayAuthoriseRequestFactory;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthoriseRequestFixture;
-import uk.gov.pay.connector.gateway.model.request.records.AdyenGooglePayAuthoriseRequestFixture;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenApplePayAuthorisePayloadFixture;
+import uk.gov.pay.connector.gateway.model.request.records.AdyenGooglePayAuthorisePayloadFixture;
 import uk.gov.pay.connector.gateway.model.request.records.ApplePayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.request.records.GooglePayAuthoriseRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
@@ -290,7 +290,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
     void doAuthoriseCard_applePay_with_AdyenApplePayAuthoriseRequest_shouldRespondAuthorisationSuccess() throws Exception {
         
         ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
-        ApplePayAuthoriseRequest applePayAuthoriseRequest = AdyenApplePayAuthoriseRequestFixture.anAdyenApplePayAuthoriseRequestFixture().build();
+        ApplePayAuthoriseRequest applePayAuthoriseRequest = AdyenApplePayAuthorisePayloadFixture.anAdyenApplePayAuthorisePayloadFixture().build();
 
         charge.setPaymentProvider(ADYEN.getName());
 
@@ -349,7 +349,7 @@ class WalletAuthoriseServiceTest extends CardServiceTest {
     void doAuthoriseCard_googlePay_with_AdyenGooglePayAuthoriseRequest_shouldRespondAuthorisationSuccess() throws Exception {
 
         ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
-        GooglePayAuthoriseRequest googlePayAuthoriseRequest = AdyenGooglePayAuthoriseRequestFixture.anAdyenGooglePayAuthoriseRequestFixture().build();
+        GooglePayAuthoriseRequest googlePayAuthoriseRequest = AdyenGooglePayAuthorisePayloadFixture.anAdyenGooglePayAuthorisePayloadFixture().build();
 
         charge.setPaymentProvider(ADYEN.getName());
 


### PR DESCRIPTION
In a previous commit, we renamed concrete gateway request record types (as opposed to interfaces) so their names ended with `Payload` rather than `Request` (leaving `Request` to indicate an interface implemented by one or more of the `Payload` records). Finish this up by renaming the factories and fixtures to match the `Payload`/`Request` naming consistently.