### PR TITLE
PP-15504: Restrict outgoing connector connections to TLS v1.3 for Worldpay Capture requests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/ClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/ClientFactory.java
@@ -5,6 +5,8 @@ import com.codahale.metrics.httpclient5.InstrumentedHttpClientConnectionManager;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.util.Duration;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Client;
 import org.apache.hc.client5.http.SystemDefaultDnsResolver;
 import org.apache.hc.client5.http.impl.io.ManagedHttpClientConnectionFactory;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
@@ -19,9 +21,7 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.OperationOverrides;
 import uk.gov.service.payments.logging.RestClientLoggingFilter;
 
-import jakarta.inject.Inject;
 import javax.net.ssl.SSLContext;
-import jakarta.ws.rs.client.Client;
 import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 
@@ -90,10 +90,15 @@ public class ClientFactory {
                                                                 Duration connectionTimeToLive) {
 
         SSLConnectionSocketFactory sslConnectionSocketFactory;
+
+        var supportedProtocals = (operation.equals("capture") && gatewayName.equals("worldpay"))
+                ? new String[]{"TLSv1.3"}
+                : new String[]{"TLSv1.3", "TLSv1.2"};
+
         try {
             sslConnectionSocketFactory = new SSLConnectionSocketFactory(
                     SSLContext.getDefault(),
-                    new String[]{"TLSv1.2", "TLSv1.3"},
+                    supportedProtocals,
                     null,
                     null
             );


### PR DESCRIPTION
## WHAT YOU DID
- Added a conditional to use only TLS v1.3 for capture requests with Worldpay. 
- This is a test to see if moving from using both TLSv1.2 and TLSv1.3 to using only TLS v1.3 works on production. 


## How to test

- I have done a test payment on a Worldpay test account and had no issues.
<img width="775" height="287" alt="image" src="https://github.com/user-attachments/assets/2b203d1d-a54d-4f47-9097-6d1dfde9213c" />
<img width="1280" height="402" alt="image" src="https://github.com/user-attachments/assets/d01b617b-dbf7-4e2c-85ca-58aa3c592568" />

- In the Worldpay documentation it states you should use TLSv1.3
<img width="1280" height="178" alt="image" src="https://github.com/user-attachments/assets/c9898232-3180-4798-ae14-804e3597242f" />

- primary support Dev is aware of this PR and I will monitor Grafana dashbaords for Worldpay

