### PR TITLE
PP-15789: Refactor AdyenNotificationService to delegate deserialisation and webhook type sorting logic to helper classes

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationService.java
@@ -1,43 +1,32 @@
 package uk.gov.pay.connector.gateway.adyen.webhook;
 
-import com.adyen.model.notification.NotificationRequest;
-import com.adyen.model.notification.NotificationRequestItem;
-import com.adyen.notification.WebhookHandler;
 import com.google.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
-import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
+import uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookNotification;
 import uk.gov.pay.connector.gateway.exception.AdyenNotificationException;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.queue.tasks.TaskType;
 import uk.gov.pay.connector.queue.tasks.model.Task;
-import uk.gov.pay.connector.util.JsonObjectMapper;
 
-import java.util.List;
-
-import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.ADYEN;
-import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getHmacKey;
-import static uk.gov.pay.connector.gateway.adyen.utils.AdyenConfigUtil.getTokenHmacKey;
+import static uk.gov.pay.connector.queue.tasks.TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION;
+import static uk.gov.pay.connector.queue.tasks.TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION;
 import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER;
 
 public class AdyenNotificationService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AdyenNotificationService.class);
-
-    private final AdyenGatewayConfig adyenGatewayConfig;
     private final TaskQueueService taskQueueService;
     private final AdyenNotificationValidator adyenNotificationValidator;
-    private final JsonObjectMapper jsonObjectMapper;
+    private final AdyenWebhookNotificationParser adyenWebhookNotificationParser;
 
     @Inject
