### PR TITLE
PP-15837 Override toString() on two Adyen authorise payload records

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/AuthoriseRequestPayload.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/AuthoriseRequestPayload.java
@@ -43,4 +43,23 @@ public record AuthoriseRequestPayload(
         @JsonProperty("recurringProcessingModel")
         String recurringProcessingModel
 ) {
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[amount=" + amount +
+                ", merchantAccount=" + merchantAccount +
+                ", paymentMethod=" + paymentMethod +
+                ", reference=" + reference +
+                ", returnUrl=" + returnUrl +
+                ", shopperInteraction=" + shopperInteraction +
+                ", store=" + store +
+                ", channel=" + channel +
+                ", browserInfo=" + browserInfo +
+                ", origin=" + origin +
+                ", shopperReference=" + shopperReference +
+                ", storePaymentMethod=" + storePaymentMethod +
+                ", recurringProcessingModel=" + recurringProcessingModel +
+                ']';
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/PaymentMethod.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/request/json/PaymentMethod.java
@@ -31,4 +31,10 @@ public record PaymentMethod(
     public static PaymentMethod stored(String storedPaymentMethodId) {
         return new PaymentMethod(null, null, null, null, null, "scheme", storedPaymentMethodId);
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[type" + type + ']';
+    }
+
 }


### PR DESCRIPTION
Override `toString()` on `AuthoriseRequestPayload` and `PaymentMethod` to avoid including sensitive information.