### PR TITLE
PP-15504: Restrict outgoing connector connections to TLS v1.3

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/RestClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/app/RestClientFactory.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.connector.app;
 
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
 import uk.gov.pay.connector.app.config.RestClientConfig;
 import uk.gov.service.payments.logging.RestClientLoggingFilter;
 
 import javax.net.ssl.SSLContext;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
@@ -14,18 +14,18 @@ import java.util.concurrent.TimeUnit;
 import static java.lang.String.format;
 
 public class RestClientFactory {
-    private static final String TLSV1_2 = "TLSv1.2";
+    private static final String TLSV1_3 = "TLSv1.3";
 
     public static Client buildClient(RestClientConfig clientConfig, Duration connectTimeout) {
         ClientBuilder clientBuilder = ClientBuilder.newBuilder();
 
         if (!clientConfig.isDisabledSecureConnection()) {
             try {
-                SSLContext sslContext = SSLContext.getInstance(TLSV1_2);
+                SSLContext sslContext = SSLContext.getInstance(TLSV1_3);
                 sslContext.init(null, null, null);
                 clientBuilder = clientBuilder.sslContext(sslContext);
             } catch (NoSuchAlgorithmException | KeyManagementException e) {
-                throw new RuntimeException(format("Unable to find an SSL context for %s", TLSV1_2), e);
+                throw new RuntimeException(format("Unable to find an SSL context for %s", TLSV1_3), e);
             }
         }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/ClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/ClientFactory.java
@@ -91,14 +91,10 @@ public class ClientFactory {
 
         SSLConnectionSocketFactory sslConnectionSocketFactory;
 
-        var supportedProtocals = (operation.equals("capture") && gatewayName.equals("worldpay"))
-                ? new String[]{"TLSv1.3"}
-                : new String[]{"TLSv1.3", "TLSv1.2"};
-
         try {
             sslConnectionSocketFactory = new SSLConnectionSocketFactory(
                     SSLContext.getDefault(),
-                    supportedProtocals,
+                    new String[]{"TLSv1.3"},
                     null,
                     null
             );
@@ -106,7 +102,7 @@ public class ClientFactory {
             throw new RuntimeException("Unable to create SSL connection socket factory", e);
         }
 
-       return InstrumentedHttpClientConnectionManager.builder(metricRegistry)
+        return InstrumentedHttpClientConnectionManager.builder(metricRegistry)
                 .socketFactoryRegistry(RegistryBuilder.<ConnectionSocketFactory>create()
                         .register("http", PlainConnectionSocketFactory.getSocketFactory())
                         .register("https", sslConnectionSocketFactory)

--- a/src/test/java/uk/gov/pay/connector/app/RestClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/app/RestClientFactoryTest.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.connector.app;
 
 
+import jakarta.ws.rs.client.Client;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.app.config.RestClientConfig;
 
 import javax.net.ssl.SSLContext;
-import jakarta.ws.rs.client.Client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -26,7 +26,8 @@ class RestClientFactoryTest {
 
         //then
         SSLContext sslContext = client.getSslContext();
-        assertThat(sslContext.getProtocol(), is("TLSv1.2"));
+        assertThat(sslContext.getProtocol(), is("TLSv1.3"));
+
 
     }
 
@@ -40,6 +41,6 @@ class RestClientFactoryTest {
         Client client = RestClientFactory.buildClient(clientConfiguration, null);
 
         //then
-        assertThat(client.getSslContext().getProtocol(), is(not("TLSv1.2")));
+        assertThat(client.getSslContext().getProtocol(), is(not("TLSv1.3")));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Removed conditional for restricting outgoing connector connections to TLS v1.3 only for Worldpay capture, now it is TLS v1.3 for all connections.

## How to test

- Successful captures were made after this PR for testing outgoing connector connections to TLS v1.3 only for Worldpay capture was merged.
- I will keep an eye on grafana dashboards for Connector to monitor connections once this PR is merged.