-    public AdyenNotificationService(AdyenGatewayConfig adyenGatewayConfig, TaskQueueService taskQueueService, AdyenNotificationValidator adyenNotificationValidator, JsonObjectMapper jsonObjectMapper) {
-        this.adyenGatewayConfig = adyenGatewayConfig;
+    public AdyenNotificationService(TaskQueueService taskQueueService, AdyenNotificationValidator adyenNotificationValidator, AdyenWebhookNotificationParser adyenWebhookNotificationParser) {
         this.taskQueueService = taskQueueService;
         this.adyenNotificationValidator = adyenNotificationValidator;
-        this.jsonObjectMapper = jsonObjectMapper;
+        this.adyenWebhookNotificationParser = adyenWebhookNotificationParser;
     }
 
     public boolean handleNotificationFor(String payload, String forwardedIpAddresses, String hmacSignature) {
@@ -45,119 +34,53 @@ public class AdyenNotificationService {
             return false;
         }
         try {
-            var notificationProcessed = hmacSignature == null ? handlePaymentNotifications(payload) : handleTokenNotifications(payload,
-                    hmacSignature);
+            AdyenWebhookNotification adyenWebhookNotification = adyenWebhookNotificationParser.parse(payload);
 
-            if (notificationProcessed) {
-                LOGGER.info("Processed Adyen notification", kv(PROVIDER, ADYEN.getName()),
-                        kv("notification_source", forwardedIpAddresses));
+            if (adyenWebhookNotification.event().isIgnored()) {
+                LOGGER.atInfo()
+                        .setMessage("Adyen webhook notification has been ignored")
+                        .addKeyValue("event", adyenWebhookNotification.event().name())
+                        .addKeyValue("eventCodeOrType", adyenWebhookNotification.event().getEventCodeOrType())
+                        .addKeyValue("environment", adyenWebhookNotification.environment())
+                        .log();
+                return false;
             }
 
-            return notificationProcessed;
+            boolean validHmacSignature = adyenNotificationValidator.validateHmacSignature(adyenWebhookNotification, payload, hmacSignature);
+
+            if (!validHmacSignature) {
+                return false;
+            }
+            addNotificationToTaskQueue(adyenWebhookNotification, payload);
+
+            LOGGER.atInfo()
+                    .setMessage("Processed Adyen notification")
+                    .addKeyValue(PROVIDER, ADYEN.getName())
+                    .addKeyValue("event", adyenWebhookNotification.event().getEventCodeOrType())
+                    .addKeyValue("notification_source", forwardedIpAddresses)
+                    .log();
+
+            return true;
         } catch (AdyenNotificationException e) {
-            logValidationFailure(e);
+            LOGGER.error("Failed to validate Adyen notification payload", e);
             return false;
         }
     }
 
-    private boolean handlePaymentNotifications(String payload) {
-
-        NotificationRequest notificationRequest = deserialisePayloadToNotificationRequest(payload);
-        List<NotificationRequestItem> items = extractNotificationItems(notificationRequest);
-
-        boolean live = "true".equalsIgnoreCase(notificationRequest.getLive());
-
-        String hmacKey = getHmacKey(adyenGatewayConfig, live);
-
-        for (NotificationRequestItem item : items) {
-            if (!adyenNotificationValidator.isValidHmac(item, hmacKey)) {
-                return false;
-            }
-
-            if (!AdyenPaymentEvent.contains(item.getEventCode())) {
-                return false;
-            }
-            addNotificationToTaskQueue(payload, TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION);
-        }
-        return true;
-    }
-
-    private boolean handleTokenNotifications(String payload, String hmacSignature) {
-
-        if (hmacSignature.isBlank()) {
-            logInvalidHmacSignature();
-            return false;
-        }
-
-        AdyenTokenNotification adyenTokenResponse = deserialiseTokenPayload(payload, AdyenTokenNotification.class);
-        boolean live = adyenTokenResponse
-                .environment()
-                .equalsIgnoreCase("live");
-
-        if (!AdyenTokenEvent.contains(adyenTokenResponse.type())) {
-            return false;
-        }
-
-        String hmacKey = getTokenHmacKey(adyenGatewayConfig, live);
-        if (!adyenNotificationValidator.isValidHmac(hmacSignature, hmacKey, payload)) {
-            logInvalidHmacSignature();
-            return false;
-        }
-
-        addNotificationToTaskQueue(payload, TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION);
-
-        return true;
-    }
-
-    private static void logInvalidHmacSignature() {
-        LOGGER
-                .atInfo()
-                .setMessage("Hmac signature is invalid or missing, rejecting Adyen token notification")
-                .addKeyValue(PROVIDER, ADYEN.getName())
-                .log();
-    }
-
-    public NotificationRequest deserialisePayloadToNotificationRequest(String rawAdyenJson) {
+    private void addNotificationToTaskQueue(AdyenWebhookNotification adyenWebhookNotification, String payload) {
+        TaskType taskTypeForNotification = getTaskTypeForAdyenNotification(adyenWebhookNotification);
         try {
-            WebhookHandler webhookHandler = new WebhookHandler();
-            return webhookHandler.handleNotificationJson(rawAdyenJson);
-        } catch (Exception e) {
-            LOGGER.info("Error deserialising Adyen notification payload", e);
-            throw new WebApplicationException("Error deserialising webhook Json", e);
-        }
-    }
-
-    public List<NotificationRequestItem> extractNotificationItems(NotificationRequest notificationRequest) {
-        if (notificationRequest == null || (notificationRequest.getNotificationItems() == null || notificationRequest
-                .getNotificationItems()
-                .isEmpty())) {
-            LOGGER.info("Adyen notification request is empty or missing items");
-            throw new AdyenNotificationException("Notification request is empty");
-        }
-        return notificationRequest.getNotificationItems();
-    }
-
-
-    public <T> T deserialiseTokenPayload(String payload, Class<T> targetClass) throws AdyenNotificationException {
-        try {
-            return jsonObjectMapper.getObject(payload, targetClass);
-        } catch (Exception e) {
-            LOGGER.info("Error deserialising token notification payload", e);
-            throw new WebApplicationException("Error deserialising token webhook Json", e);
-        }
-    }
-
-    private void logValidationFailure(AdyenNotificationException e) {
-        LOGGER.error("Failed to validate Adyen notification payload", e);
-    }
-
-    private void addNotificationToTaskQueue(String payload, TaskType task) {
-        try {
-            taskQueueService.add(new Task(payload, task));
+            taskQueueService.add(new Task(payload, taskTypeForNotification));
         } catch (Exception e) {
             LOGGER.error("Error sending Adyen webhook notification to task SQS queue", e);
-
             throw new WebApplicationException("Error sending message to task SQS queue", e);
         }
+    }
+
+    private TaskType getTaskTypeForAdyenNotification(AdyenWebhookNotification adyenWebhookNotification) {
+        return switch (adyenWebhookNotification.event().getWebhookType()) {
+            case PAYMENTS -> HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION;
+            case TOKENS -> HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION;
+        };
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandler.java
@@ -12,8 +12,8 @@ import uk.gov.pay.connector.charge.service.LinkPaymentInstrumentToAgreementServi
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.events.model.agreement.AgreementInactivated;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
-import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
 import uk.gov.pay.connector.gateway.adyen.webhook.AdyenTokenEvent;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenWebhookDeserialiser;
 import uk.gov.pay.connector.paymentinstrument.dao.PaymentInstrumentDao;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
@@ -38,29 +38,29 @@ public class AdyenTokenWebhookNotificationHandler {
     private final PaymentInstrumentDao paymentInstrumentDao;
     private final ChargeDao chargeDao;
     private final LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
-    private final AdyenNotificationService adyenNotificationService;
     private final AgreementDao agreementDao;
     private final LedgerService ledgerService;
+    private final AdyenWebhookDeserialiser adyenWebhookDeserialiser;
 
     @Inject
     public AdyenTokenWebhookNotificationHandler(PaymentInstrumentDao paymentInstrumentDao,
                                                 AgreementDao agreementDao,
                                                 ChargeDao chargeDao,
                                                 LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService,
-                                                AdyenNotificationService adyenNotificationService,
+                                                AdyenWebhookDeserialiser adyenWebhookDeserialiser,
                                                 LedgerService ledgerService) {
 
         this.paymentInstrumentDao = paymentInstrumentDao;
         this.agreementDao = agreementDao;
         this.chargeDao = chargeDao;
         this.linkPaymentInstrumentToAgreementService = linkPaymentInstrumentToAgreementService;
-        this.adyenNotificationService = adyenNotificationService;
+        this.adyenWebhookDeserialiser = adyenWebhookDeserialiser;
         this.ledgerService = ledgerService;
     }
 
     @Transactional
     public void process(String payload) {
-        AdyenTokenNotification notification = adyenNotificationService.deserialiseTokenPayload(payload, AdyenTokenNotification.class);
+        AdyenTokenNotification notification = adyenWebhookDeserialiser.deserialisePayload(payload, AdyenTokenNotification.class);
         String notificationType = notification.type();
 
         if (!AdyenTokenEvent.contains(notificationType)) {
@@ -175,7 +175,7 @@ public class AdyenTokenWebhookNotificationHandler {
                 .addKeyValue("PAYMENT_EXTERNAL_ID", webhookChargeExternalId)
                 .log();
     }
-    
+
     private static void logIgnoreWebhookBasedOnDuplicateStatus(PaymentInstrumentStatus
                                                                        paymentInstrumentStatus, String agreementExternalId, String paymentInstrumentExternalId) {
         LOGGER.atInfo().setMessage("Payment instrument is already in " + paymentInstrumentStatus + " state, ignoring Adyen token webhook")

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenWebhookTaskHandler.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.queue.tasks.handlers.adyen;
 
-import com.adyen.model.notification.NotificationRequest;
 import com.adyen.model.notification.NotificationRequestItem;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
@@ -8,9 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.service.ChargeService;
-import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
-
-import java.util.List;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenWebhookDeserialiser;
 
 import static com.adyen.model.notification.NotificationRequestItem.EVENT_CODE_CANCELLATION;
 import static com.adyen.model.notification.NotificationRequestItem.EVENT_CODE_CAPTURE;
@@ -23,20 +20,20 @@ public class AdyenWebhookTaskHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdyenWebhookTaskHandler.class);
     private final ChargeService chargeService;
     private final AdyenCaptureNotificationHandler adyenCaptureNotificationHandler;
-    private final AdyenNotificationService adyenNotificationService;
     private final AdyenCancellationNotificationHandler adyenCancellationNotificationHandler;
     private final AdyenRefundNotificationHandler adyenRefundNotificationHandler;
     private final AdyenTokenWebhookNotificationHandler adyenTokenWebhookNotificationHandler;
+    private final AdyenWebhookDeserialiser adyenWebhookDeserialiser;
 
     @Inject
     public AdyenWebhookTaskHandler(ChargeService chargeService,
-                                   AdyenNotificationService adyenNotificationService,
+                                   AdyenWebhookDeserialiser adyenWebhookDeserialiser,
                                    AdyenCancellationNotificationHandler adyenCancellationNotificationHandler,
                                    AdyenRefundNotificationHandler adyenRefundNotificationHandler,
                                    AdyenCaptureNotificationHandler adyenCaptureNotificationHandler,
                                    AdyenTokenWebhookNotificationHandler adyenTokenWebhookNotificationHandler) {
         this.chargeService = chargeService;
-        this.adyenNotificationService = adyenNotificationService;
+        this.adyenWebhookDeserialiser = adyenWebhookDeserialiser;
         this.adyenCancellationNotificationHandler = adyenCancellationNotificationHandler;
         this.adyenRefundNotificationHandler = adyenRefundNotificationHandler;
         this.adyenCaptureNotificationHandler = adyenCaptureNotificationHandler;
@@ -46,17 +43,12 @@ public class AdyenWebhookTaskHandler {
     public void processAdyenTokenWebhookNotification(String payload) {
         adyenTokenWebhookNotificationHandler.process(payload);
     }
-    
+
     @Transactional
     public void processAdyenWebhookNotification(String payload) {
-        NotificationRequest notificationRequest =
-                adyenNotificationService.deserialisePayloadToNotificationRequest(payload);
-
-        List<NotificationRequestItem> items = adyenNotificationService.extractNotificationItems(notificationRequest);
-
-        for (NotificationRequestItem item : items) {
-            processNotificationItemForCharge(item);
-        }
+        NotificationRequestItem notificationRequest =
+                adyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload);
+        processNotificationItemForCharge(notificationRequest);
     }
 
     private void processNotificationItemForCharge(NotificationRequestItem item) {

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/webhook/AdyenNotificationServiceTest.java
@@ -9,32 +9,20 @@ import com.adyen.model.notification.NotificationRequest;
 import com.adyen.model.notification.NotificationRequestItem;
 import com.adyen.notification.WebhookHandler;
 import com.adyen.util.HMACValidator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.WebApplicationException;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.app.adyen.AdyenGatewayConfig;
-import uk.gov.pay.connector.app.adyen.HmacKeys;
-import uk.gov.pay.connector.app.adyen.HmacKeys.WebhookHmacKeyPair;
-import uk.gov.pay.connector.app.adyen.WebhookHmacKeys;
-import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
+import uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookEvent;
+import uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookNotification;
 import uk.gov.pay.connector.gateway.exception.AdyenNotificationException;
 import uk.gov.pay.connector.queue.tasks.TaskQueueService;
-import uk.gov.pay.connector.queue.tasks.TaskType;
 import uk.gov.pay.connector.queue.tasks.model.Task;
-import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import java.io.IOException;
@@ -50,10 +38,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenEnvironment.TEST;
+import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookEvent.AUTHORISATION;
+import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookEvent.EXPIRE;
+import static uk.gov.pay.connector.gateway.adyen.webhook.model.AdyenWebhookEvent.RECURRING_TOKEN_CREATED;
+import static uk.gov.pay.connector.queue.tasks.TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_NOTIFICATION;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.ADYEN_TOKEN_NOTIFICATION;
 
@@ -70,24 +62,23 @@ class AdyenNotificationServiceTest {
     private Appender<ILoggingEvent> mockAppender;
 
     @Mock
-    private AdyenGatewayConfig mockAdyenGatewayConfig;
-
-    @Mock
     private TaskQueueService mockTaskQueueService;
 
     @Mock
     private AdyenNotificationValidator mockAdyenNotificationValidator;
 
-    private final JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(new ObjectMapper());
+    @Mock
+    private AdyenWebhookNotificationParser mockAdyenWebhookNotificationParser;
+
     private static final String FORWARDED_IP = "5.6.7.8";
     private static final String HMAC_SIGNATURE = "sha256=test-signature";
 
     @BeforeEach
     void setUp() {
-        adyenNotificationService = new AdyenNotificationService(mockAdyenGatewayConfig,
+        adyenNotificationService = new AdyenNotificationService(
                 mockTaskQueueService,
                 mockAdyenNotificationValidator,
-                jsonObjectMapper);
+                mockAdyenWebhookNotificationParser);
         Logger root = (Logger) LoggerFactory.getLogger(AdyenNotificationService.class);
         root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
@@ -95,11 +86,10 @@ class AdyenNotificationServiceTest {
 
     @Test
     void shouldAcceptNotificationWhenForwardedIpMatchesConfiguredDomain() {
-        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-        when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
-
         String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        when(mockAdyenWebhookNotificationParser.parse(payload)).thenReturn(getAdyenWebhookNotification(AUTHORISATION));
+        when(mockAdyenNotificationValidator.validateHmacSignature(any(), any(), any())).thenReturn(true);
 
         boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null);
 
@@ -117,14 +107,9 @@ class AdyenNotificationServiceTest {
 
     @Test
     void shouldRejectNotificationWhenExceptionIsThrown() {
-        var primaryTestKey = "primaryTest";
         String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION);
-        var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
-                new WebhookHmacKeys("primaryLive", "secondaryLive"));
         when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
-        when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
-        when(mockAdyenNotificationValidator.isValidHmac(any(), any(), any())).thenThrow(
-                AdyenNotificationException.class);
+        when(mockAdyenWebhookNotificationParser.parse(payload)).thenThrow(new AdyenNotificationException("error"));
 
         boolean result = adyenNotificationService.handleNotificationFor(payload, FORWARDED_IP, HMAC_SIGNATURE);
 
@@ -139,314 +124,85 @@ class AdyenNotificationServiceTest {
                 is(true));
     }
 
-    @Nested
-    class PaymentNotifications {
-        @Test
-        void shouldRejectPaymentNotificationWhenHmacSignatureIsInvalid() {
-            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-            when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(false);
+    @Test
+    void shouldRejectPaymentNotificationWhenHmacSignatureIsInvalid() {
+        String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        when(mockAdyenWebhookNotificationParser.parse(payload)).thenReturn(getAdyenWebhookNotification(AUTHORISATION));
+        when(mockAdyenNotificationValidator.validateHmacSignature(any(), any(), any())).thenReturn(false);
 
-            String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
+        boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null);
 
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null);
-
-            assertFalse(result);
-        }
-
-        @Test
-        void shouldNotAddPaymentNotificationToTaskQueueWhenHmacSignatureIsInvalid() {
-            String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
-                    .replace("{{HMAC_SIGNATURE}}", "WrongSignature");
-
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null);
-
-            assertFalse(result);
-            verify(mockTaskQueueService, never()).add(any(Task.class));
-        }
-
-        @Test
-        void shouldThrowWebApplicationExceptionWhenPaymentNotificationPayloadIsInvalidJson() {
-            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-            assertThrows(WebApplicationException.class,
-                    () -> adyenNotificationService.handleNotificationFor("not-json", "5.6.7.8", null));
-
-            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                    .stream()
-                    .anyMatch(event -> event
-                            .getFormattedMessage()
-                            .equals("Error deserialising Adyen notification payload")), is(true));
-        }
-
-        @Test
-        void shouldReturnFalseWhenPayloadIsValidJsonAndPaymentNotificationIsNull() {
-            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-            String validJsonButMissingExpectedFields = """ 
-                    {
-                        "live": false
-                    }
-                    """;
-            boolean result = adyenNotificationService.handleNotificationFor(validJsonButMissingExpectedFields, "5.6.7.8", null
-            );
-
-            assertFalse(result);
-
-            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                    .getFirst()
-                    .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
-            assertThat(loggingEvents
-                    .get(1)
-                    .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
-        }
-
-        @ParameterizedTest
-        @NullAndEmptySource
-        @ValueSource(strings = {""" 
-                {
-                    "live": false,
-                    "notificationItems": [
-                    ]
-                }
-                """})
-        void shouldReturnFalseWhenPayloadIsValidJsonAndNotificationRequestItemsIsEmptyOrNull(String payload) {
-            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null
-            );
-
-            assertFalse(result);
-            verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                    .getFirst()
-                    .getFormattedMessage(), is("Adyen notification request is empty or missing items"));
-            assertThat(loggingEvents
-                    .get(1)
-                    .getFormattedMessage(), is("Failed to validate Adyen notification payload"));
-        }
-
-        @ParameterizedTest
-        @NullAndEmptySource
-        @ValueSource(strings = {"SOME_INVALID_VALUE"})
-        void shouldNotAddInvalidPaymentNotificationTypeToTaskQueue(String eventCode) {
-            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-            when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
-            String payload = getNotificationWithValidHmacSignature(eventCode);
-
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null);
-
-            assertFalse(result);
-
-            verifyNoInteractions(mockTaskQueueService);
-        }
-
-        @ParameterizedTest
-        @EnumSource(AdyenPaymentEvent.class)
-        void shouldThrowWebApplicationExceptionWhenSendingPaymentNotificationToTaskQueueFails(AdyenPaymentEvent eventCode) {
-            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-            when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
-
-            String payload = getNotificationWithValidHmacSignature(eventCode.toString());
-
-            doThrow(new RuntimeException("SQS unavailable"))
-                    .when(mockTaskQueueService)
-                    .add(any(Task.class));
-
-            WebApplicationException exception = assertThrows(WebApplicationException.class, () ->
-                    adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null));
-
-            verify(mockTaskQueueService).add(any(Task.class));
-            assertThat(exception
-                    .getResponse()
-                    .getStatus(), is(500));
-            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                    .getFirst()
-                    .getFormattedMessage(), is("Error sending Adyen webhook notification to task SQS queue"));
-        }
-
-        @ParameterizedTest
-        @EnumSource(AdyenPaymentEvent.class)
-        void shouldAddValidPaymentNotificationToTaskQueue(AdyenPaymentEvent eventCode) {
-            when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(getHmacKeys());
-            when(mockAdyenNotificationValidator.isValidHmac(any(), any())).thenReturn(true);
-
-
-            String payload = getNotificationWithValidHmacSignature(eventCode.toString());
-
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null);
-
-            assertTrue(result);
-
-            ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
-            verify(mockTaskQueueService).add(taskCaptor.capture());
-
-            Task task = taskCaptor.getValue();
-            assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_PAYMENTS_WEBHOOK_NOTIFICATION));
-            assertThat(task.getData(), is(payload));
-        }
+        assertFalse(result);
     }
 
-    @Nested
-    class TokenNotifications {
-        @Test
-        void shouldRejectTokenNotificationWhenHmacSignatureIsBlank() {
-            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION);
-            when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
+    @Test
+    void shouldNotAddPaymentNotificationToTaskQueueWhenHmacSignatureIsInvalid() {
+        String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
+                .replace("{{HMAC_SIGNATURE}}", "WrongSignature");
 
-            boolean result = adyenNotificationService.handleNotificationFor(payload, FORWARDED_IP, "");
+        boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null);
 
-            assertFalse(result);
-            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                    .stream()
-                    .anyMatch(event -> event
-                            .getFormattedMessage()
-                            .equals("Hmac signature is invalid or missing, rejecting Adyen token notification")), is(true));
-        }
-
-        @Test
-        void shouldRejectTokenNotificationWhenHmacSignatureIsInvalid() {
-            var primaryTestKey = "primaryTest";
-            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION);
-            var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
-                    new WebhookHmacKeys("primaryLive", "secondaryLive"));
-            when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
-            when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey,
-                    payload)).thenReturn(false);
-
-            boolean result = adyenNotificationService.handleNotificationFor(payload, FORWARDED_IP, HMAC_SIGNATURE);
-
-            assertFalse(result);
-            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                            .stream()
-                            .anyMatch(event -> event
-                                    .getFormattedMessage()
-                                    .equals("Hmac signature is invalid or missing, rejecting Adyen token notification")),
-                    is(true));
-            verifyNoInteractions(mockTaskQueueService);
-        }
-
-        @ParameterizedTest
-        @NullAndEmptySource
-        @ValueSource(strings = {"recurring.token.deleted"})
-        void shouldNotAddInvalidTokenNotificationTypeToTaskQueue(String eventCode) {
-            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION).replace("\"recurring.token.created\"", "\"" + eventCode + "\"");
-            when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
-
-            boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", HMAC_SIGNATURE);
-
-            assertFalse(result);
-            verifyNoInteractions(mockTaskQueueService);
-        }
-
-        @ParameterizedTest
-        @EnumSource(AdyenTokenEvent.class)
-        void shouldAcceptValidTokenNotification(AdyenTokenEvent eventCode) {
-            var primaryTestKey = "primaryTest";
-            String payload = TestTemplateResourceLoader.load(ADYEN_TOKEN_NOTIFICATION).replace("recurring.token.created", eventCode.getName());
-            var tokenKeys = new HmacKeys.WebhookHmacKeyPair(new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
-                    new WebhookHmacKeys("primaryLive", "secondaryLive"));
-            when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP)).thenReturn(true);
-            when(mockAdyenGatewayConfig.getHmacKeys()).thenReturn(new HmacKeys(null, tokenKeys));
-            when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey,
-                    payload)).thenReturn(true);
-
-            boolean result = adyenNotificationService.handleNotificationFor(payload, FORWARDED_IP, HMAC_SIGNATURE);
-
-            assertTrue(result);
-
-            ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
-
-            verify(mockTaskQueueService).add(taskCaptor.capture());
-
-            Task task = taskCaptor.getValue();
-
-            assertThat(task.getTaskType(), is(TaskType.HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION));
-            assertThat(task.getData(), is(payload));
-        }
-
-        @Test
-        void shouldThrowExceptionWhenTokenNotificationPayloadIsInvalid() {
-            WebApplicationException exception = Assert.assertThrows(
-                    WebApplicationException.class,
-                    () -> adyenNotificationService.deserialiseTokenPayload("invalidJson", AdyenTokenNotification.class)
-            );
-
-            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertThat(loggingEvents
-                            .stream()
-                            .anyMatch(event -> event
-                                    .getFormattedMessage()
-                                    .equals("Error deserialising token notification payload")),
-                    is(true));
-
-            assertThat("Error deserialising token webhook Json", is(exception.getMessage()));
-        }
-
-        @ParameterizedTest
-        @EnumSource(AdyenTokenEvent.class)
-        void shouldThrowWebApplicationExceptionWhenAddingTokenNotificationToTaskQueueFails(AdyenTokenEvent eventCode) {
-            var primaryTestKey = "primaryTest";
-
-            String payload = TestTemplateResourceLoader.load(
-                    ADYEN_TOKEN_NOTIFICATION
-            ).replace("recurring.token.created", eventCode.getName());
-
-            var tokenKeys = new HmacKeys.WebhookHmacKeyPair(
-                    new WebhookHmacKeys(primaryTestKey, "secondaryTest"),
-                    new WebhookHmacKeys("primaryLive", "secondaryLive")
-            );
-
-            when(mockAdyenNotificationValidator.isValidIpAddress(FORWARDED_IP))
-                    .thenReturn(true);
-
-            when(mockAdyenGatewayConfig.getHmacKeys())
-                    .thenReturn(new HmacKeys(null, tokenKeys));
-
-            when(mockAdyenNotificationValidator.isValidHmac(HMAC_SIGNATURE, primaryTestKey, payload)).thenReturn(true);
-
-            doThrow(new RuntimeException("SQS unavailable"))
-                    .when(mockTaskQueueService)
-                    .add(any(Task.class));
-
-            Assert.assertThrows(WebApplicationException.class, () -> adyenNotificationService.handleNotificationFor(
-                    payload, FORWARDED_IP, HMAC_SIGNATURE));
-            verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-
-            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-
-            assertThat(loggingEvents
-                    .stream()
-                    .anyMatch(event -> event
-                            .getFormattedMessage()
-                            .equals("Error sending Adyen webhook notification to task SQS queue")), is(true)
-            );
-        }
+        assertFalse(result);
+        verify(mockTaskQueueService, never()).add(any(Task.class));
     }
 
