### PR TITLE
PP-15789: create AdyenWebhookNotificationParser to take raw json adyen notification and derive the notification's event type, environment etc.

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenWebhookNotificationParser.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenWebhookNotificationParser.java
@@ -1,6 +1,9 @@
 package uk.gov.pay.connector.gateway.adyen.webhook;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment;
@@ -13,10 +16,21 @@ import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment.
 import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment.TEST;
 
 public class AdyenWebhookNotificationParser {
-
+    private final ObjectMapper objectMapper;
     private static final Logger LOGGER = LoggerFactory.getLogger(AdyenWebhookNotificationParser.class);
 
-    public AdyenWebhookNotification parse(JsonNode root) {
+    @Inject
+    public AdyenWebhookNotificationParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public AdyenWebhookNotification parse(String rawPayload) {
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(rawPayload);
+        } catch (JsonProcessingException _) {
+            throw new UnparseableAdyenWebhookException("Failed to parse Adyen notification from raw payload");
+        }
         if (root.has("notificationItems")) {
             return processNotificationItem(root);
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenWebhookNotificationParser.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenWebhookNotificationParser.java
@@ -1,0 +1,79 @@
+package uk.gov.pay.connector.gateway.adyen.webhook;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment;
+import uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookEvent;
+import uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookNotification;
+
+import java.util.Optional;
+
+import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment.LIVE;
+import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment.TEST;
+
+public class AdyenWebhookNotificationParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdyenWebhookNotificationParser.class);
+
+    public AdyenWebhookNotification parse(JsonNode root) {
+        if (root.has("notificationItems")) {
+            return processNotificationItem(root);
+        }
+        if (root.has("type")) {
+            return processNotificationByType(root);
+        }
+        throw new UnparseableAdyenWebhookException("No recognised field in the payload to process Adyen notification");
+    }
+
+    private AdyenWebhookNotification processNotificationItem(JsonNode root) {
+        String eventCode = root
+                .path("notificationItems").path(0)
+                .path("NotificationRequestItem")
+                .path("eventCode").asText();
+
+        AdyenWebhookEvent adyenWebhookEvent = deriveWebhookEvent(eventCode);
+        AdyenEnvironment environment = deriveAdyenEnvironmentFromNotificationItem(root);
+        return new AdyenWebhookNotification(adyenWebhookEvent, environment, true);
+    }
+
+    private AdyenWebhookNotification processNotificationByType(JsonNode root) {
+        String typeField = root.get("type").asText();
+        AdyenWebhookEvent adyenWebhookEvent = deriveWebhookEvent(typeField);
+        AdyenEnvironment environment = deriveAdyenEnvironment(root);
+        return new AdyenWebhookNotification(adyenWebhookEvent, environment, false);
+    }
+
+    private AdyenWebhookEvent deriveWebhookEvent(String eventCodeOrType) {
+        Optional<AdyenWebhookEvent> adyenWebhookEvent = AdyenWebhookEvent.fromEventCodeOrType(eventCodeOrType);
+
+        if (adyenWebhookEvent.isPresent()) {
+            return adyenWebhookEvent.get();
+        } else {
+            LOGGER.atWarn()
+                    .setMessage("Unrecognised Adyen eventCode or type")
+                    .addKeyValue("eventCodeOrType", eventCodeOrType)
+                    .log();
+            throw new UnparseableAdyenWebhookException("Unrecognised eventCode or type: " + eventCodeOrType);
+        }
+    }
+
+    private AdyenEnvironment deriveAdyenEnvironmentFromNotificationItem(JsonNode root) {
+        String live = root.path("live").asText();
+        return switch (live) {
+            case "true" -> LIVE;
+            case "false" -> TEST;
+            default -> throw new UnparseableAdyenWebhookException("Unrecognised 'live' field value: " + live);
+        };
+    }
+
+    private AdyenEnvironment deriveAdyenEnvironment(JsonNode root) {
+        var environment = root.path("environment").asText();
+        return switch (environment) {
+            case "live" -> LIVE;
+            case "test" -> TEST;
+            default ->
+                    throw new UnparseableAdyenWebhookException("Unrecognised 'environment' field value: " + environment);
+        };
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/UnparseableAdyenWebhookException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/UnparseableAdyenWebhookException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.connector.gateway.adyen.webhook;
+
+public class UnparseableAdyenWebhookException extends RuntimeException {
+    public UnparseableAdyenWebhookException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/model/AdyenEnvironment.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/model/AdyenEnvironment.java
@@ -1,0 +1,6 @@
+package uk.gov.pay.connector.gateway.adyen.webhook.model;
+
+public enum AdyenEnvironment {
+    LIVE,
+    TEST
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/model/AdyenWebhookNotification.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/model/AdyenWebhookNotification.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.gateway.adyen.webhook.model;
+
+import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment.LIVE;
+
+public record AdyenWebhookNotification(
+        AdyenWebhookEvent event,
+        AdyenEnvironment environment,
+        boolean usesAdyenNotificationItem
+) {
+    
+    public boolean isLive() {
+        return LIVE.equals(environment);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenWebhookNotificationParserTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenWebhookNotificationParserTest.java
@@ -1,0 +1,117 @@
+package uk.gov.pay.connector.gateway.adyen.webhook;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment;
+import uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookNotification;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment.TEST;
+import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookEvent.AUTHORISATION;
+import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookType.PAYMENTS;
+import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookType.TOKENS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_NOTIFICATION;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION;
+
+class AdyenWebhookNotificationParserTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+    AdyenWebhookNotificationParser adyenWebhookNotificationParser = new AdyenWebhookNotificationParser();
+
+    private JsonNode paymentsNotification;
+
+    private JsonNode tokenNotification;
+
+    @BeforeEach
+    void setUp() throws JsonProcessingException {
+        paymentsNotification = mapper.readTree(TestTemplateResourceLoader
+                .load(ADYEN_NOTIFICATION)
+                .replace("{{live}}", "false"));
+        tokenNotification = mapper.readTree(TestTemplateResourceLoader
+                .load(ADYEN_TOKEN_NOTIFICATION)
+                .replace("{{environment}}", "test"));
+    }
+
+    @Test
+    void shouldProcessAdyenPaymentsNotificationBasedOnJsonRootStructure() {
+        AdyenWebhookNotification result = adyenWebhookNotificationParser.parse(paymentsNotification);
+
+        Assertions.assertTrue(result.usesAdyenNotificationItem());
+        Assertions.assertFalse(result.isLive());
+        assertThat(result.environment(), is(TEST));
+        assertThat(result.event().getWebhookType(), is(PAYMENTS));
+        assertThat(result.usesAdyenNotificationItem(), is(true));
+        assertThat(result.event().getEventCodeOrType(), is(AUTHORISATION.name()));
+    }
+
+    @Test
+    void shouldProcessAdyenTokenNotificationBasedOnJsonRootStructure() {
+        AdyenWebhookNotification result = adyenWebhookNotificationParser.parse(tokenNotification);
+
+        Assertions.assertFalse(result.usesAdyenNotificationItem());
+        Assertions.assertFalse(result.isLive());
+        assertThat(result.environment(), is(TEST));
+        assertThat(result.event().getWebhookType(), is(TOKENS));
+        assertThat(result.usesAdyenNotificationItem(), is(false));
+        assertThat(result.event().getEventCodeOrType(), is("recurring.token.created"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUnrecognisedJsonRootStructure() throws JsonProcessingException {
+        var badJsonData = mapper.writeValueAsString("badData:badData");
+        var notification = mapper.readTree(badJsonData);
+
+        var exception = assertThrows(UnparseableAdyenWebhookException.class,
+                () -> adyenWebhookNotificationParser.parse(notification));
+
+        assertThat(exception.getMessage(), is("No recognised field in the payload to process Adyen notification"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAdyenWebhookEventIsMissingOrUnrecognised() throws JsonProcessingException {
+        var notification = createNotification("AUTHORISATION", "notValid", "payments");
+
+        var exception = assertThrows(UnparseableAdyenWebhookException.class,
+                () -> adyenWebhookNotificationParser.parse(notification));
+
+        assertThat(exception.getMessage(), is("Unrecognised eventCode or type: " + "notValid"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"{{live}}, true, payments, LIVE",
+            "{{live}}, false, payments, TEST",
+            "{{environment}}, test, token, TEST",
+            "{{environment}}, live, token, LIVE"})
+    void shouldDeriveEnvironmentFromJsonRoot(String environment, String value, String webhookType, AdyenEnvironment expected) throws JsonProcessingException {
+        var notification = createNotification(environment, value, webhookType);
+
+        var result = adyenWebhookNotificationParser.parse(notification);
+
+        assertThat(result.environment(), is(expected));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"{{live}}, invalid, payments", "{{environment}}, invalid, token"})
+    void shouldThrowExceptionWhenEnvironmentCannotBeDerivedFromRoot(String environment, String value, String webhookType) throws JsonProcessingException {
+        var notification = createNotification(environment, value, webhookType);
+
+        var exception = assertThrows(UnparseableAdyenWebhookException.class, () -> adyenWebhookNotificationParser.parse(notification));
+        var fieldName = webhookType.equals("payments") ? "live" : "environment";
+
+        assertThat(exception.getMessage(), is("Unrecognised '" + fieldName + "' field value: " + value));
+    }
+
+    private JsonNode createNotification(String oldValue, String replacementValue, String webhookType) throws JsonProcessingException {
+        return mapper.readTree(TestTemplateResourceLoader
+                .load(webhookType.equals("payments") ? ADYEN_NOTIFICATION : ADYEN_TOKEN_NOTIFICATION)
+                .replace(oldValue, replacementValue));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenWebhookNotificationParserTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenWebhookNotificationParserTest.java
@@ -1,20 +1,22 @@
 package uk.gov.pay.connector.gateway.adyen.webhook;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment;
 import uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookNotification;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment.TEST;
 import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookEvent.AUTHORISATION;
 import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookType.PAYMENTS;
@@ -24,50 +26,57 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_TOKEN_N
 
 class AdyenWebhookNotificationParserTest {
     private final ObjectMapper mapper = new ObjectMapper();
-    AdyenWebhookNotificationParser adyenWebhookNotificationParser = new AdyenWebhookNotificationParser();
+    AdyenWebhookNotificationParser adyenWebhookNotificationParser = new AdyenWebhookNotificationParser(mapper);
 
-    private JsonNode paymentsNotification;
+    private String paymentsNotification;
 
-    private JsonNode tokenNotification;
+    private String tokenNotification;
 
     @BeforeEach
-    void setUp() throws JsonProcessingException {
-        paymentsNotification = mapper.readTree(TestTemplateResourceLoader
+    void setUp() {
+        paymentsNotification = TestTemplateResourceLoader
                 .load(ADYEN_NOTIFICATION)
-                .replace("{{live}}", "false"));
-        tokenNotification = mapper.readTree(TestTemplateResourceLoader
+                .replace("{{live}}", "false");
+        tokenNotification = TestTemplateResourceLoader
                 .load(ADYEN_TOKEN_NOTIFICATION)
-                .replace("{{environment}}", "test"));
+                .replace("{{environment}}", "test");
     }
 
     @Test
-    void shouldProcessAdyenPaymentsNotificationBasedOnJsonRootStructure() {
+    void shouldProcessAdyenPaymentsNotificationWhenPayloadHasNotificationItemsStructure() {
         AdyenWebhookNotification result = adyenWebhookNotificationParser.parse(paymentsNotification);
 
-        Assertions.assertTrue(result.usesAdyenNotificationItem());
-        Assertions.assertFalse(result.isLive());
+        assertTrue(result.usesAdyenNotificationItem());
+        assertFalse(result.isLive());
         assertThat(result.environment(), is(TEST));
         assertThat(result.event().getWebhookType(), is(PAYMENTS));
-        assertThat(result.usesAdyenNotificationItem(), is(true));
         assertThat(result.event().getEventCodeOrType(), is(AUTHORISATION.name()));
     }
 
     @Test
-    void shouldProcessAdyenTokenNotificationBasedOnJsonRootStructure() {
+    void shouldProcessAdyenNotificationWhenPayloadHasEventDataStructure() {
         AdyenWebhookNotification result = adyenWebhookNotificationParser.parse(tokenNotification);
 
-        Assertions.assertFalse(result.usesAdyenNotificationItem());
-        Assertions.assertFalse(result.isLive());
+        assertFalse(result.usesAdyenNotificationItem());
+        assertFalse(result.isLive());
         assertThat(result.environment(), is(TEST));
         assertThat(result.event().getWebhookType(), is(TOKENS));
-        assertThat(result.usesAdyenNotificationItem(), is(false));
         assertThat(result.event().getEventCodeOrType(), is("recurring.token.created"));
     }
 
     @Test
-    void shouldThrowExceptionWhenUnrecognisedJsonRootStructure() throws JsonProcessingException {
-        var badJsonData = mapper.writeValueAsString("badData:badData");
-        var notification = mapper.readTree(badJsonData);
+    void shouldThrowExceptionForUnparseableJsonPayload() {
+        var notification = ",,,,";
+
+        var exception = assertThrows(UnparseableAdyenWebhookException.class,
+                () -> adyenWebhookNotificationParser.parse(notification));
+
+        assertThat(exception.getMessage(), is("Failed to parse Adyen notification from raw payload"));
+    }
+
+    @Test
+    void shouldThrowExceptionForUnrecognisedPayload() throws JsonProcessingException {
+        var notification = mapper.writeValueAsString("badData:badData");
 
         var exception = assertThrows(UnparseableAdyenWebhookException.class,
                 () -> adyenWebhookNotificationParser.parse(notification));
@@ -76,7 +85,7 @@ class AdyenWebhookNotificationParserTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenAdyenWebhookEventIsMissingOrUnrecognised() throws JsonProcessingException {
+    void shouldThrowExceptionWhenEventCodeInAdyenNotificationRequestItemIsUnknown() {
         var notification = createNotification("AUTHORISATION", "notValid", "payments");
 
         var exception = assertThrows(UnparseableAdyenWebhookException.class,
@@ -90,7 +99,7 @@ class AdyenWebhookNotificationParserTest {
             "{{live}}, false, payments, TEST",
             "{{environment}}, test, token, TEST",
             "{{environment}}, live, token, LIVE"})
-    void shouldDeriveEnvironmentFromJsonRoot(String environment, String value, String webhookType, AdyenEnvironment expected) throws JsonProcessingException {
+    void shouldDeriveEnvironmentFromForDifferentPayloadStructures(String environment, String value, String webhookType, AdyenEnvironment expected) {
         var notification = createNotification(environment, value, webhookType);
 
         var result = adyenWebhookNotificationParser.parse(notification);
@@ -99,19 +108,42 @@ class AdyenWebhookNotificationParserTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"{{live}}, invalid, payments", "{{environment}}, invalid, token"})
-    void shouldThrowExceptionWhenEnvironmentCannotBeDerivedFromRoot(String environment, String value, String webhookType) throws JsonProcessingException {
-        var notification = createNotification(environment, value, webhookType);
+    @EmptySource
+    @ValueSource(strings = {"invalid", "TEST"})
+    void shouldThrowExceptionWhenEnvironmentCannotBeDerivedFromEventPayload(String value) {
+        var notification = createNotification("{{environment}}", value, "token");
 
         var exception = assertThrows(UnparseableAdyenWebhookException.class, () -> adyenWebhookNotificationParser.parse(notification));
-        var fieldName = webhookType.equals("payments") ? "live" : "environment";
 
-        assertThat(exception.getMessage(), is("Unrecognised '" + fieldName + "' field value: " + value));
+        assertThat(exception.getMessage(), is("Unrecognised 'environment' field value: " + value));
     }
 
-    private JsonNode createNotification(String oldValue, String replacementValue, String webhookType) throws JsonProcessingException {
-        return mapper.readTree(TestTemplateResourceLoader
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"invalid", "TEST"})
+    void shouldThrowExceptionWhenEnvironmentCannotBeDerivedFromNotificationRequestStructure(String value) {
+        var notification = createNotification("{{live}}", value, "payments");
+
+        var exception = assertThrows(UnparseableAdyenWebhookException.class, () -> adyenWebhookNotificationParser.parse(notification));
+
+        assertThat(exception.getMessage(), is("Unrecognised 'live' field value: " + value));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"live", "environment"})
+    void shouldThrowExceptionWhenEnvironmentFieldIsNotPresentOnEventPayload(String filedName) {
+        var environmentField = filedName.equals("live") ? "\"live\": \"{{live}}\"," : " \"environment\": \"{{environment}}\",";
+        var notification = TestTemplateResourceLoader
+                .load(filedName.equals("live") ? ADYEN_NOTIFICATION : ADYEN_TOKEN_NOTIFICATION).replace(environmentField, "");
+
+        var exception = assertThrows(UnparseableAdyenWebhookException.class, () -> adyenWebhookNotificationParser.parse(notification));
+
+        assertThat(exception.getMessage(), is("Unrecognised '" + filedName + "' field value: "));
+    }
+
+    private String createNotification(String oldValue, String replacementValue, String webhookType) {
+        return TestTemplateResourceLoader
                 .load(webhookType.equals("payments") ? ADYEN_NOTIFICATION : ADYEN_TOKEN_NOTIFICATION)
-                .replace(oldValue, replacementValue));
+                .replace(oldValue, replacementValue);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenNotificationResourceIT.java
@@ -109,7 +109,7 @@ public class AdyenNotificationResourceIT {
 
         @Test
         void shouldHandleRecurringTokenNotification() {
-            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION);
+            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION).replace("{{environment}}", "test");
 
             given()
                     .port(app.getLocalPort())
@@ -124,7 +124,7 @@ public class AdyenNotificationResourceIT {
 
         @Test
         void shouldRejectNotificationWithInvalidHmacSignatureForRecurringTokenNotification() {
-            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION);
+            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION).replace("{{environment}}", "test");
 
             given()
                     .port(app.getLocalPort())

--- a/src/test/resources/templates/adyen/notification.json
+++ b/src/test/resources/templates/adyen/notification.json
@@ -1,5 +1,5 @@
 {
-  "live": "false",
+  "live": "{{live}}",
   "notificationItems": [
     {
       "NotificationRequestItem": {

--- a/src/test/resources/templates/adyen/token-notification.json
+++ b/src/test/resources/templates/adyen/token-notification.json
@@ -1,6 +1,6 @@
 {
   "createdAt": "2026-07-14T18:10:49+01:00",
-  "environment": "test",
+  "environment": "{{environment}}",
   "type": "recurring.token.created",
   "data": {
     "merchantAccount": "YOUR_MERCHANT_ACCOUNT",


### PR DESCRIPTION
## WHAT YOU DID

-  created AdyenWebhookNotificationParser to take a raw json root node of any Adyen notification to determine the` webhookEvent` type, `environment` and whether or not it uses `adyenNotificationItem` (if the notification has `adyenNotificationItems` it will have to be deserialised differently to notifications without)
- added models needed 
- updated notification json templates to make it easer to replace environments for testing


## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

