### PR TITLE
PP-15856 Revert Adyen specific changes when creating payment instruments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -877,7 +877,9 @@ public class ChargeService {
             }
             charge.setCardDetails(detailsEntity);
 
-            checkToSavePaymentInstrument(recurringAuthToken, charge, newStatus);
+            if (charge.isSavePaymentInstrumentToAgreement()) {
+                Optional.ofNullable(recurringAuthToken).ifPresent(token -> setPaymentInstrument(token, charge));
+            }
 
             if (newStatus == AUTHORISATION_SUCCESS || newStatus == AUTHORISATION_REJECTED) {
                 if (!Boolean.TRUE.equals(charge.getRequires3ds())) {
@@ -920,7 +922,9 @@ public class ChargeService {
                 Optional.ofNullable(auth3dsRequiredDetails).ifPresent(charge::set3dsRequiredDetails);
                 Optional.ofNullable(sessionIdentifier).map(ProviderSessionIdentifier::toString).ifPresent(charge::setProviderSessionId);
 
-                checkToSavePaymentInstrument(recurringAuthToken, charge, newStatus);
+                if (charge.isSavePaymentInstrumentToAgreement()) {
+                    Optional.ofNullable(recurringAuthToken).ifPresent(token -> setPaymentInstrument(token, charge));
+                }
 
                 Optional.ofNullable(gatewayRejectionReason).ifPresent(charge::setGatewayRejectionReason);
             } catch (InvalidStateTransitionException e) {
@@ -1404,19 +1408,6 @@ public class ChargeService {
         return uriInfo.getBaseUriBuilder()
                 .path(path)
                 .build(chargeId);
-    }
-
-
-    private void checkToSavePaymentInstrument(Map<String, String> recurringAuthToken, ChargeEntity charge, ChargeStatus newStatus) {
-        if (charge.isSavePaymentInstrumentToAgreement()) {
-            Optional.ofNullable(recurringAuthToken)
-                    .ifPresentOrElse(
-                            token -> setPaymentInstrument(token, charge),
-                            () -> Optional.ofNullable(charge.getPaymentProvider())
-                                    .filter(ADYEN.getName()::equals)
-                                    .ifPresent(provider -> setPaymentInstrument(Map.of(), charge))
-                    );
-        }
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
@@ -90,6 +90,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
     }
 
     @Test
+    @Disabled
     void successful_creation_of_payment_instrument_without_recurring_auth_token() {
         var chargeId = createChargeWithAgreement(ENTERING_CARD_DETAILS);
         app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(PSP_REFERENCE_FROM_ADYEN);
@@ -125,6 +126,7 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
     }
 
     @Test
+    @Disabled
     void successful_creation_of_payment_instrument_for_3ds_without_recurring_auth_token() {
         var chargeId = createChargeWithAgreement(AUTHORISATION_3DS_REQUIRED);
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeCardResourceAuthoriseIT.java
@@ -238,6 +238,41 @@ public class StripeCardResourceAuthoriseIT {
     }
 
     @Test
+    void authoriseChargeRequest3DSToSetUpRecurringPaymentAgreement() throws Exception {
+        app.getStripeMockClient().mockCreatePaymentMethod();
+        app.getStripeMockClient().mockCreateCustomer();
+        app.getStripeMockClient().mockCreatePaymentIntentRequiring3DSWithCustomer();
+        addGatewayAccountWith3DS2Enabled();
+
+        String agreementId = addAgreement();
+        String externalChargeId = addChargeWithAgreement(ENTERING_CARD_DETAILS, agreementId);
+
+        ValidatableResponse validatableResponse = given().port(app.getLocalPort())
+                .contentType(JSON)
+                .body(validAuthorisationDetails)
+                .post(testBaseExtension.authoriseChargeUrlFor(externalChargeId))
+                .then();
+
+        validatableResponse
+                .statusCode(OK_200)
+                .body("status", is(AUTHORISATION_3DS_REQUIRED.toString()));
+
+        app.getStripeWireMockServer().verify(postRequestedFor(urlEqualTo("/v1/payment_methods"))
+                .withHeader("Content-Type", equalTo(APPLICATION_FORM_URLENCODED)));
+
+        verifyPaymentMethodRequest();
+        verifyCustomerRequest();
+        verifyPaymentIntentRequest(externalChargeId, stripeAccountId);
+
+        Map<String, Object> paymentInstrument = databaseTestHelper.getPaymentInstrumentByChargeExternalId(externalChargeId.toString());
+        Map<String, String> recurringAuthTokenMap = mapper.readValue(paymentInstrument.get("recurring_auth_token").toString(), new TypeReference<Map<String, String>>() {
+        });
+
+        assertThat(recurringAuthTokenMap, hasKey(STRIPE_RECURRING_AUTH_TOKEN_CUSTOMER_ID_KEY));
+        assertThat(recurringAuthTokenMap, hasKey(STRIPE_RECURRING_AUTH_TOKEN_PAYMENT_METHOD_ID_KEY));
+    }
+
+    @Test
     void shouldRespondAs3dsRequired_whenAuthorisationRequires3ds() {
         addGatewayAccount();
         app.getStripeMockClient().mockCreatePaymentMethod();

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -29,6 +29,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMEN
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE_WITH_CUSTOMER;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CUSTOMER;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE;
@@ -144,6 +145,11 @@ public class StripeMockClient {
         setupResponse(payload, "/v1/payment_intents", 200);
     }
 
+    public void mockCreatePaymentIntentRequiring3DSWithCustomer() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE_WITH_CUSTOMER);
+        setupResponse(payload, "/v1/payment_intents", 200);
+    }
+    
     public void mockCreatePaymentMethod() {
         String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE);
         setupResponse(payload, "/v1/payment_methods", 200);

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -108,6 +108,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CHARGE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response_with_charge.json";
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE_WITH_CUSTOMER = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response_with_customer.json";
     public static final String STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_requires_3ds_response.json";
+    public static final String STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE_WITH_CUSTOMER = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_requires_3ds_response_with_customer.json";
     public static final String STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_authorisation_rejected_response.json";
     public static final String STRIPE_PAYMENT_INTENT_AUTHORISATION_REJECTED_NO_RETRY_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_authorisation_rejected_no_retry_response.json";
     public static final String STRIPE_PAYMENT_INTENT_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_error_response.json";

--- a/src/test/resources/templates/stripe/create_payment_intent_requires_3ds_response_with_customer.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_requires_3ds_response_with_customer.json
@@ -1,0 +1,63 @@
+{
+  "id": "pi_123",
+  "object": "payment_intent",
+  "amount": 1000,
+  "amount_capturable": 0,
+  "amount_received": 0,
+  "application": null,
+  "application_fee_amount": null,
+  "canceled_at": null,
+  "cancellation_reason": null,
+  "capture_method": "manual",
+  "charges": {
+    "object": "list",
+    "data": [
+    ],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/charges?payment_intent=pi_123"
+  },
+  "confirmation_method": "automatic",
+  "created": 1568141588,
+  "currency": "gbp",
+  "customer": "cus_4QFOF3xrvBT3nU",
+  "description": null,
+  "invoice": null,
+  "last_payment_error": null,
+  "livemode": false,
+  "metadata": {
+  },
+  "next_action": {
+    "redirect_to_url": {
+      "return_url": "http://localhost:9000/card_details/charge_id/3ds_required_in",
+      "url": "https://hooks.stripe.com/3d_secure_2/hosted?payment_intent=payment_intent_id&payment_intent_client_secret=fssfbbd"
+    },
+    "type": "redirect_to_url"
+  },
+  "on_behalf_of": "acct_123",
+  "payment_method": {
+    "id": "pm_123",
+    "card": {
+      "exp_month": 8,
+      "exp_year": 2024
+    }
+  },
+  "payment_method_options": {
+    "card": {
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "receipt_email": null,
+  "review": null,
+  "setup_future_usage": null,
+  "shipping": null,
+  "source": null,
+  "statement_descriptor": null,
+  "statement_descriptor_suffix": null,
+  "status": "requires_action",
+  "transfer_data": null,
+  "transfer_group": "tgroup"
+}


### PR DESCRIPTION
## WHAT YOU DID
- Reverted Adyen specific changes introduced to create payment instruments with an empty token and disabled relevant tests. Adyen-specific logic can be in payment provider code and will be addressed separately.
- Added a missing Stripe test setting up an agreement that requires 3DS. This is a real-world scenario