-    private HmacKeys getHmacKeys(String... testKey) {
-        String exampleLiveKey = "exampleLiveKey";
-        String validTestKey = "44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056"; // pragma: allowlist secret
-        WebhookHmacKeys liveKeys = new WebhookHmacKeys(exampleLiveKey, null);
-        WebhookHmacKeys testKeys = testKey == null || testKey.length == 0 ? new WebhookHmacKeys(validTestKey,
-                null) : new WebhookHmacKeys(testKey[0], null);
 
-        WebhookHmacKeyPair pair = new WebhookHmacKeyPair(testKeys, liveKeys);
+    @Test
+    void shouldThrowWebApplicationExceptionWhenSendingPaymentNotificationToTaskQueueFails() {
+        String payload = getNotificationWithValidHmacSignature("AUTHORISATION");
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        when(mockAdyenWebhookNotificationParser.parse(payload)).thenReturn(getAdyenWebhookNotification(AUTHORISATION));
+        when(mockAdyenNotificationValidator.validateHmacSignature(any(), any(), any())).thenReturn(true);
 
-        return new HmacKeys(pair, null);
+        doThrow(new RuntimeException("SQS unavailable"))
+                .when(mockTaskQueueService)
+                .add(any(Task.class));
+
+        WebApplicationException exception = assertThrows(WebApplicationException.class, () ->
+                adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null));
+
+        verify(mockTaskQueueService).add(any(Task.class));
+        assertThat(exception
+                .getResponse()
+                .getStatus(), is(500));
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents
+                .getFirst()
+                .getFormattedMessage(), is("Error sending Adyen webhook notification to task SQS queue"));
+    }
+
+    @Test
+    void shouldNotAddIgnoredEventToTaskQueue() {
+        String payload = getNotificationWithValidHmacSignature("EXPIRE");
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        when(mockAdyenWebhookNotificationParser.parse(payload)).thenReturn(getAdyenWebhookNotification(EXPIRE));
+
+        boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null);
+
+        assertFalse(result);
+        verifyNoInteractions(mockTaskQueueService);
+    }
+
+    @Test
+    void shouldAddValidNotificationToTaskQueue() {
+        String payload = getNotificationWithValidHmacSignature("RECURRING_TOKEN_CREATED");
+        when(mockAdyenNotificationValidator.isValidIpAddress("5.6.7.8")).thenReturn(true);
+        when(mockAdyenWebhookNotificationParser.parse(payload)).thenReturn(getAdyenWebhookNotification(RECURRING_TOKEN_CREATED));
+        when(mockAdyenNotificationValidator.validateHmacSignature(any(), any(), any())).thenReturn(true);
+
+        boolean result = adyenNotificationService.handleNotificationFor(payload, "5.6.7.8", null);
+
+        assertTrue(result);
+
+        ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(mockTaskQueueService).add(taskCaptor.capture());
+
+        Task task = taskCaptor.getValue();
+
+        assertThat(task.getTaskType(), is(HANDLE_ADYEN_TOKEN_WEBHOOK_NOTIFICATION));
+        assertThat(task.getData(), is(payload));
     }
 
     private String getNotificationWithValidHmacSignature(String eventCode) {
@@ -463,14 +219,16 @@ class AdyenNotificationServiceTest {
                     .getFirst();
 
             String hmacKey = "44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056"; // pragma: allowlist secret
-
             String signature = new HMACValidator().calculateHMAC(item, hmacKey); // pragma: allowlist secret
-
             return template.replace("{{HMAC_SIGNATURE}}", signature);
 
         } catch (IOException | SignatureException e) {
             throw new RuntimeException(
                     "Failed to build Adyen test notification", e);
         }
+    }
+
+    private AdyenWebhookNotification getAdyenWebhookNotification(AdyenWebhookEvent adyenWebhookEvent) {
+        return new AdyenWebhookNotification(adyenWebhookEvent, TEST, true);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenNotificationResourceIT.java
@@ -92,7 +92,8 @@ public class AdyenNotificationResourceIT {
         void shouldHandleAValidJsonNotification() {
             String validHmacSignature = "9C3600/ujEuztt/Be8+EX74c6ysk7GyiWwsVi2KW+s0="; // pragma: allowlist secret
             String payload = TestTemplateResourceLoader.load(ADYEN_NOTIFICATION)
-                    .replace("{{HMAC_SIGNATURE}}", validHmacSignature);
+                    .replace("{{HMAC_SIGNATURE}}", validHmacSignature)
+                    .replace("{{live}}", "false");
             given()
                     .port(app.getLocalPort())
                     .body(payload)
@@ -135,8 +136,6 @@ public class AdyenNotificationResourceIT {
                     .post(NOTIFICATION_PATH)
                     .then()
                     .statusCode(403);
-
-            logs.assertContains("Hmac signature is invalid or missing, rejecting Adyen token notification");
         }
 
         @Test
@@ -156,7 +155,7 @@ public class AdyenNotificationResourceIT {
                     .contentType(APPLICATION_JSON)
                     .post(NOTIFICATION_PATH)
                     .then()
-                    .statusCode(403);
+                    .statusCode(500);
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/AdyenWebhookTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/AdyenWebhookTaskHandlerTest.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.service.ChargeService;
-import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenWebhookDeserialiser;
 import uk.gov.pay.connector.queue.tasks.handlers.adyen.AdyenCancellationNotificationHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.adyen.AdyenCaptureNotificationHandler;
 import uk.gov.pay.connector.queue.tasks.handlers.adyen.AdyenRefundNotificationHandler;
@@ -60,16 +60,13 @@ class AdyenWebhookTaskHandlerTest {
     private AdyenCancellationNotificationHandler mockAdyenCancellationNotificationHandler;
 
     @Mock
-    private AdyenNotificationService mockAdyenNotificationService;
+    private AdyenWebhookDeserialiser mockAdyenWebhookDeserialiser;
 
     @Mock
     private AdyenTokenWebhookNotificationHandler mockAdyenTokenWebhookNotificationHandler;
 
     @Mock
     private Charge mockCharge;
-
-    @Mock
-    NotificationRequest mockNotificationRequest;
 
     @Mock
     NotificationRequestItem mockNotificationItem;
@@ -97,10 +94,8 @@ class AdyenWebhookTaskHandlerTest {
 
     @Test
     void shouldProcessSuccessfulCaptureNotificationForConnectorCharge() {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
+        when(mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload))
+                .thenReturn(mockNotificationItem);
         when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
@@ -115,10 +110,8 @@ class AdyenWebhookTaskHandlerTest {
 
     @Test
     void shouldLogWarningWhenChargeDoesNotExistInConnectorOrLedger() {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
+        when(mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload))
+                .thenReturn(mockNotificationItem);
         when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CAPTURE);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(),
@@ -137,10 +130,8 @@ class AdyenWebhookTaskHandlerTest {
 
     @Test
     void shouldNotProcessRefundNotificationWhenChargeNotFound() {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
+        when(mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload))
+                .thenReturn(mockNotificationItem);
         when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_REFUND);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(), gatewayTransactionId))
@@ -153,10 +144,8 @@ class AdyenWebhookTaskHandlerTest {
 
     @Test
     void shouldProcessRefundNotificationForConnectorCharge() {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
+        when(mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload))
+                .thenReturn(mockNotificationItem);
         when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_REFUND);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(), gatewayTransactionId))
@@ -169,10 +158,8 @@ class AdyenWebhookTaskHandlerTest {
 
     @Test
     void shouldProcessCancellationNotificationForConnectorCharge() {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
+        when(mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload))
+                .thenReturn(mockNotificationItem);
         when(mockNotificationItem.getEventCode()).thenReturn(NotificationRequestItem.EVENT_CODE_CANCELLATION);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(), gatewayTransactionId))
@@ -187,10 +174,8 @@ class AdyenWebhookTaskHandlerTest {
 
     @Test
     void shouldIgnoreUnsupportedNotificationItem() {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
+        when(mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload))
+                .thenReturn(mockNotificationItem);
         when(mockNotificationItem.getEventCode()).thenReturn("UNSUPPORTED_EVENT");
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(ADYEN.getName(), gatewayTransactionId))
@@ -211,14 +196,12 @@ class AdyenWebhookTaskHandlerTest {
         var notification = NotificationRequest.fromJson(load(ADYEN_REFUND_SUCCESS_NOTIFICATION));
         var charge = Charge.from(ChargeEntityFixture.aValidChargeEntity().build());
 
-        given(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(any()))
-                .willReturn(notification);
-        given(mockAdyenNotificationService.extractNotificationItems(notification))
-                .willReturn(notification.getNotificationItems());
+        when(mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload))
+                .thenReturn(notification.getNotificationItems().getFirst());
         given(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(any(), any()))
                 .willReturn(Optional.of(charge));
 
-        adyenWebhookTaskHandler.processAdyenWebhookNotification("refund-successful-notification");
+        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
 
         then(mockAdyenRefundNotificationHandler)
                 .should()
@@ -230,14 +213,12 @@ class AdyenWebhookTaskHandlerTest {
         var notification = NotificationRequest.fromJson(load(ADYEN_REFUND_FAILURE_NOTIFICATION));
         var charge = Charge.from(ChargeEntityFixture.aValidChargeEntity().build());
 
-        given(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(any()))
-                .willReturn(notification);
-        given(mockAdyenNotificationService.extractNotificationItems(notification))
-                .willReturn(notification.getNotificationItems());
+        when(mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload))
+                .thenReturn(notification.getNotificationItems().getFirst());
         given(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(any(), any()))
                 .willReturn(Optional.of(charge));
 
-        adyenWebhookTaskHandler.processAdyenWebhookNotification("refund-failed-notification");
+        adyenWebhookTaskHandler.processAdyenWebhookNotification(payload);
 
         then(mockAdyenRefundNotificationHandler)
                 .should()

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenCancellationNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/AdyenCancellationNotificationHandlerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.queue.tasks.handlers;
 
-import com.adyen.model.notification.NotificationRequest;
 import com.adyen.model.notification.NotificationRequestItem;
 import io.github.netmikey.logunit.api.LogCapturer;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,7 +13,7 @@ import org.slf4j.event.KeyValuePair;
 import org.slf4j.event.Level;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenWebhookDeserialiser;
 import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
 import uk.gov.pay.connector.queue.tasks.handlers.adyen.AdyenCancellationNotificationHandler;
 
@@ -22,7 +21,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
-import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.everyItem;
@@ -41,13 +39,10 @@ class AdyenCancellationNotificationHandlerTest {
     private ChargeNotificationProcessor mockChargeNotificationProcessor;
 
     @Mock
-    private AdyenNotificationService mockAdyenNotificationService;
+    private AdyenWebhookDeserialiser mockAdyenWebhookDeserialiser;
 
     @Mock
     private Charge mockCharge;
-
-    @Mock
-    NotificationRequest mockNotificationRequest;
 
     @Mock
     NotificationRequestItem mockNotificationItem;
@@ -72,10 +67,8 @@ class AdyenCancellationNotificationHandlerTest {
             "false,SYSTEM CANCEL SUBMITTED,SYSTEM CANCEL ERROR",
     })
     void shouldProcessCancelNotificationForConnectorCharge(Boolean success, String currentStatus, String expectedStatus) {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
+        when(mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload))
+                .thenReturn(mockNotificationItem);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockNotificationItem.isSuccess()).thenReturn(success);
         when(mockNotificationItem.getEventDate()).thenReturn(eventDate);
