### PR TITLE
PP-15856 Return an empty map for recurring_auth_token when storedPaymentMethodId is not present

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandler.java
@@ -22,6 +22,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil.get3dsAuthUrl;
 import static uk.gov.pay.connector.gateway.adyen.utils.AdyenRequestUtil.getHeaders;
 import static uk.gov.pay.connector.gateway.model.OrderRequestType.AUTHORISE_3DS;
+import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.ERROR;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ERROR;
 import static uk.gov.service.payments.logging.LoggingKeys.HTTP_STATUS;
@@ -73,6 +74,10 @@ public class AdyenAuthorise3dsHandler {
 
             Map<String, String> recurringAuthToken = storedPaymentMethodId == null ? null
                     : Map.of("storedPaymentMethodId", storedPaymentMethodId);
+
+            if (AUTHORISED.equals(mappedStatus) && recurringAuthToken == null) {
+                recurringAuthToken = Map.of();
+            }
 
             return Gateway3DSAuthorisationResponse.of(
                     responseBody.toString(),
@@ -130,7 +135,7 @@ public class AdyenAuthorise3dsHandler {
             default -> ERROR;
         };
     }
-    
+
     private String getGatewayRejectionReason(Authorise3dsResponseBody responseBody) {
         if (!"Refused".equals(responseBody.resultCode())) {
             return null;

--- a/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponse.java
@@ -11,6 +11,11 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import java.util.Map;
 import java.util.Optional;
 
+import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED;
+import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.ERROR;
+import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REJECTED;
+import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS;
+
 public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
 
     private final String transactionId;
@@ -22,7 +27,7 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
 
     private final String paReq;
     private final String md;
-    
+
     private final String storedPaymentMethodId;
 
     public static AdyenAuthoriseResponse of(AuthoriseResponseBody authoriseResponseBody) {
@@ -38,7 +43,7 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
                 .map(Action::data)
                 .map(items -> items.get("MD"))
                 .orElse(null);
-        
+
         var additionalData = authoriseResponseBody.additionalData();
         String storedPaymentMethodId = Optional.ofNullable(additionalData)
                 .map(AdditionalData::storedPaymentMethodId)
@@ -50,7 +55,7 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
                 method,
                 paReq,
                 md,
-                authoriseResponseBody.refusalReason(), 
+                authoriseResponseBody.refusalReason(),
                 authoriseResponseBody.refusalReasonCode(),
                 storedPaymentMethodId);
     }
@@ -77,18 +82,18 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
 
     private static AuthoriseStatus mapAuthorisationStatusFrom(String resultCode) {
         return switch (resultCode) {
-            case "Authorised" -> AuthoriseStatus.AUTHORISED;
-            case "Refused" -> AuthoriseStatus.REJECTED;
-            case "RedirectShopper" -> AuthoriseStatus.REQUIRES_3DS;
-            case "Error" -> AuthoriseStatus.ERROR;
+            case "Authorised" -> AUTHORISED;
+            case "Refused" -> REJECTED;
+            case "RedirectShopper" -> REQUIRES_3DS;
+            case "Error" -> ERROR;
             default -> throw new IllegalStateException("Unexpected value: " + resultCode);
         };
     }
-    
+
     @Override
     public Optional<String> getGatewayRejectionReason() {
-        if (refusalReason != null && refusalReasonCode != null ) {
-            return Optional.of(refusalReasonCode + " - " +  refusalReason  );
+        if (refusalReason != null && refusalReasonCode != null) {
+            return Optional.of(refusalReasonCode + " - " + refusalReason);
         }
         return Optional.empty();
     }
@@ -121,7 +126,7 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
 
     @Override
     public Optional<? extends Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
-        if (AuthoriseStatus.REQUIRES_3DS == authoriseStatus) {
+        if (REQUIRES_3DS == authoriseStatus) {
             return Optional.of(new Adyen3dsRequiredParams(redirectUrl, httpMethod3ds, paReq, md));
         }
         return Optional.empty();
@@ -129,7 +134,7 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
 
     @Override
     public Optional<MappedAuthorisationRejectedReason> getMappedAuthorisationRejectedReason() {
-        if (authoriseStatus() != AuthoriseStatus.REJECTED) {
+        if (authoriseStatus() != REJECTED) {
             return Optional.empty();
         }
 
@@ -153,7 +158,12 @@ public class AdyenAuthoriseResponse implements BaseAuthoriseResponse {
 
     @Override
     public Optional<Map<String, String>> getGatewayRecurringAuthToken() {
-        return Optional.ofNullable(storedPaymentMethodId)
-                .map(_ -> Map.of("storedPaymentMethodId", storedPaymentMethodId));
+        if (storedPaymentMethodId != null) {
+            return Optional.of(Map.of("storedPaymentMethodId", storedPaymentMethodId));
+        }
+
+        return AUTHORISED.equals(authoriseStatus)
+                ? Optional.of(Map.of())
+                : Optional.empty();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/handler/AdyenAuthorise3dsHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.pay.connector.gateway.model.request.GatewayClientPostRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -68,7 +69,8 @@ class AdyenAuthorise3dsHandlerTest {
     }
 
     @Test
-    void should_send_a_authorise3ds_request_with_api_key_and_idempotency_key_headers() throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+    void should_send_a_authorise3ds_request_with_api_key_and_idempotency_key_headers() throws GatewayException.GatewayErrorException,
+            GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
         when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
         when(mockGatewayClientResponse.getEntity()).thenReturn(successResponse("Authorised"));
         var request = buildRequestWith("eyJ0cmFuc1N0YXR1cyI6IlkifQ==");
@@ -188,7 +190,7 @@ class AdyenAuthorise3dsHandlerTest {
                 auth3dsResult
         );
     }
-    
+
     @Test
     void should_return_gateway_rejection_reason_when_3ds_authorisation_is_refused() throws Exception {
         when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
@@ -217,7 +219,7 @@ class AdyenAuthorise3dsHandlerTest {
                           "pspReference": "adyen-3ds-psp-reference",
                           "resultCode": "Authorised",
                           "refusalReasonCode": "0",
-                           "refusalReason": "Authorised"
+                          "refusalReason": "Authorised"
                         }
                         """
         );
@@ -228,7 +230,47 @@ class AdyenAuthorise3dsHandlerTest {
 
         assertThat(response.getGatewayRejectionReason(), is(Optional.empty()));
     }
-    
+
+    @Test
+    void should_set_recurringAuthToken_when_storedPaymentMethodId_is_present() throws Exception {
+        when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
+        when(mockGatewayClientResponse.getEntity()).thenReturn(
+                """
+                        {
+                           "additionalData": {
+                                "tokenization.storedPaymentMethodId": "PM-123"
+                            }  
+                        }
+                        """
+        );
+
+        var response = adyenAuthorise3dsHandler.authorise3dsResponse(buildRequestWith("redirect-result"));
+
+        assertThat(response.getGatewayRecurringAuthToken().isPresent(), is(true));
+        assertThat(response.getGatewayRecurringAuthToken().get(), is(Map.of("storedPaymentMethodId", "PM-123")));
+    }
+
+    @Test
+    void should_set_recurringAuthToken_to_empty_map_when_storedPaymentMethodId_is_NOT_present_and_resultCode_is_Authorised() throws Exception {
+        when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
+        when(mockGatewayClientResponse.getEntity()).thenReturn(successResponse("Authorised"));
+
+        var response = adyenAuthorise3dsHandler.authorise3dsResponse(buildRequestWith("redirect-result"));
+
+        assertThat(response.getGatewayRecurringAuthToken().isPresent(), is(true));
+        assertThat(response.getGatewayRecurringAuthToken().get(), is(Map.of()));
+    }
+
+    @Test
+    void should_set_recurringAuthToken_to_null_map_when_storedPaymentMethodId_is_NOT_present_and_resultCode_is_NOT_Authorised() throws Exception {
+        when(mockClient.postRequestFor(any())).thenReturn(mockGatewayClientResponse);
+        when(mockGatewayClientResponse.getEntity()).thenReturn(successResponse("Refused"));
+
+        var response = adyenAuthorise3dsHandler.authorise3dsResponse(buildRequestWith("redirect-result"));
+
+        assertThat(response.getGatewayRecurringAuthToken().isPresent(), is(false));
+    }
+
     private String successResponse(String resultCode) {
         return """
                 {

--- a/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/adyen/response/AdyenAuthoriseResponseTest.java
@@ -135,7 +135,7 @@ class AdyenAuthoriseResponseTest {
     }
 
     @Test
-    void should_set_get_gateway_recurring_auth_token_to_stored_payment_method_id() {
+    void should_return_gateway_recurring_auth_token_with_stored_payment_method_id() {
         var testStoredPaymentMethodId = "testStoredPaymentMethodId";
         var adyenPaymentResponse = anAdyenPaymentResponse()
                 .withAdditionalData(new AdditionalData(testStoredPaymentMethodId))
@@ -149,8 +149,22 @@ class AdyenAuthoriseResponseTest {
     }
 
     @Test
-    void should_set_get_gateway_recurring_auth_token_to_stored_payment_method_id_null() {
+    void should_return_empty_map_for_gateway_recurring_auth_token_when_authorisation_result_is_authorised() {
         var adyenPaymentResponse = anAdyenPaymentResponse()
+                .withResultCode("Authorised")
+                .build();
+
+        var adyenAuthoriseResponse = AdyenAuthoriseResponse.of(adyenPaymentResponse);
+
+        var gatewayRecurringAuthToken = adyenAuthoriseResponse.getGatewayRecurringAuthToken();
+        assertThat(gatewayRecurringAuthToken.isPresent(), is(true));
+        assertThat(gatewayRecurringAuthToken.get(), is(Map.of()));
+    }
+
+    @Test
+    void should_return_empty_optional_for_gateway_recurring_auth_token_when_authorisation_result_is_NOT_authorised() {
+        var adyenPaymentResponse = anAdyenPaymentResponse()
+                .withResultCode("Refused")
                 .build();
 
         var adyenAuthoriseResponse = AdyenAuthoriseResponse.of(adyenPaymentResponse);

--- a/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/adyen/AdyenCardResourceAuthoriseRecurringPaymentsIT.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.it.resources.adyen;
 
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -90,7 +89,6 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
     }
 
     @Test
-    @Disabled
     void successful_creation_of_payment_instrument_without_recurring_auth_token() {
         var chargeId = createChargeWithAgreement(ENTERING_CARD_DETAILS);
         app.getAdyenCheckoutMockClient().mockAuthorisationSuccess(PSP_REFERENCE_FROM_ADYEN);
@@ -126,7 +124,6 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
     }
 
     @Test
-    @Disabled
     void successful_creation_of_payment_instrument_for_3ds_without_recurring_auth_token() {
         var chargeId = createChargeWithAgreement(AUTHORISATION_3DS_REQUIRED);
 
@@ -145,7 +142,6 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
     }
 
     @Test
-    @Disabled
     void errored_recurring_payment_should_not_create_a_paymentInstrument() {
         var chargeId = createChargeWithAgreement(ENTERING_CARD_DETAILS);
 
@@ -157,7 +153,6 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
     }
 
     @Test
-    @Disabled
     void rejected_recurring_payment_should_not_create_a_paymentInstrument() {
         var chargeId = createChargeWithAgreement(ENTERING_CARD_DETAILS);
 
@@ -169,7 +164,6 @@ class AdyenCardResourceAuthoriseRecurringPaymentsIT {
     }
 
     @Test
-    @Disabled
     void errored_3ds_recurring_payment_should_not_create_a_paymentInstrument() {
         var chargeId = createChargeWithAgreement(AUTHORISATION_3DS_REQUIRED);
 


### PR DESCRIPTION
## WHAT

- Returns an empty map for the recurring_auth_token when storedPaymentMethodId is not present after a recurring payment is authorised.
    - A payment instrument is created with state 'CREATED' when an empty map is returned by the payment provider
    - When storedPaymentMethodId is not available in the authorisation response, we expect it to be available in the `recurring.token.created` webhook processed.
- Enabled relevant integration tests that were disabled in https://github.com/govuk-pay/pay-connector/pull/6690
