### PR TITLE
PP-15789: Add Adyen config util method to return HMAC key by webhook type

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtil.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.adyen.utils;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
 import uk.gov.pay.connector.app.adyen.HmacKeys;
 import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenWebhookType;
 
 public class AdyenConfigUtil {
 
@@ -50,5 +51,14 @@ public class AdyenConfigUtil {
 
         return webhookHmacKeys.getPrimary()
                 .orElseThrow(() -> new IllegalStateException("Missing primary Adyen HMAC key"));
+    }
+
+    public static String getHmacKeyForWebhookType(AdyenGatewayConfig adyenGatewayConfig,
+                                                  AdyenWebhookType webhookType,
+                                                  boolean live) {
+        return switch (webhookType) {
+            case PAYMENTS -> getHmacKey(adyenGatewayConfig, live);
+            case TOKENS -> getTokenHmacKey(adyenGatewayConfig, live);
+        };
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenWebhookType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenWebhookType.java
@@ -1,0 +1,6 @@
+package uk.gov.pay.connector.gateway.adyen.webhook;
+
+public enum AdyenWebhookType {
+    PAYMENTS,
+    TOKENS
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/utils/AdyenConfigUtilTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
@@ -11,6 +13,7 @@ import uk.gov.pay.connector.app.adyen.ApiKeys;
 import uk.gov.pay.connector.app.adyen.BaseUrls;
 import uk.gov.pay.connector.app.adyen.HmacKeys;
 import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenWebhookType;
 
 import java.util.Optional;
 
@@ -20,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getHmacKeyForWebhookType;
+import static uk.gov.pay.connector.gateway.adyen.webhook.AdyenWebhookType.TOKENS;
 
 @ExtendWith(MockitoExtension.class)
 class AdyenConfigUtilTest {
@@ -143,6 +148,23 @@ class AdyenConfigUtilTest {
 
             assertThat(exception.getMessage(), is("Missing primary Adyen HMAC key"));
         }
+        
+        @ParameterizedTest
+        @EnumSource(AdyenWebhookType.class)
+        void shouldGetHMACKeyBasedOnType(AdyenWebhookType adyenWebhookType) {
+            var expectedValue = "live-hmac-key";
+            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(mockHmacKeys);
+            var mockHmacKey =  adyenWebhookType == TOKENS ? mockHmacKeys.tokens() : mockHmacKeys.payments();
+            when(mockHmacKey).thenReturn(mockKeyPair);
+            when(mockKeyPair.live()).thenReturn(mockLiveKeys);
+            when(mockLiveKeys.getPrimary()).thenReturn(Optional.of(expectedValue));
+            var hmacKey = getHmacKeyForWebhookType(mockAdyenGatewayConfig, adyenWebhookType, true);
+
+            assertThat(hmacKey, is(expectedValue));
+
+            verify(mockKeyPair).live();
+        }
+        
     }
     
     @Nested
@@ -188,6 +210,5 @@ class AdyenConfigUtilTest {
             verify(mockKeyPair).test();
             verify(mockKeyPair, never()).live();
         }
-        
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Added a method to return HMAC key by webhook type which is currently either `TOKEN` or `PAYMENTS`.

## How to test

- I checked all existing tests still pass and code coverage for Adyen util class is 100%