@@ -83,12 +76,11 @@ class AdyenCancellationNotificationHandlerTest {
 
         when(mockCharge.isHistoric()).thenReturn(false);
 
-        NotificationRequest notificationRequest =
-                mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload);
+        NotificationRequestItem notificationRequestItem =
+                mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload);
 
-        NotificationRequestItem item = mockAdyenNotificationService.extractNotificationItems(notificationRequest).getFirst();
 
-        adyenCancellationNotificationHandler.process(item, mockCharge);
+        adyenCancellationNotificationHandler.process(notificationRequestItem, mockCharge);
 
         verify(mockChargeNotificationProcessor).invoke(gatewayTransactionId, mockCharge,
                 ChargeStatus.fromString(expectedStatus), ZonedDateTime.ofInstant(eventDate.toInstant(), ZoneId.of("UTC")));
@@ -100,24 +92,22 @@ class AdyenCancellationNotificationHandlerTest {
             "true,CAPTURE QUEUED"
     })
     void shouldIgnoreCancelNotificationAndLogWarningWhenInUnexpectedState(Boolean success, String currentStatus) {
-        when(mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload))
-                .thenReturn(mockNotificationRequest);
-        when(mockAdyenNotificationService.extractNotificationItems(mockNotificationRequest))
-                .thenReturn(List.of(mockNotificationItem));
+        when(mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload))
+                .thenReturn(mockNotificationItem);
         when(mockNotificationItem.getOriginalReference()).thenReturn(gatewayTransactionId);
         when(mockNotificationItem.isSuccess()).thenReturn(success);
         when(mockCharge.getStatus()).thenReturn(currentStatus);
         when(mockCharge.isHistoric()).thenReturn(false);
         when(mockCharge.getExternalId()).thenReturn("someId");
 
-        NotificationRequest notificationRequest =
-                mockAdyenNotificationService.deserialisePayloadToNotificationRequest(payload);
-        NotificationRequestItem item = mockAdyenNotificationService.extractNotificationItems(notificationRequest).getFirst();
+        NotificationRequestItem notificationRequestItem =
+                mockAdyenWebhookDeserialiser.deserialiseAndGetNotificationItem(payload);
 
-        adyenCancellationNotificationHandler.process(item, mockCharge);
+
+        adyenCancellationNotificationHandler.process(notificationRequestItem, mockCharge);
 
         verifyNoInteractions(mockChargeNotificationProcessor);
-        
+
         var loggingMessage = String.format("Charge is not in expected state for cancellation: %s", currentStatus);
         var loggingEvents = logs.getEvents();
         assertThat(loggingEvents, everyItem(hasProperty("level", is(Level.WARN))));
@@ -131,7 +121,7 @@ class AdyenCancellationNotificationHandlerTest {
                 new KeyValuePair(PAYMENT_EXTERNAL_ID, mockCharge.getExternalId()),
                 new KeyValuePair("gateway_transaction_id", gatewayTransactionId),
                 new KeyValuePair("status", currentStatus),
-                new KeyValuePair("success", item.isSuccess())));
+                new KeyValuePair("success", notificationRequestItem.isSuccess())));
     }
 }
 

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/handlers/adyen/AdyenTokenWebhookNotificationHandlerTest.java
@@ -24,7 +24,7 @@ import uk.gov.pay.connector.events.model.agreement.AgreementInactivated;
 import uk.gov.pay.connector.gateway.adyen.AdyenRequestFactory;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenEventData;
 import uk.gov.pay.connector.gateway.adyen.response.AdyenTokenNotification;
-import uk.gov.pay.connector.gateway.adyen.webhook.AdyenNotificationService;
+import uk.gov.pay.connector.gateway.adyen.webhook.AdyenWebhookDeserialiser;
 import uk.gov.pay.connector.paymentinstrument.dao.PaymentInstrumentDao;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentEntity;
 import uk.gov.pay.connector.paymentinstrument.model.PaymentInstrumentStatus;
@@ -70,7 +70,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
     @Mock
     private LinkPaymentInstrumentToAgreementService linkPaymentInstrumentToAgreementService;
     @Mock
-    private AdyenNotificationService adyenNotificationService;
+    private AdyenWebhookDeserialiser adyenWebhookDeserialiser;
     @Mock
     private LedgerService ledgerService;
 
@@ -108,7 +108,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                     .withPaymentInstrument(paymentInstrument)
                     .withAgreementEntity(agreement).build();
 
-            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+            given(adyenWebhookDeserialiser.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                     .willReturn(tokenNotification(SHOPPER_REFERENCE));
             given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
             given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
@@ -138,7 +138,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                     .withPaymentInstrument(paymentInstrument)
                     .withAgreementEntity(agreement).build();
 
-            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+            given(adyenWebhookDeserialiser.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                     .willReturn(tokenNotification(SHOPPER_REFERENCE));
             given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
             given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
@@ -179,7 +179,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                     .withExternalId(LATEST_CHARGE_EXTERNAL_ID)
                     .withAgreementEntity(agreement).build();
 
-            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+            given(adyenWebhookDeserialiser.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                     .willReturn(tokenNotification(SHOPPER_REFERENCE));
             given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
             given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(latestChargeEntity));
@@ -196,7 +196,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
 
         @Test
         void shouldIgnoreAndLogWhenAgreementNotFound() {
-            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+            given(adyenWebhookDeserialiser.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                     .willReturn(tokenNotification(SHOPPER_REFERENCE));
             given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.empty());
 
@@ -211,7 +211,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
         void shouldIgnoreAndLogWhenValidChargesAreNotFound() {
             var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
 
-            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+            given(adyenWebhookDeserialiser.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                     .willReturn(tokenNotification(SHOPPER_REFERENCE));
             given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
             given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.empty());
@@ -231,7 +231,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                     .withExternalId(CHARGE_EXTERNAL_ID)
                     .withAgreementEntity(agreement).build();
 
-            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+            given(adyenWebhookDeserialiser.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                     .willReturn(tokenNotification(SHOPPER_REFERENCE));
             given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
             given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
@@ -250,7 +250,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                     .withExternalId(LATEST_CHARGE_EXTERNAL_ID)
                     .withAgreementEntity(agreement).build();
 
-            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+            given(adyenWebhookDeserialiser.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                     .willReturn(tokenNotification(SHOPPER_REFERENCE));
             given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
             given(chargeDao.findLatestChargeForAgreementId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(chargeEntity));
@@ -264,7 +264,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
 
         @Test
         void shouldIgnoreUnsupportedWebhookType() {
-            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+            given(adyenWebhookDeserialiser.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                     .willReturn(new AdyenTokenNotification(null, null, null,
                             new AdyenTokenEventData(null, STORED_PAYMENT_METHOD_ID, null, null, SHOPPER_REFERENCE),
                             "recurring.token.deleted"));
@@ -280,7 +280,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
         @NullAndEmptySource
         @ValueSource(strings = {"badId", "one-two-three", "aaaaaaaaaaaaaaaaaaaaaaaaaa-short", "short-bbbbbbbbbbbbbbbbbbbbbbbbbb"})
         void shouldLogErrorForInvalidShopperReferenceLengthFormat(String invalidShopperReference) {
-            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+            given(adyenWebhookDeserialiser.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                     .willReturn(tokenNotification(invalidShopperReference));
 
             handler.process(PAYLOAD);
@@ -351,7 +351,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
         void shouldIgnoreAndLogWhenPaymentInstrumentNotFound() {
             var agreement = anAgreementEntity().withExternalId(AGREEMENT_EXTERNAL_ID).build();
 
-            given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+            given(adyenWebhookDeserialiser.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                     .willReturn(tokenNotification(SHOPPER_REFERENCE));
             given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
             given(paymentInstrumentDao.findByChargeExternalId(CHARGE_EXTERNAL_ID)).willReturn(Optional.empty());
@@ -378,7 +378,7 @@ class AdyenTokenWebhookNotificationHandlerTest {
                 .withPaymentInstrument(paymentInstrument)
                 .withAgreementEntity(agreement).build();
 
-        given(adyenNotificationService.deserialiseTokenPayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
+        given(adyenWebhookDeserialiser.deserialisePayload(eq(PAYLOAD), eq(AdyenTokenNotification.class)))
                 .willReturn(tokenNotification(SHOPPER_REFERENCE));
         given(agreementDao.findByExternalId(AGREEMENT_EXTERNAL_ID)).willReturn(Optional.of(agreement));
         if (tokenOperation.equals("disabled")) {


### PR DESCRIPTION
## WHAT YOU DID
- refactored `AdyenNotificationService` to delegate deserialisation and webhook type sorting logic to helper classes made in previous PRs as part of refactoring adyen webhooks epic. 
https://payments-platform.atlassian.net/browse/PP-15738
- updated tests and webhook handlers that were previously using the deserialisation method in `AdyenNotificationService` to now use `AdyenWebhookDeserialiser` class.

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
